### PR TITLE
feat: Add allowWildcardWithoutResolver option to SchemaCollector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4299,7 +4299,7 @@
         },
         "packages/core": {
             "name": "rawsql-ts",
-            "version": "0.11.4-beta",
+            "version": "0.11.5-beta",
             "license": "MIT",
             "devDependencies": {
                 "@types/benchmark": "^2.1.5",
@@ -4344,6 +4344,12 @@
                 "@prisma/client": ">=4.0.0",
                 "prisma": ">=4.0.0"
             }
+        },
+        "packages/prisma-integration/node_modules/rawsql-ts": {
+            "version": "0.11.4-beta",
+            "resolved": "https://registry.npmjs.org/rawsql-ts/-/rawsql-ts-0.11.4-beta.tgz",
+            "integrity": "sha512-yNlupgzDwIjeVy5NVH0lttDN55jT3Mk3JoFNaqSLOLxpZ9GiiY2PFLTU0EhRxKcHwPqk/NGGjOSpFXw1JszMlA==",
+            "license": "MIT"
         }
     }
 }

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -12,6 +12,7 @@ npm run lint          # ESLint
 - Add test when adding/fixing features
 - Always compile to check TypeScript errors
 - Use `SqlFormatter` for SQL comparison tests
+- **Source code comments must be written in English**
 
 ## Test Strategy (t-wada Method)
 Follow Test-Driven Development with these practices:
@@ -95,3 +96,23 @@ if (mapping.rootName && mapping.rootEntity) { /* Legacy */ }
 4. **In monorepos: npm packages vs file: references**
    - `file:../packages/core` still uses built `dist/` files
    - Direct src imports bypass build/cache issues
+
+## Chat Output Format Rules
+**Chat responses MUST follow these formatting rules:**
+
+### 1. File Path Declaration
+- **First line**: Always start with recognized CLAUDE.md full path in backticks
+- If no CLAUDE.md recognized: State "CLAUDE.md: Not recognized"
+
+### 2. Compression Notation
+- Use abbreviated notation for efficiency (space-limited CLI)
+- Examples: `impl` (implementation), `cfg` (config), `err` (error), `fn` (function)
+- Document compression usage when applied
+
+### 3. Temporary File Management
+- Create temporary scripts/files in `/.tmp/` directory
+- Before cleanup: evaluate if content should be:
+  - Converted to permanent tests
+  - Added to documentation
+  - Preserved for future reference
+- Delete `/.tmp/` contents only after evaluation

--- a/packages/core/tests/transformers/SchemaCollector.allowWildcard.test.ts
+++ b/packages/core/tests/transformers/SchemaCollector.allowWildcard.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from 'vitest';
+import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
+import { SchemaCollector } from '../../src/transformers/SchemaCollector';
+
+/**
+ * Tests for the new allowWildcardWithoutResolver option
+ */
+describe('SchemaCollector - allowWildcardWithoutResolver option', () => {
+    
+    describe('Default behavior (allowWildcardWithoutResolver = false)', () => {
+        test('should throw error when wildcard used without TableColumnResolver', () => {
+            // Arrange
+            const sql = `SELECT * FROM users`;
+            const query = SelectQueryParser.parse(sql);
+            const collector = new SchemaCollector(); // No resolver, default option
+            
+            // Act & Assert
+            expect(() => {
+                collector.collect(query);
+            }).toThrow('Wildcard (*) is used. A TableColumnResolver is required to resolve wildcards. Target table: users');
+        });
+
+        test('should throw error for qualified wildcard without resolver', () => {
+            // Arrange
+            const sql = `SELECT u.* FROM users as u`;
+            const query = SelectQueryParser.parse(sql);
+            const collector = new SchemaCollector(null, false); // Explicitly false
+            
+            // Act & Assert
+            expect(() => {
+                collector.collect(query);
+            }).toThrow('Wildcard (*) is used. A TableColumnResolver is required to resolve wildcards. Target table: users');
+        });
+
+        test('should throw error for multiple table wildcards', () => {
+            // Arrange
+            const sql = `SELECT u.*, p.* FROM users u JOIN posts p ON u.id = p.user_id`;
+            const query = SelectQueryParser.parse(sql);
+            const collector = new SchemaCollector();
+            
+            // Act & Assert
+            expect(() => {
+                collector.collect(query);
+            }).toThrow(/Wildcard \(\*\) is used\. A TableColumnResolver is required/);
+        });
+    });
+
+    describe('New option enabled (allowWildcardWithoutResolver = true)', () => {
+        test('should allow wildcard without resolver when option is true', () => {
+            // Arrange
+            const sql = `SELECT * FROM users`;
+            const query = SelectQueryParser.parse(sql);
+            const collector = new SchemaCollector(null, true); // allowWildcardWithoutResolver = true
+            
+            // Act - should not throw
+            const schemaInfo = collector.collect(query);
+            
+            // Assert
+            expect(schemaInfo).toHaveLength(1);
+            expect(schemaInfo[0].name).toBe('users');
+            expect(schemaInfo[0].columns).toEqual([]); // Wildcards are excluded when no resolver
+        });
+
+        test('should handle qualified wildcards without throwing', () => {
+            // Arrange
+            const sql = `SELECT u.* FROM users as u`;
+            const query = SelectQueryParser.parse(sql);
+            const collector = new SchemaCollector(null, true);
+            
+            // Act
+            const schemaInfo = collector.collect(query);
+            
+            // Assert
+            expect(schemaInfo).toHaveLength(1);
+            expect(schemaInfo[0].name).toBe('users');
+            expect(schemaInfo[0].columns).toEqual([]); // Wildcard excluded
+        });
+
+        test('should handle simple explicit columns without JOIN', () => {
+            // Arrange
+            const sql = `SELECT name, email FROM users`;
+            const query = SelectQueryParser.parse(sql);
+            const collector = new SchemaCollector(null, true);
+            
+            // Act
+            const schemaInfo = collector.collect(query);
+            
+            // Assert
+            expect(schemaInfo).toHaveLength(1);
+            expect(schemaInfo[0].name).toBe('users');
+            expect(schemaInfo[0].columns).toEqual(['email', 'name']); // Alphabetical order
+        });
+
+        test('should work correctly with complex queries', () => {
+            // Arrange
+            const sql = `SELECT u.name FROM users u WHERE u.active = true`;
+            const query = SelectQueryParser.parse(sql);
+            const collector = new SchemaCollector(null, true);
+            
+            // Act
+            const schemaInfo = collector.collect(query);
+            
+            // Assert
+            expect(schemaInfo).toHaveLength(1);
+            expect(schemaInfo[0].name).toBe('users');
+            // Only SELECT clause columns are included (WHERE clause columns excluded with new option)
+            expect(schemaInfo[0].columns).toEqual(['name']);
+        });
+    });
+
+    describe('Backward compatibility verification', () => {
+        test('should maintain exact same behavior when option is false', () => {
+            // Arrange
+            const sql = `SELECT * FROM users`;
+            const query = SelectQueryParser.parse(sql);
+            const oldCollector = new SchemaCollector(); // Old way
+            const newCollector = new SchemaCollector(null, false); // New way, explicit false
+            
+            // Act & Assert - both should throw the same error
+            expect(() => oldCollector.collect(query)).toThrow();
+            expect(() => newCollector.collect(query)).toThrow();
+            
+            // Verify error messages are identical
+            let oldError = '';
+            let newError = '';
+            
+            try { oldCollector.collect(query); } catch (e) { oldError = (e as Error).message; }
+            try { newCollector.collect(query); } catch (e) { newError = (e as Error).message; }
+            
+            expect(oldError).toBe(newError);
+        });
+    });
+});


### PR DESCRIPTION
- Add optional second parameter to SchemaCollector constructor
- When allowWildcardWithoutResolver=true, allows wildcard usage without TableColumnResolver
- Default behavior (false) maintains backward compatibility with error throwing
- Wildcard columns are excluded when no resolver is available
- Improves filtering to exclude JOIN condition columns when new option is enabled

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>