### PR TITLE
Add async parsing method to SelectQueryParser with tests

### DIFF
--- a/src/parsers/SelectQueryParser.ts
+++ b/src/parsers/SelectQueryParser.ts
@@ -30,6 +30,17 @@ export class SelectQueryParser {
         return result.value;
     }
 
+    /**
+     * Asynchronously parse SQL string to AST.
+     * This method wraps the synchronous parse logic in a Promise for future extensibility.
+     * @param query SQL string to parse
+     * @returns Promise<SelectQuery>
+     */
+    public static async parseAsync(query: string): Promise<SelectQuery> {
+        // For now, just wrap the sync parse in a resolved Promise
+        return Promise.resolve(this.parse(query));
+    }
+
     private static unionCommandSet = new Set<string>([
         "union",
         "union all",

--- a/tests/parsers/SelectQueryParser.test.ts
+++ b/tests/parsers/SelectQueryParser.test.ts
@@ -217,3 +217,26 @@ describe('SelectQueryParser with VALUES', () => {
         expect(sql).toBe('values (1, \'Product A\'), (2, \'Product B\') union all select "id", "name" from "featured_products" order by "name"');
     });
 });
+
+describe('SelectQueryParser async', () => {
+    test('parseAsync should resolve to same result as parse', async () => {
+        // Arrange
+        const sql = 'select id, name from users where active = TRUE';
+        const expected = 'select "id", "name" from "users" where "active" = true';
+
+        // Act
+        const query = await SelectQueryParser.parseAsync(sql);
+        const formatted = formatter.format(query);
+
+        // Assert
+        expect(formatted).toBe(expected);
+    });
+
+    test('parseAsync should reject on syntax error', async () => {
+        // Arrange
+        const sql = 'select from';
+
+        // Act & Assert
+        await expect(SelectQueryParser.parseAsync(sql)).rejects.toThrow();
+    });
+});


### PR DESCRIPTION
Introduce an asynchronous parsing method for SQL strings in the SelectQueryParser, enhancing extensibility. Include tests to verify that the async method resolves correctly and handles syntax errors.