### PR TITLE
Add ArrayQueryExpression and enhance parsing for ARRAY syntax

### DIFF
--- a/src/models/ValueComponent.ts
+++ b/src/models/ValueComponent.ts
@@ -17,6 +17,7 @@ export type ValueComponent = ValueList |
     CastExpression |
     CaseExpression |
     ArrayExpression |
+    ArrayQueryExpression |
     BetweenExpression |
     InlineQuery |
     StringSpecifierExpression |
@@ -303,6 +304,15 @@ export class ArrayExpression extends SqlComponent {
     constructor(expression: ValueComponent) {
         super();
         this.expression = expression;
+    }
+}
+
+export class ArrayQueryExpression extends SqlComponent {
+    static kind = Symbol("ArrayQueryExpression");
+    query: SelectQuery;
+    constructor(query: SelectQuery) {
+        super();
+        this.query = query;
     }
 }
 

--- a/src/parsers/CommandExpressionParser.ts
+++ b/src/parsers/CommandExpressionParser.ts
@@ -1,7 +1,6 @@
 import { Lexeme, TokenType } from "../models/Lexeme";
 import { ArrayExpression, CaseExpression, CaseKeyValuePair, SwitchCaseArgument, UnaryExpression, ValueComponent } from "../models/ValueComponent";
 import { ValueParser } from "./ValueParser";
-import { FunctionExpressionParser } from "./FunctionExpressionParser";
 
 export class CommandExpressionParser {
     public static parseFromLexeme(lexemes: Lexeme[], index: number): { value: ValueComponent; newIndex: number } {

--- a/src/parsers/CommandExpressionParser.ts
+++ b/src/parsers/CommandExpressionParser.ts
@@ -1,21 +1,18 @@
 import { Lexeme, TokenType } from "../models/Lexeme";
 import { ArrayExpression, CaseExpression, CaseKeyValuePair, SwitchCaseArgument, UnaryExpression, ValueComponent } from "../models/ValueComponent";
 import { ValueParser } from "./ValueParser";
+import { FunctionExpressionParser } from "./FunctionExpressionParser";
 
 export class CommandExpressionParser {
     public static parseFromLexeme(lexemes: Lexeme[], index: number): { value: ValueComponent; newIndex: number } {
         let idx = index;
         const current = lexemes[idx];
-
         if (current.value === "case") {
             idx++;
             return this.parseCaseExpression(lexemes, idx);
         } else if (current.value === "case when") {
             idx++;
             return this.parseCaseWhenExpression(lexemes, idx);
-        } else if (current.value === "array") {
-            idx++;
-            return this.parseArrayExpression(lexemes, idx);
         }
 
         return this.parseModifierUnaryExpression(lexemes, idx);
@@ -128,17 +125,5 @@ export class CommandExpressionParser {
         idx = value.newIndex;
 
         return { value: new CaseKeyValuePair(condition.value, value.value), newIndex: idx };
-    }
-
-    private static parseArrayExpression(lexemes: Lexeme[], index: number): { value: ValueComponent; newIndex: number } {
-        let idx = index;
-        // Array function is enclosed in []
-        if (idx < lexemes.length && (lexemes[idx].type & TokenType.OpenBracket)) {
-            const arg = ValueParser.parseArgument(TokenType.OpenBracket, TokenType.CloseBracket, lexemes, idx);
-            idx = arg.newIndex;
-            const value = new ArrayExpression(arg.value);
-            return { value, newIndex: idx };
-        }
-        throw new Error(`Expected opening bracket '[' for array expression at index ${idx}`);
     }
 }

--- a/src/parsers/FunctionExpressionParser.ts
+++ b/src/parsers/FunctionExpressionParser.ts
@@ -1,15 +1,35 @@
 import { Lexeme, TokenType } from "../models/Lexeme";
-import { FunctionCall, ValueComponent, BinaryExpression, TypeValue, CastExpression, BetweenExpression, RawString } from "../models/ValueComponent";
+import { FunctionCall, ValueComponent, BinaryExpression, TypeValue, CastExpression, BetweenExpression, RawString, ArrayExpression, ArrayQueryExpression } from "../models/ValueComponent";
+import { SelectQuery } from "../models/SelectQuery";
 import { OverExpressionParser } from "./OverExpressionParser";
 import { ValueParser } from "./ValueParser";
 import { FullNameParser } from "./FullNameParser";
+import { SelectQueryParser } from "./SelectQueryParser";
 
 export class FunctionExpressionParser {
     public static parseFromLexeme(lexemes: Lexeme[], index: number): { value: ValueComponent; newIndex: number } {
         let idx = index;
         const current = lexemes[idx];
 
-        if (current.value === "substring" || current.value === "overlay") {
+        if (current.value === "array") {
+            // Check if this is array literal (ARRAY[...]) or function call (ARRAY(...))
+            if (idx + 1 < lexemes.length && (lexemes[idx + 1].type & TokenType.OpenBracket)) {
+                idx++;
+                const arg = ValueParser.parseArgument(TokenType.OpenBracket, TokenType.CloseBracket, lexemes, idx);
+                idx = arg.newIndex;
+                const value = new ArrayExpression(arg.value);
+                return { value, newIndex: idx };
+            } else if (idx + 1 < lexemes.length && (lexemes[idx + 1].type & TokenType.OpenParen)) {
+                idx++;
+                idx++; // Skip the opening parenthesis
+                const arg = SelectQueryParser.parseFromLexeme(lexemes, idx);
+                idx = arg.newIndex;
+                idx++; // Skip the closing parenthesis
+                const value = new ArrayQueryExpression(arg.value);
+                return { value, newIndex: idx };
+            }
+            throw new Error(`Invalid ARRAY syntax at index ${idx}, expected ARRAY[... or ARRAY(...)`);
+        } else if (current.value === "substring" || current.value === "overlay") {
             return this.parseKeywordFunction(lexemes, idx, [
                 { key: "from", required: false },
                 { key: "for", required: false }
@@ -92,6 +112,20 @@ export class FunctionExpressionParser {
         const namespaces = fullNameResult.namespaces;
         const name = fullNameResult.name;
         idx = fullNameResult.newIndex;
+
+        // Special handling for ARRAY function
+        if (namespaces === null && name.name.toLowerCase() === "array" && idx < lexemes.length && (lexemes[idx].type & TokenType.OpenParen)) {
+            // Check if it's ARRAY(SELECT ...) - parse as ArrayQueryExpression
+            const arg = ValueParser.parseArgument(TokenType.OpenParen, TokenType.CloseParen, lexemes, idx);
+            idx = arg.newIndex;
+
+            // Check if the argument is a SelectQuery (subquery) by checking if it has setParameter method
+            if (arg.value && typeof (arg.value as any).setParameter === 'function') {
+                // This is a SelectQuery from new parseArgument logic
+                const value = new ArrayQueryExpression(arg.value as unknown as SelectQuery);
+                return { value, newIndex: idx };
+            }
+        }
 
         if (idx < lexemes.length && (lexemes[idx].type & TokenType.OpenParen)) {
             // General argument parsing

--- a/src/parsers/FunctionExpressionParser.ts
+++ b/src/parsers/FunctionExpressionParser.ts
@@ -118,18 +118,12 @@ export class FunctionExpressionParser {
 
     private static parseFunctionCall(lexemes: Lexeme[], index: number): { value: ValueComponent; newIndex: number } {
         let idx = index;
-
         // Parse namespaced function name (e.g., myschema.myfunc, dbo.util.myfunc)
         // Use FullNameParser to get namespaces and function name
         const fullNameResult = FullNameParser.parseFromLexeme(lexemes, idx);
         const namespaces = fullNameResult.namespaces;
         const name = fullNameResult.name;
         idx = fullNameResult.newIndex;
-
-        // Special handling for ARRAY function
-        if (namespaces === null && name.name === "array") {
-            return this.parseArrayExpression(lexemes, index);
-        }
 
         if (idx < lexemes.length && (lexemes[idx].type & TokenType.OpenParen)) {
             // General argument parsing

--- a/src/parsers/SqlPrintTokenParser.ts
+++ b/src/parsers/SqlPrintTokenParser.ts
@@ -18,6 +18,7 @@ import {
     CastExpression,
     CaseExpression,
     ArrayExpression,
+    ArrayQueryExpression,
     BetweenExpression,
     StringSpecifierExpression,
     TypeValue,
@@ -209,6 +210,7 @@ export class SqlPrintTokenParser implements SqlComponentVisitor<SqlPrintToken> {
         this.handlers.set(CastExpression.kind, (expr) => this.visitCastExpression(expr as CastExpression));
         this.handlers.set(CaseExpression.kind, (expr) => this.visitCaseExpression(expr as CaseExpression));
         this.handlers.set(ArrayExpression.kind, (expr) => this.visitArrayExpression(expr as ArrayExpression));
+        this.handlers.set(ArrayQueryExpression.kind, (expr) => this.visitArrayQueryExpression(expr as ArrayQueryExpression));
         this.handlers.set(BetweenExpression.kind, (expr) => this.visitBetweenExpression(expr as BetweenExpression));
         this.handlers.set(StringSpecifierExpression.kind, (expr) => this.visitStringSpecifierExpression(expr as StringSpecifierExpression));
         this.handlers.set(TypeValue.kind, (expr) => this.visitTypeValue(expr as TypeValue));
@@ -622,6 +624,18 @@ export class SqlPrintTokenParser implements SqlComponentVisitor<SqlPrintToken> {
         token.innerTokens.push(new SqlPrintToken(SqlPrintTokenType.parenthesis, '['));
         token.innerTokens.push(this.visit(arg.expression));
         token.innerTokens.push(new SqlPrintToken(SqlPrintTokenType.parenthesis, ']'));
+
+        return token;
+    }
+
+    private visitArrayQueryExpression(arg: ArrayQueryExpression): SqlPrintToken {
+        const token = new SqlPrintToken(SqlPrintTokenType.container, '', SqlPrintTokenContainerType.ArrayExpression);
+
+        token.innerTokens.push(new SqlPrintToken(SqlPrintTokenType.keyword, 'array'));
+        // ARRAY(SELECT ...)
+        token.innerTokens.push(new SqlPrintToken(SqlPrintTokenType.parenthesis, '('));
+        token.innerTokens.push(this.visit(arg.query));
+        token.innerTokens.push(new SqlPrintToken(SqlPrintTokenType.parenthesis, ')'));
 
         return token;
     }

--- a/src/tokenReaders/CommandTokenReader.ts
+++ b/src/tokenReaders/CommandTokenReader.ts
@@ -104,7 +104,6 @@ const keywordTrie = new KeywordTrie([
     ["create", "table"],
     ["create", "temporary", "table"],
     ["tablesample"],
-    ["array"],
     // cast
     ["as"],
     // odrder

--- a/src/tokenReaders/FunctionTokenReader.ts
+++ b/src/tokenReaders/FunctionTokenReader.ts
@@ -6,6 +6,8 @@ import { KeywordParser } from '../parsers/KeywordParser';
 
 const trie = new KeywordTrie([
     ["grouping", "sets"],
+    // ARRAY has special syntax with [] arguments, so it is forcibly treated as a function
+    ["array"],
 ]);
 const keywordParser = new KeywordParser(trie);
 

--- a/src/transformers/CTECollector.ts
+++ b/src/transformers/CTECollector.ts
@@ -2,7 +2,7 @@ import { CommonTable, ForClause, FromClause, GroupByClause, HavingClause, JoinCl
 import { BinarySelectQuery, SimpleSelectQuery, SelectQuery, ValuesQuery } from "../models/SelectQuery";
 import { SqlComponent, SqlComponentVisitor } from "../models/SqlComponent";
 import {
-    ArrayExpression, BetweenExpression, BinaryExpression, CaseExpression, CaseKeyValuePair,
+    ArrayExpression, ArrayQueryExpression, BetweenExpression, BinaryExpression, CaseExpression, CaseKeyValuePair,
     CastExpression, ColumnReference, FunctionCall, InlineQuery, ParenExpression,
     ParameterExpression, SwitchCaseArgument, TupleExpression, UnaryExpression, ValueComponent,
     OverExpression, WindowFrameExpression, IdentifierString, RawString,
@@ -79,6 +79,7 @@ export class CTECollector implements SqlComponentVisitor<void> {
         this.handlers.set(BetweenExpression.kind, (expr) => this.visitBetweenExpression(expr as BetweenExpression));
         this.handlers.set(FunctionCall.kind, (expr) => this.visitFunctionCall(expr as FunctionCall));
         this.handlers.set(ArrayExpression.kind, (expr) => this.visitArrayExpression(expr as ArrayExpression));
+        this.handlers.set(ArrayQueryExpression.kind, (expr) => this.visitArrayQueryExpression(expr as ArrayQueryExpression));
         this.handlers.set(TupleExpression.kind, (expr) => this.visitTupleExpression(expr as TupleExpression));
         this.handlers.set(CastExpression.kind, (expr) => this.visitCastExpression(expr as CastExpression));
         this.handlers.set(WindowFrameExpression.kind, (expr) => this.visitWindowFrameExpression(expr as WindowFrameExpression));
@@ -409,6 +410,10 @@ export class CTECollector implements SqlComponentVisitor<void> {
 
     private visitArrayExpression(expr: ArrayExpression): void {
         expr.expression.accept(this);
+    }
+
+    private visitArrayQueryExpression(expr: ArrayQueryExpression): void {
+        expr.query.accept(this);
     }
 
     private visitTupleExpression(expr: TupleExpression): void {

--- a/src/transformers/CTEDisabler.ts
+++ b/src/transformers/CTEDisabler.ts
@@ -2,7 +2,7 @@ import { CommonTable, ForClause, FromClause, GroupByClause, HavingClause, JoinCl
 import { BinarySelectQuery, SimpleSelectQuery, SelectQuery, ValuesQuery } from "../models/SelectQuery";
 import { SqlComponent, SqlComponentVisitor } from "../models/SqlComponent";
 import {
-    ArrayExpression, BetweenExpression, BinaryExpression, CaseExpression, CaseKeyValuePair,
+    ArrayExpression, ArrayQueryExpression, BetweenExpression, BinaryExpression, CaseExpression, CaseKeyValuePair,
     CastExpression, ColumnReference, FunctionCall, InlineQuery, ParenExpression,
     ParameterExpression, SwitchCaseArgument, TupleExpression, UnaryExpression, ValueComponent,
     OverExpression, WindowFrameExpression, IdentifierString, RawString,
@@ -75,6 +75,7 @@ export class CTEDisabler implements SqlComponentVisitor<SqlComponent> {
         this.handlers.set(BetweenExpression.kind, (expr) => this.visitBetweenExpression(expr as BetweenExpression));
         this.handlers.set(FunctionCall.kind, (expr) => this.visitFunctionCall(expr as FunctionCall));
         this.handlers.set(ArrayExpression.kind, (expr) => this.visitArrayExpression(expr as ArrayExpression));
+        this.handlers.set(ArrayQueryExpression.kind, (expr) => this.visitArrayQueryExpression(expr as ArrayQueryExpression));
         this.handlers.set(TupleExpression.kind, (expr) => this.visitTupleExpression(expr as TupleExpression));
         this.handlers.set(CastExpression.kind, (expr) => this.visitCastExpression(expr as CastExpression));
         this.handlers.set(WindowFrameExpression.kind, (expr) => this.visitWindowFrameExpression(expr as WindowFrameExpression));
@@ -320,6 +321,11 @@ export class CTEDisabler implements SqlComponentVisitor<SqlComponent> {
     visitArrayExpression(expr: ArrayExpression): SqlComponent {
         const newExpression = this.visit(expr.expression) as ValueComponent;
         return new ArrayExpression(newExpression);
+    }
+
+    visitArrayQueryExpression(expr: ArrayQueryExpression): SqlComponent {
+        const newQuery = this.visit(expr.query) as SelectQuery;
+        return new ArrayQueryExpression(newQuery);
     }
 
     visitTupleExpression(expr: TupleExpression): SqlComponent {

--- a/src/transformers/SelectableColumnCollector.ts
+++ b/src/transformers/SelectableColumnCollector.ts
@@ -19,7 +19,7 @@ export enum DuplicateDetectionMode {
 import { CommonTable, ForClause, FromClause, GroupByClause, HavingClause, LimitClause, OrderByClause, SelectClause, WhereClause, WindowFrameClause, WindowsClause, JoinClause, JoinOnClause, JoinUsingClause, TableSource, SubQuerySource, SourceExpression, SelectItem, PartitionByClause, FetchClause, OffsetClause } from "../models/Clause";
 import { SimpleSelectQuery } from "../models/SelectQuery";
 import { SqlComponent, SqlComponentVisitor } from "../models/SqlComponent";
-import { ArrayExpression, BetweenExpression, BinaryExpression, CaseExpression, CastExpression, ColumnReference, FunctionCall, InlineQuery, ParenExpression, UnaryExpression, ValueComponent, ValueList, WindowFrameExpression } from "../models/ValueComponent";
+import { ArrayExpression, ArrayQueryExpression, BetweenExpression, BinaryExpression, CaseExpression, CastExpression, ColumnReference, FunctionCall, InlineQuery, ParenExpression, UnaryExpression, ValueComponent, ValueList, WindowFrameExpression } from "../models/ValueComponent";
 import { CTECollector } from "./CTECollector";
 import { SelectValueCollector } from "./SelectValueCollector";
 import { TableColumnResolver } from "./TableColumnResolver";
@@ -97,6 +97,7 @@ export class SelectableColumnCollector implements SqlComponentVisitor<void> {
         this.handlers.set(CastExpression.kind, (expr) => this.visitCastExpression(expr as CastExpression));
         this.handlers.set(BetweenExpression.kind, (expr) => this.visitBetweenExpression(expr as BetweenExpression));
         this.handlers.set(ArrayExpression.kind, (expr) => this.visitArrayExpression(expr as ArrayExpression));
+        this.handlers.set(ArrayQueryExpression.kind, (expr) => this.visitArrayQueryExpression(expr as ArrayQueryExpression));
         this.handlers.set(ValueList.kind, (expr) => this.visitValueList(expr as ValueList));
         this.handlers.set(WindowFrameClause.kind, (expr) => this.visitWindowFrameClause(expr as WindowFrameClause));
         this.handlers.set(WindowFrameExpression.kind, (expr) => this.visitWindowFrameExpression(expr as WindowFrameExpression));
@@ -438,6 +439,10 @@ export class SelectableColumnCollector implements SqlComponentVisitor<void> {
         if (expr.expression) {
             expr.expression.accept(this);
         }
+    }
+
+    private visitArrayQueryExpression(expr: ArrayQueryExpression): void {
+        expr.query.accept(this);
     }
 
     private visitValueList(expr: ValueList): void {

--- a/src/transformers/TableSourceCollector.ts
+++ b/src/transformers/TableSourceCollector.ts
@@ -2,7 +2,7 @@ import { CommonTable, FetchClause, ForClause, FromClause, GroupByClause, HavingC
 import { BinarySelectQuery, SelectQuery, SimpleSelectQuery, ValuesQuery } from "../models/SelectQuery";
 import { SqlComponent, SqlComponentVisitor } from "../models/SqlComponent";
 import {
-    ArrayExpression, BetweenExpression, BinaryExpression, CaseExpression, CaseKeyValuePair,
+    ArrayExpression, ArrayQueryExpression, BetweenExpression, BinaryExpression, CaseExpression, CaseKeyValuePair,
     CastExpression, ColumnReference, FunctionCall, InlineQuery, ParenExpression,
     ParameterExpression, SwitchCaseArgument, TupleExpression, UnaryExpression, ValueComponent,
     OverExpression, WindowFrameExpression, IdentifierString, RawString,
@@ -87,6 +87,7 @@ export class TableSourceCollector implements SqlComponentVisitor<void> {
             this.handlers.set(BetweenExpression.kind, (expr) => this.visitBetweenExpression(expr as BetweenExpression));
             this.handlers.set(FunctionCall.kind, (expr) => this.visitFunctionCall(expr as FunctionCall));
             this.handlers.set(ArrayExpression.kind, (expr) => this.visitArrayExpression(expr as ArrayExpression));
+            this.handlers.set(ArrayQueryExpression.kind, (expr) => this.visitArrayQueryExpression(expr as ArrayQueryExpression));
             this.handlers.set(TupleExpression.kind, (expr) => this.visitTupleExpression(expr as TupleExpression));
             this.handlers.set(CastExpression.kind, (expr) => this.visitCastExpression(expr as CastExpression));
         }
@@ -465,6 +466,10 @@ export class TableSourceCollector implements SqlComponentVisitor<void> {
 
     private visitArrayExpression(expr: ArrayExpression): void {
         expr.expression.accept(this);
+    }
+
+    private visitArrayQueryExpression(expr: ArrayQueryExpression): void {
+        expr.query.accept(this);
     }
 
     private visitTupleExpression(expr: TupleExpression): void {

--- a/tests/parsers/ValueParser.test.ts
+++ b/tests/parsers/ValueParser.test.ts
@@ -25,6 +25,7 @@ describe('ValueParser', () => {
         ["FunctionCall - Namespaced (multiple)", "dbo.util.myfunc(5)", '"dbo"."util".myfunc(5)'],
         ["ParameterExpression - Parameter", "@userId", ":userId"],
         ["ArrayExpression - Array", "ARRAY[1, 2, 3]", "array[1, 2, 3]"],
+        ["ArrayExpression - Function call", "ARRAY(SELECT 1)", "array(select 1)"],
         ["CASE - Simple CASE expression", "CASE age WHEN 18 THEN 'young' WHEN 65 THEN 'senior' ELSE 'adult' END", "case \"age\" when 18 then 'young' when 65 then 'senior' else 'adult' end"],
         ["CASE WHEN - Conditional branching", "CASE WHEN age > 18 THEN 'adult' ELSE 'minor' END", "case when \"age\" > 18 then 'adult' else 'minor' end"],
         ["BETWEEN - Range specification", "age BETWEEN 20 AND 30", '"age" between 20 and 30'],


### PR DESCRIPTION
This pull request introduces support for `ARRAY` query expressions, allowing both literal arrays (`ARRAY[...]`) and arrays derived from subqueries (`ARRAY(...)`). The changes include updates to the `ValueComponent` model, parser logic, and various transformers and visitors to handle the new `ArrayQueryExpression` type. Additionally, test cases have been added to ensure the functionality of the new feature.

### Support for `ARRAY` query expressions:
* [`src/models/ValueComponent.ts`](diffhunk://#diff-85ad31ae089de70d8bdfed7e448de9a61d3b8612d2019b5b47f177a021dc6e08R20): Added a new `ArrayQueryExpression` class to represent arrays derived from subqueries. Updated the `ValueComponent` type to include `ArrayQueryExpression`. [[1]](diffhunk://#diff-85ad31ae089de70d8bdfed7e448de9a61d3b8612d2019b5b47f177a021dc6e08R20) [[2]](diffhunk://#diff-85ad31ae089de70d8bdfed7e448de9a61d3b8612d2019b5b47f177a021dc6e08R310-R318)

### Parser updates:
* [`src/parsers/FunctionExpressionParser.ts`](diffhunk://#diff-7d640be34574b52b33d2ab0a3db625368d496ba01bdba7dd933b2ae947fc8838L2-R45): Implemented a new method `parseArrayExpression` to handle both literal arrays (`ARRAY[...]`) and query arrays (`ARRAY(...)`). Adjusted parser logic to route `ARRAY` expressions to this method. [[1]](diffhunk://#diff-7d640be34574b52b33d2ab0a3db625368d496ba01bdba7dd933b2ae947fc8838L2-R45) [[2]](diffhunk://#diff-7d640be34574b52b33d2ab0a3db625368d496ba01bdba7dd933b2ae947fc8838L88)
* [`src/parsers/CommandExpressionParser.ts`](diffhunk://#diff-a93e11fb347ed377728571f5a0d2a16b2fbbd2d6961078a894e7a5badeebc8a7L9-L18): Removed the old `parseArrayExpression` method and its handling of `ARRAY` expressions, as this functionality is now handled in `FunctionExpressionParser`. [[1]](diffhunk://#diff-a93e11fb347ed377728571f5a0d2a16b2fbbd2d6961078a894e7a5badeebc8a7L9-L18) [[2]](diffhunk://#diff-a93e11fb347ed377728571f5a0d2a16b2fbbd2d6961078a894e7a5badeebc8a7L132-L143)

### Transformer and visitor updates:
* Updated multiple transformers (`CTECollector`, `CTEDisabler`, `SelectableColumnCollector`, `TableSourceCollector`) to add handling for `ArrayQueryExpression`. This ensures proper traversal and transformation of subqueries within `ARRAY(...)`. [[1]](diffhunk://#diff-3f7fd8496899a3b2792cff99ddeb4d9f1a16f2f26d387a90977a0503d2f02584R82) [[2]](diffhunk://#diff-5541e2eb0318d1c0b9a95d83eeb9d6166cc4efcb99a8ffb28127ad59ab4161e0R78) [[3]](diffhunk://#diff-966b4bf78f94ea3e4484bc9cf71b5541bda356a439291a1c19e1dfcba89adc1dR100) [[4]](diffhunk://#diff-587bca4acfe9c523c3ec06fb534cdfe066aff44f2f08c0198acb75a1ca3da088R90)
* [`src/parsers/SqlPrintTokenParser.ts`](diffhunk://#diff-242b91c5834dab937d024663ab81c4bc1ac8f31ec3a9091b90dbd50e71886086R213): Added support for printing `ArrayQueryExpression` tokens, including subquery handling. [[1]](diffhunk://#diff-242b91c5834dab937d024663ab81c4bc1ac8f31ec3a9091b90dbd50e71886086R213) [[2]](diffhunk://#diff-242b91c5834dab937d024663ab81c4bc1ac8f31ec3a9091b90dbd50e71886086R631-R642)

### Test coverage:
* [`tests/parsers/ValueParser.test.ts`](diffhunk://#diff-70f057fd22038efbd6abed29c90befd082fbd559979d74d369a02dd366d9fb39R28): Added test cases for `ARRAY` query expressions to validate both literal and query-based syntax.

These changes collectively enhance the SQL parsing and transformation capabilities to support complex `ARRAY` expressions, improving functionality and flexibility in handling advanced SQL constructs.