### PR TITLE
Feature/improve-parsing

### DIFF
--- a/src/models/Clause.ts
+++ b/src/models/Clause.ts
@@ -325,16 +325,12 @@ export class WithClause extends SqlComponent {
     }
 }
 
-export type RowLimitClause = LimitClause | FetchClause;
-
 export class LimitClause extends SqlComponent {
     static kind = Symbol("LimitClause");
-    limit: ValueComponent;
-    offset: ValueComponent | null;
-    constructor(limit: ValueComponent, offset: ValueComponent | null) {
+    value: ValueComponent;
+    constructor(limit: ValueComponent) {
         super();
-        this.limit = limit;
-        this.offset = offset;
+        this.value = limit;
     }
 }
 
@@ -349,8 +345,27 @@ export enum FetchUnit {
     PercentWithTies = "percent with ties",
 }
 
+
+export class OffsetClause extends SqlComponent {
+    static kind = Symbol("OffsetClause");
+    value: ValueComponent;
+    constructor(value: ValueComponent) {
+        super();
+        this.value = value;
+    }
+}
+
 export class FetchClause extends SqlComponent {
-    static kind = Symbol("FetchSpecification");
+    static kind = Symbol("FetchClause");
+    expression: FecthExpression;
+    constructor(expression: FecthExpression) {
+        super();
+        this.expression = expression;
+    }
+}
+
+export class FecthExpression extends SqlComponent {
+    static kind = Symbol("FecthExpression");
     type: FetchType;
     count: ValueComponent;
     unit: FetchUnit | null;

--- a/src/models/Clause.ts
+++ b/src/models/Clause.ts
@@ -357,15 +357,15 @@ export class OffsetClause extends SqlComponent {
 
 export class FetchClause extends SqlComponent {
     static kind = Symbol("FetchClause");
-    expression: FecthExpression;
-    constructor(expression: FecthExpression) {
+    expression: FetchExpression;
+    constructor(expression: FetchExpression) {
         super();
         this.expression = expression;
     }
 }
 
-export class FecthExpression extends SqlComponent {
-    static kind = Symbol("FecthExpression");
+export class FetchExpression extends SqlComponent {
+    static kind = Symbol("FetchExpression");
     type: FetchType;
     count: ValueComponent;
     unit: FetchUnit | null;

--- a/src/models/Clause.ts
+++ b/src/models/Clause.ts
@@ -72,6 +72,19 @@ export class WindowFrameClause extends SqlComponent {
     }
 }
 
+/**
+ * Represents a collection of window definitions (WINDOW clause in SQL).
+ * @param windows Array of WindowFrameClause
+ */
+export class WindowsClause extends SqlComponent {
+    static kind = Symbol("WindowsClause");
+    windows: WindowFrameClause[];
+    constructor(windows: WindowFrameClause[]) {
+        super();
+        this.windows = windows;
+    }
+}
+
 export enum SortDirection {
     Ascending = "asc",
     Descending = "desc",
@@ -312,7 +325,7 @@ export class WithClause extends SqlComponent {
     }
 }
 
-//export type RowLimitComponent = LimitOffset | FetchSpecification;
+export type RowLimitClause = LimitClause | FetchClause;
 
 export class LimitClause extends SqlComponent {
     static kind = Symbol("LimitClause");
@@ -336,7 +349,7 @@ export enum FetchUnit {
     PercentWithTies = "percent with ties",
 }
 
-export class FetchSpecification extends SqlComponent {
+export class FetchClause extends SqlComponent {
     static kind = Symbol("FetchSpecification");
     type: FetchType;
     count: ValueComponent;

--- a/src/models/CreateTableQuery.ts
+++ b/src/models/CreateTableQuery.ts
@@ -42,49 +42,33 @@ export class CreateTableQuery extends SqlComponent {
             // fallback: wildcard
             selectItems = [new SelectItem(new RawString("*"))];
         }
-        return new SimpleSelectQuery(
-            null, // withClause
-            new SelectClause(selectItems),
-            new FromClause(
+        return new SimpleSelectQuery({
+            selectClause: new SelectClause(selectItems),
+            fromClause: new FromClause(
                 new SourceExpression(
                     new TableSource(null, this.tableName.name),
                     null
                 ),
                 null // joins
             ),
-            null, // whereClause
-            null, // groupByClause
-            null, // havingClause
-            null, // orderByClause
-            null, // windowFrameClause
-            null, // rowLimitClause
-            null  // forClause
-        );
+        });
     }
 
     /**
      * Returns a SelectQuery that counts all rows in this table.
      */
     getCountQuery(): SimpleSelectQuery {
-        return new SimpleSelectQuery(
-            null, // withClause
-            new SelectClause([
+        return new SimpleSelectQuery({
+            selectClause: new SelectClause([
                 new SelectItem(new FunctionCall(null, "count", new ColumnReference(null, "*"), null))
             ]),
-            new FromClause(
+            fromClause: new FromClause(
                 new SourceExpression(
                     new TableSource(null, this.tableName.name),
                     null
                 ),
                 null // joins
             ),
-            null, // whereClause
-            null, // groupByClause
-            null, // havingClause
-            null, // orderByClause
-            null, // windowFrameClause
-            null, // rowLimitClause
-            null  // forClause
-        );
+        });
     }
 }

--- a/src/models/SimpleSelectQuery.ts
+++ b/src/models/SimpleSelectQuery.ts
@@ -1,5 +1,5 @@
 import { SqlComponent } from "./SqlComponent";
-import { ForClause, FromClause, GroupByClause, HavingClause, JoinClause, JoinOnClause, LimitClause, OrderByClause, SelectClause, SourceExpression, SubQuerySource, SourceAliasExpression, WhereClause, WindowFrameClause, WithClause, CommonTable } from "./Clause";
+import { ForClause, FromClause, GroupByClause, HavingClause, JoinClause, JoinOnClause, LimitClause, OrderByClause, SelectClause, SourceExpression, SubQuerySource, SourceAliasExpression, WhereClause, WindowFrameClause, WindowsClause, WithClause, CommonTable, RowLimitClause } from "./Clause";
 import { BinaryExpression, ColumnReference, ValueComponent } from "./ValueComponent";
 import { ValueParser } from "../parsers/ValueParser";
 import { CTENormalizer } from "../transformers/CTENormalizer";
@@ -28,8 +28,8 @@ export class SimpleSelectQuery extends SqlComponent implements SelectQuery {
     groupByClause: GroupByClause | null;
     havingClause: HavingClause | null;
     orderByClause: OrderByClause | null;
-    windowFrameClause: WindowFrameClause | null;
-    rowLimitClause: LimitClause | null;
+    windowsClause: WindowsClause | null;
+    rowLimitClause: RowLimitClause | null;
     forClause: ForClause | null;
 
     constructor(
@@ -40,8 +40,8 @@ export class SimpleSelectQuery extends SqlComponent implements SelectQuery {
         groupByClause: GroupByClause | null,
         havingClause: HavingClause | null,
         orderByClause: OrderByClause | null,
-        windowFrameClause: WindowFrameClause | null,
-        rowLimitClause: LimitClause | null,
+        windowsClause: WindowsClause | null,
+        rowLimitClause: RowLimitClause | null,
         forClause: ForClause | null
     ) {
         super();
@@ -52,7 +52,7 @@ export class SimpleSelectQuery extends SqlComponent implements SelectQuery {
         this.groupByClause = groupByClause;
         this.havingClause = havingClause;
         this.orderByClause = orderByClause;
-        this.windowFrameClause = windowFrameClause;
+        this.windowsClause = windowsClause;
         this.rowLimitClause = rowLimitClause;
         this.forClause = forClause;
     }
@@ -385,7 +385,7 @@ export class SimpleSelectQuery extends SqlComponent implements SelectQuery {
         }
         const item = items[0];
         const formatter = new Formatter();
-        const exprSql = formatter.visit(item.value);
+        const exprSql = formatter.visit(item.value).join("\n");
         const newValue = fn(exprSql);
         item.value = ValueParser.parse(newValue);
     }

--- a/src/parsers/FetchClauseParser.ts
+++ b/src/parsers/FetchClauseParser.ts
@@ -1,5 +1,5 @@
 import { off } from "process";
-import { FetchClause, FetchType, FetchUnit, FecthExpression } from "../models/Clause";
+import { FetchClause, FetchType, FetchUnit, FetchExpression } from "../models/Clause";
 import { Lexeme } from "../models/Lexeme";
 import { LiteralValue, ValueComponent } from "../models/ValueComponent";
 import { ValueParser } from "./ValueParser";
@@ -22,7 +22,7 @@ export class FetchClauseParser {
             throw new Error(`Syntax error: Unexpected end of input after 'FETCH' keyword.`);
         }
 
-        const fetchExprResult = FecthExpressionParser.parseFromLexeme(lexemes, idx);
+        const fetchExprResult = FetchExpressionParser.parseFromLexeme(lexemes, idx);
         const fetchExpr = fetchExprResult.value;
         idx = fetchExprResult.newIndex;
 
@@ -30,12 +30,12 @@ export class FetchClauseParser {
     }
 }
 
-// FecthExpressionParser: parses FETCH [FIRST|NEXT] <count> ROWS ONLY ...
-export class FecthExpressionParser {
+// FetchExpressionParser: parses FETCH [FIRST|NEXT] <count> ROWS ONLY ...
+export class FetchExpressionParser {
     /**
      * Parses a FETCH expression (not the whole clause, just the fetch part)
      */
-    public static parseFromLexeme(lexemes: Lexeme[], index: number): { value: FecthExpression; newIndex: number } {
+    public static parseFromLexeme(lexemes: Lexeme[], index: number): { value: FetchExpression; newIndex: number } {
         let idx = index;
         let type: FetchType;
         const typeToken = lexemes[idx].value;
@@ -59,7 +59,7 @@ export class FecthExpressionParser {
             count = new LiteralValue(1);
             unit = FetchUnit.RowsOnly;
             idx++;
-            return { value: new FecthExpression(type, count, unit), newIndex: idx };
+            return { value: new FetchExpression(type, count, unit), newIndex: idx };
         }
 
         // <count>
@@ -84,6 +84,6 @@ export class FecthExpressionParser {
         if (!unit) {
             throw new Error(`Syntax error: Expected 'ROWS ONLY', 'PERCENT', or 'PERCENT WITH TIES' after 'FETCH FIRST|NEXT <count>'.`);
         }
-        return { value: new FecthExpression(type, count, unit), newIndex: idx };
+        return { value: new FetchExpression(type, count, unit), newIndex: idx };
     }
 }

--- a/src/parsers/FetchClauseParser.ts
+++ b/src/parsers/FetchClauseParser.ts
@@ -1,4 +1,3 @@
-import { off } from "process";
 import { FetchClause, FetchType, FetchUnit, FetchExpression } from "../models/Clause";
 import { Lexeme } from "../models/Lexeme";
 import { LiteralValue, ValueComponent } from "../models/ValueComponent";

--- a/src/parsers/FetchClauseParser.ts
+++ b/src/parsers/FetchClauseParser.ts
@@ -1,0 +1,60 @@
+import { FetchClause, FetchType, FetchUnit } from "../models/Clause";
+import { Lexeme } from "../models/Lexeme";
+import { ValueParser } from "./ValueParser";
+
+export class FetchClauseParser {
+    /**
+     * Parses a FETCH clause from a lexeme array starting at the given index.
+     * Supports syntax like: FETCH [FIRST|NEXT] <count> ROWS ONLY
+     * @param lexemes The array of lexemes
+     * @param index The starting index
+     * @returns { value: FetchSpecification, newIndex: number }
+     */
+    public static parseFromLexeme(lexemes: Lexeme[], index: number): { value: FetchClause; newIndex: number } {
+        let idx = index;
+        if (lexemes[idx].value !== 'fetch') {
+            throw new Error(`Syntax error at position ${idx}: Expected 'FETCH' keyword but found "${lexemes[idx].value}".`);
+        }
+        idx++;
+        if (idx >= lexemes.length) {
+            throw new Error(`Syntax error: Unexpected end of input after 'FETCH' keyword.`);
+        }
+        // [FIRST|NEXT]
+        let type: FetchType;
+        const typeToken = lexemes[idx].value;
+        if (typeToken === 'first') {
+            type = FetchType.First;
+        } else if (typeToken === 'next') {
+            type = FetchType.Next;
+        } else {
+            throw new Error(`Syntax error at position ${idx}: Expected 'FIRST' or 'NEXT' after 'FETCH' but found "${lexemes[idx].value}".`);
+        }
+        idx++;
+        if (idx >= lexemes.length) {
+            throw new Error(`Syntax error: Unexpected end of input after 'FETCH FIRST|NEXT'.`);
+        }
+        // <count>
+        const countResult = ValueParser.parseFromLexeme(lexemes, idx);
+        const count = countResult.value;
+        idx = countResult.newIndex;
+        if (idx >= lexemes.length) {
+            throw new Error(`Syntax error: Unexpected end of input after 'FETCH FIRST|NEXT <count>'.`);
+        }
+        // ROWS ONLY (or other unit)
+        let unit: FetchUnit | null = null;
+        if (lexemes[idx].value === 'rows only') {
+            unit = FetchUnit.RowsOnly;
+            idx++;
+        } else if (lexemes[idx].value === 'percent') {
+            unit = FetchUnit.Percent;
+            idx++;
+        } else if (lexemes[idx].value === 'percent with ties') {
+            unit = FetchUnit.PercentWithTies;
+            idx++;
+        }
+        if (!unit) {
+            throw new Error(`Syntax error: Expected 'ROWS ONLY', 'PERCENT', or 'PERCENT WITH TIES' after 'FETCH FIRST|NEXT <count>'.`);
+        }
+        return { value: new FetchClause(type, count, unit), newIndex: idx };
+    }
+}

--- a/src/parsers/LimitClauseParser.ts
+++ b/src/parsers/LimitClauseParser.ts
@@ -37,23 +37,7 @@ export class LimitClauseParser {
         const limitItem = ValueParser.parseFromLexeme(lexemes, idx);
         idx = limitItem.newIndex;
 
-        let offsetItem = null;
-
-        // Check if there is an OFFSET clause
-        if (idx < lexemes.length && lexemes[idx].value === 'offset') {
-            idx++;
-
-            if (idx >= lexemes.length) {
-                throw new Error(`Syntax error: Unexpected end of input after 'OFFSET' keyword. The OFFSET clause requires a numeric expression.`);
-            }
-
-            // Parse OFFSET value
-            const offsetValueItem = ValueParser.parseFromLexeme(lexemes, idx);
-            offsetItem = offsetValueItem.value;
-            idx = offsetValueItem.newIndex;
-        }
-
-        const clause = new LimitClause(limitItem.value, offsetItem);
+        const clause = new LimitClause(limitItem.value);
 
         return { value: clause, newIndex: idx };
     }

--- a/src/parsers/OffsetClauseParser.ts
+++ b/src/parsers/OffsetClauseParser.ts
@@ -1,0 +1,49 @@
+import { OffsetClause } from "../models/Clause";
+import { Lexeme } from "../models/Lexeme";
+import { SqlTokenizer } from "./SqlTokenizer";
+import { ValueParser } from "./ValueParser";
+
+export class OffsetClauseParser {
+    // Parse SQL string to AST (was: parse)
+    public static parse(query: string): OffsetClause {
+        const tokenizer = new SqlTokenizer(query); // Initialize tokenizer
+        const lexemes = tokenizer.readLexmes(); // Get tokens
+
+        // Parse
+        const result = this.parseFromLexeme(lexemes, 0);
+
+        // Error if there are remaining tokens
+        if (result.newIndex < lexemes.length) {
+            throw new Error(`Syntax error: Unexpected token "${lexemes[result.newIndex].value}" at position ${result.newIndex}. The OFFSET clause is complete but there are additional tokens.`);
+        }
+
+        return result.value;
+    }
+
+    // Parse from lexeme array (was: parse)
+    public static parseFromLexeme(lexemes: Lexeme[], index: number): { value: OffsetClause; newIndex: number } {
+        let idx = index;
+
+        if (lexemes[idx].value !== 'offset') {
+            throw new Error(`Syntax error at position ${idx}: Expected 'OFFSET' keyword but found "${lexemes[idx].value}". OFFSET clauses must start with the OFFSET keyword.`);
+        }
+        idx++;
+
+        if (idx >= lexemes.length) {
+            throw new Error(`Syntax error: Unexpected end of input after 'OFFSET' keyword. The OFFSET clause requires a numeric expression.`);
+        }
+
+        // Parse OFFSET value
+        const offsetItem = ValueParser.parseFromLexeme(lexemes, idx);
+        idx = offsetItem.newIndex;
+
+        // If there is a "row" or "rows" command, skip it
+        if (idx < lexemes.length && (lexemes[idx].value === 'row' || lexemes[idx].value === 'rows')) {
+            idx++;
+        }
+
+        const clause = new OffsetClause(offsetItem.value);
+
+        return { value: clause, newIndex: idx };
+    }
+}

--- a/src/parsers/SelectQueryParser.ts
+++ b/src/parsers/SelectQueryParser.ts
@@ -12,6 +12,8 @@ import { ForClauseParser } from "./ForClauseParser";
 import { SqlTokenizer } from "./SqlTokenizer";
 import { WithClauseParser } from "./WithClauseParser";
 import { ValuesQueryParser } from "./ValuesQueryParser";
+import { FetchClauseParser } from "./FetchClauseParser";
+import { OffsetClauseParser } from "./OffsetClauseParser";
 
 export class SelectQueryParser {
     // Parse SQL string to AST (was: parse)
@@ -102,13 +104,13 @@ export class SelectQueryParser {
         let withClauseResult = null;
 
         // Parse optional WITH clause
-        if (idx < lexemes.length && lexemes[idx].value.toLowerCase() === 'with') {
+        if (idx < lexemes.length && lexemes[idx].value === 'with') {
             withClauseResult = WithClauseParser.parseFromLexeme(lexemes, idx);
             idx = withClauseResult.newIndex;
         }
 
         // Parse SELECT clause (required)
-        if (idx >= lexemes.length || lexemes[idx].value.toLowerCase() !== 'select') {
+        if (idx >= lexemes.length || lexemes[idx].value !== 'select') {
             throw new Error(`Syntax error at position ${idx}: Expected 'SELECT' keyword but found "${idx < lexemes.length ? lexemes[idx].value : 'end of input'}". SELECT queries must start with the SELECT keyword.`);
         }
 
@@ -117,51 +119,65 @@ export class SelectQueryParser {
 
         // Parse FROM clause (optional)
         let fromClauseResult = null;
-        if (idx < lexemes.length && lexemes[idx].value.toLowerCase() === 'from') {
+        if (idx < lexemes.length && lexemes[idx].value === 'from') {
             fromClauseResult = FromClauseParser.parseFromLexeme(lexemes, idx);
             idx = fromClauseResult.newIndex;
         }
 
         // Parse WHERE clause (optional)
         let whereClauseResult = null;
-        if (idx < lexemes.length && lexemes[idx].value.toLowerCase() === 'where') {
+        if (idx < lexemes.length && lexemes[idx].value === 'where') {
             whereClauseResult = WhereClauseParser.parseFromLexeme(lexemes, idx);
             idx = whereClauseResult.newIndex;
         }
 
         // Parse GROUP BY clause (optional)
         let groupByClauseResult = null;
-        if (idx < lexemes.length && lexemes[idx].value.toLowerCase() === 'group by') {
+        if (idx < lexemes.length && lexemes[idx].value === 'group by') {
             groupByClauseResult = GroupByClauseParser.parseFromLexeme(lexemes, idx);
             idx = groupByClauseResult.newIndex;
         }
 
         // Parse HAVING clause (optional)
         let havingClauseResult = null;
-        if (idx < lexemes.length && lexemes[idx].value.toLowerCase() === 'having') {
+        if (idx < lexemes.length && lexemes[idx].value === 'having') {
             havingClauseResult = HavingClauseParser.parseFromLexeme(lexemes, idx);
             idx = havingClauseResult.newIndex;
         }
 
         // Parse WINDOW clause (optional)
-        let windowFrameClauseResult = null;
-        if (idx < lexemes.length && lexemes[idx].value.toLowerCase() === 'window') {
-            windowFrameClauseResult = WindowClauseParser.parseFromLexeme(lexemes, idx);
-            idx = windowFrameClauseResult.newIndex;
+        let windowClauseResult = null;
+        if (idx < lexemes.length && lexemes[idx].value === 'window') {
+            windowClauseResult = WindowClauseParser.parseFromLexeme(lexemes, idx);
+            idx = windowClauseResult.newIndex;
         }
 
         // Parse ORDER BY clause (optional)
         let orderByClauseResult = null;
-        if (idx < lexemes.length && lexemes[idx].value.toLowerCase() === 'order by') {
+        if (idx < lexemes.length && lexemes[idx].value === 'order by') {
             orderByClauseResult = OrderByClauseParser.parseFromLexeme(lexemes, idx);
             idx = orderByClauseResult.newIndex;
         }
 
         // Parse LIMIT clause (optional)
-        let limitClauseResult = null;
-        if (idx < lexemes.length && lexemes[idx].value.toLowerCase() === 'limit') {
-            limitClauseResult = LimitClauseParser.parseFromLexeme(lexemes, idx);
-            idx = limitClauseResult.newIndex;
+        let limitClausResult = null;
+        if (idx < lexemes.length && lexemes[idx].value === 'limit') {
+            limitClausResult = LimitClauseParser.parseFromLexeme(lexemes, idx);
+            idx = limitClausResult.newIndex;
+        }
+
+        // Parse OFFSET clause (optional)
+        let offsetClausResult = null;
+        if (idx < lexemes.length && lexemes[idx].value === 'offset') {
+            offsetClausResult = OffsetClauseParser.parseFromLexeme(lexemes, idx);
+            idx = offsetClausResult.newIndex;
+        }
+
+        // Parse FETCH clause (optional)
+        let fetchClauseResult = null;
+        if (idx < lexemes.length && lexemes[idx].value === 'fetch') {
+            fetchClauseResult = FetchClauseParser.parseFromLexeme(lexemes, idx);
+            idx = fetchClauseResult.newIndex;
         }
 
         // Parse FOR clause (optional)
@@ -172,18 +188,20 @@ export class SelectQueryParser {
         }
 
         // Create and return the SelectQuery object
-        const selectQuery = new SimpleSelectQuery(
-            withClauseResult ? withClauseResult.value : null,
-            selectClauseResult.value,
-            fromClauseResult ? fromClauseResult.value : null,
-            whereClauseResult ? whereClauseResult.value : null,
-            groupByClauseResult ? groupByClauseResult.value : null,
-            havingClauseResult ? havingClauseResult.value : null,
-            orderByClauseResult ? orderByClauseResult.value : null,
-            windowFrameClauseResult ? windowFrameClauseResult.value : null,
-            limitClauseResult ? limitClauseResult.value : null,
-            forClauseResult ? forClauseResult.value : null
-        );
+        const selectQuery = new SimpleSelectQuery({
+            withClause: withClauseResult ? withClauseResult.value : null,
+            selectClause: selectClauseResult.value,
+            fromClause: fromClauseResult ? fromClauseResult.value : null,
+            whereClause: whereClauseResult ? whereClauseResult.value : null,
+            groupByClause: groupByClauseResult ? groupByClauseResult.value : null,
+            havingClause: havingClauseResult ? havingClauseResult.value : null,
+            orderByClause: orderByClauseResult ? orderByClauseResult.value : null,
+            windowsClause: windowClauseResult ? windowClauseResult.value : null,
+            limitClause: limitClausResult ? limitClausResult.value : null,
+            offsetClause: offsetClausResult ? offsetClausResult.value : null,
+            fetchClause: fetchClauseResult ? fetchClauseResult.value : null,
+            forClause: forClauseResult ? forClauseResult.value : null
+        });
 
         return { value: selectQuery, newIndex: idx };
     }

--- a/src/parsers/SelectQueryParser.ts
+++ b/src/parsers/SelectQueryParser.ts
@@ -160,10 +160,10 @@ export class SelectQueryParser {
         }
 
         // Parse LIMIT clause (optional)
-        let limitClausResult = null;
+        let limitClauseResult = null;
         if (idx < lexemes.length && lexemes[idx].value === 'limit') {
-            limitClausResult = LimitClauseParser.parseFromLexeme(lexemes, idx);
-            idx = limitClausResult.newIndex;
+            limitClauseResult = LimitClauseParser.parseFromLexeme(lexemes, idx);
+            idx = limitClauseResult.newIndex;
         }
 
         // Parse OFFSET clause (optional)
@@ -197,7 +197,7 @@ export class SelectQueryParser {
             havingClause: havingClauseResult ? havingClauseResult.value : null,
             orderByClause: orderByClauseResult ? orderByClauseResult.value : null,
             windowsClause: windowClauseResult ? windowClauseResult.value : null,
-            limitClause: limitClausResult ? limitClausResult.value : null,
+            limitClause: limitClauseResult ? limitClauseResult.value : null,
             offsetClause: offsetClausResult ? offsetClausResult.value : null,
             fetchClause: fetchClauseResult ? fetchClauseResult.value : null,
             forClause: forClauseResult ? forClauseResult.value : null

--- a/src/parsers/WindowClauseParser.ts
+++ b/src/parsers/WindowClauseParser.ts
@@ -20,12 +20,12 @@ export class WindowClauseParser {
         let idx = index;
 
         if (lexemes[idx].value !== 'window') {
-            throw new Error(`Syntax error at position ${idx}: Expected 'HAVING' keyword but found "${lexemes[idx].value}". HAVING clauses must start with the HAVING keyword.`);
+            throw new Error(`Syntax error at position ${idx}: Expected 'WINDOW' keyword but found "${lexemes[idx].value}". WINDOW clauses must start with the WINDOW keyword.`);
         }
         idx++;
 
         if (idx >= lexemes.length) {
-            throw new Error(`Syntax error: Unexpected end of input after 'HAVING' keyword. The HAVING clause requires a condition expression.`);
+            throw new Error(`Syntax error: Unexpected end of input after 'WINDOW' keyword. The WINDOW clause requires at least one window definition.`);
         }
 
         const windows: WindowFrameClause[] = [];

--- a/src/parsers/WindowClauseParser.ts
+++ b/src/parsers/WindowClauseParser.ts
@@ -1,51 +1,59 @@
-import { WindowFrameClause } from "../models/Clause";
+import { WindowFrameClause, WindowsClause } from "../models/Clause";
 import { Lexeme, TokenType } from "../models/Lexeme";
 import { SqlTokenizer } from "./SqlTokenizer";
 import { WindowExpressionParser } from "./WindowExpressionParser";
 
 export class WindowClauseParser {
     // Parse SQL string to AST (was: parse)
-    public static parse(query: string): WindowFrameClause {
+    public static parse(query: string): WindowsClause {
         const tokenizer = new SqlTokenizer(query);
         const lexemes = tokenizer.readLexmes();
-
-        // Parse
         const result = this.parseFromLexeme(lexemes, 0);
-
-        // Error if there are remaining tokens
         if (result.newIndex < lexemes.length) {
             throw new Error(`Syntax error: Unexpected token "${lexemes[result.newIndex].value}" at position ${result.newIndex}. The WINDOW clause is complete but there are additional tokens.`);
         }
-
         return result.value;
     }
 
     // Parse from lexeme array (was: parse)
-    public static parseFromLexeme(lexemes: Lexeme[], index: number): { value: WindowFrameClause; newIndex: number } {
+    public static parseFromLexeme(lexemes: Lexeme[], index: number): { value: WindowsClause; newIndex: number } {
         let idx = index;
 
         if (lexemes[idx].value !== 'window') {
-            throw new Error(`Syntax error at position ${idx}: Expected 'WINDOW' keyword but found "${lexemes[idx].value}". WINDOW clauses must start with the WINDOW keyword.`);
+            throw new Error(`Syntax error at position ${idx}: Expected 'HAVING' keyword but found "${lexemes[idx].value}". HAVING clauses must start with the HAVING keyword.`);
         }
         idx++;
 
-        if (idx >= lexemes.length || lexemes[idx].type !== TokenType.Identifier) {
-            throw new Error(`Syntax error: Expected window name after 'WINDOW' keyword.`);
+        if (idx >= lexemes.length) {
+            throw new Error(`Syntax error: Unexpected end of input after 'HAVING' keyword. The HAVING clause requires a condition expression.`);
         }
 
-        // Get the window name
-        const name = lexemes[idx].value;
-        idx++;
+        const windows: WindowFrameClause[] = [];
+        while (idx < lexemes.length) {
 
-        if (idx >= lexemes.length || lexemes[idx].value !== 'as') {
-            throw new Error(`Syntax error at position ${idx}: Expected 'AS' keyword after window name.`);
+            if (idx >= lexemes.length || lexemes[idx].type !== TokenType.Identifier) {
+                throw new Error(`Syntax error: Expected window name after 'WINDOW' keyword.`);
+            }
+            const name = lexemes[idx].value;
+            idx++;
+            if (idx >= lexemes.length || lexemes[idx].value !== 'as') {
+                throw new Error(`Syntax error at position ${idx}: Expected 'AS' keyword after window name.`);
+            }
+            idx++;
+            const expr = WindowExpressionParser.parseFromLexeme(lexemes, idx);
+            idx = expr.newIndex;
+            windows.push(new WindowFrameClause(name, expr.value));
+
+            if (idx < lexemes.length && lexemes[idx].type & TokenType.Comma) {
+                idx++;
+            } else {
+                break;
+            }
         }
-        idx++;
 
-        const expr = WindowExpressionParser.parseFromLexeme(lexemes, idx);
-        idx = expr.newIndex;
-
-        const windowFrame = new WindowFrameClause(name, expr.value);
-        return { value: windowFrame, newIndex: idx };
+        if (windows.length === 0) {
+            throw new Error('At least one WINDOW clause is required after WINDOW keyword.');
+        }
+        return { value: new WindowsClause(windows), newIndex: idx };
     }
 }

--- a/src/tokenReaders/CommandTokenReader.ts
+++ b/src/tokenReaders/CommandTokenReader.ts
@@ -42,6 +42,12 @@ const keywordTrie = new KeywordTrie([
     ["order", "by"],
     ["limit"],
     ["offset"],
+    ["fetch"],
+    ["first"],
+    ["next"],
+    ["rows", "only"],
+    ["percent"],
+    ["percent", "with", "ties"],
     // for
     ["for"],
     ["update"],

--- a/src/tokenReaders/CommandTokenReader.ts
+++ b/src/tokenReaders/CommandTokenReader.ts
@@ -45,6 +45,8 @@ const keywordTrie = new KeywordTrie([
     ["fetch"],
     ["first"],
     ["next"],
+    ["row"],
+    ["row", "only"],
     ["rows", "only"],
     ["percent"],
     ["percent", "with", "ties"],
@@ -68,9 +70,7 @@ const keywordTrie = new KeywordTrie([
     ["over"],
     ["partition", "by"],
     ["range"],
-    ["range"],
     ["rows"],
-    ["groups"],
     ["groups"],
     // window frame
     ["current", "row"],

--- a/src/transformers/CTECollector.ts
+++ b/src/transformers/CTECollector.ts
@@ -1,4 +1,4 @@
-import { CommonTable, ForClause, FromClause, GroupByClause, HavingClause, JoinClause, JoinOnClause, JoinUsingClause, LimitClause, OrderByClause, OrderByItem, ParenSource, PartitionByClause, SelectClause, SelectItem, SourceExpression, SubQuerySource, TableSource, WhereClause, WindowFrameClause, WithClause } from "../models/Clause";
+import { CommonTable, ForClause, FromClause, GroupByClause, HavingClause, JoinClause, JoinOnClause, JoinUsingClause, LimitClause, OrderByClause, OrderByItem, ParenSource, PartitionByClause, SelectClause, SelectItem, SourceExpression, SubQuerySource, TableSource, WhereClause, WindowFrameClause, WindowsClause, WithClause } from "../models/Clause";
 import { BinarySelectQuery, SimpleSelectQuery, SelectQuery, ValuesQuery } from "../models/SelectQuery";
 import { SqlComponent, SqlComponentVisitor } from "../models/SqlComponent";
 import {
@@ -195,8 +195,10 @@ export class CTECollector implements SqlComponentVisitor<void> {
             query.orderByClause.accept(this);
         }
 
-        if (query.windowFrameClause) {
-            query.windowFrameClause.accept(this);
+        if (query.windowsClause) {
+            for (const win of query.windowsClause.windows) {
+                win.accept(this);
+            }
         }
 
         if (query.rowLimitClause) {

--- a/src/transformers/CTECollector.ts
+++ b/src/transformers/CTECollector.ts
@@ -201,8 +201,8 @@ export class CTECollector implements SqlComponentVisitor<void> {
             }
         }
 
-        if (query.rowLimitClause) {
-            query.rowLimitClause.accept(this);
+        if (query.limitClause) {
+            query.limitClause.accept(this);
         }
 
         if (query.forClause) {
@@ -217,6 +217,7 @@ export class CTECollector implements SqlComponentVisitor<void> {
         if (query.WithClause) {
             query.WithClause.accept(this);
         }
+
     }
 
     private visitBinarySelectQuery(query: BinarySelectQuery): void {
@@ -339,10 +340,7 @@ export class CTECollector implements SqlComponentVisitor<void> {
     }
 
     private visitLimitClause(clause: LimitClause): void {
-        clause.limit.accept(this);
-        if (clause.offset) {
-            clause.offset.accept(this);
-        }
+        clause.value.accept(this);
     }
 
     private visitForClause(clause: ForClause): void {

--- a/src/transformers/CTEDisabler.ts
+++ b/src/transformers/CTEDisabler.ts
@@ -1,4 +1,4 @@
-import { CommonTable, ForClause, FromClause, GroupByClause, HavingClause, JoinClause, JoinConditionComponent, JoinOnClause, JoinUsingClause, LimitClause, OrderByClause, OrderByComponent, OrderByItem, ParenSource, PartitionByClause, SelectClause, SelectItem, SourceAliasExpression, SourceComponent, SourceExpression, SubQuerySource, TableSource, WhereClause, WindowFrameClause, WithClause } from "../models/Clause";
+import { CommonTable, ForClause, FromClause, GroupByClause, HavingClause, JoinClause, JoinConditionComponent, JoinOnClause, JoinUsingClause, LimitClause, OrderByClause, OrderByComponent, OrderByItem, ParenSource, PartitionByClause, SelectClause, SelectItem, SourceAliasExpression, SourceComponent, SourceExpression, SubQuerySource, TableSource, WhereClause, WindowFrameClause, WindowsClause, WithClause } from "../models/Clause";
 import { BinarySelectQuery, SimpleSelectQuery, SelectQuery, ValuesQuery } from "../models/SelectQuery";
 import { SqlComponent, SqlComponentVisitor } from "../models/SqlComponent";
 import {
@@ -167,7 +167,9 @@ export class CTEDisabler implements SqlComponentVisitor<SqlComponent> {
         arg.groupByClause = arg.groupByClause ? this.visit(arg.groupByClause) as GroupByClause : null;
         arg.havingClause = arg.havingClause ? this.visit(arg.havingClause) as HavingClause : null;
         arg.orderByClause = arg.orderByClause ? this.visit(arg.orderByClause) as OrderByClause : null;
-        arg.windowFrameClause = arg.windowFrameClause ? this.visit(arg.windowFrameClause) as WindowFrameClause : null;
+        if (arg.windowsClause) {
+            arg.windowsClause = new WindowsClause(arg.windowsClause.windows.map(w => this.visit(w) as WindowFrameClause));
+        }
         arg.rowLimitClause = arg.rowLimitClause ? this.visit(arg.rowLimitClause) as LimitClause : null;
         arg.forClause = arg.forClause ? this.visit(arg.forClause) as ForClause : null;
         return arg;

--- a/src/transformers/CTEDisabler.ts
+++ b/src/transformers/CTEDisabler.ts
@@ -170,7 +170,7 @@ export class CTEDisabler implements SqlComponentVisitor<SqlComponent> {
         if (arg.windowsClause) {
             arg.windowsClause = new WindowsClause(arg.windowsClause.windows.map(w => this.visit(w) as WindowFrameClause));
         }
-        arg.rowLimitClause = arg.rowLimitClause ? this.visit(arg.rowLimitClause) as LimitClause : null;
+        arg.limitClause = arg.limitClause ? this.visit(arg.limitClause) as LimitClause : null;
         arg.forClause = arg.forClause ? this.visit(arg.forClause) as ForClause : null;
         return arg;
     }
@@ -262,9 +262,8 @@ export class CTEDisabler implements SqlComponentVisitor<SqlComponent> {
     }
 
     visitLimitClause(clause: LimitClause): SqlComponent {
-        const newLimit = this.visit(clause.limit) as ValueComponent;
-        const newOffset = clause.offset ? this.visit(clause.offset) as ValueComponent : null;
-        return new LimitClause(newLimit, newOffset);
+        const newLimit = this.visit(clause.value) as ValueComponent;
+        return new LimitClause(newLimit);
     }
 
     visitForClause(clause: ForClause): SqlComponent {

--- a/src/transformers/Formatter.ts
+++ b/src/transformers/Formatter.ts
@@ -27,7 +27,7 @@ import {
     InlineQuery,
     TupleExpression
 } from "../models/ValueComponent";
-import { CommonTable, Distinct, DistinctOn, FecthExpression, FetchClause, FetchType, ForClause, FromClause, FunctionSource, GroupByClause, HavingClause, InsertClause, JoinClause, JoinOnClause, JoinUsingClause, LimitClause, NullsSortDirection, OffsetClause, OrderByClause, OrderByItem, PartitionByClause, ReturningClause, SelectClause, SelectItem, SetClause, SetClauseItem, SortDirection, SourceAliasExpression, SourceExpression, SubQuerySource, TableSource, UpdateClause, WhereClause, WindowFrameClause, WindowsClause, WithClause } from "../models/Clause";
+import { CommonTable, Distinct, DistinctOn, FetchExpression, FetchClause, FetchType, ForClause, FromClause, FunctionSource, GroupByClause, HavingClause, InsertClause, JoinClause, JoinOnClause, JoinUsingClause, LimitClause, NullsSortDirection, OffsetClause, OrderByClause, OrderByItem, PartitionByClause, ReturningClause, SelectClause, SelectItem, SetClause, SetClauseItem, SortDirection, SourceAliasExpression, SourceExpression, SubQuerySource, TableSource, UpdateClause, WhereClause, WindowFrameClause, WindowsClause, WithClause } from "../models/Clause";
 import { CreateTableQuery } from "../models/CreateTableQuery";
 import { InsertQuery } from "../models/InsertQuery";
 import { UpdateQuery } from "../models/UpdateQuery";
@@ -164,7 +164,7 @@ export class Formatter implements SqlComponentVisitor<string> {
         this.handlers.set(LimitClause.kind, (expr) => this.visitLimitClause(expr as LimitClause));
         this.handlers.set(OffsetClause.kind, (expr) => this.visitOffsetClause(expr as OffsetClause));
         this.handlers.set(FetchClause.kind, (expr) => this.visitFetchClause(expr as FetchClause));
-        this.handlers.set(FecthExpression.kind, (expr) => this.visitFecthExpression(expr as FecthExpression));
+        this.handlers.set(FetchExpression.kind, (expr) => this.visitFetchExpression(expr as FetchExpression));
 
         // for clause
         this.handlers.set(ForClause.kind, (expr) => this.visitForClause(expr as ForClause));
@@ -671,8 +671,7 @@ export class Formatter implements SqlComponentVisitor<string> {
         return `fetch ${arg.expression.accept(this)}`;
     }
 
-    private visitFecthExpression(arg: any): string {
-        // arg: FecthExpression
+    private visitFetchExpression(arg: FetchExpression): string {
         const type = arg.type === FetchType.First ? 'first' : 'next';
         const count = arg.count.accept(this);
         if (arg.unit !== null) {

--- a/src/transformers/Formatter.ts
+++ b/src/transformers/Formatter.ts
@@ -27,7 +27,7 @@ import {
     InlineQuery,
     TupleExpression
 } from "../models/ValueComponent";
-import { CommonTable, Distinct, DistinctOn, FetchSpecification, FetchType, ForClause, FromClause, FunctionSource, GroupByClause, HavingClause, InsertClause, JoinClause, JoinOnClause, JoinUsingClause, LimitClause, NullsSortDirection, OrderByClause, OrderByItem, PartitionByClause, ReturningClause, SelectClause, SelectItem, SetClause, SetClauseItem, SortDirection, SourceAliasExpression, SourceExpression, SubQuerySource, TableSource, UpdateClause, WhereClause, WindowFrameClause, WithClause } from "../models/Clause";
+import { CommonTable, Distinct, DistinctOn, FecthExpression, FetchClause, FetchType, ForClause, FromClause, FunctionSource, GroupByClause, HavingClause, InsertClause, JoinClause, JoinOnClause, JoinUsingClause, LimitClause, NullsSortDirection, OffsetClause, OrderByClause, OrderByItem, PartitionByClause, ReturningClause, SelectClause, SelectItem, SetClause, SetClauseItem, SortDirection, SourceAliasExpression, SourceExpression, SubQuerySource, TableSource, UpdateClause, WhereClause, WindowFrameClause, WindowsClause, WithClause } from "../models/Clause";
 import { CreateTableQuery } from "../models/CreateTableQuery";
 import { InsertQuery } from "../models/InsertQuery";
 import { UpdateQuery } from "../models/UpdateQuery";
@@ -138,6 +138,7 @@ export class Formatter implements SqlComponentVisitor<string> {
         this.handlers.set(PartitionByClause.kind, (expr) => this.visitPartitionByClause(expr as PartitionByClause));
 
         // window frame
+        this.handlers.set(WindowsClause.kind, (expr) => this.visitWindowsClause(expr as WindowsClause));
         this.handlers.set(WindowFrameExpression.kind, (expr) => this.visitWindowFrameExpression(expr as WindowFrameExpression));
         this.handlers.set(WindowFrameSpec.kind, (arg) => this.visitWindowFrameSpec(arg));
         this.handlers.set(WindowFrameBoundStatic.kind, (arg) => this.visitWindowFrameBoundStatic(arg as WindowFrameBoundStatic));
@@ -161,7 +162,9 @@ export class Formatter implements SqlComponentVisitor<string> {
 
         // row limit
         this.handlers.set(LimitClause.kind, (expr) => this.visitLimitClause(expr as LimitClause));
-        this.handlers.set(FetchSpecification.kind, (expr) => this.visitFetchSpecification(expr as FetchSpecification));
+        this.handlers.set(OffsetClause.kind, (expr) => this.visitOffsetClause(expr as OffsetClause));
+        this.handlers.set(FetchClause.kind, (expr) => this.visitFetchClause(expr as FetchClause));
+        this.handlers.set(FecthExpression.kind, (expr) => this.visitFecthExpression(expr as FecthExpression));
 
         // for clause
         this.handlers.set(ForClause.kind, (expr) => this.visitForClause(expr as ForClause));
@@ -569,16 +572,24 @@ export class Formatter implements SqlComponentVisitor<string> {
             parts.push(arg.havingClause.accept(this));
         }
 
-        if (arg.windowFrameClause !== null) {
-            parts.push(arg.windowFrameClause.accept(this));
+        if (arg.windowsClause !== null) {
+            parts.push(arg.windowsClause.accept(this));
         }
 
         if (arg.orderByClause !== null) {
             parts.push(arg.orderByClause.accept(this));
         }
 
-        if (arg.rowLimitClause !== null) {
-            parts.push(arg.rowLimitClause.accept(this));
+        if (arg.limitClause !== null) {
+            parts.push(arg.limitClause.accept(this));
+        }
+
+        if (arg.offsetClause !== null) {
+            parts.push(arg.offsetClause.accept(this));
+        }
+
+        if (arg.fetchClause !== null) {
+            parts.push(arg.fetchClause.accept(this));
         }
 
         if (arg.forClause !== null) {
@@ -637,26 +648,37 @@ export class Formatter implements SqlComponentVisitor<string> {
         return arg.value.accept(this);
     }
 
+    private visitWindowsClause(arg: WindowsClause): string {
+        const part = arg.windows.map((e) => e.accept(this)).join(", ");
+        return `window ${part}`;
+    }
+
+
     private visitWindowFrameClause(arg: WindowFrameClause): string {
         const partExpr = arg.expression.accept(this);
-        return `window ${arg.name.accept(this)} as ${partExpr}`;
+        return `${arg.name.accept(this)} as ${partExpr}`;
     }
 
     private visitLimitClause(arg: LimitClause): string {
-        if (arg.offset !== null) {
-            return `limit ${arg.limit.accept(this)} offset ${arg.offset.accept(this)}`;
-        }
-        return `limit ${arg.limit.accept(this)}`;
+        return `limit ${arg.value.accept(this)}`;
     }
 
-    private visitFetchSpecification(arg: FetchSpecification): string {
+    private visitOffsetClause(arg: OffsetClause): string {
+        return `offset ${arg.value.accept(this)}`;
+    }
+
+    private visitFetchClause(arg: FetchClause): string {
+        return `fetch ${arg.expression.accept(this)}`;
+    }
+
+    private visitFecthExpression(arg: any): string {
+        // arg: FecthExpression
         const type = arg.type === FetchType.First ? 'first' : 'next';
         const count = arg.count.accept(this);
-
         if (arg.unit !== null) {
-            return `fetch ${type} ${count} ${arg.unit}`;
+            return `${type} ${count} ${arg.unit}`;
         }
-        return `fetch ${type} ${count}`;
+        return `${type} ${count}`;
     }
 
     private visitForClause(arg: ForClause): string {

--- a/src/transformers/QueryBuilder.ts
+++ b/src/transformers/QueryBuilder.ts
@@ -81,16 +81,10 @@ export class QueryBuilder {
 
         // Create the final simple select query
         const q = new SimpleSelectQuery(
-            null, // No WITH clause
-            selectClause,
-            fromClause,
-            null, // No WHERE
-            null, // No GROUP BY
-            null, // No HAVING
-            null, // No ORDER BY
-            null, // No WINDOW
-            null, // No LIMIT
-            null  // No FOR
+            {
+                selectClause,
+                fromClause
+            }
         );
 
         return CTENormalizer.normalize(q) as SimpleSelectQuery;
@@ -132,16 +126,10 @@ export class QueryBuilder {
 
         // Create the final simple select query
         return new SimpleSelectQuery(
-            null, // No WITH clause
-            selectClause,
-            fromClause,
-            null, // No WHERE
-            null, // No GROUP BY
-            null, // No HAVING
-            null, // No ORDER BY
-            null, // No WINDOW
-            null, // No LIMIT
-            null  // No FOR
+            {
+                selectClause,
+                fromClause
+            }
         );
     }
 

--- a/src/transformers/SelectableColumnCollector.ts
+++ b/src/transformers/SelectableColumnCollector.ts
@@ -1,4 +1,4 @@
-import { CommonTable, ForClause, FromClause, GroupByClause, HavingClause, LimitClause, OrderByClause, SelectClause, WhereClause, WindowFrameClause, JoinClause, JoinOnClause, JoinUsingClause, TableSource, SubQuerySource, SourceExpression, SelectItem, PartitionByClause } from "../models/Clause";
+import { CommonTable, ForClause, FromClause, GroupByClause, HavingClause, LimitClause, OrderByClause, SelectClause, WhereClause, WindowFrameClause, WindowsClause, JoinClause, JoinOnClause, JoinUsingClause, TableSource, SubQuerySource, SourceExpression, SelectItem, PartitionByClause } from "../models/Clause";
 import { SimpleSelectQuery } from "../models/SelectQuery";
 import { SqlComponent, SqlComponentVisitor } from "../models/SqlComponent";
 import { ArrayExpression, BetweenExpression, BinaryExpression, CaseExpression, CastExpression, ColumnReference, FunctionCall, InlineQuery, ParenExpression, UnaryExpression, ValueComponent, ValueList, WindowFrameExpression } from "../models/ValueComponent";
@@ -172,8 +172,10 @@ export class SelectableColumnCollector implements SqlComponentVisitor<void> {
             query.havingClause.accept(this);
         }
 
-        if (query.windowFrameClause) {
-            query.windowFrameClause.accept(this);
+        if (query.windowsClause) {
+            for (const win of query.windowsClause.windows) {
+                win.accept(this);
+            }
         }
 
         if (query.orderByClause) {

--- a/src/transformers/SelectableColumnCollector.ts
+++ b/src/transformers/SelectableColumnCollector.ts
@@ -1,4 +1,3 @@
-import { off } from "process";
 import { CommonTable, ForClause, FromClause, GroupByClause, HavingClause, LimitClause, OrderByClause, SelectClause, WhereClause, WindowFrameClause, WindowsClause, JoinClause, JoinOnClause, JoinUsingClause, TableSource, SubQuerySource, SourceExpression, SelectItem, PartitionByClause, FetchClause, OffsetClause } from "../models/Clause";
 import { SimpleSelectQuery } from "../models/SelectQuery";
 import { SqlComponent, SqlComponentVisitor } from "../models/SqlComponent";

--- a/src/transformers/SqlOutputToken.ts
+++ b/src/transformers/SqlOutputToken.ts
@@ -1,0 +1,11 @@
+// Composite pattern for SQL lines
+export class SqlOutputToken {
+    type: string;
+    text: string;
+    innerTokens: SqlOutputToken[];
+    constructor(type: string, text: string, innerTokens: SqlOutputToken[] = []) {
+        this.type = type;
+        this.text = text;
+        this.innerTokens = innerTokens;
+    }
+}

--- a/src/transformers/TableSourceCollector.ts
+++ b/src/transformers/TableSourceCollector.ts
@@ -70,8 +70,8 @@ export class TableSourceCollector implements SqlComponentVisitor<void> {
             this.handlers.set(OrderByClause.kind, (expr) => this.visitOrderByClause(expr as OrderByClause));
             this.handlers.set(WindowFrameClause.kind, (expr) => this.visitWindowFrameClause(expr as WindowFrameClause));
             this.handlers.set(LimitClause.kind, (expr) => this.visitLimitClause(expr as LimitClause));
-            this.handlers.set(OffsetClause.kind, (expr) => this.visitOffsetClause(expr as any));
-            this.handlers.set(FetchClause.kind, (expr) => this.visitFetchClause(expr as any));
+            this.handlers.set(OffsetClause.kind, (expr) => this.visitOffsetClause(expr as OffsetClause));
+            this.handlers.set(FetchClause.kind, (expr) => this.visitFetchClause(expr as FetchClause));
             this.handlers.set(ForClause.kind, (expr) => this.visitForClause(expr as ForClause));
             this.handlers.set(OrderByItem.kind, (expr) => this.visitOrderByItem(expr as OrderByItem));
             this.handlers.set(SelectClause.kind, (expr) => this.visitSelectClause(expr as SelectClause));

--- a/src/transformers/TableSourceCollector.ts
+++ b/src/transformers/TableSourceCollector.ts
@@ -1,4 +1,4 @@
-import { CommonTable, ForClause, FromClause, GroupByClause, HavingClause, JoinClause, JoinOnClause, JoinUsingClause, LimitClause, OrderByClause, OrderByItem, ParenSource, PartitionByClause, SelectClause, SelectItem, SourceExpression, SubQuerySource, TableSource, WhereClause, WindowFrameClause, WithClause } from "../models/Clause";
+import { CommonTable, ForClause, FromClause, GroupByClause, HavingClause, JoinClause, JoinOnClause, JoinUsingClause, LimitClause, OrderByClause, OrderByItem, ParenSource, PartitionByClause, SelectClause, SelectItem, SourceExpression, SubQuerySource, TableSource, WhereClause, WindowFrameClause, WindowsClause, WithClause } from "../models/Clause";
 import { BinarySelectQuery, SelectQuery, SimpleSelectQuery, ValuesQuery } from "../models/SelectQuery";
 import { SqlComponent, SqlComponentVisitor } from "../models/SqlComponent";
 import {
@@ -216,8 +216,10 @@ export class TableSourceCollector implements SqlComponentVisitor<void> {
                 query.orderByClause.accept(this);
             }
 
-            if (query.windowFrameClause) {
-                query.windowFrameClause.accept(this);
+            if (query.windowsClause) {
+                for (const win of query.windowsClause.windows) {
+                    win.accept(this);
+                }
             }
 
             if (query.rowLimitClause) {

--- a/src/transformers/TableSourceCollector.ts
+++ b/src/transformers/TableSourceCollector.ts
@@ -1,4 +1,4 @@
-import { CommonTable, ForClause, FromClause, GroupByClause, HavingClause, JoinClause, JoinOnClause, JoinUsingClause, LimitClause, OrderByClause, OrderByItem, ParenSource, PartitionByClause, SelectClause, SelectItem, SourceExpression, SubQuerySource, TableSource, WhereClause, WindowFrameClause, WindowsClause, WithClause } from "../models/Clause";
+import { CommonTable, FetchClause, ForClause, FromClause, GroupByClause, HavingClause, JoinClause, JoinOnClause, JoinUsingClause, LimitClause, OffsetClause, OrderByClause, OrderByItem, ParenSource, PartitionByClause, SelectClause, SelectItem, SourceExpression, SubQuerySource, TableSource, WhereClause, WindowFrameClause, WindowsClause, WithClause } from "../models/Clause";
 import { BinarySelectQuery, SelectQuery, SimpleSelectQuery, ValuesQuery } from "../models/SelectQuery";
 import { SqlComponent, SqlComponentVisitor } from "../models/SqlComponent";
 import {
@@ -70,6 +70,8 @@ export class TableSourceCollector implements SqlComponentVisitor<void> {
             this.handlers.set(OrderByClause.kind, (expr) => this.visitOrderByClause(expr as OrderByClause));
             this.handlers.set(WindowFrameClause.kind, (expr) => this.visitWindowFrameClause(expr as WindowFrameClause));
             this.handlers.set(LimitClause.kind, (expr) => this.visitLimitClause(expr as LimitClause));
+            this.handlers.set(OffsetClause.kind, (expr) => this.visitOffsetClause(expr as any));
+            this.handlers.set(FetchClause.kind, (expr) => this.visitFetchClause(expr as any));
             this.handlers.set(ForClause.kind, (expr) => this.visitForClause(expr as ForClause));
             this.handlers.set(OrderByItem.kind, (expr) => this.visitOrderByItem(expr as OrderByItem));
             this.handlers.set(SelectClause.kind, (expr) => this.visitSelectClause(expr as SelectClause));
@@ -222,8 +224,16 @@ export class TableSourceCollector implements SqlComponentVisitor<void> {
                 }
             }
 
-            if (query.rowLimitClause) {
-                query.rowLimitClause.accept(this);
+            if (query.limitClause) {
+                query.limitClause.accept(this);
+            }
+
+            if (query.offsetClause) {
+                query.offsetClause.accept(this);
+            }
+
+            if (query.fetchClause) {
+                query.fetchClause.accept(this);
             }
 
             if (query.forClause) {
@@ -371,10 +381,15 @@ export class TableSourceCollector implements SqlComponentVisitor<void> {
     }
 
     private visitLimitClause(clause: LimitClause): void {
-        clause.limit.accept(this);
-        if (clause.offset) {
-            clause.offset.accept(this);
-        }
+        clause.value.accept(this);
+    }
+
+    private visitOffsetClause(clause: OffsetClause): void {
+        clause.value.accept(this);
+    }
+
+    private visitFetchClause(clause: FetchClause): void {
+        clause.expression.accept(this);
     }
 
     private visitForClause(clause: ForClause): void {

--- a/tests/parsers/LimitClauseParser.test.ts
+++ b/tests/parsers/LimitClauseParser.test.ts
@@ -16,18 +16,6 @@ test('simple limit', () => {
     expect(sql).toEqual(`limit 10`);
 });
 
-test('limit with offset', () => {
-    // Arrange
-    const text = `limit 10 offset 5`;
-
-    // Act
-    const clause = LimitClauseParser.parse(text);
-    const sql = formatter.format(clause);
-
-    // Assert
-    expect(sql).toEqual(`limit 10 offset 5`);
-});
-
 test('limit with variable', () => {
     // Arrange
     const text = `limit :limit_count`;
@@ -38,18 +26,6 @@ test('limit with variable', () => {
 
     // Assert
     expect(sql).toEqual(`limit :limit_count`);
-});
-
-test('limit with variable and offset', () => {
-    // Arrange
-    const text = `limit :limit_count offset :offset_count`;
-
-    // Act
-    const clause = LimitClauseParser.parse(text);
-    const sql = formatter.format(clause);
-
-    // Assert
-    expect(sql).toEqual(`limit :limit_count offset :offset_count`);
 });
 
 test('limit with expression', () => {
@@ -74,18 +50,6 @@ test('limit with parenthesized expression', () => {
 
     // Assert
     expect(sql).toEqual(`limit (5 + 5)`);
-});
-
-test('case insensitive keywords', () => {
-    // Arrange
-    const text = `LIMIT 10 OFFSET 5`;
-
-    // Act
-    const clause = LimitClauseParser.parse(text);
-    const sql = formatter.format(clause);
-
-    // Assert
-    expect(sql).toEqual(`limit 10 offset 5`);
 });
 
 test('error on invalid syntax - missing limit value', () => {

--- a/tests/parsers/SelectQueryParser.test.ts
+++ b/tests/parsers/SelectQueryParser.test.ts
@@ -1,3 +1,4 @@
+// --- FETCH句のテストケースは下のtest.each配列に追加するよ！ ---
 import { describe, test, expect } from 'vitest';
 import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
 import { Formatter, ParameterStyle } from '../../src/transformers/Formatter';
@@ -180,6 +181,27 @@ describe('SelectQueryParser', () => {
         ["SELECT with template variable",
             "select ${name}",
             'select :name'],
+
+
+        ["SELECT with FETCH FIRST ROW ONLY",
+            "select id, name from users fetch first row only",
+            'select "id", "name" from "users" fetch first 1 rows only'],
+
+        ["SELECT with FETCH NEXT 5 ROWS ONLY",
+            "select * from products fetch next 5 rows only",
+            'select * from "products" fetch next 5 rows only'],
+
+        ["SELECT with ORDER BY and FETCH",
+            "select id, name from users order by id fetch first 10 rows only",
+            'select "id", "name" from "users" order by "id" fetch first 10 rows only'],
+
+        ["SELECT with OFFSET and FETCH",
+            "select * from logs offset 20 rows fetch next 10 rows only",
+            'select * from "logs" offset 20 fetch next 10 rows only'],
+
+        ["SELECT with multiple named WINDOW clauses",
+            "select id, value, avg(value) over w1, sum(value) over w2 from measurements window w1 as (partition by id), w2 as (order by value)",
+            'select "id", "value", avg("value") over "w1", sum("value") over "w2" from "measurements" window "w1" as (partition by "id"), "w2" as (order by "value")'],
 
     ])('%s', (_, text, expected) => {
         // Parse the query

--- a/tests/transformers/defaultFormatter.test.ts
+++ b/tests/transformers/defaultFormatter.test.ts
@@ -36,19 +36,11 @@ test('BinaryExpression', () => {
 
 test('SelectQuery', () => {
     const formatter = new Formatter();
-    const sql = formatter.format(new SimpleSelectQuery(
-        null,
-        new SelectClause([
+    const sql = formatter.format(new SimpleSelectQuery({
+        selectClause: new SelectClause([
             new SelectItem(new ColumnReference(['a'], 'id')),
             new SelectItem(new ColumnReference(['a'], 'value')),
         ]),
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null));
+    }));
     expect(sql).toBe('select "a"."id", "a"."value"');
 });


### PR DESCRIPTION
- Removed offset handling from LimitClause and introduced OffsetClause.
- Updated LimitClause to only handle limit values.
- Introduced FetchClause and FecthExpression to manage FETCH SQL syntax.
- Refactored SimpleSelectQuery to accommodate new OffsetClause and FetchClause.
- Updated various parsers (LimitClauseParser, FetchClauseParser, OffsetClauseParser) to reflect changes in clause structure.
- Modified SelectQueryParser to parse and handle FETCH and OFFSET clauses.
- Updated Formatter to format new FETCH and OFFSET clauses correctly.
- Refactored tests to remove obsolete limit with offset tests and add new tests for FETCH functionality.
- Adjusted related transformers and collectors to support new clause structures.