### PR TITLE
fix: correct full-oneline behavior for WITH clause formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3057,7 +3057,7 @@
         },
         "packages/core": {
             "name": "rawsql-ts",
-            "version": "0.11.10-beta",
+            "version": "0.11.11-beta",
             "license": "MIT",
             "devDependencies": {
                 "@types/benchmark": "^2.1.5",

--- a/packages/core/tests/transformers/SqlFormatter.withClauseStyle.test.ts
+++ b/packages/core/tests/transformers/SqlFormatter.withClauseStyle.test.ts
@@ -105,17 +105,9 @@ order by
             withClauseStyle: 'full-oneline'
         });
         
-        // Expected: Complete SQL with entire WITH clause as continuous block
-        const expectedSql = `with "user_summary" as (
-  select
-    "id", "name", count(*)
-  from
-    "users"
-  where
-    "active" = true
-  group by
-    "id", "name"
-) select
+        // Expected: WITH clause content completely on one line, followed by normal formatted SELECT
+        const expectedSql = `with "user_summary" as (select "id", "name", count(*) from "users" where "active" = true group by "id", "name")
+select
   *
 from
   "user_summary"
@@ -139,22 +131,9 @@ order by
             withClauseStyle: 'full-oneline'
         });
         
-        // Expected: Complete SQL with entire WITH clause as continuous block
-        const expectedSql = `with "active_users" as (
-  select
-    "id", "name"
-  from
-    "users"
-  where
-    "active" = true
-), "user_orders" as (
-  select
-    "user_id", count(*) as "order_count"
-  from
-    "orders"
-  group by
-    "user_id"
-) select
+        // Expected: WITH clause content completely on one line, followed by normal formatted SELECT
+        const expectedSql = `with "active_users" as (select "id", "name" from "users" where "active" = true), "user_orders" as (select "user_id", count(*) as "order_count" from "orders" group by "user_id")
+select
   "u"."id", "u"."name", "o"."order_count"
 from
   "active_users" as "u"
@@ -180,17 +159,9 @@ order by
             withClauseStyle: 'full-oneline'
         });
         
-        // Expected: Complete SQL with keywords in uppercase
-        const expectedSql = `WITH "user_summary" AS (
-  SELECT
-    "id", "name", count(*)
-  FROM
-    "users"
-  WHERE
-    "active" = true
-  GROUP BY
-    "id", "name"
-) SELECT
+        // Expected: WITH clause content completely on one line with keywords in uppercase, followed by normal formatted SELECT
+        const expectedSql = `WITH "user_summary" AS (SELECT "id", "name", count(*) FROM "users" WHERE "active" = true GROUP BY "id", "name")
+SELECT
   *
 FROM
   "user_summary"
@@ -226,17 +197,9 @@ ORDER BY
             exportComment: true
         });
         
-        // Expected: Complete SQL with entire WITH clause as continuous block including comments
-        const expectedSql = `with "user_summary" as (
-  /* Get active users */ select
-    "id", "name", count(*)
-  from
-    "users"
-  where
-    "active" = true
-  group by
-    "id", "name"
-) select
+        // Expected: WITH clause content completely on one line including comments, followed by normal formatted SELECT
+        const expectedSql = `with "user_summary" as (/* Get active users */ select "id", "name", count(*) from "users" where "active" = true group by "id", "name")
+select
   *
 from
   "user_summary"`;


### PR DESCRIPTION
The full-oneline style was not properly formatting WITH clause content as a single line. This fix implements proper context tracking to ensure that WITH clause content is compressed to one line while maintaining normal formatting for the rest of the query.

Changes:
- Add insideWithClause state tracking to SqlPrinter
- Suppress newlines for all containers within WITH clause during full-oneline formatting
- Update test expectations to match correct behavior
- Remove unused handleWithClauseOnelineToken method

🤖 Generated with [Claude Code](https://claude.ai/code)