### PR TITLE
Enhance SQL parsing with comment preservation and type safety improvements

### DIFF
--- a/docs/usage-guides/class-SelectQueryParser-usage-guide.md
+++ b/docs/usage-guides/class-SelectQueryParser-usage-guide.md
@@ -76,7 +76,7 @@ console.log(ast);
 ## Important Notes
 
 - The parser only supports SELECT-family queries (SELECT, WITH, VALUES, UNION, etc.).
-- SQL comments (both single-line `--` and block `/* ... */`) are automatically removed during parsing and do not appear in the AST.
+- SQL comments (both single-line `--` and block `/* ... */`) are parsed and preserved in the AST, but are not exported by default. Use `SqlFormatter` with `exportComment: true` to include comments in formatted output.
 - The output AST is compatible with other rawsql-ts tools (e.g., SqlParamInjector, SqlFormatter).
 - The parser does not validate table existence or column types; it only parses SQL syntax.
 

--- a/docs/usage-guides/class-SqlParamInjector-usage-guide.md
+++ b/docs/usage-guides/class-SqlParamInjector-usage-guide.md
@@ -385,6 +385,51 @@ const formatter = new SqlFormatter({
 const { formattedSql, params } = formatter.format(injectedQuery);
 ```
 
+### Comment Preservation
+
+SqlParamInjector preserves SQL comments throughout the parameter injection process. Comments are maintained in the Abstract Syntax Tree (AST) and can be exported using SqlFormatter:
+
+```typescript
+import { SqlParamInjector, SqlFormatter } from 'rawsql-ts';
+
+// SQL with comments
+const sqlWithComments = `
+-- Get active users with filtering
+SELECT 
+    u.user_id, 
+    u.user_name /* Full name */
+FROM users u
+WHERE u.active = true -- Only active users
+`;
+
+const injector = new SqlParamInjector();
+const injectedQuery = injector.inject(sqlWithComments, { 
+    user_id: 42 
+});
+
+// Format with comment preservation
+const formatter = new SqlFormatter({ 
+    exportComment: true  // Enable comment export
+});
+
+const { formattedSql, params } = formatter.format(injectedQuery);
+
+console.log(formattedSql);
+// Output includes comments preserved as block comments for SQL safety:
+// /* Get active users with filtering */
+// SELECT 
+//     u.user_id, 
+//     u.user_name /* Full name */
+// FROM users u
+// WHERE u.active = true /* Only active users */ AND u.user_id = :user_id
+```
+
+**Comment Features:**
+- **Full Preservation**: Comments are preserved throughout parameter injection
+- **AST Integration**: Comments are stored in the query's Abstract Syntax Tree
+- **Safe Export**: Line comments (`--`) are automatically converted to block comments (`/* */`) for SQL safety
+- **Configurable Output**: Use `exportComment: true` in SqlFormatter to include comments in formatted output
+
 ## Practical Examples
 
 ### E-commerce Product Search

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -246,7 +246,7 @@ For SelectQueryParser details, see the [SelectQueryParser Usage Guide](../../doc
 
 ## SqlFormatter Features
 
-The `SqlFormatter` class is the recommended way to format SQL queries, offering advanced capabilities like indentation, keyword casing, and multi-line formatting.
+The `SqlFormatter` class is the recommended way to format SQL queries, offering advanced capabilities like indentation, keyword casing, multi-line formatting, and comprehensive comment preservation.
 It also allows for detailed style customization. For example, you can define your own formatting rules:
 
 ```typescript
@@ -285,6 +285,43 @@ order by
     created_at desc;
 */
 ```
+
+### Comment Handling
+
+SqlFormatter provides comprehensive comment parsing and export capabilities:
+
+```typescript
+import { SqlFormatter } from 'rawsql-ts';
+
+// Enable comment export (disabled by default for backward compatibility)
+const formatter = new SqlFormatter({ 
+  exportComment: true,
+  strictCommentPlacement: true  // Only export comments from clause-level keywords
+});
+
+const sqlWithComments = `
+  -- This is a query to get active users
+  SELECT 
+    u.id, 
+    u.name /* User's full name */
+  FROM users u
+  WHERE u.active = true -- Only active users
+`;
+
+const query = SelectQueryParser.parse(sqlWithComments);
+const { formattedSql } = formatter.format(query);
+
+console.log(formattedSql);
+// Output includes comments preserved as block comments for SQL safety
+```
+
+**Comment Features:**
+- **Full Comment Parsing**: Supports both `--` line comments and `/* */` block comments
+- **AST Preservation**: Comments are stored in the Abstract Syntax Tree and preserved throughout transformations
+- **Safe Export**: Line comments are automatically converted to block comments during export to prevent SQL structure issues
+- **Configurable Export**: Enable/disable comment export with `exportComment` option
+- **Comment Editing API**: Programmatically add, edit, delete, and search comments using the `CommentEditor` class
+- **Clause Association**: Comments can be associated with specific SQL clauses and keywords
 
 For more details, see the [SqlFormatter Usage Guide](../../docs/usage-guides/class-SqlFormatter-usage-guide.md).
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rawsql-ts",
-    "version": "0.11.7-beta",
+    "version": "0.11.8-beta",
     "description": "[beta]High-performance SQL parser and AST analyzer written in TypeScript. Provides fast parsing and advanced transformation capabilities.",
     "main": "dist/src/index.js",
     "module": "dist/esm/index.js",

--- a/packages/core/src/models/BinarySelectQuery.ts
+++ b/packages/core/src/models/BinarySelectQuery.ts
@@ -1,7 +1,7 @@
 import { SourceExpression, SubQuerySource, SourceAliasExpression } from "./Clause";
 import type { SelectQuery, CTEOptions } from "./SelectQuery";
 import { SqlComponent } from "./SqlComponent";
-import { RawString } from "./ValueComponent";
+import { RawString, SqlParameterValue } from "./ValueComponent";
 import { CTENormalizer } from "../transformers/CTENormalizer";
 import { SelectQueryParser } from "../parsers/SelectQueryParser";
 import { ParameterCollector } from "../transformers/ParameterCollector";
@@ -161,7 +161,7 @@ export class BinarySelectQuery extends SqlComponent implements SelectQuery {
      * @param name Parameter name
      * @param value Value to set
      */
-    public setParameter(name: string, value: any): this {
+    public setParameter(name: string, value: SqlParameterValue): this {
         ParameterHelper.set(this, name, value);
         return this;
     }

--- a/packages/core/src/models/SelectQuery.ts
+++ b/packages/core/src/models/SelectQuery.ts
@@ -3,6 +3,7 @@ import { InsertQuery } from "./InsertQuery";
 import { SimpleSelectQuery } from "./SimpleSelectQuery";
 import { BinarySelectQuery } from "./BinarySelectQuery";
 import { ValuesQuery } from "./ValuesQuery";
+import { SqlParameterValue } from "./ValueComponent";
 
 export interface CTEOptions {
     materialized?: boolean | null;
@@ -19,7 +20,7 @@ export interface CTEManagement {
 }
 
 export interface SelectQuery extends SqlComponent {
-    setParameter(name: string, value: any): this;
+    setParameter(name: string, value: SqlParameterValue): this;
     toSimpleQuery(): SimpleSelectQuery;
 }
 export { SimpleSelectQuery, BinarySelectQuery, ValuesQuery, InsertQuery };

--- a/packages/core/src/models/SimpleSelectQuery.ts
+++ b/packages/core/src/models/SimpleSelectQuery.ts
@@ -1,6 +1,6 @@
 import { SqlComponent } from "./SqlComponent";
 import { ForClause, FromClause, GroupByClause, HavingClause, JoinClause, JoinOnClause, LimitClause, OrderByClause, SelectClause, SourceExpression, SubQuerySource, SourceAliasExpression, WhereClause, WindowsClause as WindowClause, WithClause, CommonTable, OffsetClause, FetchClause } from "./Clause";
-import { BinaryExpression, ColumnReference, ValueComponent } from "./ValueComponent";
+import { BinaryExpression, ColumnReference, ValueComponent, SqlParameterValue } from "./ValueComponent";
 import { ValueParser } from "../parsers/ValueParser";
 import { CTENormalizer } from "../transformers/CTENormalizer";
 import { SelectableColumnCollector } from "../transformers/SelectableColumnCollector";
@@ -463,7 +463,7 @@ export class SimpleSelectQuery extends SqlComponent implements SelectQuery, CTEM
      * @param name Parameter name
      * @param value Value to set
      */
-    public setParameter(name: string, value: any): this {
+    public setParameter(name: string, value: SqlParameterValue): this {
         ParameterHelper.set(this, name, value);
         return this;
     }

--- a/packages/core/src/models/ValueComponent.ts
+++ b/packages/core/src/models/ValueComponent.ts
@@ -212,16 +212,18 @@ export class LiteralValue extends SqlComponent {
     }
 }
 
+export type SqlParameterValue = string | number | boolean | Date | null | undefined | (string | number | Date)[];
+
 export class ParameterExpression extends SqlComponent {
     static kind = Symbol("ParameterExpression");
     name: RawString;
-    value: any | null; // Holds the parameter value; can be provided via second argument.
+    value: SqlParameterValue; // Holds the parameter value; can be provided via second argument.
     /**
      * The index assigned by the formatter when generating parameterized queries.
      * Used for naming parameters like $1, $2, etc.
      */
     index: number | null;
-    constructor(name: string, value: any | null = null) {
+    constructor(name: string, value: SqlParameterValue = null) {
         super();
         this.name = new RawString(name);
         this.value = value; // Value is now accepted as a second argument (optional)

--- a/packages/core/src/models/ValuesQuery.ts
+++ b/packages/core/src/models/ValuesQuery.ts
@@ -3,6 +3,7 @@ import { ParameterCollector } from "../transformers/ParameterCollector";
 import { QueryBuilder } from "../transformers/QueryBuilder";
 import { SelectQuery } from "./SelectQuery";
 import { SimpleSelectQuery } from "./SimpleSelectQuery";
+import { SqlParameterValue } from "./ValueComponent";
 import { SqlComponent } from "./SqlComponent";
 import { TupleExpression } from "./ValueComponent";
 
@@ -34,7 +35,7 @@ export class ValuesQuery extends SqlComponent implements SelectQuery {
        * @param name Parameter name
        * @param value Value to set
        */
-    public setParameter(name: string, value: any): this {
+    public setParameter(name: string, value: SqlParameterValue): this {
         ParameterHelper.set(this, name, value);
         return this;
     }

--- a/packages/core/src/transformers/DynamicQueryBuilder.ts
+++ b/packages/core/src/transformers/DynamicQueryBuilder.ts
@@ -7,13 +7,36 @@ import { PostgresJsonQueryBuilder, JsonMapping } from "./PostgresJsonQueryBuilde
 import { QueryBuilder } from "./QueryBuilder";
 import { SqlParameterBinder } from "./SqlParameterBinder";
 import { ParameterDetector } from "../utils/ParameterDetector";
+import { SqlParameterValue } from "../models/ValueComponent";
+
+// Type-safe filter condition values
+export type FilterConditionValue = SqlParameterValue | SqlParameterValue[] | {
+    min?: SqlParameterValue;
+    max?: SqlParameterValue;
+    like?: string;
+    ilike?: string;
+    in?: SqlParameterValue[];
+    any?: SqlParameterValue[];
+    '='?: SqlParameterValue;
+    '>'?: SqlParameterValue;
+    '<'?: SqlParameterValue;
+    '>='?: SqlParameterValue;
+    '<='?: SqlParameterValue;
+    '!='?: SqlParameterValue;
+    '<>'?: SqlParameterValue;
+    or?: { column: string; [operator: string]: SqlParameterValue | string }[];
+    and?: { column: string; [operator: string]: SqlParameterValue | string }[];
+    column?: string;
+};
+
+export type FilterConditions = Record<string, FilterConditionValue>;
 
 /**
  * Options for dynamic query building
  */
 export interface QueryBuildOptions {
     /** Filter conditions to inject into WHERE clause */
-    filter?: Record<string, any>;
+    filter?: FilterConditions;
     /** Sort conditions to inject into ORDER BY clause */
     sort?: SortConditions;
     /** Pagination options to inject LIMIT/OFFSET clauses */
@@ -144,7 +167,7 @@ export class DynamicQueryBuilder {
      * @param filter Filter conditions to apply
      * @returns Modified SelectQuery with filter conditions applied
      */
-    buildFilteredQuery(sqlContent: string, filter: Record<string, any>): SelectQuery {
+    buildFilteredQuery(sqlContent: string, filter: FilterConditions): SelectQuery {
         return this.buildQuery(sqlContent, { filter });
     }
 

--- a/packages/core/src/transformers/TypeTransformationPostProcessor.ts
+++ b/packages/core/src/transformers/TypeTransformationPostProcessor.ts
@@ -14,7 +14,7 @@ export interface TypeTransformationConfig {
     };
     /** Custom transformation functions */
     customTransformers?: {
-        [transformerName: string]: (value: any) => any;
+        [transformerName: string]: (value: unknown) => unknown;
     };
     /** Enable value-based type detection when column mapping is not provided (default: true) */
     enableValueBasedDetection?: boolean;
@@ -32,7 +32,7 @@ export interface TypeTransformation {
     /** Whether to handle null values (default: true) */
     handleNull?: boolean;
     /** Validation function for the value */
-    validator?: (value: any) => boolean;
+    validator?: (value: unknown) => boolean;
 }
 
 /**
@@ -52,9 +52,9 @@ export class TypeTransformationPostProcessor {
      * @param result The result object from PostgreSQL JSON query
      * @returns Transformed result with proper TypeScript types
      */
-    public transformResult<T = any>(result: any): T {
+    public transformResult<T = unknown>(result: unknown): T {
         if (result === null || result === undefined) {
-            return result;
+            return result as T;
         }
 
         if (Array.isArray(result)) {
@@ -67,7 +67,7 @@ export class TypeTransformationPostProcessor {
     /**
      * Transform a single object recursively
      */
-    private transformSingleObject(obj: any): any {
+    private transformSingleObject(obj: unknown): unknown {
         if (obj === null || obj === undefined || typeof obj !== 'object') {
             return obj;
         }
@@ -76,7 +76,7 @@ export class TypeTransformationPostProcessor {
             return obj.map(item => this.transformSingleObject(item));
         }
 
-        const transformed: any = {};
+        const transformed: Record<string, unknown> = {};
 
         for (const [key, value] of Object.entries(obj)) {
             if (value === null || value === undefined) {
@@ -149,8 +149,11 @@ export class TypeTransformationPostProcessor {
                 handleNull: true,
                 validator: (v) => {
                     try {
-                        BigInt(v);
-                        return true;
+                        if (typeof v === 'string' || typeof v === 'number' || typeof v === 'bigint' || typeof v === 'boolean') {
+                            BigInt(v);
+                            return true;
+                        }
+                        return false;
                     } catch {
                         return false;
                     }
@@ -166,8 +169,11 @@ export class TypeTransformationPostProcessor {
                 handleNull: true,
                 validator: (v) => {
                     try {
-                        BigInt(v);
-                        return true;
+                        if (typeof v === 'string' || typeof v === 'number' || typeof v === 'bigint' || typeof v === 'boolean') {
+                            BigInt(v);
+                            return true;
+                        }
+                        return false;
                     } catch {
                         return false;
                     }
@@ -305,8 +311,11 @@ export class TypeTransformationPostProcessor {
                     handleNull: true,
                     validator: (value) => {
                         try {
-                            BigInt(value);
-                            return true;
+                            if (typeof value === 'string' || typeof value === 'number' || typeof value === 'bigint' || typeof value === 'boolean') {
+                                BigInt(value);
+                                return true;
+                            }
+                            return false;
                         } catch {
                             return false;
                         }
@@ -344,8 +353,11 @@ export class TypeTransformationPostProcessor {
                     handleNull: true,
                     validator: (value) => {
                         try {
-                            BigInt(value);
-                            return true;
+                            if (typeof value === 'string' || typeof value === 'number' || typeof value === 'bigint' || typeof value === 'boolean') {
+                                BigInt(value);
+                                return true;
+                            }
+                            return false;
                         } catch {
                             return false;
                         }
@@ -359,8 +371,8 @@ export class TypeTransformationPostProcessor {
 /**
  * Convenience function to create and apply transformations
  */
-export function transformDatabaseResult<T = any>(
-    result: any,
+export function transformDatabaseResult<T = unknown>(
+    result: unknown,
     config?: TypeTransformationConfig
 ): T {
     const processor = new TypeTransformationPostProcessor(
@@ -397,7 +409,7 @@ export const TypeTransformers = {
     /**
      * Transform JSON string to object
      */
-    toObject: <T = any>(value: string | null): T | null => {
+    toObject: <T = unknown>(value: string | null): T | null => {
         if (value === null || value === undefined) return null;
         try {
             return JSON.parse(value) as T;


### PR DESCRIPTION
Update documentation to reflect comment preservation capabilities in SQL parsing. Improve type safety by replacing 'any' types with specific TypeScript types throughout the codebase. Bump version to 0.11.8-beta.