### PR TITLE
feat: add SchemaCollector.analyze method for non-throwing schema analysis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3057,7 +3057,7 @@
         },
         "packages/core": {
             "name": "rawsql-ts",
-            "version": "0.11.21-beta",
+            "version": "0.11.22-beta",
             "license": "MIT",
             "devDependencies": {
                 "@types/benchmark": "^2.1.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rawsql-ts",
-    "version": "0.11.22-beta",
+    "version": "0.11.23-beta",
     "description": "[beta]High-performance SQL parser and AST analyzer written in TypeScript. Provides fast parsing and advanced transformation capabilities.",
     "main": "dist/src/index.js",
     "module": "dist/esm/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 // Entry point for rawsql-ts package
 export * from './parsers/SelectQueryParser';
+export { ParseAnalysisResult } from './parsers/SelectQueryParser';
 export * from './parsers/InsertQueryParser';
 export * from './parsers/WithClauseParser';
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -52,6 +52,7 @@ export * from './transformers/UpstreamSelectQueryFinder';
 export * from './transformers/TypeTransformationPostProcessor';
 
 export * from './transformers/SchemaCollector';
+export { TableSchema, SchemaAnalysisResult } from './transformers/SchemaCollector';
 export * from './transformers/QueryFlowDiagramGenerator';
 export * from './transformers/SqlParamInjector';
 export * from './transformers/SqlSortInjector';

--- a/packages/core/tests/parsers/SelectQueryParser.analyze.test.ts
+++ b/packages/core/tests/parsers/SelectQueryParser.analyze.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from 'vitest';
+import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
+
+describe('SelectQueryParser.analyze', () => {
+    test('should successfully analyze valid SELECT query', () => {
+        // Arrange
+        const sql = `SELECT id, name FROM users WHERE active = true`;
+
+        // Act
+        const result = SelectQueryParser.analyze(sql);
+
+        // Assert
+        expect(result.success).toBe(true);
+        expect(result.query).toBeDefined();
+        expect(result.error).toBeUndefined();
+        expect(result.errorPosition).toBeUndefined();
+        expect(result.remainingTokens).toBeUndefined();
+    });
+
+    test('should successfully analyze complex query with JOIN', () => {
+        // Arrange
+        const sql = `
+            SELECT u.id, u.name, o.order_id 
+            FROM users u 
+            JOIN orders o ON u.id = o.user_id 
+            WHERE u.active = true
+        `;
+
+        // Act
+        const result = SelectQueryParser.analyze(sql);
+
+        // Assert
+        expect(result.success).toBe(true);
+        expect(result.query).toBeDefined();
+        expect(result.error).toBeUndefined();
+    });
+
+    test('should successfully parse query with alias (not missing FROM)', () => {
+        // Arrange
+        const sql = `SELECT id, name users`; // This is valid SQL: SELECT id, name AS users
+
+        // Act
+        const result = SelectQueryParser.analyze(sql);
+
+        // Assert
+        expect(result.success).toBe(true);
+        expect(result.query).toBeDefined();
+        expect(result.error).toBeUndefined();
+    });
+
+    test('should successfully parse query with table alias', () => {
+        // Arrange
+        const sql = `SELECT id FROM users EXTRA_TOKEN`; // EXTRA_TOKEN is parsed as table alias
+
+        // Act
+        const result = SelectQueryParser.analyze(sql);
+
+        // Assert
+        expect(result.success).toBe(true);
+        expect(result.query).toBeDefined();
+        expect(result.error).toBeUndefined();
+    });
+
+    test('should detect error when missing SELECT keyword', () => {
+        // Arrange
+        const sql = `UPDATE users SET name = 'test'`; // Wrong query type
+
+        // Act
+        const result = SelectQueryParser.analyze(sql);
+
+        // Assert
+        expect(result.success).toBe(false);
+        expect(result.error).toBeDefined();
+        expect(result.error).toContain("Expected 'SELECT' or 'VALUES'");
+        expect(result.errorPosition).toBe(0); // Character position of 'update'
+    });
+
+    test('should handle empty query', () => {
+        // Arrange
+        const sql = ``;
+
+        // Act
+        const result = SelectQueryParser.analyze(sql);
+
+        // Assert
+        expect(result.success).toBe(false);
+        expect(result.error).toBeDefined();
+        expect(result.error).toContain('Unexpected end of input');
+    });
+
+    test('should analyze VALUES query successfully', () => {
+        // Arrange
+        const sql = `VALUES (1, 'John'), (2, 'Jane')`;
+
+        // Act
+        const result = SelectQueryParser.analyze(sql);
+
+        // Assert
+        expect(result.success).toBe(true);
+        expect(result.query).toBeDefined();
+        expect(result.error).toBeUndefined();
+    });
+
+    test('should analyze UNION query successfully', () => {
+        // Arrange
+        const sql = `
+            SELECT id, name FROM users 
+            UNION 
+            SELECT id, title FROM posts
+        `;
+
+        // Act
+        const result = SelectQueryParser.analyze(sql);
+
+        // Assert
+        expect(result.success).toBe(true);
+        expect(result.query).toBeDefined();
+        expect(result.error).toBeUndefined();
+    });
+
+    test('should detect error in UNION query with incomplete second part', () => {
+        // Arrange
+        const sql = `SELECT id FROM users UNION`; // Incomplete UNION
+
+        // Act
+        const result = SelectQueryParser.analyze(sql);
+
+        // Assert
+        expect(result.success).toBe(false);
+        expect(result.error).toBeDefined();
+        expect(result.error).toContain("Expected a query after 'UNION'");
+    });
+
+    test('should analyze WITH clause query successfully', () => {
+        // Arrange
+        const sql = `
+            WITH user_data AS (SELECT * FROM users)
+            SELECT id, name FROM user_data
+        `;
+
+        // Act
+        const result = SelectQueryParser.analyze(sql);
+
+        // Assert
+        expect(result.success).toBe(true);
+        expect(result.query).toBeDefined();
+        expect(result.error).toBeUndefined();
+    });
+
+    test('should detect invalid FROM clause syntax', () => {
+        // Arrange
+        const sql = `SELECT id FROM FROM users`; // Invalid double FROM
+
+        // Act
+        const result = SelectQueryParser.analyze(sql);
+
+        // Assert
+        expect(result.success).toBe(false);
+        expect(result.error).toBeDefined();
+        expect(result.error).toContain('Identifier list is empty');
+    });
+
+    test('should detect incomplete FROM clause', () => {
+        // Arrange
+        const sql = `SELECT id FROM`; // Incomplete FROM clause
+
+        // Act
+        const result = SelectQueryParser.analyze(sql);
+
+        // Assert
+        expect(result.success).toBe(false);
+        expect(result.error).toBeDefined();
+        expect(result.error).toContain('Unexpected end of input after \'FROM\' keyword');
+    });
+
+    test('should detect remaining tokens after complete query', () => {
+        // Arrange
+        const sql = `SELECT * FROM users LIMIT 10 INVALID_KEYWORD`; 
+
+        // Act  
+        const result = SelectQueryParser.analyze(sql);
+
+        // Assert
+        expect(result.success).toBe(false);
+        expect(result.query).toBeDefined(); // Partial parsing successful
+        expect(result.error).toContain('Unexpected token "INVALID_KEYWORD"');
+        expect(result.errorPosition).toBe(29); // Character position of 'INVALID_KEYWORD'
+        expect(result.remainingTokens).toEqual(['INVALID_KEYWORD']);
+    });
+});

--- a/packages/core/tests/transformers/SchemaCollector.analyze.test.ts
+++ b/packages/core/tests/transformers/SchemaCollector.analyze.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from 'vitest';
+import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
+import { SchemaCollector } from '../../src/transformers/SchemaCollector';
+
+describe('SchemaCollector.analyze', () => {
+    test('should successfully analyze simple SELECT query', () => {
+        // Arrange
+        const sql = `SELECT u.id, u.name FROM users as u`;
+        const query = SelectQueryParser.parse(sql);
+        const collector = new SchemaCollector();
+
+        // Act
+        const result = collector.analyze(query);
+
+        // Assert
+        expect(result.success).toBe(true);
+        expect(result.schemas.length).toBe(1);
+        expect(result.schemas[0].name).toBe('users');
+        expect(result.schemas[0].columns).toEqual(['id', 'name']);
+        expect(result.unresolvedColumns).toEqual([]);
+        expect(result.error).toBeUndefined();
+    });
+
+    test('should detect unresolved columns in JOIN queries', () => {
+        // Arrange
+        const sql = `SELECT id, name FROM users u JOIN orders o ON u.id = o.user_id`;
+        const query = SelectQueryParser.parse(sql);
+        const collector = new SchemaCollector();
+
+        // Act
+        const result = collector.analyze(query);
+
+        // Assert
+        expect(result.success).toBe(false);
+        expect(result.unresolvedColumns).toEqual(['id', 'name']);
+        expect(result.error).toBe('Column reference(s) without table name found in query: id, name');
+        expect(result.schemas.length).toBe(2); // Still collects table info
+    });
+
+    test('should handle wildcard without resolver', () => {
+        // Arrange
+        const sql = `SELECT * FROM users`;
+        const query = SelectQueryParser.parse(sql);
+        const collector = new SchemaCollector(); // No resolver, default option
+
+        // Act
+        const result = collector.analyze(query);
+
+        // Assert
+        expect(result.success).toBe(false);
+        expect(result.unresolvedColumns).toEqual(['*']);
+        expect(result.error).toBe('Wildcard (*) is used. A TableColumnResolver is required to resolve wildcards. Target table: users');
+        expect(result.schemas.length).toBe(1); // Still collects table info
+    });
+
+    test('should handle qualified wildcard without resolver', () => {
+        // Arrange
+        const sql = `SELECT u.* FROM users as u`;
+        const query = SelectQueryParser.parse(sql);
+        const collector = new SchemaCollector(null, false); // Explicitly false
+
+        // Act
+        const result = collector.analyze(query);
+
+        // Assert
+        expect(result.success).toBe(false);
+        expect(result.unresolvedColumns).toEqual(['u.*']);
+        expect(result.error).toBe('Wildcard (*) is used. A TableColumnResolver is required to resolve wildcards. Target table: users');
+    });
+
+    test('should handle multiple unresolved columns from different tables', () => {
+        // Arrange
+        const sql = `SELECT id, name, order_id FROM users u JOIN orders o ON u.id = o.user_id`;
+        const query = SelectQueryParser.parse(sql);
+        const collector = new SchemaCollector();
+
+        // Act
+        const result = collector.analyze(query);
+
+        // Assert
+        expect(result.success).toBe(false);
+        expect(result.unresolvedColumns).toEqual(['id', 'name', 'order_id']);
+        expect(result.error).toBe('Column reference(s) without table name found in query: id, name, order_id');
+    });
+
+    test('should successfully analyze query with proper table prefixes', () => {
+        // Arrange
+        const sql = `SELECT u.id, u.name, o.order_id FROM users u JOIN orders o ON u.id = o.user_id`;
+        const query = SelectQueryParser.parse(sql);
+        const collector = new SchemaCollector();
+
+        // Act
+        const result = collector.analyze(query);
+
+        // Assert
+        expect(result.success).toBe(true);
+        expect(result.schemas.length).toBe(2);
+        expect(result.unresolvedColumns).toEqual([]);
+        expect(result.error).toBeUndefined();
+    });
+
+    test('should handle wildcards with allowWildcardWithoutResolver option', () => {
+        // Arrange
+        const sql = `SELECT * FROM users`;
+        const query = SelectQueryParser.parse(sql);
+        const collector = new SchemaCollector(null, true); // allowWildcardWithoutResolver = true
+
+        // Act
+        const result = collector.analyze(query);
+
+        // Assert
+        expect(result.success).toBe(true); // Should succeed with the option enabled
+        expect(result.schemas.length).toBe(1);
+        expect(result.schemas[0].name).toBe('users');
+        expect(result.schemas[0].columns).toEqual([]); // Wildcards are excluded when no resolver
+        expect(result.unresolvedColumns).toEqual([]);
+        expect(result.error).toBeUndefined();
+    });
+
+    test('should handle UNION queries', () => {
+        // Arrange
+        const sql = `
+            SELECT u.id, u.name FROM users as u
+            UNION
+            SELECT c.id, c.email FROM customers c
+        `;
+        const query = SelectQueryParser.parse(sql);
+        const collector = new SchemaCollector();
+
+        // Act
+        const result = collector.analyze(query);
+
+        // Assert
+        expect(result.success).toBe(true);
+        expect(result.schemas.length).toBe(2);
+        expect(result.unresolvedColumns).toEqual([]);
+        expect(result.error).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Added analyze() method to SchemaCollector that returns structured results
instead of throwing errors. This allows graceful handling of unresolved
columns and validation errors while maintaining backward compatibility.

- Added SchemaAnalysisResult interface with success status, schemas, and unresolved columns
- Implemented analyze() method that collects errors instead of throwing
- Added comprehensive test coverage for the new functionality
- Exported new types in index.ts

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>