### PR TITLE
refactor: Improve SqlParamInjector maintainability and reduce complexity

### DIFF
--- a/packages/core/tests/transformers/SqlParamInjector.cte-binary.test.ts
+++ b/packages/core/tests/transformers/SqlParamInjector.cte-binary.test.ts
@@ -1,0 +1,241 @@
+import { describe, test, expect } from 'vitest';
+import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
+import { SqlParamInjector } from '../../src/transformers/SqlParamInjector';
+import { SqlFormatter } from '../../src/transformers/SqlFormatter';
+import { SimpleSelectQuery } from '../../src/models/SimpleSelectQuery';
+import { BinarySelectQuery } from '../../src/models/BinarySelectQuery';
+
+// Common formatter configuration for readable test output
+const createFormatter = () => new SqlFormatter({
+    identifierEscape: { start: "", end: "" },
+    parameterSymbol: ":",
+    parameterStyle: "named",
+    indentSize: 4,
+    indentChar: " ",
+    newline: "\n",
+    keywordCase: "lower",
+    commaBreak: "before",
+    andBreak: "before"
+});
+
+/**
+ * Test that BinarySelectQuery (UNION/INTERSECT/EXCEPT) within CTEs 
+ * can be processed for column collection without errors
+ */
+describe('SqlParamInjector - BinarySelectQuery in CTE Column Collection', () => {
+    
+    test('should inject parameter into CTE containing UNION ALL', () => {
+        // Arrange: parse query with UNION ALL in CTE
+        const sql = `SELECT * FROM (
+            WITH union_cte as (
+                SELECT id, name FROM table1
+                UNION ALL
+                SELECT id, name FROM table2
+            )
+            SELECT * FROM union_cte
+        ) subq`;
+        const baseQuery = SelectQueryParser.parse(sql) as SimpleSelectQuery;
+        
+        // Arrange: prepare search conditions
+        const searchConditions = {
+            name: { ilike: '%test%' }
+        };
+        
+        // Act: inject parameters
+        const injector = new SqlParamInjector();
+        const injectedQuery = injector.inject(baseQuery, searchConditions);
+        
+        // Act: format SQL and extract parameters
+        const formatter = createFormatter();
+        const { formattedSql, params } = formatter.format(injectedQuery);
+        
+        // Assert: SQL contains parameters injected into each UNION branch
+        expect(formattedSql).toBe(`select
+    *
+from
+    (
+        with
+            union_cte as (
+                select
+                    id
+                    , name
+                from
+                    table1
+                where
+                    name ilike :name_ilike
+                union all
+                select
+                    id
+                    , name
+                from
+                    table2
+                where
+                    name ilike :name_ilike
+            )
+        select
+            *
+        from
+            union_cte
+    ) as subq`);
+        
+        // Assert: parameters are correctly extracted
+        expect(params).toEqual({ name_ilike: '%test%' });
+    });
+
+    test('should inject parameter into column that only exists in UNION CTE', () => {
+        // Arrange: parse query where target column only exists in UNION CTE
+        const sql = `WITH customers_and_users as (
+                SELECT customer_id as search_id, customer_name as search_name FROM customers
+                UNION
+                SELECT user_id as search_id, user_name as search_name FROM users
+            )
+            SELECT search_id FROM customers_and_users`;
+        const baseQuery = SelectQueryParser.parse(sql) as SimpleSelectQuery;
+        
+        // Arrange: search for column that only exists in the UNION CTE
+        const searchConditions = {
+            search_name: { like: '%John%' }
+        };
+        
+        // Act: inject parameters
+        const injector = new SqlParamInjector();
+        const injectedQuery = injector.inject(baseQuery, searchConditions);
+        
+        // Act: format SQL and extract parameters
+        const formatter = createFormatter();
+        const { formattedSql, params } = formatter.format(injectedQuery);
+        
+        // Assert: parameter is injected into each UNION branch
+        expect(formattedSql).toBe(`with
+    customers_and_users as (
+        select
+            customer_id as search_id
+            , customer_name as search_name
+        from
+            customers
+        where
+            customer_name like :search_name_like
+        union
+        select
+            user_id as search_id
+            , user_name as search_name
+        from
+            users
+        where
+            user_name like :search_name_like
+    )
+select
+    search_id
+from
+    customers_and_users`);
+        
+        // Assert: parameters are correctly extracted
+        expect(params).toEqual({ search_name_like: '%John%' });
+    });
+
+    test('should handle INTERSECT operation in CTE', () => {
+        // Arrange: parse query with INTERSECT in CTE
+        const sql = `WITH common_items as (
+                SELECT product_id, product_name FROM available_products
+                INTERSECT
+                SELECT product_id, product_name FROM featured_products
+            )
+            SELECT * FROM common_items`;
+        const baseQuery = SelectQueryParser.parse(sql) as SimpleSelectQuery;
+        
+        // Arrange: prepare search conditions
+        const searchConditions = {
+            product_name: { ilike: '%widget%' }
+        };
+        
+        // Act: inject parameters
+        const injector = new SqlParamInjector();
+        const injectedQuery = injector.inject(baseQuery, searchConditions);
+        
+        // Act: format SQL and extract parameters
+        const formatter = createFormatter();
+        const { formattedSql, params } = formatter.format(injectedQuery);
+        
+        // Assert: parameter is injected into each INTERSECT branch
+        expect(formattedSql).toBe(`with
+    common_items as (
+        select
+            product_id
+            , product_name
+        from
+            available_products
+        where
+            product_name ilike :product_name_ilike
+        intersect
+        select
+            product_id
+            , product_name
+        from
+            featured_products
+        where
+            product_name ilike :product_name_ilike
+    )
+select
+    *
+from
+    common_items`);
+        
+        // Assert: parameters are correctly extracted
+        expect(params).toEqual({ product_name_ilike: '%widget%' });
+    });
+
+    test('should verify BinarySelectQuery parsing and parameter injection', () => {
+        // Arrange: parse query with UNION ALL in CTE
+        const sql = `WITH union_cte as (
+                SELECT id, name FROM table1
+                UNION ALL
+                SELECT id, name FROM table2
+            )
+            SELECT * FROM union_cte`;
+        const baseQuery = SelectQueryParser.parse(sql) as SimpleSelectQuery;
+        
+        // Assert: verify that CTE contains BinarySelectQuery
+        expect(baseQuery.withClause).toBeDefined();
+        expect(baseQuery.withClause!.tables).toHaveLength(1);
+        const cte = baseQuery.withClause!.tables[0];
+        expect(cte.query).toBeInstanceOf(BinarySelectQuery);
+        const binaryQuery = cte.query as BinarySelectQuery;
+        expect(binaryQuery.operator.value).toBe('union all');
+        
+        // Arrange: prepare search conditions
+        const searchConditions = { name: { ilike: '%test%' } };
+        
+        // Act: inject parameters
+        const injector = new SqlParamInjector();
+        const injectedQuery = injector.inject(baseQuery, searchConditions);
+        
+        // Act: format SQL and extract parameters
+        const formatter = createFormatter();
+        const { formattedSql, params } = formatter.format(injectedQuery);
+        
+        // Assert: parameter is injected into each UNION branch
+        expect(formattedSql).toBe(`with
+    union_cte as (
+        select
+            id
+            , name
+        from
+            table1
+        where
+            name ilike :name_ilike
+        union all
+        select
+            id
+            , name
+        from
+            table2
+        where
+            name ilike :name_ilike
+    )
+select
+    *
+from
+    union_cte`);
+        expect(params).toEqual({ name_ilike: '%test%' });
+    });
+});

--- a/packages/core/tests/transformers/SqlParamInjectorCTEJoin.test.ts
+++ b/packages/core/tests/transformers/SqlParamInjectorCTEJoin.test.ts
@@ -1,0 +1,285 @@
+import { describe, test, expect } from 'vitest';
+import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
+import { SqlParamInjector } from '../../src/transformers/SqlParamInjector';
+import { Formatter } from '../../src/transformers/Formatter';
+import { SimpleSelectQuery } from '../../src/models/SimpleSelectQuery';
+
+/**
+ * SqlParamInjector with CTE + JOIN combinations
+ * Tests for column detection and parameter injection in complex query structures
+ */
+describe('SqlParamInjector - CTE + JOIN Support', () => {
+    
+    test('should inject parameters into CTE with LATERAL JOIN', () => {
+        const sql = `
+            WITH test_cte as (
+                SELECT 
+                    id,
+                    'test_value' as test_column,
+                    UPPER(name) as filterable_name
+                FROM test_table
+            )
+            SELECT 
+                t.id,
+                t.test_column
+            FROM test_cte as t
+            LEFT JOIN LATERAL (
+                SELECT 1 as dummy
+            ) lat ON true
+        `;
+        
+        const parsedQuery = SelectQueryParser.parse(sql) as SimpleSelectQuery;
+        const injector = new SqlParamInjector();
+        
+        const searchConditions = {
+            test_column: { ilike: '%test%' },
+            filterable_name: { ilike: '%TEST%' }
+        };
+        
+        expect(() => {
+            const injectedQuery = injector.inject(parsedQuery, searchConditions);
+            const formatter = new Formatter();
+            const formattedSql = formatter.format(injectedQuery);
+            
+            expect(formattedSql).toContain('test_column');
+            expect(formattedSql).toContain('filterable_name');
+        }).not.toThrow();
+    });
+
+    test('should inject parameters into CTE with regular JOIN', () => {
+        const sql = `
+            WITH base_cte as (
+                SELECT
+                    c.customers_id,
+                    c.name,
+                    LOWER(c.email) as filterable_email
+                FROM customers as c
+            )
+            SELECT
+                b.customers_id,
+                b.name,
+                e.entry_id
+            FROM base_cte as b
+            LEFT JOIN entry e ON e.customers_id = b.customers_id
+        `;
+        
+        const parsedQuery = SelectQueryParser.parse(sql) as SimpleSelectQuery;
+        const injector = new SqlParamInjector();
+        
+        const searchConditions = {
+            filterable_email: { ilike: '%@example.com' }
+        };
+        
+        expect(() => {
+            const injectedQuery = injector.inject(parsedQuery, searchConditions);
+            const formatter = new Formatter();
+            const formattedSql = formatter.format(injectedQuery);
+            expect(formattedSql).toContain('filterable_email');
+        }).not.toThrow();
+    });
+
+    test('should handle multiple CTEs with UNION and JOIN', () => {
+        const sql = `
+            WITH cte1 as (
+                SELECT
+                    c.customers_id as filterable_id,
+                    UPPER(c.name) as filterable_name,
+                    'cte1' as source
+                FROM customers as c
+            ),
+            cte2 as (
+                SELECT
+                    u.users_id as filterable_id,
+                    UPPER(u.name) as filterable_name,
+                    'cte2' as source
+                FROM users as u
+            ),
+            union_cte as (
+                SELECT * FROM cte1
+                UNION ALL
+                SELECT * FROM cte2
+            )
+            SELECT
+                uc.filterable_id,
+                uc.source,
+                e.entry_id
+            FROM union_cte as uc
+            LEFT JOIN entry e ON e.customers_id = uc.filterable_id
+        `;
+        
+        const parsedQuery = SelectQueryParser.parse(sql) as SimpleSelectQuery;
+        const injector = new SqlParamInjector();
+        
+        const searchConditions = {
+            filterable_name: { ilike: '%JOHN%' }
+        };
+        
+        expect(() => {
+            const injectedQuery = injector.inject(parsedQuery, searchConditions);
+            const formatter = new Formatter();
+            const formattedSql = formatter.format(injectedQuery);
+            expect(formattedSql).toContain('filterable_name');
+        }).not.toThrow();
+    });
+
+    test('should handle nested CTEs with LATERAL JOIN', () => {
+        const sql = `
+            WITH filtered_customers as (
+                SELECT
+                    3 as kind,
+                    c.customers_id as filterable_id,
+                    CONCAT(c.first_name, c.last_name) as filterable_name
+                FROM customers as c
+            ),
+            filtered_users as (
+                SELECT
+                    2 as kind,
+                    u.users_id as filterable_id,
+                    CONCAT(u.first_name, u.last_name) as filterable_name
+                FROM users as u
+            ),
+            combined_data as (
+                SELECT kind, filterable_id, filterable_name FROM filtered_customers
+                UNION ALL
+                SELECT kind, filterable_id, filterable_name FROM filtered_users
+            ),
+            final_data as (
+                SELECT 
+                    q.kind,
+                    q.filterable_id,
+                    e.entry_id
+                FROM combined_data as q
+                LEFT JOIN LATERAL (
+                    SELECT entry_id FROM entry e 
+                    WHERE e.customers_id = q.filterable_id
+                    ORDER BY e.create_date_time DESC LIMIT 1
+                ) e ON true
+            )
+            SELECT kind FROM final_data
+        `;
+        
+        const parsedQuery = SelectQueryParser.parse(sql) as SimpleSelectQuery;
+        const injector = new SqlParamInjector();
+        
+        const searchConditions = {
+            filterable_name: { ilike: '%john%' }
+        };
+        
+        expect(() => {
+            const injectedQuery = injector.inject(parsedQuery, searchConditions);
+            const formatter = new Formatter();
+            const formattedSql = formatter.format(injectedQuery);
+            expect(formattedSql).toContain('filterable_name');
+        }).not.toThrow();
+    });
+
+    test('should handle deep nested CTEs with multiple JOINs', () => {
+        const sql = `
+            WITH level1_cte as (
+                SELECT 
+                    id,
+                    'level1_value' as test_column,
+                    UPPER(name) as filterable_name
+                FROM base_table
+            ),
+            level2_cte as (
+                SELECT 
+                    l1.id,
+                    l1.test_column,
+                    l1.filterable_name,
+                    'level2' as level
+                FROM level1_cte as l1
+            ),
+            level3_cte as (
+                SELECT 
+                    l2.*,
+                    'level3' as final_level
+                FROM level2_cte as l2
+            )
+            SELECT 
+                l3.id,
+                l3.test_column,
+                t1.related_id,
+                t2.other_id
+            FROM level3_cte as l3
+            LEFT JOIN table1 t1 ON t1.id = l3.id
+            LEFT JOIN LATERAL (
+                SELECT other_id FROM table2 t2 
+                WHERE t2.parent_id = l3.id LIMIT 1
+            ) t2 ON true
+        `;
+        
+        const parsedQuery = SelectQueryParser.parse(sql) as SimpleSelectQuery;
+        const injector = new SqlParamInjector();
+        
+        const searchConditions = {
+            test_column: { ilike: '%level1%' },
+            filterable_name: { ilike: '%JOHN%' }
+        };
+        
+        expect(() => {
+            const injectedQuery = injector.inject(parsedQuery, searchConditions);
+            const formatter = new Formatter();
+            const formattedSql = formatter.format(injectedQuery);
+            expect(formattedSql).toContain('test_column');
+            expect(formattedSql).toContain('filterable_name');
+        }).not.toThrow();
+    });
+
+    // Control tests to verify baseline functionality
+    test('baseline: CTE without JOIN should work', () => {
+        const sql = `
+            WITH root_customers as (
+                SELECT
+                    c.customers_id as filterable_id,
+                    CONCAT(c.first_name, c.last_name) as filterable_name
+                FROM customers as c
+            )
+            SELECT
+                rc.filterable_id
+            FROM root_customers as rc
+        `;
+        
+        const parsedQuery = SelectQueryParser.parse(sql) as SimpleSelectQuery;
+        const injector = new SqlParamInjector();
+        
+        const searchConditions = {
+            filterable_name: { ilike: '%john%' }
+        };
+        
+        expect(() => {
+            const injectedQuery = injector.inject(parsedQuery, searchConditions);
+            const formatter = new Formatter();
+            const formattedSql = formatter.format(injectedQuery);
+            expect(formattedSql).toContain('filterable_name');
+        }).not.toThrow();
+    });
+
+    test('baseline: JOIN without CTE should work', () => {
+        const sql = `
+            SELECT
+                c.customers_id,
+                CONCAT(c.first_name, c.last_name) as filterable_name,
+                e.entry_id
+            FROM customers as c
+            LEFT JOIN LATERAL (
+                SELECT entry_id FROM entry e 
+                WHERE e.customers_id = c.customers_id LIMIT 1
+            ) e ON true
+        `;
+        
+        const parsedQuery = SelectQueryParser.parse(sql) as SimpleSelectQuery;
+        const injector = new SqlParamInjector();
+        
+        const searchConditions = {
+            filterable_name: { ilike: '%john%' }
+        };
+        
+        expect(() => {
+            const injectedQuery = injector.inject(parsedQuery, searchConditions);
+            const formatter = new Formatter();
+            const formattedSql = formatter.format(injectedQuery);
+            expect(formattedSql).toContain('filterable_name');
+        }).not.toThrow();
+    });
+});


### PR DESCRIPTION
- Extract type guard functions for cleaner condition checking
- Split 500+ line inject method into focused smaller methods
- Create reusable getAllAvailableColumns method to eliminate duplication
- Add processStateParameter and processRegularColumnCondition methods
- Improve code readability with descriptive method names
- Maintain full backward compatibility with all existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)