### PR TITLE
Rename QueryConverter to QueryBuilder for consistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rawsql-ts",
-    "version": "0.3.0-beta",
+    "version": "0.4.0-beta",
     "description": "[beta]High-performance SQL parser and AST analyzer written in TypeScript. Provides fast parsing and advanced transformation capabilities.",
     "main": "dist/index.js",
     "module": "dist/esm/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export * from './models/ValuesQuery';
 export * from './transformers/CTECollector';
 export * from './transformers/CTENormalizer';
 export * from './transformers/Formatter';
-export * from './transformers/QueryConverter';
+export * from './transformers/QueryBuilder'; // old name:QueryConverter
 export * from './transformers/SelectValueCollector';
 export * from './transformers/SelectableColumnCollector';
 export * from './transformers/TableColumnResolver';

--- a/src/models/BinarySelectQuery.ts
+++ b/src/models/BinarySelectQuery.ts
@@ -1,6 +1,4 @@
 import { SourceExpression, SubQuerySource, SourceAliasExpression } from "./Clause";
-import { SimpleSelectQuery } from "./SimpleSelectQuery";
-import { ValuesQuery } from "./ValuesQuery";
 import type { SelectQuery } from "./SelectQuery";
 import { SqlComponent } from "./SqlComponent";
 import { RawString } from "./ValueComponent";
@@ -109,8 +107,6 @@ export class BinarySelectQuery extends SqlComponent {
         this.operator = new RawString(operator);
         this.right = query;
 
-        // const normalizer = new CTENormalizer();
-        // normalizer.normalize(this);
         CTENormalizer.normalize(this);
 
         return this;

--- a/src/models/SimpleSelectQuery.ts
+++ b/src/models/SimpleSelectQuery.ts
@@ -12,6 +12,7 @@ import { SelectQueryParser } from "../parsers/SelectQueryParser";
 import { Formatter } from "../transformers/Formatter";
 import { TableColumnResolver } from "../transformers/TableColumnResolver";
 import { UpstreamSelectQueryFinder } from "../transformers/UpstreamSelectQueryFinder";
+import { QueryBuilder } from "../transformers/QueryBuilder";
 
 /**
  * Represents a simple SELECT query in SQL.
@@ -129,7 +130,7 @@ export class SimpleSelectQuery extends SqlComponent {
      * @returns A new BinarySelectQuery representing "this [operator] rightQuery"
      */
     public toBinaryQuery(operator: string, rightQuery: SelectQuery): BinarySelectQuery {
-        return new BinarySelectQuery(this, operator, rightQuery);
+        return QueryBuilder.buildBinaryQuery([this, rightQuery], operator);
     }
 
     /**

--- a/src/models/ValuesQuery.ts
+++ b/src/models/ValuesQuery.ts
@@ -1,3 +1,5 @@
+import { QueryBuilder } from "../transformers/QueryBuilder";
+import { SimpleSelectQuery } from "./SimpleSelectQuery";
 import { SqlComponent } from "./SqlComponent";
 import { TupleExpression } from "./ValueComponent";
 
@@ -18,5 +20,9 @@ export class ValuesQuery extends SqlComponent {
         super();
         this.tuples = tuples;
         this.columnAliases = columnAliases;
+    }
+
+    public toSimpleSelectQuery(): SimpleSelectQuery {
+        return QueryBuilder.buildSimpleQuery(this);
     }
 }

--- a/tests/transformers/CreateTableQueryConverter.test.ts
+++ b/tests/transformers/CreateTableQueryConverter.test.ts
@@ -1,17 +1,17 @@
 import { describe, it, expect } from 'vitest';
 import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
-import { QueryConverter } from '../../src/transformers/QueryConverter';
+import { QueryBuilder } from '../../src/transformers/QueryBuilder';
 import { Formatter } from '../../src/transformers/Formatter';
 import { CreateTableQuery } from '../../src/models/CreateTableQuery';
 
 
-describe('QueryConverter.toCreateTableQuery', () => {
+describe('QueryBuilder.toCreateTableQuery', () => {
     it('should convert a simple SELECT to CREATE TABLE ... AS SELECT', () => {
         // Arrange
         const select = SelectQueryParser.parse('SELECT id, name FROM users');
 
         // Act
-        const create = QueryConverter.toCreateTableQuery(select, 'my_table');
+        const create = QueryBuilder.buildCreateTableQuery(select, 'my_table');
         const sql = new Formatter().format(create);
 
         // Assert
@@ -24,7 +24,7 @@ describe('QueryConverter.toCreateTableQuery', () => {
         const select = SelectQueryParser.parse('SELECT id FROM users');
 
         // Act
-        const create = QueryConverter.toCreateTableQuery(select, 'tmp_table', true);
+        const create = QueryBuilder.buildCreateTableQuery(select, 'tmp_table', true);
         const sql = new Formatter().format(create);
 
         // Assert

--- a/tests/transformers/QueryConverter.toInsertQuery.test.ts
+++ b/tests/transformers/QueryConverter.toInsertQuery.test.ts
@@ -1,23 +1,24 @@
 import { describe, it, expect } from 'vitest';
-import { QueryConverter } from '../../src/transformers/QueryConverter';
+import { QueryBuilder } from '../../src/transformers/QueryBuilder';
 import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
 import { Formatter } from '../../src/transformers/Formatter';
 import { SimpleSelectQuery } from '../../src/models/SimpleSelectQuery';
 import { ValuesQuery } from '../../src/models/ValuesQuery';
 
-describe('QueryConverter.toInsertQuery', () => {
+describe('QueryBuilder.toInsertQuery', () => {
     it('infers columns from SELECT and generates correct InsertQuery', () => {
         const select = SelectQueryParser.parse('SELECT id, name FROM users_old') as SimpleSelectQuery;
-        const insert = QueryConverter.toInsertQuery(select, 'users');
+        const insert = QueryBuilder.buildInsertQuery(select, 'users');
         const sql = new Formatter().format(insert);
         expect(sql).toBe('insert into "users" ("id", "name") select "id", "name" from "users_old"');
     });
 
     it('supports VALUES query via SelectQueryParser', () => {
         const query = SelectQueryParser.parse("VALUES (1, 'Alice'), (2, 'Bob')") as ValuesQuery;
-        const select = QueryConverter.toSimple(query, ['id', 'name'])
+        query.columnAliases = ["id", "name"]; //set column aliases
+        const select = QueryBuilder.buildSimpleQuery(query);
 
-        const insert = QueryConverter.toInsertQuery(select, 'users');
+        const insert = QueryBuilder.buildInsertQuery(select, 'users');
         const sql = new Formatter().format(insert);
         expect(sql).toBe('insert into "users" ("id", "name") select "vq"."id", "vq"."name" from (values (1, \'Alice\'), (2, \'Bob\')) as "vq"("id", "name")');
     });
@@ -25,12 +26,12 @@ describe('QueryConverter.toInsertQuery', () => {
     it('throws if columns cannot be inferred from wildcard select (SELECT *)', () => {
         // Should throw if column names cannot be inferred (e.g. select *)
         const select = SelectQueryParser.parse('SELECT * FROM users_old') as SimpleSelectQuery;
-        expect(() => QueryConverter.toInsertQuery(select, 'users')).toThrow();
+        expect(() => QueryBuilder.buildInsertQuery(select, 'users')).toThrow();
     });
 
     it('throws if columns cannot be inferred from constant select (SELECT 1)', () => {
         // Should throw if there are no column names (e.g. SELECT 1)
         const select = SelectQueryParser.parse('SELECT 1') as SimpleSelectQuery;
-        expect(() => QueryConverter.toInsertQuery(select, 'users')).toThrow();
+        expect(() => QueryBuilder.buildInsertQuery(select, 'users')).toThrow();
     });
 });

--- a/tests/transformers/QueryNormalizer.test.ts
+++ b/tests/transformers/QueryNormalizer.test.ts
@@ -1,4 +1,4 @@
-import { QueryConverter } from "../../src/transformers/QueryConverter";
+import { QueryBuilder } from "../../src/transformers/QueryBuilder";
 import { SelectQueryParser } from "../../src/parsers/SelectQueryParser";
 import { Formatter } from "../../src/transformers/Formatter";
 import { BinarySelectQuery, SimpleSelectQuery, ValuesQuery } from "../../src/models/SelectQuery";
@@ -13,7 +13,7 @@ describe('QueryNormalizer', () => {
         const query = SelectQueryParser.parse(sql);
 
         // Act
-        const normalizedQuery = QueryConverter.toSimple(query);
+        const normalizedQuery = QueryBuilder.buildSimpleQuery(query);
 
         // Assert
         expect(normalizedQuery).toBe(query); // Should be the same object instance
@@ -27,7 +27,7 @@ describe('QueryNormalizer', () => {
         expect(query).toBeInstanceOf(BinarySelectQuery);
 
         // Act
-        const normalizedQuery = QueryConverter.toSimple(query);
+        const normalizedQuery = QueryBuilder.buildSimpleQuery(query);
 
         // Assert
         expect(normalizedQuery).toBeInstanceOf(SimpleSelectQuery);
@@ -41,7 +41,7 @@ describe('QueryNormalizer', () => {
 
         // Act & Assert
         expect(() => {
-            QueryConverter.toSimple(query);
+            QueryBuilder.buildSimpleQuery(query);
         }).toThrow();
     });
 
@@ -54,7 +54,7 @@ describe('QueryNormalizer', () => {
 
         // Act   
         query.columnAliases = ["id", "value"]; //set column aliases
-        const normalizedQuery = QueryConverter.toSimple(query);
+        const normalizedQuery = QueryBuilder.buildSimpleQuery(query);
 
         // Assert
         expect(normalizedQuery).toBeInstanceOf(SimpleSelectQuery);
@@ -67,7 +67,7 @@ describe('QueryNormalizer', () => {
         const query = SelectQueryParser.parse(sql);
 
         // Act
-        const normalizedQuery = QueryConverter.toSimple(query);
+        const normalizedQuery = QueryBuilder.buildSimpleQuery(query);
 
         // Assert
         expect(normalizedQuery).toBeInstanceOf(SimpleSelectQuery);
@@ -80,7 +80,7 @@ describe('QueryNormalizer', () => {
         const query = SelectQueryParser.parse(sql);
 
         // Act
-        const normalizedQuery = QueryConverter.toSimple(query);
+        const normalizedQuery = QueryBuilder.buildSimpleQuery(query);
 
         // Assert
         expect(normalizedQuery).toBeInstanceOf(SimpleSelectQuery);
@@ -93,7 +93,7 @@ describe('QueryNormalizer', () => {
         const query = SelectQueryParser.parse(sql);
 
         // Act
-        const normalizedQuery = QueryConverter.toSimple(query);
+        const normalizedQuery = QueryBuilder.buildSimpleQuery(query);
 
         // Assert
         expect(normalizedQuery).toBeInstanceOf(SimpleSelectQuery);


### PR DESCRIPTION
Update the class name from `QueryConverter` to `QueryBuilder` and modify related methods accordingly. This change introduces breaking changes, requiring users to update their code to reflect the new naming conventions and method signatures. Version number updated to 0.4.0-beta.