### PR TITLE
fix: resolve ESM module resolution issue in 0.11.31-beta release

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rawsql-ts",
-    "version": "0.11.31-beta",
+    "version": "0.11.32-beta",
     "description": "[beta]High-performance SQL parser and AST analyzer written in TypeScript. Provides fast parsing and advanced transformation capabilities.",
     "main": "dist/src/index.js",
     "module": "dist/esm/index.js",
@@ -13,7 +13,7 @@
         "coverage": "vitest run --coverage",
         "build": "tsc --build",
         "build:browser": "tsc --project tsconfig.browser.json && npm run build:copy",
-        "build:copy": "node -e \"const fs = require('fs'); fs.copyFileSync('dist/esm/src/index.js', 'dist/esm/index.js'); fs.copyFileSync('dist/esm/src/index.js.map', 'dist/esm/index.js.map');\"",
+        "build:copy": "node -e \"const fs = require('fs'); const content = fs.readFileSync('dist/esm/src/index.js', 'utf8').replace(/from '\\.\\/(?!src)/g, 'from \\'./src/'); fs.writeFileSync('dist/esm/index.js', content); fs.copyFileSync('dist/esm/src/index.js.map', 'dist/esm/index.js.map');\"",
         "build:minify": "esbuild src/index.ts --bundle --minify --outfile=dist/index.min.js --format=cjs --sourcemap && esbuild src/index.ts --bundle --minify --outfile=dist/esm/index.min.js --format=esm --sourcemap",
         "build:all": "npm run clean && npm run build && npm run build:browser && npm run build:minify",
         "release": "npm run build:all && npm pack --dry-run && npm publish",


### PR DESCRIPTION
## Summary

- Fix ESM module resolution issue that broke rawsql-ts 0.11.31-beta package
- Update build:copy command to properly adjust relative paths in ESM index.js  
- Bump version to 0.11.32-beta for corrected release

## Problem Description

The 0.11.31-beta release had broken ESM package resolution causing build failures:
```
✘ [ERROR] Could not resolve "./parsers/SelectQueryParser"
✘ [ERROR] Could not resolve "./parsers/InsertQueryParser"
[... 43 more similar errors]
```

## Root Cause

Commit 5fe7e8c changed `tsconfig.browser.json` declarationDir from `"dist/esm/types"` to `"dist/esm"`, but the `build:copy` command wasn't updated to handle the new file structure. The ESM index.js was copied with incorrect relative paths.

## Solution

- Modified `build:copy` command to transform relative paths from `./parsers/...` to `./src/parsers/...`
- Now properly resolves all ESM module imports
- All tests, build, and lint checks pass

## Test Plan

- [x] Run `npm test` - all tests pass
- [x] Run `npm run build` - successful build
- [x] Run `npm run lint` - no lint errors  
- [x] Verify `dist/esm/index.js` has correct paths with `./src/` prefix
- [x] Manual verification of ESM export path resolution

🤖 Generated with [Claude Code](https://claude.ai/code)