### PR TITLE
Add SqlParser entry point with multi-statement support

### DIFF
--- a/docs/guide/overview.md
+++ b/docs/guide/overview.md
@@ -7,23 +7,39 @@ outline: deep
 `rawsql-ts` is a **TypeScript-native, zero-dependency SQL parser and transformer** designed for high performance and real-world workflows.
 Instead of relying on complex DSL builders, `rawsql-ts` starts from your existing SQL, parses it into an AST, and lets you programmatically analyze, transform, and regenerate optimized queries.
 
-It’s lightweight, fast, and built to keep your SQL expressive and reusable — not buried in code.
+It is lightweight, fast, and built to keep your SQL expressive and reusable, not buried in code.
 
 ---
 
 ## Key Features
 
-- **Start from SQL, not DSL** — Parse existing SQL into an AST and manipulate it with functions, not chained builders.
-- **High performance** — Up to 3–8× faster than popular SQL parsers, even with complex PostgreSQL queries.
-- **Dynamic query manipulation** — Easily inject filters, sorting, and pagination, or transform structures for advanced workflows.
-- **Zero dependencies** — Works in Node.js and browsers via CDN, no external packages required.
-- **TypeScript-first** — Full type coverage and API reference generated automatically from the source.
+- **Start from SQL, not DSL** - Parse existing SQL into an AST and manipulate it with functions, not chained builders.
+- **High performance** - Up to 3-8x faster than popular SQL parsers, even with complex PostgreSQL queries.
+- **Dynamic query manipulation** - Easily inject filters, sorting, and pagination, or transform structures for advanced workflows.
+- **Zero dependencies** - Works in Node.js and browsers via CDN, no external packages required.
+- **TypeScript-first** - Full type coverage and API reference generated automatically from the source.
 
 ## Repository Structure
 
-- packages/core/src — Core TypeScript source, exported via index.ts.
-- docs/ — VitePress documentation site, including auto-generated API under docs/api.
-- .github/workflows — CI pipelines for docs generation and deployment.
+- packages/core/src - Core TypeScript source, exported via index.ts.
+- docs/ - VitePress documentation site, including auto-generated API under docs/api.
+- .github/workflows - CI pipelines for docs generation and deployment.
+
+## Parsing Entry Point
+
+`SqlParser` is the canonical gateway for turning raw SQL into AST objects. Today it delegates to `SelectQueryParser` for SELECT/VALUES statements and will fan out to INSERT/UPDATE/DDL parsers as they land.
+
+```typescript
+import { SqlParser } from 'rawsql-ts';
+
+const statement = SqlParser.parse('SELECT id, email FROM users');
+const statements = SqlParser.parseMany(`
+    SELECT id FROM users WHERE active = true;
+    SELECT id FROM accounts WHERE suspended = false;
+`);
+```
+
+`SelectQueryParser` stays available when you explicitly need SELECT-only semantics, but new capabilities will surface through `SqlParser`.
 
 ## Next Steps
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 // Entry point for rawsql-ts package
+export * from './parsers/SqlParser';
 export * from './parsers/SelectQueryParser';
 export { ParseAnalysisResult } from './parsers/SelectQueryParser';
 export * from './parsers/InsertQueryParser';

--- a/packages/core/src/parsers/SelectQueryParser.ts
+++ b/packages/core/src/parsers/SelectQueryParser.ts
@@ -24,6 +24,10 @@ export interface ParseAnalysisResult {
     remainingTokens?: string[];
 }
 
+/**
+ * Legacy SELECT-only parser.
+ * Prefer using SqlParser as the canonical entry point for multi-statement or mixed-statement workflows.
+ */
 export class SelectQueryParser {
     // Parse SQL string to AST (was: parse)
     public static parse(query: string): SelectQuery {

--- a/packages/core/src/parsers/SqlParser.ts
+++ b/packages/core/src/parsers/SqlParser.ts
@@ -1,0 +1,150 @@
+import type { SelectQuery } from '../models/SelectQuery';
+import { SqlTokenizer, StatementLexemeResult } from './SqlTokenizer';
+import { SelectQueryParser } from './SelectQueryParser';
+
+export type ParsedStatement = SelectQuery;
+
+export interface SqlParserOptions {
+    mode?: 'single' | 'multiple';
+    skipEmptyStatements?: boolean;
+}
+
+export interface SqlParserManyOptions {
+    skipEmptyStatements?: boolean;
+}
+
+/**
+ * Canonical entry point for SQL parsing.
+ * Today it delegates to SelectQueryParser, but it is designed to embrace INSERT/UPDATE/DDL parsers next.
+ */
+export class SqlParser {
+    public static parse(sql: string, options: SqlParserOptions = {}): ParsedStatement {
+        const skipEmpty = options.skipEmptyStatements ?? true;
+        const mode = options.mode ?? 'single';
+        const tokenizer = new SqlTokenizer(sql);
+
+        // Acquire the first meaningful statement so future dispatching can inspect its leading keyword.
+        const first = this.consumeNextStatement(tokenizer, 0, skipEmpty);
+        if (!first) {
+            throw new Error('[SqlParser] No SQL statements found in input.');
+        }
+
+        const parsed = this.dispatchParse(first.segment, 1);
+
+        if (mode === 'single') {
+            // Ensure callers opting into single-statement mode are protected against trailing statements.
+            const remainder = this.consumeNextStatement(tokenizer, first.nextCursor, skipEmpty);
+            if (remainder) {
+                throw new Error('[SqlParser] Unexpected additional statement detected at index 2. Use parseMany or set mode to "multiple" to allow multiple statements.');
+            }
+        }
+
+        return parsed;
+    }
+
+    public static parseMany(sql: string, options: SqlParserManyOptions = {}): ParsedStatement[] {
+        const skipEmpty = options.skipEmptyStatements ?? true;
+        const tokenizer = new SqlTokenizer(sql);
+        const statements: ParsedStatement[] = [];
+        let cursor = 0;
+        let carry: string[] | null = null;
+        let index = 0;
+
+        while (true) {
+            // Collect the next logical statement segment, carrying forward detached comments when necessary.
+            const segment = tokenizer.readNextStatement(cursor, carry);
+            carry = null;
+
+            if (!segment) {
+                break;
+            }
+
+            cursor = segment.nextPosition;
+
+            if (segment.lexemes.length === 0) {
+                // Preserve dangling comments so they can attach to the next real statement.
+                if (segment.leadingComments && segment.leadingComments.length > 0) {
+                    carry = segment.leadingComments;
+                }
+                if (skipEmpty || segment.rawText.trim().length === 0) {
+                    continue;
+                }
+            }
+
+            index++;
+            statements.push(this.dispatchParse(segment, index));
+        }
+
+        return statements;
+    }
+
+    private static dispatchParse(segment: StatementLexemeResult, statementIndex: number): ParsedStatement {
+        if (segment.lexemes.length === 0) {
+            throw new Error(`[SqlParser] Statement ${statementIndex} does not contain any tokens.`);
+        }
+
+        const firstToken = segment.lexemes[0].value.toLowerCase();
+
+        // Interpret common SELECT lead tokens including WITH-based CTEs and VALUES clauses.
+        if (firstToken === 'select' || firstToken === 'with' || firstToken === 'values') {
+            return this.parseSelectStatement(segment, statementIndex);
+        }
+
+        // Placeholder for future INSERT/UPDATE/DDL support.
+        throw new Error(
+            `[SqlParser] Statement ${statementIndex} starts with unsupported token "${segment.lexemes[0].value}". Support for additional statement types will be introduced soon.`
+        );
+    }
+
+    private static parseSelectStatement(segment: StatementLexemeResult, statementIndex: number): SelectQuery {
+        try {
+            const result = SelectQueryParser.parseFromLexeme(segment.lexemes, 0);
+
+            if (result.newIndex < segment.lexemes.length) {
+                const unexpected = segment.lexemes[result.newIndex];
+                const position = unexpected.position?.startPosition ?? segment.statementStart;
+                throw new Error(
+                    `[SqlParser] Unexpected token "${unexpected.value}" in statement ${statementIndex} at character ${position}.`
+                );
+            }
+
+            return result.value;
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            throw new Error(`[SqlParser] Failed to parse SELECT statement ${statementIndex}: ${message}`);
+        }
+    }
+
+    private static consumeNextStatement(
+        tokenizer: SqlTokenizer,
+        cursor: number,
+        skipEmpty: boolean
+    ): { segment: StatementLexemeResult; nextCursor: number } | null {
+        let localCursor = cursor;
+        let carry: string[] | null = null;
+
+        // Advance until a statement with tokens is found or the input ends.
+        while (true) {
+            const segment = tokenizer.readNextStatement(localCursor, carry);
+            carry = null;
+
+            if (!segment) {
+                return null;
+            }
+
+            localCursor = segment.nextPosition;
+
+            if (segment.lexemes.length === 0) {
+                // Retain comments so the next statement can inherit them when appropriate.
+                if (segment.leadingComments && segment.leadingComments.length > 0) {
+                    carry = segment.leadingComments;
+                }
+                if (skipEmpty || segment.rawText.trim().length === 0) {
+                    continue;
+                }
+            }
+
+            return { segment, nextCursor: localCursor };
+        }
+    }
+}

--- a/packages/core/tests/parsers/SqlParser.test.ts
+++ b/packages/core/tests/parsers/SqlParser.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'vitest';
+import { SqlParser } from '../../src/parsers/SqlParser';
+import { SimpleSelectQuery } from '../../src/models/SelectQuery';
+
+describe('SqlParser', () => {
+    test('parse returns a SelectQuery for single-statement input', () => {
+        const sql = 'SELECT id FROM users';
+
+        const result = SqlParser.parse(sql);
+
+        expect(result).toBeInstanceOf(SimpleSelectQuery);
+        expect(() => result.toSimpleQuery()).not.toThrow();
+    });
+
+    test('parse throws when additional statements are present in single mode', () => {
+        const sql = `
+            SELECT id FROM users;
+            SELECT id FROM accounts;
+        `;
+
+        expect(() => SqlParser.parse(sql)).toThrow(/additional statement/i);
+    });
+
+    test('parse does not enforce trailing check when mode is multiple', () => {
+        const sql = `
+            SELECT id FROM users;
+            SELECT id FROM accounts;
+        `;
+
+        const result = SqlParser.parse(sql, { mode: 'multiple' });
+
+        expect(result).toBeInstanceOf(SimpleSelectQuery);
+    });
+
+    test('parseMany returns each statement as an independent SelectQuery', () => {
+        const sql = `
+            SELECT id, name FROM users WHERE active = true;
+            VALUES (1), (2), (3);
+            SELECT * FROM orders ORDER BY created_at DESC;
+        `;
+
+        const statements = SqlParser.parseMany(sql);
+
+        expect(statements).toHaveLength(3);
+        expect(statements[0]).toBeInstanceOf(SimpleSelectQuery);
+        expect(statements[1].constructor.name).toBe('ValuesQuery');
+        expect(statements[2]).toBeInstanceOf(SimpleSelectQuery);
+    });
+
+    test('parseMany skips empty statements while preserving leading comments', () => {
+        const sql = `
+            -- carries forward
+            ;
+            ;
+            SELECT id FROM users;
+        `;
+
+        const statements = SqlParser.parseMany(sql);
+
+        expect(statements).toHaveLength(1);
+        expect(statements[0].headerComments).toContain('carries forward');
+    });
+
+    test('parseMany surfaces statement index in errors', () => {
+        const sql = `
+            SELECT id FROM users;
+            INSERT INTO audit_log VALUES (1);
+        `;
+
+        expect(() => SqlParser.parseMany(sql)).toThrow(/statement 2/i);
+    });
+});

--- a/packages/core/tests/parsers/SqlTokenizer.integrated-formatting.test.ts
+++ b/packages/core/tests/parsers/SqlTokenizer.integrated-formatting.test.ts
@@ -12,10 +12,12 @@ describe('SqlTokenizer - Integrated Formatting Functionality', () => {
         expect(lexemes.length).toBeGreaterThan(0);
         expect(lexemes[0].value.toLowerCase()).toBe('select');
         
-        // Verify it's regular Lexeme, not FormattingLexeme
+        // Verify it's regular Lexeme without formatting-only properties
         expect('followingWhitespace' in lexemes[0]).toBe(false);
         expect('inlineComments' in lexemes[0]).toBe(false);
-        expect('position' in lexemes[0]).toBe(false);
+        expect(lexemes[0].position).toBeDefined();
+        expect(lexemes[0].position!.startPosition).toBe(0);
+        expect(lexemes[0].position!.endPosition).toBeGreaterThan(0);
     });
 
     it('should tokenize with formatting preservation when requested', () => {


### PR DESCRIPTION
Introduce `SqlParser` as the primary entry point for parsing SQL, enabling multi-statement support and delegating to `SelectQueryParser` for specific cases. Update documentation to reflect the new structure and capabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new SqlParser for SQL parsing with flexible mode support for single or multiple SQL statements.
  * Added configurable parsing options to control behavior including empty statement filtering and error handling.
  * Improved error messages with detailed statement-level context information to help identify and fix parsing issues.

* **Documentation**
  * Added a new parsing entry point guide with practical usage examples, code snippets, and recommendations for selecting the appropriate parser.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->