### PR TITLE
feat: Add QueryFlowDiagramGenerator for SQL data flow visualization

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -492,6 +492,50 @@ For more details, see the [DynamicQueryBuilder Usage Guide](../../docs/usage-gui
 
 ---
 
+## Query Flow Diagram Generation
+
+Generate Mermaid flow diagrams from SQL queries to visualize data flow and query execution order.
+
+```typescript
+import { QueryFlowDiagramGenerator } from 'rawsql-ts';
+
+const sql = `
+  WITH user_stats AS (
+    SELECT user_id, COUNT(*) as post_count
+    FROM posts GROUP BY user_id
+  )
+  SELECT u.name, us.post_count
+  FROM users u
+  LEFT JOIN user_stats us ON u.id = us.user_id
+`;
+
+const mermaid = QueryFlowDiagramGenerator.generate(sql);
+console.log(mermaid);
+// Output: Mermaid flowchart showing data flow through SQL operations
+```
+
+### Symbol Reference
+
+| SQL Element | Shape | Example |
+|-------------|-------|---------|
+| Table/CTE/Subquery | Cylinder | `table_users[(users)]`, `cte_stats[(CTE:user_stats)]` |
+| SELECT/WHERE/GROUP BY | Hexagon | `{{SELECT}}`, `{{WHERE}}` |
+| JOIN/UNION | Diamond | `{LEFT JOIN}`, `{UNION ALL}` |
+
+Example output for CTE query:
+```mermaid
+flowchart TD
+    table_posts[(posts)] --> cte_user_stats_group_by{{GROUP BY}}
+    cte_user_stats_group_by --> cte_user_stats_select{{SELECT}}
+    cte_user_stats_select --> cte_user_stats[(CTE:user_stats)]
+    table_users[(users)] -->|NOT NULL| join_1{LEFT JOIN}
+    cte_user_stats -->|NULLABLE| join_1
+    join_1 --> main_select{{SELECT}}
+    main_select --> main_output(Final Result)
+```
+
+---
+
 ## PostgresJsonQueryBuilder Features
 
 The `PostgresJsonQueryBuilder` class transforms relational SQL queries into PostgreSQL JSON queries that return hierarchical JSON structures. It automatically handles complex relationships between entities and generates optimized Common Table Expressions (CTEs) for efficient JSON aggregation, making it perfect for building APIs, reports, and data exports.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,6 +43,7 @@ export * from './transformers/UpstreamSelectQueryFinder';
 export * from './transformers/TypeTransformationPostProcessor';
 
 export * from './transformers/SchemaCollector';
+export * from './transformers/QueryFlowDiagramGenerator';
 export * from './transformers/SqlParamInjector';
 export * from './transformers/SqlSortInjector';
 export * from './transformers/SqlPaginationInjector';

--- a/packages/core/src/reporting/models/DataFlowEdge.ts
+++ b/packages/core/src/reporting/models/DataFlowEdge.ts
@@ -1,0 +1,69 @@
+/**
+ * Represents an edge (connection) in the SQL data flow diagram
+ */
+export interface DataFlowEdge {
+    from: string;
+    to: string;
+    label?: string;
+}
+
+/**
+ * Represents a connection between nodes in the data flow
+ */
+export class DataFlowConnection implements DataFlowEdge {
+    constructor(
+        public from: string,
+        public to: string,
+        public label?: string
+    ) {}
+
+    getMermaidRepresentation(): string {
+        const arrow = this.label ? ` -->|${this.label}| ` : ' --> ';
+        return `${this.from}${arrow}${this.to}`;
+    }
+
+    static create(from: string, to: string, label?: string): DataFlowConnection {
+        return new DataFlowConnection(from, to, label);
+    }
+
+    static createWithNullability(from: string, to: string, isNullable: boolean): DataFlowConnection {
+        const label = isNullable ? 'NULLABLE' : 'NOT NULL';
+        return new DataFlowConnection(from, to, label);
+    }
+}
+
+/**
+ * Collection of edges with utilities for managing connections
+ */
+export class DataFlowEdgeCollection {
+    private edges: DataFlowConnection[] = [];
+    private connectionSet = new Set<string>();
+
+    add(edge: DataFlowConnection): void {
+        const key = `${edge.from}->${edge.to}`;
+        if (!this.connectionSet.has(key)) {
+            this.edges.push(edge);
+            this.connectionSet.add(key);
+        }
+    }
+
+    addConnection(from: string, to: string, label?: string): void {
+        this.add(DataFlowConnection.create(from, to, label));
+    }
+
+    addJoinConnection(from: string, to: string, isNullable: boolean): void {
+        this.add(DataFlowConnection.createWithNullability(from, to, isNullable));
+    }
+
+    hasConnection(from: string, to: string): boolean {
+        return this.connectionSet.has(`${from}->${to}`);
+    }
+
+    getAll(): DataFlowConnection[] {
+        return [...this.edges];
+    }
+
+    getMermaidRepresentation(): string {
+        return this.edges.map(edge => edge.getMermaidRepresentation()).join('\n    ');
+    }
+}

--- a/packages/core/src/reporting/models/DataFlowGraph.ts
+++ b/packages/core/src/reporting/models/DataFlowGraph.ts
@@ -1,0 +1,184 @@
+import { BaseDataFlowNode, DataSourceNode, ProcessNode, OperationNode, OutputNode } from './DataFlowNode';
+import { DataFlowConnection, DataFlowEdgeCollection } from './DataFlowEdge';
+
+/**
+ * Represents the complete data flow graph for a SQL query
+ */
+export class DataFlowGraph {
+    private nodes = new Map<string, BaseDataFlowNode>();
+    private edges = new DataFlowEdgeCollection();
+
+    addNode(node: BaseDataFlowNode): void {
+        this.nodes.set(node.id, node);
+    }
+
+    addEdge(edge: DataFlowConnection): void {
+        this.edges.add(edge);
+    }
+
+    addConnection(from: string, to: string, label?: string): void {
+        this.edges.addConnection(from, to, label);
+    }
+
+    hasNode(nodeId: string): boolean {
+        return this.nodes.has(nodeId);
+    }
+
+    hasConnection(from: string, to: string): boolean {
+        return this.edges.hasConnection(from, to);
+    }
+
+    getNode(nodeId: string): BaseDataFlowNode | undefined {
+        return this.nodes.get(nodeId);
+    }
+
+    getAllNodes(): BaseDataFlowNode[] {
+        return Array.from(this.nodes.values());
+    }
+
+    getAllEdges(): DataFlowConnection[] {
+        return this.edges.getAll();
+    }
+
+    /**
+     * Generates the complete Mermaid flowchart syntax
+     */
+    generateMermaid(direction: string = 'TD', title?: string): string {
+        let mermaid = `flowchart ${direction}\n`;
+
+        // Add title if provided
+        if (title) {
+            mermaid += `    %% ${title}\n`;
+        }
+
+        // Add nodes
+        const nodeLines = Array.from(this.nodes.values())
+            .map(node => `    ${node.getMermaidRepresentation()}`)
+            .join('\n');
+        
+        if (nodeLines) {
+            mermaid += nodeLines + '\n';
+        }
+
+        // Add blank line between nodes and edges if both exist
+        if (this.nodes.size > 0 && this.edges.getAll().length > 0) {
+            mermaid += '\n';
+        }
+
+        // Add edges
+        const edgeRepresentation = this.edges.getMermaidRepresentation();
+        if (edgeRepresentation) {
+            mermaid += `    ${edgeRepresentation}\n`;
+        }
+
+        return mermaid;
+    }
+
+    /**
+     * Creates or gets a table node
+     */
+    getOrCreateTable(tableName: string): DataSourceNode {
+        const nodeId = `table_${tableName}`;
+        let node = this.nodes.get(nodeId) as DataSourceNode;
+        
+        if (!node) {
+            node = DataSourceNode.createTable(tableName);
+            this.addNode(node);
+        }
+        
+        return node;
+    }
+
+    /**
+     * Creates or gets a CTE node
+     */
+    getOrCreateCTE(cteName: string): DataSourceNode {
+        const nodeId = `cte_${cteName}`;
+        let node = this.nodes.get(nodeId) as DataSourceNode;
+        
+        if (!node) {
+            node = DataSourceNode.createCTE(cteName);
+            this.addNode(node);
+        }
+        
+        return node;
+    }
+
+    /**
+     * Creates or gets a subquery node
+     */
+    getOrCreateSubquery(alias: string): DataSourceNode {
+        const nodeId = `subquery_${alias}`;
+        let node = this.nodes.get(nodeId) as DataSourceNode;
+        
+        if (!node) {
+            node = DataSourceNode.createSubquery(alias);
+            this.addNode(node);
+        }
+        
+        return node;
+    }
+
+    /**
+     * Creates a process node
+     */
+    createProcessNode(type: string, context: string): ProcessNode {
+        let node: ProcessNode;
+        
+        switch (type.toLowerCase()) {
+            case 'where':
+                node = ProcessNode.createWhere(context);
+                break;
+            case 'group by':
+                node = ProcessNode.createGroupBy(context);
+                break;
+            case 'having':
+                node = ProcessNode.createHaving(context);
+                break;
+            case 'select':
+                node = ProcessNode.createSelect(context);
+                break;
+            case 'order by':
+                node = ProcessNode.createOrderBy(context);
+                break;
+            case 'limit':
+                node = ProcessNode.createLimit(context, false);
+                break;
+            case 'limit/offset':
+                node = ProcessNode.createLimit(context, true);
+                break;
+            default:
+                node = new ProcessNode(context, type);
+        }
+        
+        this.addNode(node);
+        return node;
+    }
+
+    /**
+     * Creates a JOIN operation node
+     */
+    createJoinNode(joinId: string, joinType: string): OperationNode {
+        const node = OperationNode.createJoin(joinId, joinType);
+        this.addNode(node);
+        return node;
+    }
+
+    /**
+     * Creates a set operation node (UNION, EXCEPT, etc.)
+     */
+    createSetOperationNode(operationId: string, operation: string): OperationNode {
+        const node = OperationNode.createSetOperation(operationId, operation);
+        this.addNode(node);
+        return node;
+    }
+
+    /**
+     * Creates an output node
+     */
+    createOutputNode(context: string = 'main'): OutputNode {
+        const node = new OutputNode(context);
+        this.addNode(node);
+        return node;
+    }
+}

--- a/packages/core/src/reporting/models/DataFlowNode.ts
+++ b/packages/core/src/reporting/models/DataFlowNode.ts
@@ -1,0 +1,145 @@
+/**
+ * Represents a node in the SQL data flow diagram
+ */
+export interface DataFlowNode {
+    id: string;
+    label: string;
+    type: NodeType;
+    shape: NodeShape;
+    details?: string[];
+}
+
+export type NodeType = 'table' | 'cte' | 'subquery' | 'process' | 'operation' | 'output';
+
+export type NodeShape = 'cylinder' | 'hexagon' | 'diamond' | 'rounded' | 'rectangle' | 'circle';
+
+/**
+ * Base class for all data flow nodes
+ */
+export abstract class BaseDataFlowNode implements DataFlowNode {
+    constructor(
+        public id: string,
+        public label: string,
+        public type: NodeType,
+        public shape: NodeShape,
+        public details?: string[]
+    ) {}
+
+    abstract getMermaidRepresentation(): string;
+}
+
+/**
+ * Represents a data source (table, CTE, subquery)
+ */
+export class DataSourceNode extends BaseDataFlowNode {
+    constructor(id: string, label: string, type: 'table' | 'cte' | 'subquery') {
+        super(id, label, type, 'cylinder');
+    }
+
+    getMermaidRepresentation(): string {
+        return `${this.id}[(${this.label})]`;
+    }
+
+    static createTable(tableName: string): DataSourceNode {
+        return new DataSourceNode(`table_${tableName}`, tableName, 'table');
+    }
+
+    static createCTE(cteName: string): DataSourceNode {
+        return new DataSourceNode(`cte_${cteName}`, `CTE:${cteName}`, 'cte');
+    }
+
+    static createSubquery(alias: string): DataSourceNode {
+        return new DataSourceNode(`subquery_${alias}`, `QUERY:${alias}`, 'subquery');
+    }
+}
+
+/**
+ * Represents a processing operation (WHERE, GROUP BY, SELECT, etc.)
+ */
+export class ProcessNode extends BaseDataFlowNode {
+    constructor(id: string, operation: string, context: string = '') {
+        const nodeId = context ? `${context}_${operation.toLowerCase().replace(/\s+/g, '_')}` : operation.toLowerCase().replace(/\s+/g, '_');
+        super(nodeId, operation, 'process', 'hexagon');
+    }
+
+    getMermaidRepresentation(): string {
+        return `${this.id}{{${this.label}}}`;
+    }
+
+    static createWhere(context: string): ProcessNode {
+        return new ProcessNode(`${context}_where`, 'WHERE', context);
+    }
+
+    static createGroupBy(context: string): ProcessNode {
+        return new ProcessNode(`${context}_group_by`, 'GROUP BY', context);
+    }
+
+    static createHaving(context: string): ProcessNode {
+        return new ProcessNode(`${context}_having`, 'HAVING', context);
+    }
+
+    static createSelect(context: string): ProcessNode {
+        return new ProcessNode(`${context}_select`, 'SELECT', context);
+    }
+
+    static createOrderBy(context: string): ProcessNode {
+        return new ProcessNode(`${context}_order_by`, 'ORDER BY', context);
+    }
+
+    static createLimit(context: string, hasOffset: boolean = false): ProcessNode {
+        const label = hasOffset ? 'LIMIT/OFFSET' : 'LIMIT';
+        return new ProcessNode(`${context}_limit`, label, context);
+    }
+}
+
+/**
+ * Represents an operation (JOIN, UNION, etc.)
+ */
+export class OperationNode extends BaseDataFlowNode {
+    constructor(id: string, operation: string) {
+        super(id, operation, 'operation', 'diamond');
+    }
+
+    getMermaidRepresentation(): string {
+        return `${this.id}{${this.label}}`;
+    }
+
+    static createJoin(joinId: string, joinType: string): OperationNode {
+        let label: string;
+        const normalizedType = joinType.trim().toLowerCase();
+        
+        if (normalizedType === 'join') {
+            label = 'INNER JOIN';
+        } else if (normalizedType.endsWith(' join')) {
+            label = normalizedType.toUpperCase();
+        } else {
+            label = normalizedType.toUpperCase() + ' JOIN';
+        }
+        
+        return new OperationNode(`join_${joinId}`, label);
+    }
+
+    static createUnion(unionId: string, unionType: string = 'UNION ALL'): OperationNode {
+        return new OperationNode(`${unionType.toLowerCase().replace(/\s+/g, '_')}_${unionId}`, unionType.toUpperCase());
+    }
+
+    static createSetOperation(operationId: string, operation: string): OperationNode {
+        const normalizedOp = operation.toUpperCase();
+        const id = `${normalizedOp.toLowerCase().replace(/\s+/g, '_')}_${operationId}`;
+        return new OperationNode(id, normalizedOp);
+    }
+}
+
+/**
+ * Represents the final output
+ */
+export class OutputNode extends BaseDataFlowNode {
+    constructor(context: string = 'main') {
+        const label = context === 'main' ? 'Final Result' : `${context} Result`;
+        super(`${context}_output`, label, 'output', 'rounded');
+    }
+
+    getMermaidRepresentation(): string {
+        return `${this.id}(${this.label})`;
+    }
+}

--- a/packages/core/src/reporting/services/CTEHandler.ts
+++ b/packages/core/src/reporting/services/CTEHandler.ts
@@ -1,0 +1,37 @@
+import { WithClause } from '../../models/Clause';
+import { DataFlowGraph } from '../models/DataFlowGraph';
+import { DataSourceNode } from '../models/DataFlowNode';
+
+/**
+ * Handles the processing of Common Table Expressions (CTEs)
+ */
+export class CTEHandler {
+    constructor(private graph: DataFlowGraph) {}
+
+    /**
+     * Processes all CTEs in a WITH clause
+     */
+    processCTEs(
+        withClause: WithClause,
+        cteNames: Set<string>,
+        queryProcessor: (query: any, context: string, cteNames: Set<string>) => string
+    ): void {
+        for (const cte of withClause.tables) {
+            const cteName = cte.getSourceAliasName();
+            
+            // Create virtual data source node for CTE
+            const cteNode = this.graph.getOrCreateCTE(cteName);
+            
+            // Track CTE name
+            cteNames.add(cteName);
+            
+            // Process CTE query and connect its result to the CTE virtual data source
+            const cteResultId = queryProcessor(cte.query, `cte_${cteName}`, cteNames);
+            
+            // Connect CTE query result to CTE virtual data source
+            if (cteResultId && !this.graph.hasConnection(cteResultId, cteNode.id)) {
+                this.graph.addConnection(cteResultId, cteNode.id);
+            }
+        }
+    }
+}

--- a/packages/core/src/reporting/services/DataSourceHandler.ts
+++ b/packages/core/src/reporting/services/DataSourceHandler.ts
@@ -1,0 +1,114 @@
+import { TableSource, SubQuerySource } from '../../models/Clause';
+import { SourceExpression } from '../../models/Clause';
+import { DataFlowGraph } from '../models/DataFlowGraph';
+import { DataSourceNode } from '../models/DataFlowNode';
+
+/**
+ * Handles the processing of data sources (tables, CTEs, subqueries)
+ */
+export class DataSourceHandler {
+    constructor(private graph: DataFlowGraph) {}
+
+    /**
+     * Processes a source expression and returns the node ID
+     */
+    processSource(
+        sourceExpr: SourceExpression,
+        cteNames: Set<string>,
+        queryProcessor: (query: any, context: string, cteNames: Set<string>) => string
+    ): string {
+        if (sourceExpr.datasource instanceof TableSource) {
+            return this.processTableSource(sourceExpr.datasource, cteNames);
+        } else if (sourceExpr.datasource instanceof SubQuerySource) {
+            return this.processSubquerySource(sourceExpr, cteNames, queryProcessor);
+        }
+        
+        throw new Error('Unsupported source type');
+    }
+
+    /**
+     * Processes a table source (including CTE references)
+     */
+    private processTableSource(tableSource: TableSource, cteNames: Set<string>): string {
+        const tableName = tableSource.getSourceName();
+        
+        if (cteNames.has(tableName)) {
+            // Reference to existing CTE
+            const cteNode = this.graph.getOrCreateCTE(tableName);
+            return cteNode.id;
+        } else {
+            // Regular table
+            const tableNode = this.graph.getOrCreateTable(tableName);
+            return tableNode.id;
+        }
+    }
+
+    /**
+     * Processes a subquery source
+     */
+    private processSubquerySource(
+        sourceExpr: SourceExpression,
+        cteNames: Set<string>,
+        queryProcessor: (query: any, context: string, cteNames: Set<string>) => string
+    ): string {
+        const alias = sourceExpr.aliasExpression?.table.name || 'subquery';
+        
+        // Create virtual data source node for named subquery
+        const subqueryNode = this.graph.getOrCreateSubquery(alias);
+        
+        // Process subquery content and connect its result to the subquery virtual data source
+        const subqueryResultId = queryProcessor(
+            (sourceExpr.datasource as SubQuerySource).query,
+            `subquery_${alias}_internal`,
+            cteNames
+        );
+
+        // Connect subquery result to subquery virtual data source
+        if (subqueryResultId && !this.graph.hasConnection(subqueryResultId, subqueryNode.id)) {
+            this.graph.addConnection(subqueryResultId, subqueryNode.id);
+        }
+
+        return subqueryNode.id;
+    }
+
+    /**
+     * Extracts table node IDs from a FROM clause for WHERE subqueries
+     */
+    extractTableNodeIds(fromClause: any, cteNames: Set<string>): string[] {
+        const tableNodeIds: string[] = [];
+        const sourceExpr = fromClause.source;
+
+        // Process main source
+        if (sourceExpr.datasource instanceof TableSource) {
+            const tableName = sourceExpr.datasource.getSourceName();
+            
+            if (cteNames.has(tableName)) {
+                const cteNode = this.graph.getOrCreateCTE(tableName);
+                tableNodeIds.push(cteNode.id);
+            } else {
+                const tableNode = this.graph.getOrCreateTable(tableName);
+                tableNodeIds.push(tableNode.id);
+            }
+        }
+
+        // Process JOINs
+        if (fromClause.joins && fromClause.joins.length > 0) {
+            for (const join of fromClause.joins) {
+                const joinSourceExpr = join.source;
+                if (joinSourceExpr.datasource instanceof TableSource) {
+                    const tableName = joinSourceExpr.datasource.getSourceName();
+                    
+                    if (cteNames.has(tableName)) {
+                        const cteNode = this.graph.getOrCreateCTE(tableName);
+                        tableNodeIds.push(cteNode.id);
+                    } else {
+                        const tableNode = this.graph.getOrCreateTable(tableName);
+                        tableNodeIds.push(tableNode.id);
+                    }
+                }
+            }
+        }
+
+        return tableNodeIds;
+    }
+}

--- a/packages/core/src/reporting/services/JoinHandler.ts
+++ b/packages/core/src/reporting/services/JoinHandler.ts
@@ -1,0 +1,115 @@
+import { FromClause, JoinClause } from '../../models/Clause';
+import { DataFlowGraph } from '../models/DataFlowGraph';
+import { OperationNode } from '../models/DataFlowNode';
+import { DataSourceHandler } from './DataSourceHandler';
+
+/**
+ * Handles the processing of JOIN operations
+ */
+export class JoinHandler {
+    private joinIdCounter = 0;
+
+    constructor(
+        private graph: DataFlowGraph,
+        private dataSourceHandler: DataSourceHandler
+    ) {}
+
+    /**
+     * Resets the join ID counter for deterministic IDs
+     */
+    resetJoinCounter(): void {
+        this.joinIdCounter = 0;
+    }
+
+    /**
+     * Gets the next join ID
+     */
+    private getNextJoinId(): string {
+        return String(++this.joinIdCounter);
+    }
+
+    /**
+     * Processes a FROM clause with JOINs and returns the final node ID
+     */
+    processFromClause(
+        fromClause: FromClause,
+        cteNames: Set<string>,
+        queryProcessor: (query: any, context: string, cteNames: Set<string>) => string
+    ): string {
+        // Process main source
+        const mainSourceId = this.dataSourceHandler.processSource(
+            fromClause.source,
+            cteNames,
+            queryProcessor
+        );
+
+        // Process JOINs if they exist
+        if (fromClause.joins && fromClause.joins.length > 0) {
+            return this.processJoins(fromClause.joins, mainSourceId, cteNames, queryProcessor);
+        }
+
+        return mainSourceId;
+    }
+
+    /**
+     * Processes a series of JOINs sequentially
+     */
+    private processJoins(
+        joins: JoinClause[],
+        currentNodeId: string,
+        cteNames: Set<string>,
+        queryProcessor: (query: any, context: string, cteNames: Set<string>) => string
+    ): string {
+        let resultNodeId = currentNodeId;
+
+        for (const join of joins) {
+            const joinNodeId = this.dataSourceHandler.processSource(
+                join.source,
+                cteNames,
+                queryProcessor
+            );
+
+            // Create join operation node
+            const joinOpId = this.getNextJoinId();
+            const joinNode = this.graph.createJoinNode(joinOpId, join.joinType.value);
+
+            // Get nullability labels for the JOIN
+            const { leftLabel, rightLabel } = this.getJoinNullabilityLabels(join.joinType.value);
+
+            // Connect current source and join source to join operation with nullability labels
+            if (resultNodeId && !this.graph.hasConnection(resultNodeId, joinNode.id)) {
+                this.graph.addConnection(resultNodeId, joinNode.id, leftLabel);
+            }
+            if (joinNodeId && !this.graph.hasConnection(joinNodeId, joinNode.id)) {
+                this.graph.addConnection(joinNodeId, joinNode.id, rightLabel);
+            }
+
+            resultNodeId = joinNode.id;
+        }
+
+        return resultNodeId;
+    }
+
+    /**
+     * Gets nullability labels for JOIN edges based on JOIN type
+     */
+    private getJoinNullabilityLabels(joinType: string): { leftLabel: string, rightLabel: string } {
+        switch (joinType.toLowerCase()) {
+            case 'left join':
+                return { leftLabel: 'NOT NULL', rightLabel: 'NULLABLE' };
+            case 'right join':
+                return { leftLabel: 'NULLABLE', rightLabel: 'NOT NULL' };
+            case 'inner join':
+            case 'join':
+                return { leftLabel: 'NOT NULL', rightLabel: 'NOT NULL' };
+            case 'full join':
+            case 'full outer join':
+                return { leftLabel: 'NULLABLE', rightLabel: 'NULLABLE' };
+            case 'cross join':
+                return { leftLabel: 'NOT NULL', rightLabel: 'NOT NULL' };
+            default:
+                // Default to no nullability info for unknown join types
+                return { leftLabel: '', rightLabel: '' };
+        }
+    }
+}

--- a/packages/core/src/reporting/services/ProcessHandler.ts
+++ b/packages/core/src/reporting/services/ProcessHandler.ts
@@ -1,0 +1,225 @@
+import { SimpleSelectQuery } from '../../models/SimpleSelectQuery';
+import { WhereClause } from '../../models/Clause';
+import { ValueComponent, InlineQuery, FunctionCall, UnaryExpression, BinaryExpression } from '../../models/ValueComponent';
+import { DataFlowGraph } from '../models/DataFlowGraph';
+import { ProcessNode } from '../models/DataFlowNode';
+import { DataSourceHandler } from './DataSourceHandler';
+
+/**
+ * Handles the processing of SQL clauses (WHERE, GROUP BY, HAVING, etc.)
+ */
+export class ProcessHandler {
+    constructor(
+        private graph: DataFlowGraph,
+        private dataSourceHandler: DataSourceHandler
+    ) {}
+
+    /**
+     * Processes SQL clauses in the correct execution order
+     */
+    processQueryClauses(
+        query: SimpleSelectQuery,
+        context: string,
+        currentNodeId: string,
+        cteNames: Set<string>,
+        queryProcessor: (query: any, context: string, cteNames: Set<string>) => string
+    ): string {
+        let resultNodeId = currentNodeId;
+
+        // 2. Process WHERE clause
+        if (query.whereClause && resultNodeId) {
+            resultNodeId = this.processWhereClause(query.whereClause, context, resultNodeId, cteNames, queryProcessor);
+        }
+
+        // 3. Process GROUP BY clause
+        if (query.groupByClause && resultNodeId) {
+            resultNodeId = this.processGroupByClause(context, resultNodeId);
+        }
+
+        // 4. Process HAVING clause
+        if (query.havingClause && resultNodeId) {
+            resultNodeId = this.processHavingClause(context, resultNodeId);
+        }
+
+        // 5. Process SELECT clause - only add if needed
+        if (this.shouldAddSelectNode(query, context)) {
+            resultNodeId = this.processSelectClause(context, resultNodeId);
+        }
+
+        // 6. Process ORDER BY clause
+        if (query.orderByClause && resultNodeId) {
+            resultNodeId = this.processOrderByClause(context, resultNodeId);
+        }
+
+        // 7. Process LIMIT/OFFSET clause
+        if ((query.limitClause || query.offsetClause) && resultNodeId) {
+            resultNodeId = this.processLimitClause(context, resultNodeId, !!query.offsetClause);
+        }
+
+        return resultNodeId;
+    }
+
+    /**
+     * Processes WHERE clause including subqueries
+     */
+    private processWhereClause(
+        whereClause: WhereClause,
+        context: string,
+        currentNodeId: string,
+        cteNames: Set<string>,
+        queryProcessor: (query: any, context: string, cteNames: Set<string>) => string
+    ): string {
+        const whereNode = this.graph.createProcessNode('where', context);
+
+        // Connect FROM result to WHERE
+        this.graph.addConnection(currentNodeId, whereNode.id);
+
+        // Process WHERE subqueries
+        const whereSubqueryInfo = this.processWhereSubqueries(whereClause, context, cteNames, queryProcessor);
+
+        // Connect WHERE subqueries to WHERE node
+        for (const subqueryInfo of whereSubqueryInfo) {
+            this.graph.addConnection(subqueryInfo.nodeId, whereNode.id, subqueryInfo.operator);
+        }
+
+        return whereNode.id;
+    }
+
+    /**
+     * Processes GROUP BY clause
+     */
+    private processGroupByClause(context: string, currentNodeId: string): string {
+        const groupByNode = this.graph.createProcessNode('group by', context);
+        this.graph.addConnection(currentNodeId, groupByNode.id);
+        return groupByNode.id;
+    }
+
+    /**
+     * Processes HAVING clause
+     */
+    private processHavingClause(context: string, currentNodeId: string): string {
+        const havingNode = this.graph.createProcessNode('having', context);
+        this.graph.addConnection(currentNodeId, havingNode.id);
+        return havingNode.id;
+    }
+
+    /**
+     * Processes SELECT clause
+     */
+    private processSelectClause(context: string, currentNodeId: string): string {
+        const selectNode = this.graph.createProcessNode('select', context);
+        this.graph.addConnection(currentNodeId, selectNode.id);
+        return selectNode.id;
+    }
+
+    /**
+     * Processes ORDER BY clause
+     */
+    private processOrderByClause(context: string, currentNodeId: string): string {
+        const orderByNode = this.graph.createProcessNode('order by', context);
+        this.graph.addConnection(currentNodeId, orderByNode.id);
+        return orderByNode.id;
+    }
+
+    /**
+     * Processes LIMIT/OFFSET clause
+     */
+    private processLimitClause(context: string, currentNodeId: string, hasOffset: boolean): string {
+        const limitNode = this.graph.createProcessNode(hasOffset ? 'limit/offset' : 'limit', context);
+        this.graph.addConnection(currentNodeId, limitNode.id);
+        return limitNode.id;
+    }
+
+    /**
+     * Determines if a SELECT node should be added
+     */
+    private shouldAddSelectNode(query: SimpleSelectQuery, context: string): boolean {
+        // Always add SELECT node - UNION combines SELECT results, not raw data sources
+        return true;
+    }
+
+    /**
+     * Processes WHERE clause to find subqueries (EXISTS, IN, etc.)
+     */
+    private processWhereSubqueries(
+        whereClause: WhereClause,
+        context: string,
+        cteNames: Set<string>,
+        queryProcessor: (query: any, context: string, cteNames: Set<string>) => string
+    ): Array<{ nodeId: string, operator: string }> {
+        const subqueryInfo: Array<{ nodeId: string, operator: string }> = [];
+        this.processValueComponent(whereClause.condition, context, cteNames, queryProcessor, subqueryInfo);
+        return subqueryInfo;
+    }
+
+    /**
+     * Recursively processes ValueComponent to find InlineQuery (subqueries)
+     */
+    private processValueComponent(
+        value: ValueComponent,
+        context: string,
+        cteNames: Set<string>,
+        queryProcessor: (query: any, context: string, cteNames: Set<string>) => string,
+        subqueryInfo: Array<{ nodeId: string, operator: string }>
+    ): void {
+        if (value instanceof InlineQuery) {
+            const subqueryNodeId = queryProcessor(value.selectQuery, `${context}_where_subquery`, cteNames);
+            subqueryInfo.push({ nodeId: subqueryNodeId, operator: 'SUBQUERY' });
+        } else if (value instanceof FunctionCall) {
+            const functionName = value.qualifiedName.name.toString().toLowerCase();
+            if (functionName === 'exists' && value.argument instanceof InlineQuery) {
+                const subqueryNodeId = queryProcessor(value.argument.selectQuery, `${context}_where_subquery`, cteNames);
+                subqueryInfo.push({ nodeId: subqueryNodeId, operator: 'EXISTS' });
+            } else if (value.argument) {
+                this.processValueComponent(value.argument, context, cteNames, queryProcessor, subqueryInfo);
+            }
+        } else if (value instanceof UnaryExpression) {
+            const operator = value.operator.value.toLowerCase();
+            if ((operator === 'exists' || operator === 'not exists') && value.expression instanceof InlineQuery) {
+                this.processQueryTablesOnly(value.expression.selectQuery, context, cteNames, subqueryInfo, operator.toUpperCase());
+            } else {
+                this.processValueComponent(value.expression, context, cteNames, queryProcessor, subqueryInfo);
+            }
+        } else if (value instanceof BinaryExpression) {
+            const operator = value.operator.value.toLowerCase();
+            if ((operator === 'in' || operator === 'not in') && value.right instanceof InlineQuery) {
+                this.processQueryTablesOnly(value.right.selectQuery, context, cteNames, subqueryInfo, operator.toUpperCase());
+            } else {
+                this.processValueComponent(value.left, context, cteNames, queryProcessor, subqueryInfo);
+                this.processValueComponent(value.right, context, cteNames, queryProcessor, subqueryInfo);
+            }
+        } else if (value && typeof value === 'object') {
+            for (const [key, val] of Object.entries(value)) {
+                if (val && typeof val === 'object') {
+                    if (Array.isArray(val)) {
+                        val.forEach(item => {
+                            if (item && typeof item === 'object' && 'selectQuery' in item) {
+                                this.processValueComponent(item as ValueComponent, context, cteNames, queryProcessor, subqueryInfo);
+                            }
+                        });
+                    } else if ('selectQuery' in val) {
+                        this.processValueComponent(val as ValueComponent, context, cteNames, queryProcessor, subqueryInfo);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Processes only the tables from a query for EXISTS/NOT EXISTS conditions
+     */
+    private processQueryTablesOnly(
+        query: any,
+        context: string,
+        cteNames: Set<string>,
+        subqueryInfo: Array<{ nodeId: string, operator: string }>,
+        operator: string
+    ): void {
+        if (query.fromClause) {
+            const tableNodes = this.dataSourceHandler.extractTableNodeIds(query.fromClause, cteNames);
+            for (const tableNodeId of tableNodes) {
+                subqueryInfo.push({ nodeId: tableNodeId, operator });
+            }
+        }
+    }
+}

--- a/packages/core/src/transformers/QueryFlowDiagramGenerator.ts
+++ b/packages/core/src/transformers/QueryFlowDiagramGenerator.ts
@@ -1,0 +1,219 @@
+import { SelectQuery } from '../models/SelectQuery';
+import { SelectQueryParser } from '../parsers/SelectQueryParser';
+import { SimpleSelectQuery } from '../models/SimpleSelectQuery';
+import { BinarySelectQuery } from '../models/BinarySelectQuery';
+import { DataFlowGraph } from '../reporting/models/DataFlowGraph';
+import { DataSourceHandler } from '../reporting/services/DataSourceHandler';
+import { JoinHandler } from '../reporting/services/JoinHandler';
+import { ProcessHandler } from '../reporting/services/ProcessHandler';
+import { CTEHandler } from '../reporting/services/CTEHandler';
+// Base interface for Mermaid diagram options
+export interface BaseMermaidOptions {
+    /** Diagram title */
+    title?: string;
+}
+
+export interface FlowDiagramOptions extends BaseMermaidOptions {
+    /** Show detailed information (columns, conditions) */
+    showDetails?: boolean;
+    /** Include CTE dependencies */
+    showCTEDependencies?: boolean;
+    /** Direction of flow (top-down, left-right) */
+    direction?: 'TD' | 'LR' | 'TB' | 'RL';
+}
+
+/**
+ * QueryFlowDiagramGenerator using model-based architecture
+ * Generates Mermaid diagrams from SQL queries following consistent principles
+ */
+export class QueryFlowDiagramGenerator {
+    private graph: DataFlowGraph;
+    private dataSourceHandler: DataSourceHandler;
+    private joinHandler: JoinHandler;
+    private processHandler: ProcessHandler;
+    private cteHandler: CTEHandler;
+
+    constructor() {
+        this.graph = new DataFlowGraph();
+        this.dataSourceHandler = new DataSourceHandler(this.graph);
+        this.joinHandler = new JoinHandler(this.graph, this.dataSourceHandler);
+        this.processHandler = new ProcessHandler(this.graph, this.dataSourceHandler);
+        this.cteHandler = new CTEHandler(this.graph);
+    }
+
+    generateMermaidFlow(query: SelectQuery | string, options?: FlowDiagramOptions): string {
+        // Reset state for new diagram generation
+        this.graph = new DataFlowGraph();
+        this.dataSourceHandler = new DataSourceHandler(this.graph);
+        this.joinHandler = new JoinHandler(this.graph, this.dataSourceHandler);
+        this.processHandler = new ProcessHandler(this.graph, this.dataSourceHandler);
+        this.cteHandler = new CTEHandler(this.graph);
+        this.joinHandler.resetJoinCounter();
+
+        // Parse SQL if string
+        const parsedQuery = typeof query === 'string'
+            ? SelectQueryParser.parse(query)
+            : query;
+
+        // Process the query
+        const cteNames = new Set<string>();
+        this.processQuery(parsedQuery, 'main', cteNames);
+
+        // Generate Mermaid output
+        return this.graph.generateMermaid(
+            options?.direction || 'TD',
+            options?.title
+        );
+    }
+
+    static generate(sql: string): string {
+        const generator = new QueryFlowDiagramGenerator();
+        return generator.generateMermaidFlow(sql);
+    }
+
+    private processQuery(
+        query: SelectQuery,
+        context: string,
+        cteNames: Set<string>
+    ): string {
+        if (query instanceof SimpleSelectQuery) {
+            return this.processSimpleQuery(query, context, cteNames);
+        } else if (query instanceof BinarySelectQuery) {
+            return this.processBinaryQuery(query, context, cteNames);
+        }
+
+        throw new Error('Unsupported query type');
+    }
+
+    private processSimpleQuery(
+        query: SimpleSelectQuery,
+        context: string,
+        cteNames: Set<string>
+    ): string {
+        // Process CTEs first
+        if (query.withClause) {
+            this.cteHandler.processCTEs(query.withClause, cteNames, this.processQuery.bind(this));
+        }
+
+        let currentNodeId = '';
+
+        // 1. Process FROM clause (including JOINs)
+        if (query.fromClause) {
+            currentNodeId = this.joinHandler.processFromClause(
+                query.fromClause,
+                cteNames,
+                this.processQuery.bind(this)
+            );
+        }
+
+        // 2-7. Process other clauses in execution order
+        if (currentNodeId) {
+            currentNodeId = this.processHandler.processQueryClauses(
+                query,
+                context,
+                currentNodeId,
+                cteNames,
+                this.processQuery.bind(this)
+            );
+        }
+
+        // Handle output node creation based on context
+        return this.handleOutputNode(currentNodeId, context);
+    }
+
+    private processBinaryQuery(
+        query: BinarySelectQuery,
+        context: string,
+        cteNames: Set<string>
+    ): string {
+        // Check if this is a chain of the same operation
+        const parts = this.flattenBinaryChain(query, query.operator.value);
+
+        if (parts.length > 2) {
+            return this.processMultiPartOperation(parts, query.operator.value, context, cteNames);
+        } else {
+            return this.processSimpleBinaryOperation(query, context, cteNames);
+        }
+    }
+
+    private processSimpleBinaryOperation(
+        query: BinarySelectQuery,
+        context: string,
+        cteNames: Set<string>
+    ): string {
+        const leftNodeId = this.processQuery(query.left, `${context}_left`, cteNames);
+        const rightNodeId = this.processQuery(query.right, `${context}_right`, cteNames);
+
+        // Create operation node
+        const operationNode = this.graph.createSetOperationNode('1', query.operator.value);
+
+        // Connect left and right to operation
+        if (leftNodeId && !this.graph.hasConnection(leftNodeId, operationNode.id)) {
+            this.graph.addConnection(leftNodeId, operationNode.id);
+        }
+        if (rightNodeId && !this.graph.hasConnection(rightNodeId, operationNode.id)) {
+            this.graph.addConnection(rightNodeId, operationNode.id);
+        }
+
+        return operationNode.id;
+    }
+
+    private processMultiPartOperation(
+        parts: SelectQuery[],
+        operator: string,
+        context: string,
+        cteNames: Set<string>
+    ): string {
+        const partNodes: string[] = [];
+        const operationNode = this.graph.createSetOperationNode('1', operator);
+
+        // Process each part with numbered naming
+        for (let i = 0; i < parts.length; i++) {
+            const partContext = `${context}_part${i + 1}`;
+            const partNodeId = this.processQuery(parts[i], partContext, cteNames);
+            partNodes.push(partNodeId);
+        }
+
+        // Connect all parts to operation
+        for (const partNodeId of partNodes) {
+            if (partNodeId && !this.graph.hasConnection(partNodeId, operationNode.id)) {
+                this.graph.addConnection(partNodeId, operationNode.id);
+            }
+        }
+
+        return operationNode.id;
+    }
+
+    private handleOutputNode(currentNodeId: string, context: string): string {
+        // Simple principle: Only create output node for main query
+        // All other contexts return their processing result directly
+        if (context === 'main') {
+            const outputNode = this.graph.createOutputNode(context);
+            if (currentNodeId) {
+                this.graph.addConnection(currentNodeId, outputNode.id);
+            }
+            return outputNode.id;
+        }
+        
+        return currentNodeId;
+    }
+
+    /**
+     * Flattens a binary operation chain into individual parts
+     */
+    private flattenBinaryChain(query: BinarySelectQuery, operator: string): SelectQuery[] {
+        const parts: SelectQuery[] = [];
+
+        const collectParts = (q: SelectQuery) => {
+            if (q instanceof BinarySelectQuery && q.operator.value === operator) {
+                collectParts(q.left);
+                collectParts(q.right);
+            } else {
+                parts.push(q);
+            }
+        };
+
+        collectParts(query);
+        return parts;
+    }
+}

--- a/packages/core/tests/transformers/QueryFlowDiagramGenerator.test.ts
+++ b/packages/core/tests/transformers/QueryFlowDiagramGenerator.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, beforeEach, expect } from 'vitest';
+import { QueryFlowDiagramGenerator } from '../../src/transformers/QueryFlowDiagramGenerator';
+
+describe('QueryFlowDiagramGenerator - Full Mermaid Output Tests', () => {
+    let generator: QueryFlowDiagramGenerator;
+
+    beforeEach(() => {
+        generator = new QueryFlowDiagramGenerator();
+    });
+
+    describe('Basic SELECT Queries', () => {
+        it('should generate complete Mermaid for simple SELECT from table', () => {
+            const sql = 'SELECT id, name FROM users';
+            
+            const result = generator.generateMermaidFlow(sql);
+            
+            expect(result).toBe(`flowchart TD
+    table_users[(users)]
+    main_select{{SELECT}}
+    main_output(Final Result)
+
+    table_users --> main_select
+    main_select --> main_output
+`);
+        });
+
+        it('should generate complete Mermaid for SELECT without FROM clause', () => {
+            const sql = "SELECT 1 as num, 'test' as str";
+            
+            const result = generator.generateMermaidFlow(sql);
+            
+            expect(result).toBe(`flowchart TD
+    main_output(Final Result)
+`);
+        });
+
+        it('should generate complete Mermaid for SELECT with WHERE', () => {
+            const sql = 'SELECT id, name FROM users WHERE active = true';
+            
+            const result = generator.generateMermaidFlow(sql);
+            
+            expect(result).toBe(`flowchart TD
+    table_users[(users)]
+    main_where{{WHERE}}
+    main_select{{SELECT}}
+    main_output(Final Result)
+
+    table_users --> main_where
+    main_where --> main_select
+    main_select --> main_output
+`);
+        });
+
+        it('should generate complete Mermaid for SELECT with ORDER BY', () => {
+            const sql = 'SELECT id, name FROM users ORDER BY name';
+            
+            const result = generator.generateMermaidFlow(sql);
+            
+            expect(result).toBe(`flowchart TD
+    table_users[(users)]
+    main_select{{SELECT}}
+    main_order_by{{ORDER BY}}
+    main_output(Final Result)
+
+    table_users --> main_select
+    main_select --> main_order_by
+    main_order_by --> main_output
+`);
+        });
+
+        it('should generate complete Mermaid for SELECT with GROUP BY', () => {
+            const sql = 'SELECT status, COUNT(*) FROM users GROUP BY status';
+            
+            const result = generator.generateMermaidFlow(sql);
+            
+            expect(result).toBe(`flowchart TD
+    table_users[(users)]
+    main_group_by{{GROUP BY}}
+    main_select{{SELECT}}
+    main_output(Final Result)
+
+    table_users --> main_group_by
+    main_group_by --> main_select
+    main_select --> main_output
+`);
+        });
+
+        it('should generate complete Mermaid for SELECT with LIMIT', () => {
+            const sql = 'SELECT id, name FROM users LIMIT 10';
+            
+            const result = generator.generateMermaidFlow(sql);
+            
+            expect(result).toBe(`flowchart TD
+    table_users[(users)]
+    main_select{{SELECT}}
+    main_limit{{LIMIT}}
+    main_output(Final Result)
+
+    table_users --> main_select
+    main_select --> main_limit
+    main_limit --> main_output
+`);
+        });
+    });
+
+    describe('JOIN Queries', () => {
+        it('should generate complete Mermaid for simple INNER JOIN', () => {
+            const sql = `
+                SELECT u.name, p.title
+                FROM users u
+                INNER JOIN posts p ON u.id = p.author_id
+            `;
+            
+            const result = generator.generateMermaidFlow(sql);
+            
+            expect(result).toBe(`flowchart TD
+    table_users[(users)]
+    table_posts[(posts)]
+    join_1{INNER JOIN}
+    main_select{{SELECT}}
+    main_output(Final Result)
+
+    table_users -->|NOT NULL| join_1
+    table_posts -->|NOT NULL| join_1
+    join_1 --> main_select
+    main_select --> main_output
+`);
+        });
+
+        it('should generate complete Mermaid for LEFT JOIN', () => {
+            const sql = `
+                SELECT u.name, p.title
+                FROM users u
+                LEFT JOIN posts p ON u.id = p.author_id
+            `;
+            
+            const result = generator.generateMermaidFlow(sql);
+            
+            expect(result).toBe(`flowchart TD
+    table_users[(users)]
+    table_posts[(posts)]
+    join_1{LEFT JOIN}
+    main_select{{SELECT}}
+    main_output(Final Result)
+
+    table_users -->|NOT NULL| join_1
+    table_posts -->|NULLABLE| join_1
+    join_1 --> main_select
+    main_select --> main_output
+`);
+        });
+    });
+
+    describe('UNION Queries', () => {
+        it('should generate complete Mermaid for simple UNION ALL', () => {
+            const sql = `
+                SELECT name FROM users
+                UNION ALL
+                SELECT name FROM admins
+            `;
+            
+            const result = generator.generateMermaidFlow(sql);
+            
+            expect(result).toBe(`flowchart TD
+    table_users[(users)]
+    main_left_select{{SELECT}}
+    table_admins[(admins)]
+    main_right_select{{SELECT}}
+    union_all_1{UNION ALL}
+
+    table_users --> main_left_select
+    table_admins --> main_right_select
+    main_left_select --> union_all_1
+    main_right_select --> union_all_1
+`);
+        });
+    });
+
+    describe('Simple CTE Queries', () => {
+        it('should generate flow for basic CTE', () => {
+            const sql = `
+                WITH active_users AS (
+                    SELECT id, name FROM users WHERE active = true
+                )
+                SELECT * FROM active_users
+            `;
+            
+            const result = generator.generateMermaidFlow(sql);
+            
+            expect(result).toContain('cte_active_users[(CTE:active_users)]');
+            expect(result).toContain('table_users[(users)]');
+            expect(result).toContain('cte_active_users_where{{WHERE}}');
+            expect(result).toContain('cte_active_users_select{{SELECT}}');
+            expect(result).toContain('cte_active_users --> main_select');
+        });
+    });
+
+    describe('Simple Subquery Tests', () => {
+        it('should generate flow for subquery in FROM clause', () => {
+            const sql = `
+                SELECT * FROM (
+                    SELECT id, name FROM users WHERE active = true
+                ) active_users
+            `;
+            
+            const result = generator.generateMermaidFlow(sql);
+            
+            expect(result).toContain('subquery_active_users[(QUERY:active_users)]');
+            expect(result).toContain('table_users[(users)]');
+            expect(result).toContain('subquery_active_users --> main_select');
+        });
+    });
+
+    describe('Complex Queries', () => {
+        it('should generate complete Mermaid for complex CTE with subquery and UNION', () => {
+            const sql = `
+                WITH user_stats AS (
+                    SELECT u.id, u.name, COUNT(p.id) as post_count
+                    FROM users u
+                    LEFT JOIN posts p ON u.id = p.author_id
+                    GROUP BY u.id, u.name
+                )
+                SELECT * FROM (
+                    SELECT id, name, post_count FROM user_stats
+                    UNION ALL
+                    SELECT admin_id as id, name, 0 as post_count FROM admins
+                ) as combined
+                WHERE post_count > 0
+            `;
+            
+            const result = generator.generateMermaidFlow(sql);
+            
+            expect(result).toBe(`flowchart TD
+    cte_user_stats[(CTE:user_stats)]
+    table_users[(users)]
+    table_posts[(posts)]
+    join_1{LEFT JOIN}
+    cte_user_stats_group_by{{GROUP BY}}
+    cte_user_stats_select{{SELECT}}
+    subquery_combined[(QUERY:combined)]
+    subquery_combined_internal_left_select{{SELECT}}
+    table_admins[(admins)]
+    subquery_combined_internal_right_select{{SELECT}}
+    union_all_1{UNION ALL}
+    main_where{{WHERE}}
+    main_select{{SELECT}}
+    main_output(Final Result)
+
+    table_users -->|NOT NULL| join_1
+    table_posts -->|NULLABLE| join_1
+    join_1 --> cte_user_stats_group_by
+    cte_user_stats_group_by --> cte_user_stats_select
+    cte_user_stats_select --> cte_user_stats
+    cte_user_stats --> subquery_combined_internal_left_select
+    table_admins --> subquery_combined_internal_right_select
+    subquery_combined_internal_left_select --> union_all_1
+    subquery_combined_internal_right_select --> union_all_1
+    union_all_1 --> subquery_combined
+    subquery_combined --> main_where
+    main_where --> main_select
+    main_select --> main_output
+`);
+        });
+    });
+
+    describe('Mermaid Format Options', () => {
+        it('should support direction option', () => {
+            const sql = 'SELECT id FROM users';
+            
+            const resultTD = generator.generateMermaidFlow(sql, { direction: 'TD' });
+            const resultLR = generator.generateMermaidFlow(sql, { direction: 'LR' });
+            
+            expect(resultTD).toMatch(/^flowchart TD\n/);
+            expect(resultLR).toMatch(/^flowchart LR\n/);
+        });
+
+        it('should support title option', () => {
+            const sql = 'SELECT id FROM users';
+            
+            const result = generator.generateMermaidFlow(sql, { title: 'Test Query Flow' });
+            
+            expect(result).toContain('%% Test Query Flow');
+        });
+    });
+});


### PR DESCRIPTION
- Implement model-based QueryFlowDiagramGenerator with 212 lines (vs 875 lines in previous version)
- Add comprehensive data flow graph system with nodes and edges
- Support for CTEs, subqueries, JOINs with nullability labels
- Generate Mermaid flowcharts showing SQL execution order
- Add documentation and examples to README
- Remove ERDiagramGenerator (deprecated in favor of flow diagrams)

🤖 Generated with [Claude Code](https://claude.ai/code)