### PR TITLE
feat: enhance SQL parser error messages with detailed context

### DIFF
--- a/packages/core/src/parsers/FunctionExpressionParser.ts
+++ b/packages/core/src/parsers/FunctionExpressionParser.ts
@@ -7,6 +7,7 @@ import { ValueParser } from "./ValueParser";
 import { FullNameParser } from "./FullNameParser";
 import { SelectQueryParser } from "./SelectQueryParser";
 import { OrderByClauseParser } from "./OrderByClauseParser";
+import { ParseError } from "./ParseError";
 
 export class FunctionExpressionParser {
     /**
@@ -167,7 +168,7 @@ export class FunctionExpressionParser {
                 return { value, newIndex: idx };
             }
         } else {
-            throw new Error(`Expected opening parenthesis after function name '${name.name}' at index ${idx}`);
+            throw ParseError.fromUnparsedLexemes(lexemes, idx, `Expected opening parenthesis after function name '${name.name}'.`);
         }
     }
 
@@ -211,7 +212,7 @@ export class FunctionExpressionParser {
                     }
 
                 } else if (required) {
-                    throw new Error(`Keyword '${key}' is required at index ${idx}`);
+                    throw ParseError.fromUnparsedLexemes(lexemes, idx, `Keyword '${key}' is required for ${name.name} function.`);
                 }
             }
 
@@ -238,10 +239,10 @@ export class FunctionExpressionParser {
                     return { value, newIndex: idx };
                 }
             } else {
-                throw new Error(`Missing closing parenthesis for function '${name.name}' at index ${idx}`);
+                throw ParseError.fromUnparsedLexemes(lexemes, idx, `Missing closing parenthesis for function '${name.name}'.`);
             }
         } else {
-            throw new Error(`Missing opening parenthesis for function '${name.name}' at index ${idx}`);
+            throw ParseError.fromUnparsedLexemes(lexemes, idx, `Missing opening parenthesis for function '${name.name}'.`);
         }
     }
 

--- a/packages/core/src/parsers/ValueParser.ts
+++ b/packages/core/src/parsers/ValueParser.ts
@@ -225,7 +225,7 @@ export class ValueParser {
             }
         }
 
-        throw new Error(`[ValueParser] Invalid lexeme. index: ${idx}, type: ${lexemes[idx].type}, value: ${lexemes[idx].value}`);
+        throw ParseError.fromUnparsedLexemes(lexemes, idx, `[ValueParser] Invalid lexeme.`);
     }
 
     public static parseArgument(openToken: TokenType, closeToken: TokenType, lexemes: Lexeme[], index: number): { value: ValueComponent; newIndex: number } {
@@ -251,7 +251,7 @@ export class ValueParser {
                     idx++;
                     return { value: wildcard, newIndex: idx };
                 } else {
-                    throw new Error(`Expected closing parenthesis at index ${idx}`);
+                    throw ParseError.fromUnparsedLexemes(lexemes, idx, `Expected closing parenthesis after wildcard '*'.`);
                 }
             }
 
@@ -279,11 +279,11 @@ export class ValueParser {
                 const value = new ValueList(args);
                 return { value, newIndex: idx };
             } else {
-                throw new Error(`Missing closing parenthesis at index ${idx}`);
+                throw ParseError.fromUnparsedLexemes(lexemes, idx, `Missing closing parenthesis.`);
             }
         }
 
-        throw new Error(`Expected opening parenthesis at index ${index}`);
+        throw ParseError.fromUnparsedLexemes(lexemes, index, `Expected opening parenthesis.`);
     }
 
     /**

--- a/packages/core/tests/parsers/ExtractError.test.ts
+++ b/packages/core/tests/parsers/ExtractError.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from 'vitest';
+import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
+
+describe('EXTRACT function error reproduction', () => {
+    test('Valid EXTRACT with DAY should work', () => {
+        const validQuery = `SELECT EXTRACT(DAY FROM end_date) as day_number FROM events`;
+        
+        expect(() => {
+            SelectQueryParser.parse(validQuery);
+        }).not.toThrow();
+    });
+
+    test('Valid EXTRACT with MONTH should work', () => {
+        const validQuery = `SELECT EXTRACT(MONTH FROM created_at) as month_number FROM events`;
+        
+        expect(() => {
+            SelectQueryParser.parse(validQuery);
+        }).not.toThrow();
+    });
+
+    test('EXTRACT with invalid time unit DAYS should provide clear error message', () => {
+        const invalidQuery = `SELECT EXTRACT(DAYS FROM end_date) as duration FROM events`;
+        
+        try {
+            SelectQueryParser.parse(invalidQuery);
+            expect.fail('Should have thrown an error');
+        } catch (error: any) {
+            console.log('Error message for invalid time unit DAYS:');
+            console.log(error.message);
+            // The error should indicate what was found and provide context
+            expect(error.message).toBeDefined();
+            expect(error.message.length).toBeGreaterThan(20); // More detailed than before
+        }
+    });
+
+    test('EXTRACT with comma instead of FROM should provide clear error message', () => {
+        const invalidQuery = `SELECT EXTRACT(MONTH, created_at) as month_number FROM events`;
+        
+        try {
+            SelectQueryParser.parse(invalidQuery);
+            expect.fail('Should have thrown an error');
+        } catch (error: any) {
+            console.log('Error message for comma instead of FROM:');
+            console.log(error.message);
+            expect(error.message).toBeDefined();
+            expect(error.message.length).toBeGreaterThan(20);
+        }
+    });
+
+    test('Complex query with EXTRACT error should provide context', () => {
+        const complexInvalidQuery = `
+        WITH user_stats AS (
+            SELECT 
+                user_id,
+                EXTRACT(DAYS FROM last_order_date - first_order_date) as customer_lifetime_days
+            FROM orders
+        )
+        SELECT * FROM user_stats`;
+        
+        try {
+            SelectQueryParser.parse(complexInvalidQuery);
+            expect.fail('Should have thrown an error');
+        } catch (error: any) {
+            console.log('Error message for complex query with invalid DAYS:');
+            console.log(error.message);
+            expect(error.message).toBeDefined();
+            expect(error.message.length).toBeGreaterThan(20);
+        }
+    });
+
+    test('Original user query should provide clear error message', () => {
+        const originalUserQuery = `WITH user_stats AS (
+    SELECT 
+        user_id,
+        COUNT(*) as total_orders,
+        SUM(amount) as total_amount,
+        AVG(amount) as avg_order_amount,
+        MIN(created_at) as first_order_date,
+        MAX(created_at) as last_order_date
+    FROM orders 
+    WHERE created_at >= '2024-01-01' 
+      AND created_at < '2024-02-01'
+      AND status IN ('completed', 'shipped')
+    GROUP BY user_id
+    HAVING COUNT(*) >= 2
+)
+,
+customer_segments AS (
+    SELECT 
+        us.user_id,
+        us.total_amount,
+        us.total_orders,
+        us.avg_order_amount,
+        EXTRACT(DAYS FROM (us.last_order_date - us.first_order_date)) as customer_lifetime_days
+    FROM user_stats us
+)
+SELECT 
+    customer_lifetime_days
+FROM customer_segments`;
+        
+        try {
+            SelectQueryParser.parse(originalUserQuery);
+            expect.fail('Should have thrown an error');
+        } catch (error: any) {
+            console.log('Error message for original user query:');
+            console.log(error.message);
+            expect(error.message).toContain('Missing closing parenthesis');
+            expect(error.message).toContain('Context:');
+            expect(error.message).toContain('DAYS [Identifier]');
+        }
+    });
+});


### PR DESCRIPTION
Improve error handling for SQL parsing failures by providing detailed lexeme context and position information instead of basic index numbers.

- Replace generic Error with ParseError.fromUnparsedLexemes()
- Add surrounding token context with visual indicators
- Include token type information ([Identifier], [Command], etc.)
- Enhance error messages for function parsing failures
- Add comprehensive test cases for improved error messages

Before: "Missing closing parenthesis at index 4"
After: Shows exact lexeme, context, and token types with > indicator

🤖 Generated with [Claude Code](https://claude.ai/code)