### PR TITLE
refactor: improve flow diagram shapes for better readability

### DIFF
--- a/packages/core/tests/transformers/QueryFlowDiagramGenerator.test.ts
+++ b/packages/core/tests/transformers/QueryFlowDiagramGenerator.test.ts
@@ -16,7 +16,7 @@ describe('QueryFlowDiagramGenerator - Full Mermaid Output Tests', () => {
             
             expect(result).toBe(`flowchart TD
     table_users[(users)]
-    main_output(Final Result)
+    main_output([Final Result])
 
     table_users --> main_output
 `);
@@ -28,7 +28,7 @@ describe('QueryFlowDiagramGenerator - Full Mermaid Output Tests', () => {
             const result = generator.generateMermaidFlow(sql);
             
             expect(result).toBe(`flowchart TD
-    main_output(Final Result)
+    main_output([Final Result])
 `);
         });
 
@@ -39,7 +39,7 @@ describe('QueryFlowDiagramGenerator - Full Mermaid Output Tests', () => {
             
             expect(result).toBe(`flowchart TD
     table_users[(users)]
-    main_output(Final Result)
+    main_output([Final Result])
 
     table_users --> main_output
 `);
@@ -52,7 +52,7 @@ describe('QueryFlowDiagramGenerator - Full Mermaid Output Tests', () => {
             
             expect(result).toBe(`flowchart TD
     table_users[(users)]
-    main_output(Final Result)
+    main_output([Final Result])
 
     table_users --> main_output
 `);
@@ -65,7 +65,7 @@ describe('QueryFlowDiagramGenerator - Full Mermaid Output Tests', () => {
             
             expect(result).toBe(`flowchart TD
     table_users[(users)]
-    main_output(Final Result)
+    main_output([Final Result])
 
     table_users --> main_output
 `);
@@ -78,7 +78,7 @@ describe('QueryFlowDiagramGenerator - Full Mermaid Output Tests', () => {
             
             expect(result).toBe(`flowchart TD
     table_users[(users)]
-    main_output(Final Result)
+    main_output([Final Result])
 
     table_users --> main_output
 `);
@@ -98,8 +98,8 @@ describe('QueryFlowDiagramGenerator - Full Mermaid Output Tests', () => {
             expect(result).toBe(`flowchart TD
     table_users[(users)]
     table_posts[(posts)]
-    join_1{{INNER JOIN}}
-    main_output(Final Result)
+    join_1[INNER JOIN]
+    main_output([Final Result])
 
     table_users -->|NOT NULL| join_1
     table_posts -->|NOT NULL| join_1
@@ -119,8 +119,8 @@ describe('QueryFlowDiagramGenerator - Full Mermaid Output Tests', () => {
             expect(result).toBe(`flowchart TD
     table_users[(users)]
     table_posts[(posts)]
-    join_1{{LEFT JOIN}}
-    main_output(Final Result)
+    join_1[LEFT JOIN]
+    main_output([Final Result])
 
     table_users -->|NOT NULL| join_1
     table_posts -->|NULLABLE| join_1
@@ -141,10 +141,10 @@ describe('QueryFlowDiagramGenerator - Full Mermaid Output Tests', () => {
             expect(result).toBe(`flowchart TD
     table_users[(users)]
     table_posts[(posts)]
-    join_1{{INNER JOIN}}
+    join_1[INNER JOIN]
     table_categories[(categories)]
-    join_2{{INNER JOIN}}
-    main_output(Final Result)
+    join_2[INNER JOIN]
+    main_output([Final Result])
 
     table_users -->|NOT NULL| join_1
     table_posts -->|NOT NULL| join_1
@@ -168,12 +168,12 @@ describe('QueryFlowDiagramGenerator - Full Mermaid Output Tests', () => {
             expect(result).toBe(`flowchart TD
     table_users[(users)]
     table_posts[(posts)]
-    join_1{{LEFT JOIN}}
+    join_1[LEFT JOIN]
     table_categories[(categories)]
-    join_2{{INNER JOIN}}
+    join_2[INNER JOIN]
     table_tags[(tags)]
-    join_3{{RIGHT JOIN}}
-    main_output(Final Result)
+    join_3[RIGHT JOIN]
+    main_output([Final Result])
 
     table_users -->|NOT NULL| join_1
     table_posts -->|NULLABLE| join_1
@@ -234,7 +234,7 @@ describe('QueryFlowDiagramGenerator - Full Mermaid Output Tests', () => {
             
             const result = generator.generateMermaidFlow(sql);
             
-            expect(result).toContain('subquery_active_users[(SUB:active_users)]');
+            expect(result).toContain('subquery_active_users{{SubQuery:active_users}}');
             expect(result).toContain('table_users[(users)]');
             expect(result).toContain('subquery_active_users --> main_output');
         });
@@ -263,11 +263,11 @@ describe('QueryFlowDiagramGenerator - Full Mermaid Output Tests', () => {
     cte_user_stats[(CTE:user_stats)]
     table_users[(users)]
     table_posts[(posts)]
-    join_1{{LEFT JOIN}}
-    subquery_combined[(SUB:combined)]
+    join_1[LEFT JOIN]
+    subquery_combined{{SubQuery:combined}}
     table_admins[(admins)]
     union_all_subquery_combined_internal[UNION ALL]
-    main_output(Final Result)
+    main_output([Final Result])
 
     table_users -->|NOT NULL| join_1
     table_posts -->|NULLABLE| join_1


### PR DESCRIPTION
- Change subquery representation from cylinder to hexagon (preparation symbol)
- Update subquery label from SUB: to SubQuery: for clarity
- Change JOIN operations from hexagon to rectangle (standard process)
- Change terminal nodes from rounded to stadium shape (standard terminal)
- Update all test expectations to match new node shapes

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>