### PR TITLE
Enhance parsing of source aliases in VALUES clause

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rawsql-ts",
-    "version": "0.7.1-beta",
+    "version": "0.7.2-beta",
     "description": "[beta]High-performance SQL parser and AST analyzer written in TypeScript. Provides fast parsing and advanced transformation capabilities.",
     "main": "dist/index.js",
     "module": "dist/esm/index.js",

--- a/src/parsers/SourceExpressionParser.ts
+++ b/src/parsers/SourceExpressionParser.ts
@@ -53,7 +53,7 @@ export class SourceExpressionParser {
              * SQL: select t.* from (values(1)) t(id)
              * Explanation: The alias 't' and its column alias 'id' are parsed as a source alias expression.
              */
-            if (idx < lexemes.length && ((lexemes[idx].type & TokenType.Identifier) || (lexemes[idx].type & TokenType.Function))) {
+            if (idx < lexemes.length && this.isTokenTypeAliasCandidate(lexemes[idx].type)) {
                 const aliasResult = SourceAliasExpressionParser.parseFromLexeme(lexemes, idx);
                 idx = aliasResult.newIndex;
                 const sourceExpr = new SourceExpression(sourceResult.value, aliasResult.value);
@@ -64,5 +64,9 @@ export class SourceExpressionParser {
         // no alias
         const expr = new SourceExpression(sourceResult.value, null);
         return { value: expr, newIndex: idx };
+    }
+
+    private static isTokenTypeAliasCandidate(type: number): boolean {
+        return (type & TokenType.Identifier) !== 0 || (type & TokenType.Function) !== 0;
     }
 }

--- a/tests/parsers/SelectQueryParser.test.ts
+++ b/tests/parsers/SelectQueryParser.test.ts
@@ -257,14 +257,6 @@ describe('SelectQueryParser with VALUES', () => {
         expect(formatted).toBe(expected);
     });
 
-    test('VALUES with alias without AS', () => {
-        // Arrange
-        const sql = 'select a.* from (values (1)) a("id")';
-
-        // Act & Assert
-        expect(() => SelectQueryParser.parse(sql)).toThrow();
-    });
-
     test('TABLE with alias using AS', () => {
         // Arrange
         const sql = 'select a.* from table as a';

--- a/tests/parsers/ValuesQueryParser.test.ts
+++ b/tests/parsers/ValuesQueryParser.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import { Formatter } from "../../src/transformers/Formatter";
 import { ValuesQueryParser } from "../../src/parsers/ValuesQueryParser";
+import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
 
 const formatter = new Formatter();
 
@@ -118,4 +119,16 @@ test('error on unexpected end after comma', () => {
 
     // Act & Assert
     expect(() => ValuesQueryParser.parse(text)).toThrow();
+});
+
+test("parses VALUES clause with subquery alias", () => {
+    // Arrange
+    const sql = `select t.* from (values (1)) t(val)`;
+
+    // Act
+    const query = SelectQueryParser.parse(sql);
+    const formattedSQL = formatter.format(query);
+
+    // Assert
+    expect(formattedSQL).toBe(sql);
 });


### PR DESCRIPTION
Improve the parsing logic to correctly interpret source aliases in the VALUES clause, including cases where the 'AS' keyword is omitted. Add tests to validate this functionality.