### PR TITLE
feat: add cursor-to-lexeme mapping functionality

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ export * from './models/SelectQuery';
 export * from './models/ValueComponent';
 export * from './models/ValuesQuery';
 export * from './models/CTEError';
+export * from './models/Lexeme';
 
 export * from './transformers/CTECollector';
 export * from './transformers/CTENormalizer';
@@ -53,6 +54,7 @@ export * from './utils/SqlSchemaValidator';
 export * from './utils/JsonSchemaValidator';
 export * from './utils/SchemaManager';
 export * from './utils/CommentEditor';
+export * from './utils/LexemeCursor';
 
 
 // Add more exports here if you want to expose additional public API

--- a/packages/core/src/models/Lexeme.ts
+++ b/packages/core/src/models/Lexeme.ts
@@ -17,10 +17,23 @@
 }
 
 /**
+ * Position information for a lexeme in the source text
+ */
+export interface LexemePosition {
+    startPosition: number;  // Character offset in source
+    endPosition: number;    // Character offset in source
+    startLine?: number;     // Line number (1-based)
+    startColumn?: number;   // Column number (1-based)
+    endLine?: number;       // Line number (1-based)
+    endColumn?: number;     // Column number (1-based)
+}
+
+/**
  * Represents a lexical token in SQL parsing
  */
 export interface Lexeme {
     type: number; // Bit flags for TokenType
     value: string;
     comments: string[] | null;
+    position?: LexemePosition; // Optional position information for cursor-to-lexeme mapping
 }

--- a/packages/core/src/tokenReaders/BaseTokenReader.ts
+++ b/packages/core/src/tokenReaders/BaseTokenReader.ts
@@ -1,4 +1,4 @@
-﻿import { Lexeme, TokenType } from '../models/Lexeme';
+﻿import { Lexeme, TokenType, LexemePosition } from '../models/Lexeme';
 import { StringUtils } from '../utils/stringUtils';
 
 /**
@@ -61,22 +61,31 @@ export abstract class BaseTokenReader {
     /**
      * Create a lexeme with the specified type and value
      */
-    protected createLexeme(type: TokenType, value: string, comments: string[] | null = null): Lexeme {
-        if (type === TokenType.Command || type === TokenType.Operator || type === TokenType.Function) {
-            // Benchmark tests showed that directly calling toLowerCase() is ~5x faster
-            // than first checking if the string is already lowercase.
-            // See benchmarks/lowercase-benchmark.js for detailed performance analysis.
-            return {
-                type,
-                value: value.toLowerCase(),
-                comments: comments,
-            };
-        }
-        return {
+    protected createLexeme(type: TokenType, value: string, comments: string[] | null = null, startPosition?: number, endPosition?: number): Lexeme {
+        const lexeme: Lexeme = {
             type,
-            value,
+            value: (type === TokenType.Command || type === TokenType.Operator || type === TokenType.Function) 
+                ? value.toLowerCase() 
+                : value,
             comments: comments,
         };
+
+        // Add position information if provided
+        if (startPosition !== undefined && endPosition !== undefined) {
+            lexeme.position = {
+                startPosition,
+                endPosition,
+            };
+        }
+
+        return lexeme;
+    }
+
+    /**
+     * Create a lexeme with automatic position tracking
+     */
+    protected createLexemeWithPosition(type: TokenType, value: string, startPos: number, comments: string[] | null = null): Lexeme {
+        return this.createLexeme(type, value, comments, startPos, startPos + value.length);
     }
 
     /**

--- a/packages/core/src/utils/LexemeCursor.ts
+++ b/packages/core/src/utils/LexemeCursor.ts
@@ -1,0 +1,219 @@
+import { Lexeme, TokenType } from '../models/Lexeme';
+
+/**
+ * Utility class for cursor-to-lexeme mapping in SQL text
+ * Provides functionality to find lexemes at specific cursor positions for IDE integration
+ */
+export class LexemeCursor {
+    private static readonly SQL_COMMANDS = new Set([
+        'select', 'from', 'where', 'and', 'or', 'order', 'by', 'group', 'having',
+        'limit', 'offset', 'as', 'on', 'inner', 'left', 'right', 'join', 'union',
+        'insert', 'update', 'delete', 'into', 'values', 'set'
+    ]);
+    /**
+     * Find the lexeme at the specified cursor position
+     * @param sql The SQL string
+     * @param cursorPosition The cursor position (0-based)
+     * @returns The lexeme at the position, or null if not found
+     */
+    public static findLexemeAtPosition(sql: string, cursorPosition: number): Lexeme | null {
+        if (cursorPosition < 0 || cursorPosition >= sql.length) {
+            return null;
+        }
+
+        const lexemes = this.getAllLexemesWithPosition(sql);
+        
+        for (const lexeme of lexemes) {
+            if (lexeme.position && 
+                cursorPosition >= lexeme.position.startPosition && 
+                cursorPosition < lexeme.position.endPosition) {
+                return lexeme;
+            }
+        }
+        
+        return null;
+    }
+
+    /**
+     * Get all lexemes with position information
+     * @param sql The SQL string
+     * @returns Array of lexemes with position information
+     */
+    public static getAllLexemesWithPosition(sql: string): Lexeme[] {
+        if (!sql?.trim()) {
+            return [];
+        }
+
+        try {
+            const lexemes: Lexeme[] = [];
+            let position = 0;
+            
+            while (position < sql.length) {
+                position = this.skipWhitespace(sql, position);
+                
+                if (position >= sql.length) {
+                    break;
+                }
+                
+                const lexeme = this.parseNextToken(sql, position);
+                if (lexeme) {
+                    lexemes.push(lexeme);
+                    position = lexeme.position!.endPosition;
+                } else {
+                    position++; // Skip unknown character
+                }
+            }
+            
+            return lexemes;
+        } catch (error) {
+            return [];
+        }
+    }
+
+    /**
+     * Skip whitespace characters
+     */
+    private static skipWhitespace(sql: string, position: number): number {
+        while (position < sql.length && /\s/.test(sql[position])) {
+            position++;
+        }
+        return position;
+    }
+
+    /**
+     * Parse the next token starting at the given position
+     */
+    private static parseNextToken(sql: string, startPos: number): Lexeme | null {
+        const char = sql[startPos];
+        
+        // String literals
+        if (char === "'" || char === '"') {
+            return this.parseStringLiteral(sql, startPos);
+        }
+        
+        // Operators and special characters
+        if (/[=<>!+\-*/%().*]/.test(char)) {
+            return this.parseOperator(sql, startPos);
+        }
+        
+        // Comma
+        if (char === ',') {
+            return this.createLexeme(TokenType.Comma, ',', startPos, startPos + 1);
+        }
+        
+        // Word tokens (identifiers, commands, functions)
+        if (/[a-zA-Z0-9_]/.test(char)) {
+            return this.parseWordToken(sql, startPos);
+        }
+        
+        return null;
+    }
+
+    /**
+     * Parse string literal tokens
+     */
+    private static parseStringLiteral(sql: string, startPos: number): Lexeme {
+        const quote = sql[startPos];
+        let position = startPos + 1;
+        let token = quote;
+        
+        while (position < sql.length && sql[position] !== quote) {
+            token += sql[position++];
+        }
+        
+        if (position < sql.length) {
+            token += sql[position++]; // closing quote
+        }
+        
+        return this.createLexeme(TokenType.Literal, token, startPos, position);
+    }
+
+    /**
+     * Parse operator tokens
+     */
+    private static parseOperator(sql: string, startPos: number): Lexeme {
+        let token = sql[startPos];
+        let position = startPos + 1;
+        
+        // Handle compound operators (<=, >=, !=, etc.)
+        if (position < sql.length && /[=<>!]/.test(sql[position]) && /[=<>!]/.test(token)) {
+            token += sql[position++];
+        }
+        
+        const tokenType = this.getOperatorTokenType(token);
+        return this.createLexeme(tokenType, token, startPos, position);
+    }
+
+    /**
+     * Parse word tokens (identifiers, commands, functions)
+     */
+    private static parseWordToken(sql: string, startPos: number): Lexeme {
+        let position = startPos;
+        let token = '';
+        
+        while (position < sql.length && /[a-zA-Z0-9_]/.test(sql[position])) {
+            token += sql[position++];
+        }
+        
+        const tokenType = this.getWordTokenType(token, sql, position);
+        const value = this.shouldLowercase(tokenType) ? token.toLowerCase() : token;
+        
+        return this.createLexeme(tokenType, value, startPos, position);
+    }
+
+    /**
+     * Determine the token type for operators
+     */
+    private static getOperatorTokenType(token: string): number {
+        switch (token) {
+            case '(': return TokenType.OpenParen;
+            case ')': return TokenType.CloseParen;
+            case '*': return TokenType.Identifier; // Treat * as identifier for SELECT *
+            default: return TokenType.Operator;
+        }
+    }
+
+    /**
+     * Determine the token type for word tokens
+     */
+    private static getWordTokenType(token: string, sql: string, position: number): number {
+        const lowerToken = token.toLowerCase();
+        
+        // Check if it's a command
+        if (this.SQL_COMMANDS.has(lowerToken)) {
+            return TokenType.Command;
+        }
+        
+        // Check if it's followed by parentheses (function)
+        const nextNonWhitespacePos = this.skipWhitespace(sql, position);
+        if (nextNonWhitespacePos < sql.length && sql[nextNonWhitespacePos] === '(') {
+            return TokenType.Function;
+        }
+        
+        return TokenType.Identifier;
+    }
+
+    /**
+     * Check if token value should be lowercased
+     */
+    private static shouldLowercase(tokenType: number): boolean {
+        return !!(tokenType & TokenType.Command) || 
+               !!(tokenType & TokenType.Operator) || 
+               !!(tokenType & TokenType.Function);
+    }
+
+    /**
+     * Create a lexeme with position information
+     */
+    private static createLexeme(type: number, value: string, startPos: number, endPos: number): Lexeme {
+        return {
+            type,
+            value,
+            comments: null,
+            position: {
+                startPosition: startPos,
+                endPosition: endPos
+            }
+        };
+    }
+}

--- a/packages/core/tests/utils/LexemeCursor.test.ts
+++ b/packages/core/tests/utils/LexemeCursor.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import { LexemeCursor } from '../../src/utils/LexemeCursor';
+import { TokenType } from '../../src/models/Lexeme';
+
+describe('LexemeCursor', () => {
+    describe('findLexemeAtPosition', () => {
+        it('should find lexeme at cursor position in simple SQL', () => {
+            // Arrange
+            const sql = 'SELECT id FROM users';
+            const cursorPosition = 7; // Position at 'id'
+            
+            // Act
+            const lexeme = LexemeCursor.findLexemeAtPosition(sql, cursorPosition);
+            
+            // Assert
+            expect(lexeme).toBeDefined();
+            expect(lexeme!.value).toBe('id');
+            expect(lexeme!.type).toBe(TokenType.Identifier);
+            expect(lexeme!.position).toBeDefined();
+            expect(lexeme!.position!.startPosition).toBe(7);
+            expect(lexeme!.position!.endPosition).toBe(9);
+        });
+
+        it('should find lexeme at start position', () => {
+            // Arrange
+            const sql = 'SELECT id FROM users';
+            const cursorPosition = 0; // Position at 'S' in SELECT
+            
+            // Act
+            const lexeme = LexemeCursor.findLexemeAtPosition(sql, cursorPosition);
+            
+            // Assert
+            expect(lexeme).toBeDefined();
+            expect(lexeme!.value).toBe('select');
+            expect(lexeme!.type).toBe(TokenType.Command);
+            expect(lexeme!.position!.startPosition).toBe(0);
+            expect(lexeme!.position!.endPosition).toBe(6);
+        });
+
+        it('should find lexeme at end position', () => {
+            // Arrange
+            const sql = 'SELECT id FROM users';
+            const cursorPosition = 18; // Position at 's' in users
+            
+            // Act
+            const lexeme = LexemeCursor.findLexemeAtPosition(sql, cursorPosition);
+            
+            // Assert
+            expect(lexeme).toBeDefined();
+            expect(lexeme!.value).toBe('users');
+            expect(lexeme!.type).toBe(TokenType.Identifier);
+            expect(lexeme!.position!.startPosition).toBe(15);
+            expect(lexeme!.position!.endPosition).toBe(20);
+        });
+
+        it('should return null for position in whitespace', () => {
+            // Arrange
+            const sql = 'SELECT id FROM users';
+            const cursorPosition = 6; // Position in space after SELECT
+            
+            // Act
+            const lexeme = LexemeCursor.findLexemeAtPosition(sql, cursorPosition);
+            
+            // Assert
+            expect(lexeme).toBeNull();
+        });
+
+        it('should return null for position out of bounds', () => {
+            // Arrange
+            const sql = 'SELECT id';
+            const cursorPosition = 100; // Position beyond string length
+            
+            // Act
+            const lexeme = LexemeCursor.findLexemeAtPosition(sql, cursorPosition);
+            
+            // Assert
+            expect(lexeme).toBeNull();
+        });
+
+        it('should find operator lexeme', () => {
+            // Arrange
+            const sql = 'SELECT * FROM users WHERE id = 1';
+            const cursorPosition = 29; // Position at '='
+            
+            // Act
+            const lexeme = LexemeCursor.findLexemeAtPosition(sql, cursorPosition);
+            
+            // Assert
+            expect(lexeme).toBeDefined();
+            expect(lexeme!.value).toBe('=');
+            expect(lexeme!.type).toBe(TokenType.Operator);
+            expect(lexeme!.position!.startPosition).toBe(29);
+            expect(lexeme!.position!.endPosition).toBe(30);
+        });
+
+        it('should find function lexeme', () => {
+            // Arrange
+            const sql = 'SELECT COUNT(*) FROM users';
+            const cursorPosition = 8; // Position at 'O' in COUNT
+            
+            // Act
+            const lexeme = LexemeCursor.findLexemeAtPosition(sql, cursorPosition);
+            
+            // Assert
+            expect(lexeme).toBeDefined();
+            expect(lexeme!.value).toBe('count');
+            expect(lexeme!.type).toBe(TokenType.Function);
+            expect(lexeme!.position!.startPosition).toBe(7);
+            expect(lexeme!.position!.endPosition).toBe(12);
+        });
+
+        it('should find literal lexeme', () => {
+            // Arrange
+            const sql = "SELECT * FROM users WHERE name = 'John'";
+            const cursorPosition = 36; // Position at 'h' in 'John'
+            
+            // Act
+            const lexeme = LexemeCursor.findLexemeAtPosition(sql, cursorPosition);
+            
+            // Assert
+            expect(lexeme).toBeDefined();
+            expect(lexeme!.value).toBe("'John'");
+            expect(lexeme!.type).toBe(TokenType.Literal);
+            expect(lexeme!.position!.startPosition).toBe(33);
+            expect(lexeme!.position!.endPosition).toBe(39);
+        });
+    });
+
+    describe('getAllLexemesWithPosition', () => {
+        it('should return all lexemes with position information', () => {
+            // Arrange
+            const sql = 'SELECT id FROM users';
+            
+            // Act
+            const lexemes = LexemeCursor.getAllLexemesWithPosition(sql);
+            
+            // Assert
+            expect(lexemes).toHaveLength(4);
+            
+            expect(lexemes[0].value).toBe('select');
+            expect(lexemes[0].position!.startPosition).toBe(0);
+            expect(lexemes[0].position!.endPosition).toBe(6);
+            
+            expect(lexemes[1].value).toBe('id');
+            expect(lexemes[1].position!.startPosition).toBe(7);
+            expect(lexemes[1].position!.endPosition).toBe(9);
+            
+            expect(lexemes[2].value).toBe('from');
+            expect(lexemes[2].position!.startPosition).toBe(10);
+            expect(lexemes[2].position!.endPosition).toBe(14);
+            
+            expect(lexemes[3].value).toBe('users');
+            expect(lexemes[3].position!.startPosition).toBe(15);
+            expect(lexemes[3].position!.endPosition).toBe(20);
+        });
+
+        it('should handle empty SQL', () => {
+            // Arrange
+            const sql = '';
+            
+            // Act
+            const lexemes = LexemeCursor.getAllLexemesWithPosition(sql);
+            
+            // Assert
+            expect(lexemes).toHaveLength(0);
+        });
+    });
+});


### PR DESCRIPTION
- Add LexemePosition interface with startPosition/endPosition
- Extend Lexeme interface with optional position field
- Implement LexemeCursor utility class for cursor-to-lexeme mapping
- Add comprehensive test coverage with 10 test cases
- Enhance BaseTokenReader with position tracking capabilities
- Export new functionality through index.ts

This enables IDE integration features like hover information and
go-to-definition by mapping editor cursor positions to SQL lexemes.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>