### PR TITLE
Relocate ORDER BY comments

### DIFF
--- a/packages/core/tests/transformers/SqlFormatter.select-comments.test.ts
+++ b/packages/core/tests/transformers/SqlFormatter.select-comments.test.ts
@@ -144,6 +144,28 @@ describe('SqlFormatter - SELECT Comments (Bug 3)', () => {
         });
     });
 
+    describe('ORDER BY comments', () => {
+        test('should keep comments attached to ORDER BY expressions', () => {
+            const inputSql = `
+                select
+                    region,
+                    product,
+                    sum(amount) as total_amount
+                from sales
+                group by cube (region, product)
+                order by
+                  --comment
+                  coalesce(region, 'ZZZ'), coalesce(product, 'ZZZ')
+            `;
+
+            const query = SelectQueryParser.parse(inputSql);
+            const formatter = new SqlFormatter({ exportComment: true });
+            const result = formatter.format(query);
+
+            expect(result.formattedSql).toContain('comment');
+        });
+    });
+
     describe('Edge Cases', () => {
         test('should work when exportComment is false', () => {
             const inputSql = `


### PR DESCRIPTION
## Summary
- move ORDER BY trailing comments onto the next clause so generators see them with the expression
- add regression coverage to SQL formatter comments suite

## Testing
- pnpm test *(fails: packages/ztd-cli/tests/diff.unit.test.ts missing dependency 'diff'; packages/ztd-cli/tests/cliCommands.test.ts missing dependency 'commander')