### PR TITLE
Add support for escaped identifiers in SQL tokenizer

### DIFF
--- a/src/parsers/SqlTokenizer.ts
+++ b/src/parsers/SqlTokenizer.ts
@@ -10,6 +10,7 @@ import { CommandTokenReader } from '../tokenReaders/CommandTokenReader';
 import { StringSpecifierTokenReader } from '../tokenReaders/StringSpecifierTokenReader';
 import { FunctionTokenReader } from '../tokenReaders/FunctionTokenReader';
 import { TypeTokenReader } from '../tokenReaders/TypeTokenReader';
+import { EscapedIdentifierTokenReader } from '../tokenReaders/EscapedIdentifierTokenReader';
 
 /**
  * Class responsible for tokenizing SQL input.
@@ -39,6 +40,7 @@ export class SqlTokenizer {
 
         // Initialize the token reader manager and register all readers
         this.readerManager = new TokenReaderManager(input)
+            .register(new EscapedIdentifierTokenReader(input))
             .register(new ParameterTokenReader(input))
             .register(new StringSpecifierTokenReader(input))
             // LiteralTokenReader should be registered before SpecialSymbolTokenReader and OperatorTokenReader

--- a/src/tokenReaders/EscapedIdentifierTokenReader.ts
+++ b/src/tokenReaders/EscapedIdentifierTokenReader.ts
@@ -1,0 +1,66 @@
+import { BaseTokenReader } from './BaseTokenReader';
+import { Lexeme, TokenType } from '../models/Lexeme';
+import { StringUtils } from '../utils/stringUtils';
+
+/**
+ * Reads SQL identifier tokens
+ */
+export class EscapedIdentifierTokenReader extends BaseTokenReader {
+    /**
+     * Try to read an identifier token
+     */
+    public tryRead(previous: Lexeme | null): Lexeme | null {
+        if (this.isEndOfInput()) {
+            return null;
+        }
+
+        const char = this.input[this.position];
+
+        // MySQL escaped identifier (escape character is backtick)
+        if (char === '`') {
+            const identifier = this.readEscapedIdentifier('`');
+            return this.createLexeme(TokenType.Identifier, identifier);
+        }
+
+        // Postgres escaped identifier (escape character is double quote)
+        if (char === '"') {
+            const identifier = this.readEscapedIdentifier('"');
+            return this.createLexeme(TokenType.Identifier, identifier);
+        }
+
+        // SQLServer escaped identifier (escape character is square bracket)
+        if (char === '[' && (previous === null || previous.value !== "array")) {
+            const identifier = this.readEscapedIdentifier(']');
+            return this.createLexeme(TokenType.Identifier, identifier);
+        }
+
+        return null;
+    }
+
+    /**
+     * Read an escaped identifier (surrounded by delimiters)
+     */
+    private readEscapedIdentifier(delimiter: string): string {
+        const start = this.position;
+
+        // Skip the opening delimiter
+        this.position++;
+
+        while (this.canRead()) {
+            if (this.input[this.position] === delimiter) {
+                break;
+            }
+            this.position++;
+        }
+
+        if (start === this.position) {
+            throw new Error(`Closing delimiter is not found. position: ${start}, delimiter: ${delimiter}\n${this.getDebugPositionInfo(start)}}`);
+        }
+
+        // Skip the closing delimiter
+        this.position++;
+
+        // exclude the delimiter
+        return this.input.slice(start + 1, this.position - 1);
+    }
+}

--- a/src/tokenReaders/IdentifierTokenReader.ts
+++ b/src/tokenReaders/IdentifierTokenReader.ts
@@ -25,54 +25,9 @@ export class IdentifierTokenReader extends BaseTokenReader {
             return this.createLexeme(TokenType.Identifier, char);
         }
 
-        // MySQL escaped identifier (escape character is backtick)
-        if (char === '`') {
-            const identifier = this.readEscapedIdentifier('`');
-            return this.createLexeme(TokenType.Identifier, identifier);
-        }
-
-        // Postgres escaped identifier (escape character is double quote)
-        if (char === '"') {
-            const identifier = this.readEscapedIdentifier('"');
-            return this.createLexeme(TokenType.Identifier, identifier);
-        }
-
-        // SQLServer escaped identifier (escape character is square bracket)
-        if (char === '[' && (previous === null || previous.value !== "array")) {
-            const identifier = this.readEscapedIdentifier(']');
-            return this.createLexeme(TokenType.Identifier, identifier);
-        }
-
         // Regular identifier
         const result = StringUtils.readRegularIdentifier(this.input, this.position);
         this.position = result.newPosition;
         return this.createLexeme(TokenType.Identifier, result.identifier);
-    }
-
-    /**
-     * Read an escaped identifier (surrounded by delimiters)
-     */
-    private readEscapedIdentifier(delimiter: string): string {
-        const start = this.position;
-
-        // Skip the opening delimiter
-        this.position++;
-
-        while (this.canRead()) {
-            if (this.input[this.position] === delimiter) {
-                break;
-            }
-            this.position++;
-        }
-
-        if (start === this.position) {
-            throw new Error(`Closing delimiter is not found. position: ${start}, delimiter: ${delimiter}\n${this.getDebugPositionInfo(start)}}`);
-        }
-
-        // Skip the closing delimiter
-        this.position++;
-
-        // exclude the delimiter
-        return this.input.slice(start + 1, this.position - 1);
     }
 }

--- a/tests/parsers/FromClauseParser.test.ts
+++ b/tests/parsers/FromClauseParser.test.ts
@@ -243,3 +243,76 @@ test('from with left join lateral without on clause', () => {
     // Assert
     expect(sql).toEqual(`from "users" as "u" left join lateral unnest("u"."order_ids") as "o"("order_id")`);
 });
+
+test('from with escaped table name', () => {
+    // Arrange
+    const text = `from [users] as [u]`;
+
+    // Act
+    const clause = FromClauseParser.parse(text);
+    const sql = formatter.format(clause);
+
+    // Assert
+    expect(sql).toEqual(`from "users" as "u"`);
+});
+
+test('from with quoted alias', () => {
+    // Arrange
+    const text = "from `users` as `u`";
+
+    // Act
+    const clause = FromClauseParser.parse(text);
+    const sql = formatter.format(clause);
+
+    // Assert
+    expect(sql).toEqual(`from "users" as "u"`);
+});
+
+test('from with quoted alias', () => {
+    // Arrange
+    const text = 'from "users" as "u"';
+
+    // Act
+    const clause = FromClauseParser.parse(text);
+    const sql = formatter.format(clause);
+
+    // Assert
+    expect(sql).toEqual(`from "users" as "u"`);
+});
+
+
+test('from with escaped table name', () => {
+    // Arrange
+    const text = `from [users] [u]`;
+
+    // Act
+    const clause = FromClauseParser.parse(text);
+    const sql = formatter.format(clause);
+
+    // Assert
+    expect(sql).toEqual(`from "users" as "u"`);
+});
+
+test('from with quoted alias', () => {
+    // Arrange
+    const text = "from `users` `u`";
+
+    // Act
+    const clause = FromClauseParser.parse(text);
+    const sql = formatter.format(clause);
+
+    // Assert
+    expect(sql).toEqual(`from "users" as "u"`);
+});
+
+test('from with quoted alias', () => {
+    // Arrange
+    const text = 'from "users" "u"';
+
+    // Act
+    const clause = FromClauseParser.parse(text);
+    const sql = formatter.format(clause);
+
+    // Assert
+    expect(sql).toEqual(`from "users" as "u"`);
+});

--- a/tests/parsers/SelectClauseParser.test.ts
+++ b/tests/parsers/SelectClauseParser.test.ts
@@ -147,3 +147,27 @@ test('with distinct on multiple columns', () => {
     // Assert
     expect(sql).toEqual(`select distinct on(\"a\".\"department_id\", \"a\".\"job_title\") \"a\".\"employee_id\", \"a\".\"salary\", \"a\".\"hire_date\"`);
 });
+
+test('with column alias using as keyword', () => {
+    // Arrange
+    const text = `select [a].[id] as [user_id]`;
+
+    // Act
+    const clause = SelectClauseParser.parse(text);
+    const sql = formatter.format(clause);
+
+    // Assert
+    expect(sql).toEqual(`select "a"."id" as "user_id"`);
+});
+
+test('with column alias using as keyword', () => {
+    // Arrange
+    const text = "select `a`.`id` as `user_id`";
+
+    // Act
+    const clause = SelectClauseParser.parse(text);
+    const sql = formatter.format(clause);
+
+    // Assert
+    expect(sql).toEqual(`select "a"."id" as "user_id"`);
+});


### PR DESCRIPTION
Introduce `EscapedIdentifierTokenReader` to handle escaped identifiers in SQL syntax, enhancing the `SqlTokenizer`. Update tests for `FromClauseParser` and `SelectClauseParser` to validate escaped table names and aliases.