### PR TITLE
Implement CreateTableQuery model and QueryConverter functionality

### DIFF
--- a/src/transformers/Formatter.ts
+++ b/src/transformers/Formatter.ts
@@ -28,6 +28,7 @@ import {
     TupleExpression
 } from "../models/ValueComponent";
 import { CommonTable, Distinct, DistinctOn, FetchSpecification, FetchType, ForClause, FromClause, FunctionSource, GroupByClause, HavingClause, JoinClause, JoinOnClause, JoinUsingClause, LimitClause, NullsSortDirection, OrderByClause, OrderByItem, PartitionByClause, SelectClause, SelectItem, SortDirection, SourceAliasExpression, SourceExpression, SubQuerySource, TableSource, WhereClause, WindowFrameClause, WithClause } from "../models/Clause";
+import { CreateTableQuery } from "../models/CreateTableQuery";
 
 interface FormatterConfig {
     identifierEscape: {
@@ -131,6 +132,7 @@ export class Formatter implements SqlComponentVisitor<string> {
         // select query
         this.handlers.set(SimpleSelectQuery.kind, (expr) => this.visitSelectQuery(expr as SimpleSelectQuery));
         this.handlers.set(BinarySelectQuery.kind, (expr) => this.visitBinarySelectQuery(expr as BinarySelectQuery));
+        this.handlers.set(CreateTableQuery.kind, (expr) => this.visitCreateTableQuery(expr as CreateTableQuery));
     }
 
     /**
@@ -574,5 +576,17 @@ export class Formatter implements SqlComponentVisitor<string> {
     private visitTupleExpression(arg: TupleExpression): string {
         const values = arg.values.map((value) => value.accept(this)).join(", ");
         return `(${values})`;
+    }
+
+    /**
+     * Formats a CreateTableQuery into SQL string.
+     */
+    private visitCreateTableQuery(arg: CreateTableQuery): string {
+        const temp = arg.isTemporary ? "temporary " : "";
+        let sql = `create ${temp}table ${arg.tableName.accept(this)}`;
+        if (arg.asSelectQuery) {
+            sql += ` as ${this.visit(arg.asSelectQuery)}`;
+        }
+        return sql;
     }
 }

--- a/src/transformers/QueryConverter.ts
+++ b/src/transformers/QueryConverter.ts
@@ -4,6 +4,7 @@ import { SqlComponent } from "../models/SqlComponent";
 import { ColumnReference, IdentifierString, RawString } from "../models/ValueComponent";
 import { CTECollector } from "./CTECollector";
 import { CTENormalizer } from "./CTENormalizer";
+import { CreateTableQuery } from "../models/CreateTableQuery";
 
 /**
  * Converts various SELECT query types to a standard SimpleSelectQuery format.
@@ -143,5 +144,20 @@ export class QueryConverter {
 
         // Create and return a SelectClause with the item
         return new SelectClause([selectItem], null);
+    }
+
+    /**
+     * Converts a SELECT query to a CREATE TABLE query (CREATE [TEMPORARY] TABLE ... AS SELECT ...)
+     * @param query The SELECT query to use as the source
+     * @param tableName The name of the table to create
+     * @param isTemporary If true, creates a temporary table
+     * @returns A CreateTableQuery instance
+     */
+    public static toCreateTableQuery(query: SelectQuery, tableName: string, isTemporary: boolean = false): CreateTableQuery {
+        return new CreateTableQuery({
+            tableName,
+            isTemporary,
+            asSelectQuery: query
+        });
     }
 }

--- a/tests/models/CreateTableQuery.model.test.ts
+++ b/tests/models/CreateTableQuery.model.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
+import { CreateTableQuery } from '../../src/models/CreateTableQuery';
+import { Formatter } from '../../src/transformers/Formatter';
+
+describe('CreateTableQuery#getSelectQuery & getCountQuery', () => {
+    it('getSelectQuery() should return select columns from asSelectQuery', () => {
+        // Arrange
+        const select = SelectQueryParser.parse('SELECT id, name FROM users');
+        const create = new CreateTableQuery({
+            tableName: 'my_table',
+            asSelectQuery: select
+        });
+        // Act
+        const selectQuery = create.getSelectQuery();
+        const sql = new Formatter().format(selectQuery);
+        // Assert
+        expect(sql).toBe('select "id", "name" from "my_table"');
+    });
+
+    it('getSelectQuery() should fallback to wildcard if asSelectQuery is not set', () => {
+        // Arrange
+        const create = new CreateTableQuery({
+            tableName: 'my_table'
+        });
+        // Act
+        const selectQuery = create.getSelectQuery();
+        const sql = new Formatter().format(selectQuery);
+        // Assert
+        expect(sql).toBe('select * from "my_table"');
+    });
+
+    it('getCountQuery() should return count query for the table', () => {
+        // Arrange
+        const create = new CreateTableQuery({
+            tableName: 'my_table'
+        });
+        // Act
+        const countQuery = create.getCountQuery();
+        const sql = new Formatter().format(countQuery);
+        // Assert
+        expect(sql).toBe('select count(*) from "my_table"');
+    });
+
+    it('getCountQuery() should work even if asSelectQuery is set', () => {
+        // Arrange
+        const select = SelectQueryParser.parse('SELECT id, name FROM users');
+        const create = new CreateTableQuery({
+            tableName: 'my_table',
+            asSelectQuery: select
+        });
+        // Act
+        const countQuery = create.getCountQuery();
+        const sql = new Formatter().format(countQuery);
+        // Assert
+        expect(sql).toBe('select count(*) from "my_table"');
+    });
+});

--- a/tests/transformers/CreateTableQueryConverter.test.ts
+++ b/tests/transformers/CreateTableQueryConverter.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
+import { QueryConverter } from '../../src/transformers/QueryConverter';
+import { Formatter } from '../../src/transformers/Formatter';
+import { CreateTableQuery } from '../../src/models/CreateTableQuery';
+
+
+describe('QueryConverter.toCreateTableQuery', () => {
+    it('should convert a simple SELECT to CREATE TABLE ... AS SELECT', () => {
+        // Arrange
+        const select = SelectQueryParser.parse('SELECT id, name FROM users');
+
+        // Act
+        const create = QueryConverter.toCreateTableQuery(select, 'my_table');
+        const sql = new Formatter().format(create);
+
+        // Assert
+        expect(create).toBeInstanceOf(CreateTableQuery);
+        expect(sql).toBe('create table "my_table" as select "id", "name" from "users"');
+    });
+
+    it('should support temporary tables', () => {
+        // Arrange
+        const select = SelectQueryParser.parse('SELECT id FROM users');
+
+        // Act
+        const create = QueryConverter.toCreateTableQuery(select, 'tmp_table', true);
+        const sql = new Formatter().format(create);
+
+        // Assert
+        expect(sql).toBe('create temporary table "tmp_table" as select "id" from "users"');
+    });
+});

--- a/tests/transformers/UpstreamSelectQueryFinder.test.ts
+++ b/tests/transformers/UpstreamSelectQueryFinder.test.ts
@@ -389,7 +389,7 @@ describe('UpstreamSelectQueryFinder Demo', () => {
         order by "transaction_date" desc`;
         // Compare ignoring whitespace, newlines, and tabs
         const normalize = (str: string) => str.replace(/\s+/g, '');
-        expect(normalize(actual)).toBe(normalize(excepted));
+        expect(normalize(actual)).toBe(normalize(expected));
     });
 
     test('appendWhereExpr', () => {
@@ -457,6 +457,6 @@ describe('UpstreamSelectQueryFinder Demo', () => {
         order by "transaction_date" desc`;
         // Compare ignoring whitespace, newlines, and tabs
         const normalize = (str: string) => str.replace(/\s+/g, '');
-        expect(normalize(actual)).toBe(normalize(excepted));
+        expect(normalize(actual)).toBe(normalize(expected));
     });
 });


### PR DESCRIPTION
Introduce the CreateTableQuery model to represent CREATE TABLE queries, including support for temporary tables and AS SELECT. Enhance QueryConverter to facilitate conversion from SELECT queries to CreateTableQuery instances. Add corresponding unit tests to ensure functionality.