### PR TITLE
fix: Update path resolution to use process.cwd() instead of module directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4299,7 +4299,7 @@
         },
         "packages/core": {
             "name": "rawsql-ts",
-            "version": "0.11.4-beta",
+            "version": "0.11.5-beta",
             "license": "MIT",
             "devDependencies": {
                 "@types/benchmark": "^2.1.5",
@@ -4344,6 +4344,12 @@
                 "@prisma/client": ">=4.0.0",
                 "prisma": ">=4.0.0"
             }
+        },
+        "packages/prisma-integration/node_modules/rawsql-ts": {
+            "version": "0.11.4-beta",
+            "resolved": "https://registry.npmjs.org/rawsql-ts/-/rawsql-ts-0.11.4-beta.tgz",
+            "integrity": "sha512-yNlupgzDwIjeVy5NVH0lttDN55jT3Mk3JoFNaqSLOLxpZ9GiiY2PFLTU0EhRxKcHwPqk/NGGjOSpFXw1JszMlA==",
+            "license": "MIT"
         }
     }
 }

--- a/packages/prisma-integration/src/AutoTypeCompatibilityValidator.ts
+++ b/packages/prisma-integration/src/AutoTypeCompatibilityValidator.ts
@@ -35,9 +35,8 @@ export class AutoTypeCompatibilityValidator {
     private options: AutoTypeValidationOptions;
 
     constructor(options: AutoTypeValidationOptions = {}) {
-        // Use module directory as default base instead of process.cwd() for consistent resolution
-        const moduleDir = path.dirname(__filename);
-        const defaultBaseDir = path.resolve(moduleDir, '..');
+        // Use project current directory for proper path resolution
+        const defaultBaseDir = process.cwd();
         
         this.options = {
             baseDir: defaultBaseDir,
@@ -128,9 +127,7 @@ export class AutoTypeCompatibilityValidator {
 
         // If already has an extension, return as-is
         if (path.extname(resolved)) {
-            if (fs.existsSync(resolved)) {
-                return resolved;
-            }
+            return resolved; // Let validation handle file existence
         }
 
         // Try common TypeScript file extensions

--- a/packages/prisma-integration/src/DomainModelCompatibilityTester.ts
+++ b/packages/prisma-integration/src/DomainModelCompatibilityTester.ts
@@ -35,9 +35,8 @@ export class DomainModelCompatibilityTester {
     private options: TestValidationOptions;
 
     constructor(options: TestValidationOptions = {}) {
-        // Use module directory as default base instead of process.cwd() for consistent resolution
-        const moduleDir = path.dirname(__filename);
-        const defaultBaseDir = path.resolve(moduleDir, '..');
+        // Use project current directory for proper path resolution
+        const defaultBaseDir = process.cwd();
         
         this.options = {
             baseDir: defaultBaseDir,


### PR DESCRIPTION
- Fix DomainModelCompatibilityTester to use project current directory for proper path resolution
- Fix AutoTypeCompatibilityValidator to prevent duplicate extension issues
- Remove unnecessary file existence check when extension already present
- Resolves duplicate directory path and extension bugs reported in path-resolution-fixes.md

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>