### PR TITLE
fix: correct column validation behavior to ignore non-existent columns

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rawsql-ts",
-    "version": "0.11.24-beta",
+    "version": "0.11.25-beta",
     "description": "[beta]High-performance SQL parser and AST analyzer written in TypeScript. Provides fast parsing and advanced transformation capabilities.",
     "main": "dist/src/index.js",
     "module": "dist/esm/index.js",

--- a/packages/core/src/transformers/SqlParamInjector.ts
+++ b/packages/core/src/transformers/SqlParamInjector.ts
@@ -13,8 +13,8 @@ export interface SqlParamInjectorOptions {
     ignoreCaseAndUnderscore?: boolean;
     /** Whether to allow injection when all parameters are undefined (defaults to false for safety) */
     allowAllUndefined?: boolean;
-    /** Whether to skip column validation entirely (defaults to false for safety) */
-    skipColumnValidation?: boolean;
+    /** Whether to ignore non-existent columns instead of throwing errors (defaults to false for safety) */
+    ignoreNonExistentColumns?: boolean;
 }
 
 // Type for state parameter values - can be simple values, conditions, or complex objects
@@ -512,27 +512,12 @@ export class SqlParamInjector {
         injectComplexConditions: Function,
         validateOperators: Function
     ): void {
-        // Skip column validation if option is enabled
-        if (this.options.skipColumnValidation) {
-            // if object, validate its keys
-            if (this.isValidatableObject(stateValue)) {
-                validateOperators(stateValue, allowedOps, name);
-            }
-            
-            // Create a column reference using the name directly
-            const columnRef = new ColumnReference(null, name);
-            
-            // Handle complex conditions if needed
-            if (this.isValidatableObject(stateValue)) {
-                injectComplexConditions(query, columnRef, name, stateValue);
-            } else {
-                injectSimpleCondition(query, columnRef, name, stateValue);
-            }
-            return;
-        }
-        
         const queries = finder.find(query, name);
         if (queries.length === 0) {
+            // Ignore non-existent columns if option is enabled
+            if (this.options.ignoreNonExistentColumns) {
+                return;
+            }
             throw new Error(`Column '${name}' not found in query`);
         }
 

--- a/packages/core/tests/transformers/SqlParamInjector.test.ts
+++ b/packages/core/tests/transformers/SqlParamInjector.test.ts
@@ -104,23 +104,23 @@ describe('SqlParamInjector', () => {
         expect(params).toEqual({ article_id: 100 });
     });
 
-    test('should skip column validation when skipColumnValidation option is enabled', () => {
+    test('should ignore non-existent columns when ignoreNonExistentColumns option is enabled', () => {
         // Arrange: parse base query with limited columns
         const baseQuery = SelectQueryParser.parse('select a.article_id from article as a') as SimpleSelectQuery;
-        // Arrange: state with non-existent column - should not throw error with skipColumnValidation
-        const state = { nonExistentColumn: 'value' };
+        // Arrange: state with both existing and non-existent columns
+        const state = { nonExistentColumn: 'value', article_id: 100 };
 
-        // Act: inject parameters with skipColumnValidation option
-        const injector = new SqlParamInjector({ skipColumnValidation: true });
+        // Act: inject parameters with ignoreNonExistentColumns option
+        const injector = new SqlParamInjector({ ignoreNonExistentColumns: true });
         const injectedQuery = injector.inject(baseQuery, state);
 
         // Act: format SQL and extract parameters
         const formatter = new SqlFormatter();
         const { formattedSql, params } = formatter.format(injectedQuery);
 
-        // Assert: WHERE clause should be added even for non-existent column
-        expect(formattedSql).toBe('select "a"."article_id" from "article" as "a" where "nonExistentColumn" = :nonExistentColumn');
-        expect(params).toEqual({ nonExistentColumn: 'value' });
+        // Assert: only existing columns should be in WHERE clause, non-existent columns ignored
+        expect(formattedSql).toBe('select "a"."article_id" from "article" as "a" where "a"."article_id" = :article_id');
+        expect(params).toEqual({ article_id: 100 });
     });
 
     test('injects state using custom tableColumnResolver', () => {


### PR DESCRIPTION
- Rename skipColumnValidation to ignoreNonExistentColumns for clarity
- Fix implementation to ignore (skip) non-existent columns instead of adding them to WHERE clause
- Update test cases to reflect correct behavior expectations
- Maintain undefined value handling for dynamic filtering scenarios

This provides the correct behavior where non-existent columns are silently
ignored rather than causing errors, improving usability for dynamic forms.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>