### PR TITLE
Fix grouping set comment placement

### DIFF
--- a/packages/core/src/parsers/ValueParser.ts
+++ b/packages/core/src/parsers/ValueParser.ts
@@ -143,8 +143,38 @@ export class ValueParser {
      * Transfer positioned comments from lexeme to value component if the component doesn't already handle them
      */
     private static transferPositionedComments(lexeme: Lexeme, value: ValueComponent): void {
-        if (lexeme.positionedComments && lexeme.positionedComments.length > 0 && !value.positionedComments) {
-            value.positionedComments = lexeme.positionedComments;
+        if (lexeme.positionedComments && lexeme.positionedComments.length > 0) {
+            const beforeComments = lexeme.positionedComments.filter(comment => comment.position === 'before');
+            const afterComments = lexeme.positionedComments.filter(comment => comment.position === 'after');
+
+            if (beforeComments.length > 0) {
+                const clonedBefore = beforeComments.map(comment => ({
+                    position: comment.position,
+                    comments: [...comment.comments],
+                }));
+                value.positionedComments = value.positionedComments
+                    ? [...clonedBefore, ...value.positionedComments]
+                    : clonedBefore;
+            }
+
+            if (afterComments.length > 0) {
+                const clonedAfter = afterComments.map(comment => ({
+                    position: comment.position,
+                    comments: [...comment.comments],
+                }));
+                value.positionedComments = value.positionedComments
+                    ? [...value.positionedComments, ...clonedAfter]
+                    : clonedAfter;
+            }
+
+            // Preserve other comment positions when no before/after segments were processed.
+            if (!beforeComments.length && !afterComments.length && !value.positionedComments) {
+                value.positionedComments = lexeme.positionedComments.map(comment => ({
+                    position: comment.position,
+                    comments: [...comment.comments],
+                }));
+            }
+            return;
         }
         // Fall back to legacy comments if positioned comments aren't available
         else if (value.comments === null && lexeme.comments && lexeme.comments.length > 0) {

--- a/packages/core/tests/transformers/SqlFormatter.grouping-sets-comments.test.ts
+++ b/packages/core/tests/transformers/SqlFormatter.grouping-sets-comments.test.ts
@@ -1,0 +1,23 @@
+import { describe, test, expect } from 'vitest';
+import { SqlFormatter } from '../../src/transformers/SqlFormatter';
+import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
+
+describe('SqlFormatter grouping sets comments', () => {
+    test('keeps comments adjacent to grouping set entries', () => {
+        const rawSql = `
+SELECT
+  region,
+  product,
+  SUM(amount)
+FROM sales
+GROUP BY GROUPING SETS (
+  (region, product),   -- comment1
+  (region),            -- comment2
+  ()                   -- comment3
+);
+`;
+        const formatter = new SqlFormatter({ exportComment: true });
+        const formatted = formatter.format(SelectQueryParser.parse(rawSql)).formattedSql;
+        expect(formatted).toBe('select "region", "product", sum("amount") from "sales" group by grouping sets(("region", "product") /* comment1 */ , ("region") /* comment2 */ , () /* comment3 */ )');
+    });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Fixed incorrect positioning of inline comments within GROUPING SETS SQL clauses during formatting. Comments adjacent to grouping set entries are now correctly preserved and relocated to maintain their intended associations with corresponding SQL elements when comment export is enabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->