### PR TITLE
feat: export WithClauseParser with comprehensive JSDoc documentation

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rawsql-ts",
-    "version": "0.11.20-beta",
+    "version": "0.11.21-beta",
     "description": "[beta]High-performance SQL parser and AST analyzer written in TypeScript. Provides fast parsing and advanced transformation capabilities.",
     "main": "dist/src/index.js",
     "module": "dist/esm/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 // Entry point for rawsql-ts package
 export * from './parsers/SelectQueryParser';
 export * from './parsers/InsertQueryParser';
+export * from './parsers/WithClauseParser';
 
 export * from './models/BinarySelectQuery';
 export * from './models/SelectQuery';

--- a/packages/core/src/parsers/WithClauseParser.ts
+++ b/packages/core/src/parsers/WithClauseParser.ts
@@ -3,8 +3,41 @@ import { Lexeme, TokenType } from "../models/Lexeme";
 import { SqlTokenizer } from "./SqlTokenizer";
 import { CommonTableParser } from "./CommonTableParser";
 
+/**
+ * Parser for SQL WITH clauses (Common Table Expressions - CTEs).
+ * Parses only the WITH clause portion of SQL, not the entire query.
+ * 
+ * **Note**: For most use cases, use `SelectQueryParser` which provides more comprehensive SQL parsing.
+ * This parser should only be used for the special case where you need to analyze only the WITH clause portion.
+ * 
+ * @example
+ * ```typescript
+ * // Parses only the WITH clause, not the following SELECT
+ * const sql = "WITH recursive_cte AS (SELECT 1 as n UNION SELECT n+1 FROM recursive_cte WHERE n < 10)";
+ * const withClause = WithClauseParser.parse(sql);
+ * console.log(withClause.recursive); // true
+ * console.log(withClause.tables.length); // 1
+ * ```
+ */
 export class WithClauseParser {
-    // Parse SQL string to AST (was: parse)
+    /**
+     * Parses a SQL string containing only a WITH clause into a WithClause AST.
+     * The input should contain only the WITH clause, not the subsequent main query.
+     * 
+     * @param query - The SQL string containing only the WITH clause
+     * @returns The parsed WithClause object
+     * @throws Error if the syntax is invalid or there are unexpected tokens after the WITH clause
+     * 
+     * @example
+     * ```typescript
+     * // Correct: Only the WITH clause
+     * const sql = "WITH users_data AS (SELECT id, name FROM users)";
+     * const withClause = WithClauseParser.parse(sql);
+     * 
+     * // Error: Contains SELECT after WITH clause
+     * // const badSql = "WITH users_data AS (SELECT id, name FROM users) SELECT * FROM users_data";
+     * ```
+     */
     public static parse(query: string): WithClause {
         const tokenizer = new SqlTokenizer(query); // Initialize tokenizer
         const lexemes = tokenizer.readLexmes(); // Get tokens
@@ -20,7 +53,23 @@ export class WithClauseParser {
         return result.value;
     }
 
-    // Parse from lexeme array (was: parse)
+    /**
+     * Parses a WITH clause from an array of lexemes starting at the specified index.
+     * 
+     * @param lexemes - Array of lexemes to parse from
+     * @param index - Starting index in the lexemes array
+     * @returns Object containing the parsed WithClause and the new index position
+     * @throws Error if the syntax is invalid or WITH keyword is not found
+     * 
+     * @example
+     * ```typescript
+     * const tokenizer = new SqlTokenizer("WITH cte AS (SELECT 1)");
+     * const lexemes = tokenizer.readLexmes();
+     * const result = WithClauseParser.parseFromLexeme(lexemes, 0);
+     * console.log(result.value.tables.length); // 1
+     * console.log(result.newIndex); // position after the WITH clause
+     * ```
+     */
     public static parseFromLexeme(lexemes: Lexeme[], index: number): { value: WithClause; newIndex: number } {
         let idx = index;
 


### PR DESCRIPTION
- Add WithClauseParser to public API exports in index.ts
- Add detailed JSDoc documentation for class and methods
- Clarify that parser handles only WITH clause portion, not full queries
- Add usage notes recommending SelectQueryParser for general use cases
- Include proper examples and parameter documentation

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>