### PR TITLE
fix: resolve broken style selector in demo pages

### DIFF
--- a/docs/public/cud-demo/script.js
+++ b/docs/public/cud-demo/script.js
@@ -156,8 +156,8 @@ function initStyleConfig() {
         revertStyleBtn: document.getElementById('revert-style-btn')
     };
 
-    // We don't have a quick style select in the header for this demo, pass a dummy element
-    const quickStyleSelectElem = document.createElement('select');
+    // Use the output style select in the header as the quick style select
+    const quickStyleSelectElem = document.getElementById('output-style-select');
 
     styleConfigModule.initStyleConfig(
         elements,

--- a/docs/public/demo/style-config.js
+++ b/docs/public/demo/style-config.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Global variables for style config, managed within this module
-const DEFAULT_STYLE_KEY = 'rawsql-formatter-styles';
+const DEFAULT_STYLE_KEY = 'rawsql-formatter-styles-v2';
 let currentStyles = {};
 
 // DOM elements and external functions - these will be initialized via initStyleConfig


### PR DESCRIPTION
## Description\n\nFixed an issue where the style selector in cud-demo and migration-demo was not showing all options.\n\n## Changes\n\n- Updated \DEFAULT_STYLE_KEY\ in \style-config.js\ to force a reset of stored styles, resolving potential localStorage corruption/incompatibility.\n- Connected \output-style-select\ correctly in \cud-demo/script.js\ so the header style selector works as expected.\n\n## Verification\n\nVerified manually that the style selector now displays all options (Default, Postgres, MySQL, etc.) in both demo pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed quick style selection to properly reference available style options instead of placeholder elements
  * Updated style storage key to ensure clean separation from previous configurations, potentially requiring users to reconfigure saved style preferences

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->