### PR TITLE
feat: auto-regenerate migration script on checkbox change

### DIFF
--- a/docs/public/migration-demo/script.js
+++ b/docs/public/migration-demo/script.js
@@ -160,6 +160,7 @@ sql1Editor.on('changes', triggerGeneration);
 sql2Editor.on('changes', triggerGeneration);
 document.getElementById('migration-direction').addEventListener('change', generateMigration);
 document.getElementById('opt-drop-columns').addEventListener('change', generateMigration);
+document.getElementById('opt-drop-tables').addEventListener('change', generateMigration);
 document.getElementById('opt-drop-constraints').addEventListener('change', generateMigration);
 document.getElementById('opt-check-names').addEventListener('change', generateMigration);
 


### PR DESCRIPTION
Added event listeners to migration option checkboxes to trigger script regeneration automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the drop-tables toggle option to properly regenerate the migration script when toggled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->