### PR TITLE
Add parameter suffix support

### DIFF
--- a/src/parsers/ParameterExpressionParser.ts
+++ b/src/parsers/ParameterExpressionParser.ts
@@ -4,8 +4,18 @@ import { ParameterExpression, ValueComponent } from "../models/ValueComponent";
 export class ParameterExpressionParser {
     public static parseFromLexeme(lexemes: Lexeme[], index: number): { value: ValueComponent; newIndex: number } {
         let idx = index;
-        // Exclude the parameter symbol (first character)
-        const value = new ParameterExpression(lexemes[idx].value.slice(1));
+        let paramName = lexemes[idx].value;
+
+        // Normalize parameter: Remove the parameter symbol and extract the parameter name.
+        if (paramName.startsWith('${') && paramName.endsWith('}')) {
+            // ${name} → name
+            paramName = paramName.slice(2, -1);
+        } else {
+            // :name → name
+            paramName = paramName.slice(1);
+        }
+
+        const value = new ParameterExpression(paramName);
         idx++;
         return { value, newIndex: idx };
     }

--- a/src/tokenReaders/ParameterTokenReader.ts
+++ b/src/tokenReaders/ParameterTokenReader.ts
@@ -28,7 +28,12 @@ export class ParameterTokenReader extends BaseTokenReader {
             if (this.isEndOfInput()) {
                 throw new Error(`Unexpected end of input. Expected closing '}' for parameter at position ${start}`);
             }
+
             const identifier = this.input.slice(start, this.position);
+            if (identifier.length === 0) {
+                throw new Error('Empty parameter name is not allowed: found ${} at position ' + (start - 2));
+            }
+
             this.position++; // Skip }
             return this.createLexeme(TokenType.Parameter, '${' + identifier + '}');
         }

--- a/src/tokenReaders/ParameterTokenReader.ts
+++ b/src/tokenReaders/ParameterTokenReader.ts
@@ -6,8 +6,7 @@ import { CharLookupTable } from '../utils/charLookupTable';
  * Reads SQL parameter tokens (@param, :param, $param, ?, ${param})
  */
 export class ParameterTokenReader extends BaseTokenReader {
-
-    constructor(input: string, supportSuffixes: boolean = true) {
+    constructor(input: string) {
         super(input);
     }
 
@@ -19,7 +18,7 @@ export class ParameterTokenReader extends BaseTokenReader {
             return null;
         }
 
-        // parameter with suffix (${param}) - check this first!
+        // parameter with suffix (${param}) - check this first
         if (this.canRead(1) && this.input[this.position] === '$' && this.input[this.position + 1] === '{') {
             this.position += 2; // Skip ${
             const start = this.position;

--- a/tests/parameter.test.ts
+++ b/tests/parameter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-﻿import { TokenType } from "../src/models/Lexeme";
+import { TokenType } from "../src/models/Lexeme";
 import { SqlTokenizer } from "../src/parsers/SqlTokenizer";
 
 test('tokenizes named parameter in SQLServer', () => {
@@ -52,4 +52,19 @@ test('tokenizes named parameter with colon prefix in PostgreSQL', () => {
     expect(tokens.length).toBe(1);
     expect(tokens[0].type).toBe(TokenType.Parameter);
     expect(tokens[0].value).toBe(':param1');
+});
+
+test('tokenizes parameter with suffix syntax', () => {
+    // Arrange
+    const tokenizer = new SqlTokenizer('select ${name}');
+
+    // Act
+    const tokens = tokenizer.readLexmes();
+
+    // Assert
+    // Should tokenize 'select' as identifier/keyword and '${name}' as parameter
+    expect(tokens.length).toBe(2);
+    expect(tokens[0].value.toLowerCase()).toBe('select');
+    expect(tokens[1].type).toBe(TokenType.Parameter);
+    expect(tokens[1].value).toBe('${name}');
 });

--- a/tests/parsers/SelectQueryParser.test.ts
+++ b/tests/parsers/SelectQueryParser.test.ts
@@ -175,7 +175,11 @@ describe('SelectQueryParser', () => {
 
         ["WITH multiple CTEs with VALUES and column aliases",
             "with fruits(id, name) as (values (1, 'apple'), (2, 'orange')), vegetables(id, name) as (values (3, 'carrot'), (4, 'potato')) select * from fruits union select * from vegetables",
-            'with "fruits"("id", "name") as (values (1, \'apple\'), (2, \'orange\')), "vegetables"("id", "name") as (values (3, \'carrot\'), (4, \'potato\')) select * from "fruits" union select * from "vegetables"']
+            'with "fruits"("id", "name") as (values (1, \'apple\'), (2, \'orange\')), "vegetables"("id", "name") as (values (3, \'carrot\'), (4, \'potato\')) select * from "fruits" union select * from "vegetables"'],
+
+        ["SELECT with template variable",
+            "select ${name}",
+            'select :name'],
 
     ])('%s', (_, text, expected) => {
         // Parse the query
@@ -238,5 +242,63 @@ describe('SelectQueryParser async', () => {
 
         // Act & Assert
         await expect(SelectQueryParser.parseAsync(sql)).rejects.toThrow();
+    });
+
+    test('Dialect conversion: Postgres to SQL Server', async () => {
+        // Arrange
+        const sql = 'select "id", "name" from "users" where "id" = :userId';
+        const expected = 'select [id], [name] from [users] where [id] = @userId';
+
+        // Act
+        const query = await SelectQueryParser.parseAsync(sql);
+        const formatted = formatter.format(query, { identifierEscape: { start: '[', end: ']' }, parameterSymbol: '@' });
+
+        // Assert
+        expect(formatted).toBe(expected);
+    });
+
+    test('Dialect conversion: Postgres to MySQL', async () => {
+        // Arrange
+        const sql = 'select "id", "name" from "users" where "id" = :userId';
+        const expected = 'select `id`, `name` from `users` where `id` = :userId';
+
+        // Act
+        const query = await SelectQueryParser.parseAsync(sql);
+        const formatted = formatter.format(query, { identifierEscape: { start: '`', end: '`' }, parameterSymbol: ':' });
+
+        // Assert
+        expect(formatted).toBe(expected);
+    });
+
+    test('Dialect conversion: Postgres to Variable', async () => {
+        // Arrange
+        const sql = 'select "id", "name" from "users" where "id" = :userId';
+        const expected = 'select "id", "name" from "users" where "id" = ${userId}';
+
+        // Act
+        const query = await SelectQueryParser.parseAsync(sql);
+        // identifierEscape: { start: '"', end: '"' } is applied by default (Postgres style) if omitted
+        const formatted = formatter.format(query, {
+            parameterSymbol: { start: '${', end: '}' },
+        });
+
+        // Assert
+        expect(formatted).toBe(expected);
+    });
+
+    test('Dialect conversion: Postgres to No Escape', async () => {
+        // Arrange
+        const sql = 'select "id", "name" from "users" where "id" = :userId';
+        const expected = 'select id, name from users where id = :userId';
+
+        // Act
+        const query = await SelectQueryParser.parseAsync(sql);
+        const formatted = formatter.format(query, {
+            identifierEscape: { start: '', end: '' },
+            parameterSymbol: ':'
+        });
+
+        // Assert
+        expect(formatted).toBe(expected);
     });
 });


### PR DESCRIPTION
Add support for parsing parameters in the `${name}` format in `ParameterTokenReader`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mk3008/rawsql-ts/pull/64?shareId=0ae74bea-2ec3-4392-9b96-215eea759d16).