### PR TITLE
fix: Update rawsql-ts dependency version constraint for better compatibility

### DIFF
--- a/packages/prisma-integration/package.json
+++ b/packages/prisma-integration/package.json
@@ -33,7 +33,7 @@
     "license": "MIT",
     "dependencies": {
         "@prisma/internals": "^6.9.0",
-        "rawsql-ts": "^0.11.0-beta"
+        "rawsql-ts": ">=0.11.0-beta"
     },
     "peerDependencies": {
         "@prisma/client": ">=4.0.0",


### PR DESCRIPTION
This pull request includes a small change to the `packages/prisma-integration/package.json` file. The change updates the version constraint for the `rawsql-ts` dependency from `^0.11.0-beta` to `>=0.11.0-beta` to allow for greater flexibility in version compatibility.