### PR TITLE
fix: align migration demo footer layout with cud demo

### DIFF
--- a/docs/public/migration-demo/index.html
+++ b/docs/public/migration-demo/index.html
@@ -33,7 +33,7 @@
         </div>
     </div>
 
-    <div class="container" style="flex-direction: column; height: calc(100vh - 100px);">
+    <div class="container" style="flex-direction: column;">
         <div class="top-area"
             style="display: flex; flex: 1; min-height: 40%; border-bottom: 1px solid #3f3f46; gap: 20px;">
             <!-- SQL 1 -->
@@ -105,11 +105,12 @@
             </div>
         </div>
 
-        <div id="status-bar">Ready</div>
-        <div class="footer-text">
-            Powered by <a href="https://codemirror.net/" target="_blank" style="color: #888;">CodeMirror</a>.
-            Released under the MIT License.
-        </div>
+    </div>
+
+    <div id="status-bar">Ready</div>
+    <div class="footer-text">
+        Powered by <a href="https://codemirror.net/" target="_blank" style="color: #888;">CodeMirror</a>.
+        Released under the MIT License.
     </div>
 
     <script type="module" src="script.js"></script>


### PR DESCRIPTION
Fixes the footer layout in the Migration Demo to match the CUD Demo by moving the status-bar and footer-text elements outside the main container and removing the inline height style from the container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Restructured the migration demo layout to use flexible sizing instead of fixed height restrictions.
  * Repositioned status bar and footer for improved layout flow and visual hierarchy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->