### PR TITLE
feat: Replace forceString with extensible type system

### DIFF
--- a/docs/usage-guides/unified-json-mapping-usage-guide.md
+++ b/docs/usage-guides/unified-json-mapping-usage-guide.md
@@ -5,7 +5,7 @@ This guide provides comprehensive instructions for creating Unified JSON Mapping
 ## Overview
 
 Unified JSON Mapping enables:
-- **Type Protection**: Built-in `forceString` protection for string fields
+- **Type Protection**: Built-in `type: "string"` protection for string fields
 - **Automatic Type Validation**: Validates TypeScript interfaces against SQL results
 - **Static Analysis**: Catches type mismatches and protection issues during development
 - **Single File Configuration**: No need for separate .types.json files
@@ -30,14 +30,13 @@ Unified JSON Mapping enables:
     "id": "todo",
     "name": "Todo",
     "columns": {
-      "todoId": "todo_id",
-      "title": {
+      "todoId": "todo_id",      "title": {
         "column": "title",
-        "forceString": true
+        "type": "string"
       },
       "description": {
         "column": "description", 
-        "forceString": true
+        "type": "string"
       },
       "completed": "completed",
       "createdAt": "created_at",
@@ -52,14 +51,13 @@ Unified JSON Mapping enables:
       "propertyName": "user",
       "relationshipType": "object",
       "columns": {
-        "userId": "user_id",
-        "userName": {
+        "userId": "user_id",        "userName": {
           "column": "user_name",
-          "forceString": true
+          "type": "string"
         },
         "email": {
           "column": "email",
-          "forceString": true
+          "type": "string"
         },
         "createdAt": "user_created_at"
       }
@@ -71,14 +69,13 @@ Unified JSON Mapping enables:
       "propertyName": "category",
       "relationshipType": "object",
       "columns": {
-        "categoryId": "category_id",
-        "categoryName": {
+        "categoryId": "category_id",        "categoryName": {
           "column": "category_name",
-          "forceString": true
+          "type": "string"
         },
         "color": {
           "column": "color",
-          "forceString": true
+          "type": "string"
         },
         "createdAt": "category_created_at"
       }
@@ -95,7 +92,7 @@ Unified JSON Mapping enables:
 |-------|------|----------|-------------|
 | `rootName` | string | Yes | Unique identifier for the mapping |
 | `typeInfo` | object | No | Global type information for the root interface |
-| `protectedStringFields` | array | No | List of database columns that should be protected with forceString |
+| `protectedStringFields` | array | No | List of database columns that should be protected with type: "string" |
 | `rootEntity` | object | Yes | Definition of the root entity structure |
 | `nestedEntities` | array | No | Array of nested entity definitions |
 | `useJsonb` | boolean | No | Whether to use JSONB aggregation (default: true) |
@@ -134,7 +131,7 @@ Column mappings can be defined in two ways:
 {
   "fieldName": {
     "column": "database_column_name",
-    "forceString": true
+    "type": "string"
   }
 }
 ```
@@ -142,11 +139,11 @@ Column mappings can be defined in two ways:
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `column` | string | Yes | Database column name |
-| `forceString` | boolean | No | Force value to be converted to string for type safety |
+| `type` | string | No | Column type enforcement ("string" or "auto") |
 
 ## String Field Protection
 
-### Why Use forceString?
+### Why Use Type Protection?
 
 String fields in the database may return unexpected types due to:
 - Database driver type conversion
@@ -154,9 +151,9 @@ String fields in the database may return unexpected types due to:
 - Date/timestamp formatting differences
 - NULL value handling
 
-### When to Use forceString
+### When to Use Type Protection
 
-Use `forceString: true` for:
+Use `type: "string"` for:
 - User-generated content (titles, descriptions, names)
 - Email addresses and usernames  
 - Text-based identifiers
@@ -165,17 +162,16 @@ Use `forceString: true` for:
 ### Example with Protection
 
 ```json
-{
-  "columns": {    "title": {
+{  "columns": {    "title": {
       "column": "title",
-      "forceString": true
+      "type": "string"
     },
     "email": {
       "column": "email", 
-      "forceString": true
+      "type": "string"
     },
-    "id": "user_id",  // Numbers don't need forceString
-    "isActive": "is_active"  // Booleans don't need forceString
+    "id": "user_id",  // Numbers don't need type protection
+    "isActive": "is_active"  // Booleans don't need type protection
   }
 }
 
@@ -315,11 +311,11 @@ Please generate the complete JSON mapping file following the Enhanced JSON Mappi
       "id": "user_id",
       "name": {
         "column": "name",
-        "forceString": true
+        "type": "string"
       },
       "email": {
         "column": "email",
-        "forceString": true
+        "type": "string"
       }
     }
   },

--- a/examples/prisma-comparison-demo/rawsql-ts/getTodoDetail-unsafe.json
+++ b/examples/prisma-comparison-demo/rawsql-ts/getTodoDetail-unsafe.json
@@ -12,7 +12,7 @@
             "title": "title",
             "description": {
                 "column": "description",
-                "forceString": true
+                "type": "string"
             },
             "completed": "completed",
             "createdAt": "created_at",
@@ -31,7 +31,7 @@
                 "userName": "user_name",
                 "email": {
                     "column": "email",
-                    "forceString": true
+                    "type": "string"
                 },
                 "createdAt": "user_created_at"
             }

--- a/examples/prisma-comparison-demo/rawsql-ts/getTodoDetail.json
+++ b/examples/prisma-comparison-demo/rawsql-ts/getTodoDetail.json
@@ -11,11 +11,11 @@
             "todoId": "todo_id",
             "title": {
                 "column": "title",
-                "forceString": true
+                "type": "string"
             },
             "description": {
                 "column": "description",
-                "forceString": true
+                "type": "string"
             },
             "completed": "completed",
             "createdAt": "created_at",
@@ -33,11 +33,11 @@
                 "userId": "user_id",
                 "userName": {
                     "column": "user_name",
-                    "forceString": true
+                    "type": "string"
                 },
                 "email": {
                     "column": "email",
-                    "forceString": true
+                    "type": "string"
                 },
                 "createdAt": "user_created_at"
             }
@@ -52,11 +52,11 @@
                 "categoryId": "category_id",
                 "categoryName": {
                     "column": "category_name",
-                    "forceString": true
+                    "type": "string"
                 },
                 "color": {
                     "column": "color",
-                    "forceString": true
+                    "type": "string"
                 },
                 "createdAt": "category_created_at"
             }
@@ -71,7 +71,7 @@
                 "commentId": "comment_id",
                 "commentText": {
                     "column": "comment_text",
-                    "forceString": true
+                    "type": "string"
                 },
                 "createdAt": "comment_created_at"
             }
@@ -86,11 +86,11 @@
                 "userId": "comment_user_id",
                 "userName": {
                     "column": "comment_user_name",
-                    "forceString": true
+                    "type": "string"
                 },
                 "email": {
                     "column": "comment_user_email",
-                    "forceString": true
+                    "type": "string"
                 }
             }
         }

--- a/examples/prisma-comparison-demo/rawsql-ts/searchTodos.json
+++ b/examples/prisma-comparison-demo/rawsql-ts/searchTodos.json
@@ -7,11 +7,11 @@
             "todoId": "todo_id",
             "title": {
                 "column": "title",
-                "forceString": true
+                "type": "string"
             },
             "description": {
                 "column": "description",
-                "forceString": true
+                "type": "string"
             },
             "completed": "completed",
             "createdAt": "created_at",
@@ -30,11 +30,11 @@
                 "userId": "user_id",
                 "userName": {
                     "column": "user_name",
-                    "forceString": true
+                    "type": "string"
                 },
                 "email": {
                     "column": "email",
-                    "forceString": true
+                    "type": "string"
                 }
             }
         },
@@ -48,11 +48,11 @@
                 "categoryId": "category_id",
                 "categoryName": {
                     "column": "category_name",
-                    "forceString": true
+                    "type": "string"
                 },
                 "color": {
                     "column": "color",
-                    "forceString": true
+                    "type": "string"
                 }
             }
         }

--- a/examples/prisma-comparison-demo/src/test-runners/unified-mapping-test.ts
+++ b/examples/prisma-comparison-demo/src/test-runners/unified-mapping-test.ts
@@ -10,7 +10,7 @@ interface StringFieldValidation {
     fieldName: string;
     columnName: string;
     entityName: string;
-    hasForceString: boolean;
+    hasStringType: boolean;
     severity: 'warning' | 'error';
     recommendation: string;
 }
@@ -28,18 +28,18 @@ async function validateStringFields(unifiedMapping: UnifiedJsonMapping): Promise
     const checkEntityColumns = (entityName: string, columns: Record<string, ColumnMappingConfig>) => {
         for (const [fieldName, config] of Object.entries(columns)) {
             const columnName = typeof config === 'string' ? config : config.column;
-            const hasForceString = typeof config === 'object' && config.forceString === true;
+            const hasStringType = typeof config === 'object' && config.type === 'string';
 
             // Check if this column maps to a known string field in the database
             if (knownStringFields.has(columnName)) {
-                if (!hasForceString) {
+                if (!hasStringType) {
                     issues.push({
                         fieldName,
                         columnName,
                         entityName,
-                        hasForceString: false,
+                        hasStringType: false,
                         severity: 'warning',
-                        recommendation: `Add "forceString": true to protect against SQL injection and ensure type safety`
+                        recommendation: `Add "type": "string" to protect against SQL injection and ensure type safety`
                     });
                 }
             }
@@ -84,19 +84,19 @@ async function testUnifiedMapping() {
                 const icon = issue.severity === 'warning' ? '⚠️' : '❌';
                 console.log(`${icon} ${issue.severity.toUpperCase()}: ${issue.entityName}.${issue.fieldName}`);
                 console.log(`   📊 Database Column: ${issue.columnName}`);
-                console.log(`   🔒 Force String Protection: ${issue.hasForceString ? 'YES' : 'NO'}`);
+                console.log(`   🔒 String Type Protection: ${issue.hasStringType ? 'YES' : 'NO'}`);
                 console.log(`   💡 Recommendation: ${issue.recommendation}`);
                 console.log(`   🛠️  Fix: In your JSON mapping, change:`);
                 console.log(`      "${issue.fieldName}": "${issue.columnName}"`);
                 console.log(`      to:`);
-                console.log(`      "${issue.fieldName}": { "column": "${issue.columnName}", "forceString": true }`);
+                console.log(`      "${issue.fieldName}": { "column": "${issue.columnName}", "type": "string" }`);
                 console.log('');
             }
 
             console.log('🚨 Why this matters:');
-            console.log('   • String fields without forceString protection are vulnerable to SQL injection');
+            console.log('   • String fields without type protection are vulnerable to SQL injection');
             console.log('   • Type coercion issues can occur when database returns non-string values');
-            console.log('   • forceString ensures values are always converted to strings for safety');
+            console.log('   • type: "string" ensures values are always converted to strings for safety');
             console.log('');
         } else {
             console.log('✅ All string fields are properly protected!');
@@ -109,7 +109,7 @@ async function testUnifiedMapping() {
         console.log('📋 JsonMapping root columns:', Object.keys(jsonMapping.rootEntity.columns));
         console.log('🔒 Protected string fields:', typeProtection.protectedStringFields);
 
-        // Verify that forceString columns are properly converted
+        // Verify that string type columns are properly converted
         const expectedProtectedFields = [
             'title', 'description', 'user_name', 'email',
             'category_name', 'color', 'comment_text',

--- a/examples/prisma-comparison-demo/src/test-runners/validation-demo.ts
+++ b/examples/prisma-comparison-demo/src/test-runners/validation-demo.ts
@@ -10,7 +10,7 @@ interface StringFieldValidation {
     fieldName: string;
     columnName: string;
     entityName: string;
-    hasForceString: boolean;
+    hasStringType: boolean;
     severity: 'warning' | 'error';
     recommendation: string;
 }
@@ -31,18 +31,18 @@ async function validateStringFields(
     const checkEntityColumns = (entityName: string, columns: Record<string, ColumnMappingConfig>) => {
         for (const [fieldName, config] of Object.entries(columns)) {
             const columnName = typeof config === 'string' ? config : config.column;
-            const hasForceString = typeof config === 'object' && config.forceString === true;
+            const hasStringType = typeof config === 'object' && config.type === 'string';
 
             // Check if this column maps to a known string field in the database
             if (knownStringFields.has(columnName)) {
-                if (!hasForceString) {
+                if (!hasStringType) {
                     issues.push({
                         fieldName,
                         columnName,
                         entityName,
-                        hasForceString: false,
+                        hasStringType: false,
                         severity: severity,
-                        recommendation: `Add "forceString": true to ensure proper string type conversion and prevent type coercion issues`
+                        recommendation: `Add "type": "string" to ensure proper string type conversion and prevent type coercion issues`
                     });
                 }
             }
@@ -85,22 +85,22 @@ async function testUnsafeMapping() {
                 const icon = issue.severity === 'warning' ? '⚠️' : '❌';
                 console.log(`${icon} ${issue.severity.toUpperCase()}: ${issue.entityName}.${issue.fieldName}`);
                 console.log(`   📊 Database Column: ${issue.columnName}`);
-                console.log(`   🔒 Force String Protection: ${issue.hasForceString ? 'YES' : 'NO'}`);
+                console.log(`   🔒 String Type Protection: ${issue.hasStringType ? 'YES' : 'NO'}`);
                 console.log(`   💡 Recommendation: ${issue.recommendation}`);
                 console.log(`   🛠️  Fix: In your JSON mapping, change:`);
                 console.log(`      "${issue.fieldName}": "${issue.columnName}"`);
                 console.log(`      to:`);
-                console.log(`      "${issue.fieldName}": { "column": "${issue.columnName}", "forceString": true }`);
+                console.log(`      "${issue.fieldName}": { "column": "${issue.columnName}", "type": "string" }`);
                 console.log('');
             } console.log('🚨 Why this matters:');
             console.log('   • String fields may be returned as incorrect types (date, bigint, etc.) from database');
             console.log('   • Runtime errors can occur when JavaScript expects string methods on non-string values');
-            console.log('   • forceString ensures values are always converted to strings for safety');
+            console.log('   • type: "string" ensures values are always converted to strings for safety');
             console.log('   • This is especially important for user-generated content fields');
             console.log('');
 
             console.log('🔧 How to fix these issues:');
-            console.log('   1. Add forceString: true to all string fields that contain user data');
+            console.log('   1. Add type: "string" to all string fields that contain user data');
             console.log('   2. Pay special attention to fields like: title, description, names, emails');
             console.log('   3. Run this validation test regularly during development');
             console.log('   4. Consider adding this validation to your CI/CD pipeline');

--- a/examples/prisma-comparison-demo/tests/sql-static-analysis.test.ts
+++ b/examples/prisma-comparison-demo/tests/sql-static-analysis.test.ts
@@ -59,7 +59,7 @@ describe('SQL Static Analysis', () => {
 
             let errorMessage = `Found ${errorLevelIssues.length} string field protection error(s). These must be fixed for type safety.\n\n`;
 
-            errorMessage += '🚨 CRITICAL ERRORS - String fields missing forceString protection:\n';
+            errorMessage += '🚨 CRITICAL ERRORS - String fields missing type protection:\n';
             errorMessage += '─'.repeat(80) + '\n';
 
             displayIssues.forEach((issue, index) => {
@@ -67,7 +67,7 @@ describe('SQL Static Analysis', () => {
                 errorMessage += `   📁 File: ${issue.filePath}\n`;
                 errorMessage += `   📊 Database Column: ${issue.columnName}\n`;
                 errorMessage += `   💡 Fix: Change "${issue.fieldName}": "${issue.columnName}" to:\n`;
-                errorMessage += `        "${issue.fieldName}": { "column": "${issue.columnName}", "forceString": true }\n`;
+                errorMessage += `        "${issue.fieldName}": { "column": "${issue.columnName}", "type": "string" }\n`;
                 if (index < displayIssues.length - 1) errorMessage += '\n';
             });
 
@@ -79,8 +79,8 @@ describe('SQL Static Analysis', () => {
             errorMessage += '\n🔧 Why this is critical:';
             errorMessage += '\n   • String fields may return unexpected types (date, bigint, etc.) from database';
             errorMessage += '\n   • Runtime errors occur when JavaScript expects string methods on non-string values';
-            errorMessage += '\n   • forceString ensures type safety and prevents data corruption';
-            errorMessage += '\n\n🚀 To fix: Add "forceString": true to all string field mappings in the files above.';
+            errorMessage += '\n   • type: "string" ensures type safety and prevents data corruption';
+            errorMessage += '\n\n🚀 To fix: Add "type": "string" to all string field mappings in the files above.';
 
             throw new Error(errorMessage);
         }
@@ -88,7 +88,7 @@ describe('SQL Static Analysis', () => {
         console.log('🎉 **All SQL files validated successfully!**');
 
         if (report.stringFieldValidation.unprotectedFields > 0) {
-            console.log(`⚠️  **Note**: ${report.stringFieldValidation.unprotectedFields} string field(s) lack protection - consider adding forceString: true`);
+            console.log(`⚠️  **Note**: ${report.stringFieldValidation.unprotectedFields} string field(s) lack protection - consider adding type: "string"`);
         } else {
             console.log('🔒 **All string fields are properly protected!**');
         }

--- a/packages/core/src/transformers/UnifiedJsonMapping.ts
+++ b/packages/core/src/transformers/UnifiedJsonMapping.ts
@@ -6,11 +6,16 @@
 import { JsonMapping } from './PostgresJsonQueryBuilder';
 
 /**
- * Column configuration that can either be a simple string mapping or an enhanced mapping with type protection.
+ * Supported column type enforcement options.
+ */
+export type ColumnType = 'string' | 'auto';
+
+/**
+ * Column configuration that can either be a simple string mapping or an enhanced mapping with type control.
  */
 export type ColumnMappingConfig = string | {
     column: string;
-    forceString?: boolean;
+    type?: ColumnType;
 };
 
 /**
@@ -64,7 +69,7 @@ export function convertUnifiedMapping(unified: UnifiedJsonMapping): {
                 result[key] = config;
             } else {
                 result[key] = config.column;
-                if (config.forceString) {
+                if (config.type === 'string') {
                     protectedStringFields.push(config.column);
                 }
             }


### PR DESCRIPTION
- Replace forceString?: boolean with type?: ColumnType ('string' | 'auto')
- Add ColumnType enum for future extensibility (number, boolean, date, etc.)
- Update all conversion logic from config.forceString to config.type === 'string'
- Migrate static analysis and validation to use new type system
- Update all test files and error messages to use new syntax
- Update JSON mapping files to use type: 'string' instead of forceString: true
- Update documentation and usage guides with new examples
- Rename hasForceString to hasStringType for consistency
- All tests passing with new type system

Breaking changes:
- forceString property removed from ColumnMappingConfig
- type property added as replacement with better extensibility

Migration path:
- Replace forceString: true with type: 'string'
- All other usage remains the same