### PR TITLE
Update numeric prefix validation and enhance function tokenization tests

### DIFF
--- a/src/tokenReaders/LiteralTokenReader.ts
+++ b/src/tokenReaders/LiteralTokenReader.ts
@@ -65,7 +65,7 @@ export class LiteralTokenReader extends BaseTokenReader {
         }
 
         // Signed number
-        if ((char === '+' || char === '-') && this.isValidNumericPrefix(previous)) {
+        if ((char === '+' || char === '-') && this.determineSignOrOperator(previous) === "sign") {
             const sign = char;
             this.position++;
 
@@ -105,17 +105,30 @@ export class LiteralTokenReader extends BaseTokenReader {
     }
 
     /**
-     * Check if the current context allows for a signed number
+     * Determines if the current context treats '+' or '-' as a numeric sign or an operator.
+     * This method is used to differentiate between operators and numeric signs (e.g., '+' or '-').
+     *
+     * For example:
+     * - In `1-1`, the '-' is treated as an operator, so the expression is split into `1`, `-`, and `1`.
+     * - In `-1`, the '-' is treated as a sign, making `-1` a single, indivisible literal.
+     *
+     * The logic for determining whether '+' or '-' is a sign or an operator is as follows:
+     * - If there is no previous lexeme, it is considered the start of the input, so the sign is valid.
+     * - If the previous lexeme is a literal or an identifier (e.g., `a.id`), the sign is treated as an operator.
+     * - If the previous lexeme is a closing parenthesis (e.g., `count(*)`), the sign is also treated as an operator.
+     *
+     * @param previous The previous lexeme in the input stream.
+     * @returns "sign" if the context allows for a numeric sign, otherwise "operator".
      */
-    private isValidNumericPrefix(previous: Lexeme | null): boolean {
-        // Allow if there is no previous lexeme
+    private determineSignOrOperator(previous: Lexeme | null): "sign" | "operator" {
+        // If there is no previous lexeme, treat as a sign
         if (previous === null) {
-            return true;
+            return "sign";
         }
 
-        // Disallow if the previous lexeme is a literal or an identifier
-        const isDisallowedType = previous.type === TokenType.Literal || previous.type === TokenType.Identifier || previous.type === TokenType.CloseParen;
-        return !isDisallowedType;
+        // If the previous lexeme is a literal, identifier, or closing parenthesis, treat as an operator
+        const isOperatorContext = previous.type === TokenType.Literal || previous.type === TokenType.Identifier || previous.type === TokenType.CloseParen;
+        return isOperatorContext ? "operator" : "sign";
     }
 
     /**

--- a/src/tokenReaders/LiteralTokenReader.ts
+++ b/src/tokenReaders/LiteralTokenReader.ts
@@ -108,9 +108,14 @@ export class LiteralTokenReader extends BaseTokenReader {
      * Check if the current context allows for a signed number
      */
     private isValidNumericPrefix(previous: Lexeme | null): boolean {
-        return previous === null ||
-            (previous.type !== TokenType.Literal &&
-                previous.type !== TokenType.Identifier);
+        // Allow if there is no previous lexeme
+        if (previous === null) {
+            return true;
+        }
+
+        // Disallow if the previous lexeme is a literal or an identifier
+        const isDisallowedType = previous.type === TokenType.Literal || previous.type === TokenType.Identifier || previous.type === TokenType.CloseParen;
+        return !isDisallowedType;
     }
 
     /**

--- a/tests/function.test.ts
+++ b/tests/function.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
-﻿import { TokenType } from "../src/models/Lexeme";
+import { TokenType } from "../src/models/Lexeme";
 import { SqlTokenizer } from "../src/parsers/SqlTokenizer";
+import { OperatorTokenReader } from '../src/tokenReaders/OperatorTokenReader';
 
 test('tokenizes SQL function', () => {
     // Arrange
@@ -13,4 +14,19 @@ test('tokenizes SQL function', () => {
     expect(tokens.length).toBe(4);
     expect(tokens[0].type).toBe(TokenType.Function);
     expect(tokens[0].value).toBe('count');
+});
+
+test('tokenizes SQL function with arithmetic', () => {
+    // Arrange
+    const tokenizer = new SqlTokenizer('count(*) + 1');
+
+    // Act
+    const tokens = tokenizer.readLexmes();
+
+    // Assert
+    expect(tokens.length).toBe(6); // count, (, *, ), +, 1
+    expect(tokens[0].type).toBe(TokenType.Function);
+    expect(tokens[0].value).toBe('count');
+    expect(tokens[4].type).toBe(TokenType.Operator);
+    expect(tokens[4].value).toBe('+');
 });

--- a/tests/parsers/ValueParser.test.ts
+++ b/tests/parsers/ValueParser.test.ts
@@ -82,6 +82,7 @@ describe('ValueParser', () => {
         ["InlineQuery - With WHERE clause", "(SELECT name FROM products WHERE price > 100)", "(select \"name\" from \"products\" where \"price\" > 100)"],
         ["InlineQuery - In comparison", "user_id = (SELECT id FROM users WHERE name = 'Alice')", "\"user_id\" = (select \"id\" from \"users\" where \"name\" = 'Alice')"],
         ["InlineQuery - With aggregation", "department_id IN (SELECT dept_id FROM departments WHERE active = TRUE)", "\"department_id\" in (select \"dept_id\" from \"departments\" where \"active\" = true)"],
+        ["FunctionCall with arithmetic operation", "count(*) + 1", "count(*) + 1"],
     ])('%s', (_, text, expected = text) => {
         const value = ValueParser.parse(text);
         const sql = formatter.format(value);


### PR DESCRIPTION
Improve the `isValidNumericPrefix` function to allow valid numeric prefixes and prevent certain types from being accepted. Add tests for tokenizing SQL functions, including those with arithmetic operations.