### PR TITLE
perf(core): remove unnecessary array cloning in SqlParser

### DIFF
--- a/packages/core/src/parsers/SqlParser.ts
+++ b/packages/core/src/parsers/SqlParser.ts
@@ -457,24 +457,12 @@ export class SqlParser {
 
     private static getCommandAfterWith(lexemes: Lexeme[]): string | null {
         try {
-            const clone = this.cloneLexemeArray(lexemes);
-            const withResult = WithClauseParser.parseFromLexeme(clone, 0);
+            const withResult = WithClauseParser.parseFromLexeme(lexemes, 0);
             const next = lexemes[withResult.newIndex];
             return next?.value.toLowerCase() ?? null;
         } catch {
             return null;
         }
-    }
-
-    private static cloneLexemeArray(lexemes: Lexeme[]): Lexeme[] {
-        return lexemes.map((lexeme) => ({
-            ...lexeme,
-            comments: lexeme.comments ? [...lexeme.comments] : null,
-            positionedComments: lexeme.positionedComments
-                ? lexeme.positionedComments.map(pc => ({ position: pc.position, comments: [...pc.comments] }))
-                : undefined,
-            position: lexeme.position ? { ...lexeme.position } : undefined
-        }));
     }
 
     private static consumeNextStatement(


### PR DESCRIPTION
## Summary

Removed unnecessary array cloning in `SqlParser.getCommandAfterWith` method.

## Changes

- Removed `cloneLexemeArray` method
- Updated `getCommandAfterWith` to pass lexemes directly to `WithClauseParser.parseFromLexeme`

## Rationale

Code analysis confirmed that `WithClauseParser` and its dependencies do not mutate the input lexeme array, making the defensive cloning unnecessary.

## Performance Impact

Benchmark results show approximately **14% speedup** for complex queries (Tokens230):

- Before: 0.465ms
- After: 0.401ms
- Improvement: ~13.8%

## Testing

-  All existing tests pass
-  Benchmark confirms performance improvement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized SQL parsing performance by streamlining internal parsing logic and removing unnecessary intermediate processing steps. Public API remains unchanged with no impact to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->