### PR TITLE
Limit CUD fixture CTEs to referenced tables only

### DIFF
--- a/packages/core/src/transformers/DeleteResultSelectConverter.ts
+++ b/packages/core/src/transformers/DeleteResultSelectConverter.ts
@@ -387,6 +387,14 @@ export class DeleteResultSelectConverter {
             tablesToShadow.add(table);
         }
 
+        const cteReferencedTables = this.collectReferencedTablesFromWithClause(withClause);
+        for (const table of cteReferencedTables) {
+            if (ignoredTables.has(table)) {
+                continue;
+            }
+            tablesToShadow.add(table);
+        }
+
         return tablesToShadow;
     }
 
@@ -414,6 +422,21 @@ export class DeleteResultSelectConverter {
         }
 
         return filtered;
+    }
+
+    private static collectReferencedTablesFromWithClause(withClause: WithClause | null): Set<string> {
+        const tables = new Set<string>();
+        if (!withClause?.tables) {
+            return tables;
+        }
+
+        for (const cte of withClause.tables) {
+            for (const table of this.collectReferencedTables(cte.query)) {
+                tables.add(table);
+            }
+        }
+
+        return tables;
     }
 
     private static ensureFixtureCoverage(

--- a/packages/core/src/transformers/InsertResultSelectConverter.ts
+++ b/packages/core/src/transformers/InsertResultSelectConverter.ts
@@ -417,6 +417,14 @@ export class InsertResultSelectConverter {
             tablesToShadow.add(table);
         }
 
+        const cteReferencedTables = this.collectReferencedTablesFromWithClause(withClause);
+        for (const table of cteReferencedTables) {
+            if (ignoredTables.has(table)) {
+                continue;
+            }
+            tablesToShadow.add(table);
+        }
+
         return tablesToShadow;
     }
 
@@ -445,6 +453,21 @@ export class InsertResultSelectConverter {
         }
 
         return filtered;
+    }
+
+    private static collectReferencedTablesFromWithClause(withClause?: WithClause | null): Set<string> {
+        const tables = new Set<string>();
+        if (!withClause?.tables) {
+            return tables;
+        }
+
+        for (const cte of withClause.tables) {
+            for (const table of this.collectReferencedTables(cte.query)) {
+                tables.add(table);
+            }
+        }
+
+        return tables;
     }
 
     private static buildWithClause(original: WithClause | null, fixtureCtes: CommonTable[], insertedCte: CommonTable): WithClause {

--- a/packages/core/src/transformers/MergeResultSelectConverter.ts
+++ b/packages/core/src/transformers/MergeResultSelectConverter.ts
@@ -225,6 +225,14 @@ export class MergeResultSelectConverter {
             tablesToShadow.add(table);
         }
 
+        const cteReferencedTables = this.collectReferencedTablesFromWithClause(withClause);
+        for (const table of cteReferencedTables) {
+            if (ignoredTables.has(table)) {
+                continue;
+            }
+            tablesToShadow.add(table);
+        }
+
         return tablesToShadow;
     }
 
@@ -245,6 +253,21 @@ export class MergeResultSelectConverter {
         }
 
         return filtered;
+    }
+
+    private static collectReferencedTablesFromWithClause(withClause: WithClause | null): Set<string> {
+        const tables = new Set<string>();
+        if (!withClause?.tables) {
+            return tables;
+        }
+
+        for (const cte of withClause.tables) {
+            for (const table of this.collectReferencedTables(cte.query)) {
+                tables.add(table);
+            }
+        }
+
+        return tables;
     }
 
     private static extractTargetTableName(target: SourceExpression): string {

--- a/packages/core/src/transformers/UpdateResultSelectConverter.ts
+++ b/packages/core/src/transformers/UpdateResultSelectConverter.ts
@@ -334,6 +334,14 @@ export class UpdateResultSelectConverter {
             tablesToShadow.add(table);
         }
 
+        const cteReferencedTables = this.collectReferencedTablesFromWithClause(withClause);
+        for (const table of cteReferencedTables) {
+            if (ignoredTables.has(table)) {
+                continue;
+            }
+            tablesToShadow.add(table);
+        }
+
         return tablesToShadow;
     }
 
@@ -353,6 +361,21 @@ export class UpdateResultSelectConverter {
         }
 
         return filtered;
+    }
+
+    private static collectReferencedTablesFromWithClause(withClause: WithClause | null): Set<string> {
+        const tables = new Set<string>();
+        if (!withClause?.tables) {
+            return tables;
+        }
+
+        for (const cte of withClause.tables) {
+            for (const table of this.collectReferencedTables(cte.query)) {
+                tables.add(table);
+            }
+        }
+
+        return tables;
     }
 
     private static buildFixtureTableMap(fixtures: FixtureTableDefinition[]): Map<string, FixtureTableDefinition> {

--- a/packages/core/tests/transformers/DeleteResultSelectConverter.test.ts
+++ b/packages/core/tests/transformers/DeleteResultSelectConverter.test.ts
@@ -84,6 +84,24 @@ describe('DeleteResultSelectConverter', () => {
         );
     });
 
+    it('requires fixtures for tables referenced inside WITH clauses', () => {
+        const deleteQuery = DeleteQueryParser.parse(`
+            WITH source AS (
+                SELECT sale_date, price FROM users
+            )
+            DELETE FROM sale
+            USING source
+            WHERE sale.sale_date = source.sale_date
+            RETURNING sale_date, price
+        `);
+
+        expect(() =>
+            DeleteResultSelectConverter.toSelectQuery(deleteQuery, {
+                tableDefinitions: { sale: tableDefinition }
+            })
+        ).toThrowError(/fixture coverage.*users/i);
+    });
+
     it('ignores unused fixture definitions', () => {
         const deleteQuery = DeleteQueryParser.parse(
             "DELETE FROM sale RETURNING sale_date, price"

--- a/packages/core/tests/transformers/InsertResultSelectConverter.test.ts
+++ b/packages/core/tests/transformers/InsertResultSelectConverter.test.ts
@@ -144,6 +144,23 @@ describe('InsertResultSelectConverter', () => {
         ).toThrowError(/fixture coverage: users/i);
     });
 
+    it('requires fixtures for tables referenced inside WITH clauses', () => {
+        const insert = InsertQueryParser.parse(`
+            WITH source AS (
+                SELECT sale_date, price FROM users
+            )
+            INSERT INTO sale (sale_date, price)
+            SELECT sale_date, price FROM source
+            RETURNING sale_date, price
+        `);
+
+        expect(() =>
+            InsertResultSelectConverter.toSelectQuery(insert, {
+                tableDefinitions: { sale: tableDefinition }
+            })
+        ).toThrowError(/fixture coverage.*users/i);
+    });
+
     it('ignores CTE aliases when checking fixture coverage', () => {
         const insert = InsertQueryParser.parse(`
             WITH source AS (

--- a/packages/core/tests/transformers/UpdateResultSelectConverter.test.ts
+++ b/packages/core/tests/transformers/UpdateResultSelectConverter.test.ts
@@ -142,6 +142,25 @@ describe('UpdateResultSelectConverter', () => {
         );
     });
 
+    it('requires fixtures for tables referenced inside WITH clauses', () => {
+        const update = UpdateQueryParser.parse(`
+            WITH lookup AS (
+                SELECT sale_date, price FROM users
+            )
+            UPDATE sale
+            SET price = price + lookup.price
+            FROM lookup
+            WHERE sale.sale_date = lookup.sale_date
+            RETURNING sale_date, price
+        `);
+
+        expect(() =>
+            UpdateResultSelectConverter.toSelectQuery(update, {
+                tableDefinitions: { sale: tableDefinition }
+            })
+        ).toThrowError(/fixture coverage.*users/i);
+    });
+
     it('ignores unused fixture definitions', () => {
         const update = UpdateQueryParser.parse(
             "UPDATE sale SET price = price + 10 RETURNING sale_date, price"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Query generation now only enforces and injects fixtures for tables actually referenced (respecting WITH/CTE shadowing), preventing unused fixture definitions from affecting delete/insert/merge/update results.

* **Refactor**
  * Internal fixture-selection and coverage logic reorganized to compute referenced tables first and then build fixture CTEs from the reduced set.

* **Tests**
  * Added tests ensuring fixtures are required for WITH-clause references and that unused fixtures are ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->