### PR TITLE
fix: update CDN version in analysis-features.js to support PostgreSQL escape literals

### DIFF
--- a/docs/analysis-features.js
+++ b/docs/analysis-features.js
@@ -2,7 +2,7 @@
 // This module handles SQL analysis features like updating table lists, CTE lists, and schema information.
 
 // Import rawsql-ts modules
-import { SelectQueryParser, TableSourceCollector, CTECollector, SchemaCollector } from "https://unpkg.com/rawsql-ts@0.8.3-beta/dist/esm/index.js";
+import { SelectQueryParser, TableSourceCollector, CTECollector, SchemaCollector } from "https://unpkg.com/rawsql-ts/dist/esm/index.js";
 
 let tableListElement, cteListElement, schemaInfoEditorInstance, sqlInputElement, debounceDelayMs;
 


### PR DESCRIPTION
- Update rawsql-ts import from @0.8.3-beta to latest version in analysis-features.js
- Fixes issue where E-string literals (E'\\s*') were not working in demo site
- Both script.js and analysis-features.js now use the same latest version
- SchemaCollector in older version had incomplete support for escape literals