### PR TITLE
Add support for StringSpecifierExpression in CTE and TableSource collectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rawsql-ts",
-    "version": "0.10.2-beta",
+    "version": "0.10.3-beta",
     "description": "[beta]High-performance SQL parser and AST analyzer written in TypeScript. Provides fast parsing and advanced transformation capabilities.",
     "main": "dist/index.js",
     "module": "dist/esm/index.js",

--- a/src/transformers/CTECollector.ts
+++ b/src/transformers/CTECollector.ts
@@ -9,7 +9,8 @@ import {
     WindowFrameSpec,
     LiteralValue,
     TypeValue,
-    ValueList
+    ValueList,
+    StringSpecifierExpression
 } from "../models/ValueComponent";
 
 /**
@@ -87,6 +88,7 @@ export class CTECollector implements SqlComponentVisitor<void> {
         this.handlers.set(WindowFrameSpec.kind, (expr) => this.visitWindowFrameSpec(expr as WindowFrameSpec));
         this.handlers.set(TypeValue.kind, (expr) => this.visitTypeValue(expr as TypeValue));
         this.handlers.set(ValueList.kind, (expr) => this.visitValueList(expr as ValueList));
+        this.handlers.set(StringSpecifierExpression.kind, (expr) => this.visitStringSpecifierExpression(expr as StringSpecifierExpression));
 
         // Add handlers for other clause types
         this.handlers.set(SelectClause.kind, (expr) => this.visitSelectClause(expr as SelectClause));
@@ -490,5 +492,10 @@ export class CTECollector implements SqlComponentVisitor<void> {
         for (const value of valueList.values) {
             value.accept(this);
         }
+    }
+
+    private visitStringSpecifierExpression(expr: StringSpecifierExpression): void {
+        // StringSpecifierExpression contains RawString and LiteralValue which are leaf nodes
+        // No need to visit children as they don't contain subqueries
     }
 }

--- a/src/transformers/TableSourceCollector.ts
+++ b/src/transformers/TableSourceCollector.ts
@@ -8,7 +8,8 @@ import {
     OverExpression, WindowFrameExpression, IdentifierString, RawString,
     WindowFrameSpec,
     LiteralValue,
-    TypeValue
+    TypeValue,
+    StringSpecifierExpression
 } from "../models/ValueComponent";
 import { CTECollector } from "./CTECollector";
 
@@ -92,6 +93,7 @@ export class TableSourceCollector implements SqlComponentVisitor<void> {
             this.handlers.set(TupleExpression.kind, (expr) => this.visitTupleExpression(expr as TupleExpression));
             this.handlers.set(CastExpression.kind, (expr) => this.visitCastExpression(expr as CastExpression));
             this.handlers.set(ValueList.kind, (expr) => this.visitValueList(expr as ValueList));
+            this.handlers.set(StringSpecifierExpression.kind, (expr) => this.visitStringSpecifierExpression(expr as StringSpecifierExpression));
         }
     }
 
@@ -508,5 +510,12 @@ export class TableSourceCollector implements SqlComponentVisitor<void> {
         for (const value of valueList.values) {
             value.accept(this);
         }
+    }
+
+    // Handle StringSpecifierExpression (PostgreSQL E-strings)
+    private visitStringSpecifierExpression(expr: StringSpecifierExpression): void {
+        // StringSpecifierExpression is just a literal string with an escape specifier
+        // It doesn't contain table references, so we don't need to visit any children
+        // This is a no-op method to prevent "No handler" errors
     }
 }


### PR DESCRIPTION
This pull request introduces support for handling `StringSpecifierExpression` (PostgreSQL E-strings) across multiple components in the SQL transformation and collection pipeline. The changes ensure proper handling of these expressions without errors and include tests to validate their integration.

### Enhancements to SQL transformation components:

* [`src/transformers/CTECollector.ts`](diffhunk://#diff-3f7fd8496899a3b2792cff99ddeb4d9f1a16f2f26d387a90977a0503d2f02584R91): Added a handler for `StringSpecifierExpression` and implemented the `visitStringSpecifierExpression` method to handle E-strings without visiting children, as they are leaf nodes. [[1]](diffhunk://#diff-3f7fd8496899a3b2792cff99ddeb4d9f1a16f2f26d387a90977a0503d2f02584R91) [[2]](diffhunk://#diff-3f7fd8496899a3b2792cff99ddeb4d9f1a16f2f26d387a90977a0503d2f02584R496-R500)
* [`src/transformers/TableSourceCollector.ts`](diffhunk://#diff-587bca4acfe9c523c3ec06fb534cdfe066aff44f2f08c0198acb75a1ca3da088R96): Added support for `StringSpecifierExpression` by registering a handler and implementing a no-op method to prevent "No handler" errors. [[1]](diffhunk://#diff-587bca4acfe9c523c3ec06fb534cdfe066aff44f2f08c0198acb75a1ca3da088R96) [[2]](diffhunk://#diff-587bca4acfe9c523c3ec06fb534cdfe066aff44f2f08c0198acb75a1ca3da088R514-R520)

### Updates to test coverage:

* [`tests/transformers/CTECollector.test.ts`](diffhunk://#diff-01d6369e9b5c137b7d4e98c7e7bd83229f8345a691e6333a3f1bd37f337ba2d9R482-R515): Added tests to verify that `CTECollector` handles `StringSpecifierExpression` in both simple and complex queries without errors.
* [`tests/transformers/SchemaCollector.test.ts`](diffhunk://#diff-ad191f6364adc2f1b6d6d661113c902f7bca454d120efcbbcce75ff03eb8f20aR472-R499): Added tests to validate that `SchemaCollector` handles E-strings in queries and collects schema information correctly.
* [`tests/transformers/TableSourceCollector.test.ts`](diffhunk://#diff-40d8997eb4cccf7b43a5abb471ca9b04883c854cecd42f56c858b6b94344cddfL637-R782): Expanded test cases to ensure `TableSourceCollector` handles E-strings in various contexts, including subqueries, CTEs, and complex queries, without errors.