### PR TITLE
Implement allowAllUndefined option for SqlParamInjector

### DIFF
--- a/docs/usage-guides/class-SqlParamInjector-usage-guide.md
+++ b/docs/usage-guides/class-SqlParamInjector-usage-guide.md
@@ -232,7 +232,7 @@ const result = injector.inject('SELECT * FROM users', state);
 ```
 
 
-### 2. Custom Table Column Resolver
+### 3. Custom Table Column Resolver
 
 When your SQL uses wildcards (like `SELECT *`) or omits column names, `rawsql-ts` cannot resolve columns by itself because it only parses the SQL string and does not know the actual database schema.
 
@@ -255,7 +255,7 @@ const customResolver = (tableName: string) => {
 const injector = new SqlParamInjector(customResolver);
 ```
 
-### 3. Complex Condition Example
+### 4. Complex Condition Example
 
 In real-world scenarios, search conditions are often more than just simple equality checks. With SqlParamInjector, you can specify a variety of conditions for each column, such as ranges (min/max), pattern matching (like), set membership (in/any), and not-equal conditions. You can also combine multiple conditions for a single column.
 

--- a/docs/usage-guides/class-SqlParamInjector-usage-guide.md
+++ b/docs/usage-guides/class-SqlParamInjector-usage-guide.md
@@ -38,6 +38,28 @@ const injector = new SqlParamInjector();
 const injectedQuery = injector.inject(baseQuery, state);
 ```
 
+### 3. Security: Preventing Accidental Full-Table Queries
+
+By default, `SqlParamInjector` prevents potentially dangerous situations where all parameters are `undefined`, which would result in fetching all records from the database:
+
+```typescript
+// This will throw an error by default
+const state = { id: undefined, name: undefined };
+const injector = new SqlParamInjector();
+
+try {
+    injector.inject(sql, state);
+} catch (error) {
+    console.error(error.message);
+    // "All parameters are undefined. This would result in fetching all records. Use allowAllUndefined: true option to explicitly allow this behavior."
+}
+
+// To explicitly allow this behavior, use the allowAllUndefined option
+const safeInjector = new SqlParamInjector({ allowAllUndefined: true });
+const result = safeInjector.inject(sql, state);
+// This will succeed and return the query without WHERE conditions
+```
+
 ## Supported Types
 
 ### Primitive Types
@@ -192,6 +214,23 @@ const state = { articleId: 100 }; // Matches article_id
 const result = injector.inject(query, state);
 ```
 
+### 2. AllowAllUndefined Option
+
+For safety, `SqlParamInjector` prevents accidental full-table queries by throwing an error when all parameters are `undefined`. Use the `allowAllUndefined` option to explicitly allow this behavior:
+
+```typescript
+// Configuration options
+const injector = new SqlParamInjector({ 
+    ignoreCaseAndUnderscore: true,  // Allow flexible column name matching
+    allowAllUndefined: true         // Allow queries when all params are undefined
+});
+
+// This will not throw an error even if all parameters are undefined
+const state = { user_id: undefined, name: undefined };
+const result = injector.inject('SELECT * FROM users', state);
+// Returns the original query without WHERE conditions
+```
+
 
 ### 2. Custom Table Column Resolver
 
@@ -289,7 +328,19 @@ const result = injector.inject(sql, state);
 
 ## Error Handling
 
-### 1. Column Not Found
+### 1. All Parameters Undefined (Security Check)
+
+```typescript
+try {
+    const injector = new SqlParamInjector();
+    injector.inject('SELECT name FROM users', { name: undefined, email: undefined });
+} catch (error) {
+    console.error(error.message); 
+    // "All parameters are undefined. This would result in fetching all records. Use allowAllUndefined: true option to explicitly allow this behavior."
+}
+```
+
+### 2. Column Not Found
 
 ```typescript
 try {
@@ -300,7 +351,7 @@ try {
 }
 ```
 
-### 2. Unsupported Operators
+### 3. Unsupported Operators
 
 ```typescript
 try {
@@ -447,7 +498,7 @@ const complexSearch = injector.inject(productQuery, searchCriteria);
 
 ## Important Notes
 
-1. **undefined values**: undefined values in the state object are ignored and not added to WHERE conditions
+1. **undefined values**: By default, when all parameters are undefined, an error is thrown to prevent accidental full-table queries. Use `allowAllUndefined: true` to explicitly allow this behavior.
 2. **null values**: Explicit null values generate conditions in the format `column = :param`
 3. **Column name matching**: By default, case sensitivity and underscores are distinguished
 4. **Operator validation**: Using unsupported operators will result in errors

--- a/package-lock.json
+++ b/package-lock.json
@@ -4305,7 +4305,7 @@
         },
         "packages/core": {
             "name": "rawsql-ts",
-            "version": "0.10.5-beta",
+            "version": "0.10.6-beta",
             "license": "MIT",
             "devDependencies": {
                 "@types/benchmark": "^2.1.5",

--- a/packages/core/src/transformers/SqlParamInjector.ts
+++ b/packages/core/src/transformers/SqlParamInjector.ts
@@ -5,14 +5,24 @@ import { UpstreamSelectQueryFinder } from "./UpstreamSelectQueryFinder";
 import { SelectQueryParser } from "../parsers/SelectQueryParser";
 
 /**
+ * Options for SqlParamInjector
+ */
+export interface SqlParamInjectorOptions {
+    /** Whether to ignore case and underscore differences when matching column names */
+    ignoreCaseAndUnderscore?: boolean;
+    /** Whether to allow injection when all parameters are undefined (defaults to false for safety) */
+    allowAllUndefined?: boolean;
+}
+
+/**
  * SqlParamInjector injects state parameters into a SelectQuery model,
  * creating WHERE conditions and setting parameter values.
  */
 export class SqlParamInjector {
     private tableColumnResolver?: (tableName: string) => string[];
-    private options: { ignoreCaseAndUnderscore?: boolean; allowAllUndefined?: boolean };
+    private options: SqlParamInjectorOptions;
 
-    constructor(optionsOrResolver?: { ignoreCaseAndUnderscore?: boolean; allowAllUndefined?: boolean } | ((tableName: string) => string[]), options?: { ignoreCaseAndUnderscore?: boolean; allowAllUndefined?: boolean }) {
+    constructor(optionsOrResolver?: SqlParamInjectorOptions | ((tableName: string) => string[]), options?: SqlParamInjectorOptions) {
         // Type-check to decide which argument was provided
         if (typeof optionsOrResolver === 'function') {
             this.tableColumnResolver = optionsOrResolver;
@@ -28,6 +38,7 @@ export class SqlParamInjector {
      * @param query The SelectQuery to modify
      * @param state A record of parameter names and values
      * @returns The modified SelectQuery
+     * @throws Error when all parameters are undefined and allowAllUndefined is not set to true
      */
     public inject(
         query: SimpleSelectQuery | string,

--- a/packages/core/tests/transformers/SqlParamInjector.allowAllUndefined.test.ts
+++ b/packages/core/tests/transformers/SqlParamInjector.allowAllUndefined.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from 'vitest';
+import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
+import { SqlFormatter } from '../../src/transformers/SqlFormatter';
+import { SqlParamInjector } from '../../src/transformers/SqlParamInjector';
+import { SimpleSelectQuery } from '../../src/models/SimpleSelectQuery';
+
+describe('SqlParamInjector - allowAllUndefined option', () => {
+    test('throws error by default when all parameters are undefined', () => {
+        // Arrange: parse base query
+        const baseQuery = SelectQueryParser.parse('select u.id, u.name from users as u') as SimpleSelectQuery;
+        // State with all undefined values
+        const state = { id: undefined, name: undefined };
+
+        // Act & Assert: expect injection to throw error by default
+        const injector = new SqlParamInjector();
+        expect(() => {
+            injector.inject(baseQuery, state);
+        }).toThrowError(/All parameters are undefined/);
+    });
+
+    test('throws error by default when single parameter is undefined', () => {
+        // Arrange: parse base query
+        const baseQuery = SelectQueryParser.parse('select u.id from users as u') as SimpleSelectQuery;
+        // State with single undefined value
+        const state = { id: undefined };
+
+        // Act & Assert: expect injection to throw error by default
+        const injector = new SqlParamInjector();
+        expect(() => {
+            injector.inject(baseQuery, state);
+        }).toThrowError(/All parameters are undefined/);
+    });
+
+    test('allows all undefined parameters when allowAllUndefined is true', () => {
+        // Arrange: parse base query
+        const baseQuery = SelectQueryParser.parse('select u.id, u.name from users as u') as SimpleSelectQuery;
+        // State with all undefined values
+        const state = { id: undefined, name: undefined };
+
+        // Act: inject parameters with allowAllUndefined option
+        const injector = new SqlParamInjector({ allowAllUndefined: true });
+        const injectedQuery = injector.inject(baseQuery, state);
+
+        // Act: format SQL and extract parameters
+        const formatter = new SqlFormatter();
+        const { formattedSql, params } = formatter.format(injectedQuery);
+
+        // Assert: SQL should have no WHERE clause and empty params
+        expect(formattedSql).toBe('select "u"."id", "u"."name" from "users" as "u"');
+        expect(params).toEqual({});
+    });
+
+    test('allows single undefined parameter when allowAllUndefined is true', () => {
+        // Arrange: parse base query
+        const baseQuery = SelectQueryParser.parse('select u.id from users as u') as SimpleSelectQuery;
+        // State with single undefined value
+        const state = { id: undefined };
+
+        // Act: inject parameters with allowAllUndefined option
+        const injector = new SqlParamInjector({ allowAllUndefined: true });
+        const injectedQuery = injector.inject(baseQuery, state);
+
+        // Act: format SQL and extract parameters
+        const formatter = new SqlFormatter();
+        const { formattedSql, params } = formatter.format(injectedQuery);
+
+        // Assert: SQL should have no WHERE clause and empty params
+        expect(formattedSql).toBe('select "u"."id" from "users" as "u"');
+        expect(params).toEqual({});
+    });
+
+    test('works normally when not all parameters are undefined', () => {
+        // Arrange: parse base query
+        const baseQuery = SelectQueryParser.parse('select u.id, u.name from users as u') as SimpleSelectQuery;
+        // State with mixed defined and undefined values
+        const state = { id: 123, name: undefined };
+
+        // Act: inject parameters (should work normally)
+        const injector = new SqlParamInjector();
+        const injectedQuery = injector.inject(baseQuery, state);
+
+        // Act: format SQL and extract parameters
+        const formatter = new SqlFormatter();
+        const { formattedSql, params } = formatter.format(injectedQuery);
+
+        // Assert: SQL should contain WHERE clause with only defined parameter
+        expect(formattedSql).toBe('select "u"."id", "u"."name" from "users" as "u" where "u"."id" = :id');
+        expect(params).toEqual({ id: 123 });
+    });
+
+    test('works normally with empty state object', () => {
+        // Arrange: parse base query
+        const baseQuery = SelectQueryParser.parse('select u.id from users as u') as SimpleSelectQuery;
+        // Empty state object
+        const state = {};
+
+        // Act: inject parameters (should work normally)
+        const injector = new SqlParamInjector();
+        const injectedQuery = injector.inject(baseQuery, state);
+
+        // Act: format SQL and extract parameters
+        const formatter = new SqlFormatter();
+        const { formattedSql, params } = formatter.format(injectedQuery);
+
+        // Assert: SQL should have no WHERE clause and empty params
+        expect(formattedSql).toBe('select "u"."id" from "users" as "u"');
+        expect(params).toEqual({});
+    });
+
+    test('allowAllUndefined works with tableColumnResolver constructor', () => {
+        // Custom tableColumnResolver
+        const customResolver = (tableName: string) => {
+            if (tableName.toLowerCase() === 'users') return ['id', 'name'];
+            return [];
+        };
+
+        // Arrange: parse base query
+        const baseQuery = SelectQueryParser.parse('select u.* from users as u') as SimpleSelectQuery;
+        // State with all undefined values
+        const state = { id: undefined, name: undefined };
+
+        // Act: inject parameters with allowAllUndefined option and custom resolver
+        const injector = new SqlParamInjector(customResolver, { allowAllUndefined: true });
+        const injectedQuery = injector.inject(baseQuery, state);
+
+        // Act: format SQL and extract parameters
+        const formatter = new SqlFormatter();
+        const { formattedSql, params } = formatter.format(injectedQuery);
+
+        // Assert: SQL should have no WHERE clause and empty params
+        expect(formattedSql).toBe('select "u".* from "users" as "u"');
+        expect(params).toEqual({});
+    });
+
+    test('throws error with tableColumnResolver when allowAllUndefined is false', () => {
+        // Custom tableColumnResolver
+        const customResolver = (tableName: string) => {
+            if (tableName.toLowerCase() === 'users') return ['id', 'name'];
+            return [];
+        };
+
+        // Arrange: parse base query
+        const baseQuery = SelectQueryParser.parse('select u.* from users as u') as SimpleSelectQuery;
+        // State with all undefined values
+        const state = { id: undefined, name: undefined };
+
+        // Act & Assert: expect injection to throw error
+        const injector = new SqlParamInjector(customResolver);
+        expect(() => {
+            injector.inject(baseQuery, state);
+        }).toThrowError(/All parameters are undefined/);
+    });
+});

--- a/packages/core/tests/transformers/SqlParamInjector.test.ts
+++ b/packages/core/tests/transformers/SqlParamInjector.test.ts
@@ -248,8 +248,8 @@ describe('SqlParamInjector', () => {
         const baseQuery = SelectQueryParser.parse('select u.id from users as u') as SimpleSelectQuery;
         // State with undefined value should be skipped
         const state = { id: undefined };
-        // Act: inject and format
-        const injector = new SqlParamInjector();
+        // Act: inject and format with allowAllUndefined option
+        const injector = new SqlParamInjector({ allowAllUndefined: true });
         const injected = injector.inject(baseQuery, state);
         const { formattedSql, params } = new SqlFormatter().format(injected);
         // Assert: no WHERE and empty params


### PR DESCRIPTION
This pull request introduces a significant enhancement to the `SqlParamInjector` class by adding a safety mechanism to prevent accidental full-table queries when all parameters are `undefined`. It also includes updates to the usage guide and comprehensive tests to validate the new functionality.

### Enhancements to `SqlParamInjector`:

* **Safety Mechanism**: Added a check in the `inject` method to throw an error when all parameters are `undefined`, unless explicitly allowed via the new `allowAllUndefined` option. [[1]](diffhunk://#diff-6075b287727fb2c92f409640bf5598aab12ed384a47684c83f698a60edf64636R41) [[2]](diffhunk://#diff-6075b287727fb2c92f409640bf5598aab12ed384a47684c83f698a60edf64636R61-R69)
* **New Option**: Introduced `SqlParamInjectorOptions` interface, which includes the `allowAllUndefined` option for configurable behavior.

### Documentation Updates:

* **Usage Guide**: Updated `docs/usage-guides/class-SqlParamInjector-usage-guide.md` to include examples and explanations for the `allowAllUndefined` option and its implications for security and query behavior. [[1]](diffhunk://#diff-81c3e1ca6d751e118a728bd58e83fb781758a8b2108979996acaa064911faaf7R41-R62) [[2]](diffhunk://#diff-81c3e1ca6d751e118a728bd58e83fb781758a8b2108979996acaa064911faaf7R217-R235) [[3]](diffhunk://#diff-81c3e1ca6d751e118a728bd58e83fb781758a8b2108979996acaa064911faaf7L450-R501)

### Test Coverage:

* **New Test Suite**: Added `SqlParamInjector.allowAllUndefined.test.ts` to validate the behavior of the `allowAllUndefined` option, ensuring it prevents accidental full-table queries and works correctly with various configurations.
* **Existing Tests**: Updated existing tests in `SqlParamInjector.test.ts` to incorporate the `allowAllUndefined` option where applicable.