### PR TITLE
feat: add ztd-cli package with core commands, documentation, and tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint": "npm run lint --workspaces",
     "benchmark": "npm run benchmark --workspace=packages/core",
     "demo:complex-sql": "node packages/core/demo/complex-sql-demo.js",
-    "playground:gen-config": "pnpm --filter ztd-playground exec ztd ztd-config",
+    "playground:gen-config": "pnpm --filter ztd-playground exec ztd gen-config",
     "playground:typecheck": "pnpm --filter ztd-playground typecheck",
     "playground:test": "pnpm --filter ztd-playground test",
     "prepare": "husky",

--- a/packages/ztd-cli/README.md
+++ b/packages/ztd-cli/README.md
@@ -69,6 +69,10 @@ Pass `--default-schema` or `--search-path` when running `ztd ztd-config` to upda
 
 Watch mode is safe: it regenerates the tests file as soon as DDL changes are saved and logs every write so you can confirm no additional files were modified.
 
+## gen-config
+
+`ztd gen-config` is a lightweight alternative that targets setups where the schema lives under `ddl/schemas` and the row map always goes into `tests/ztd-config.ts`. It mirrors the same AST-backed metadata generation as `ztd ztd-config` but skips the interactive config updates and watcher plumbing so you can regenerate the canonical helpers inside fixtures-only playgrounds and demos. Pass `--ddl-dir`, `--extensions`, `--default-schema`, `--search-path`, or `--out` when you need to override the default paths.
+
 ## ZTD Testing
 
 Driver responsibilities live in companion packages:

--- a/packages/ztd-cli/src/commands/genConfigCommand.ts
+++ b/packages/ztd-cli/src/commands/genConfigCommand.ts
@@ -1,0 +1,43 @@
+import path from 'node:path';
+import { Command } from 'commander';
+import {
+  collectDirectories,
+  DEFAULT_EXTENSIONS,
+  DEFAULT_TESTS_DIRECTORY,
+  normalizeDirectoryList,
+  parseCsvList,
+  parseExtensions,
+  resolveExtensions
+} from './options';
+import { runGenerateZtdConfig } from './ztdConfig';
+
+const DEFAULT_GEN_CONFIG_DDL_DIRECTORY = path.join('ddl', 'schemas');
+const DEFAULT_GEN_CONFIG_OUTPUT = path.join(DEFAULT_TESTS_DIRECTORY, 'ztd-config.ts');
+
+export function registerGenConfigCommand(program: Command): void {
+  program
+    .command('gen-config')
+    .description('Generate the canonical ztd-config.ts row map for playground projects')
+    .option('--ddl-dir <directory>', 'DDL directory to scan (repeatable)', collectDirectories, [])
+    .option('--extensions <list>', 'Comma-separated extensions to include', parseExtensions, DEFAULT_EXTENSIONS)
+    .option('--out <file>', 'Destination TypeScript file', DEFAULT_GEN_CONFIG_OUTPUT)
+    .option('--default-schema <schema>', 'Default schema used when resolving unqualified tables')
+    .option('--search-path <list>', 'Comma-separated schema search path entries', parseCsvList)
+    .action((options) => {
+      // Normalize input directories while defaulting to the playground layout when none are provided.
+      const directories = normalizeDirectoryList(
+        options.ddlDir as string[],
+        DEFAULT_GEN_CONFIG_DDL_DIRECTORY
+      );
+      const extensions = resolveExtensions(options.extensions as string[], DEFAULT_EXTENSIONS);
+      const output = options.out ?? DEFAULT_GEN_CONFIG_OUTPUT;
+
+      runGenerateZtdConfig({
+        directories,
+        extensions,
+        out: output,
+        defaultSchema: options.defaultSchema,
+        searchPath: options.searchPath
+      });
+    });
+}

--- a/packages/ztd-cli/src/index.ts
+++ b/packages/ztd-cli/src/index.ts
@@ -2,6 +2,7 @@
 
 import { Command } from 'commander';
 import { registerDdlCommands } from './commands/ddl';
+import { registerGenConfigCommand } from './commands/genConfigCommand';
 import { registerInitCommand } from './commands/init';
 import { registerZtdConfigCommand } from './commands/ztdConfigCommand';
 
@@ -10,6 +11,7 @@ async function main(): Promise<void> {
   program.name('ztd').description('Zero Table Dependency scaffolding and DDL helpers');
 
   registerInitCommand(program);
+  registerGenConfigCommand(program);
   registerZtdConfigCommand(program);
   registerDdlCommands(program);
 

--- a/packages/ztd-cli/tests/__snapshots__/cliCommands.test.ts.snap
+++ b/packages/ztd-cli/tests/__snapshots__/cliCommands.test.ts.snap
@@ -1,5 +1,46 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`gen-config CLI produces the expected TypeScript snapshot 1`] = `
+"// ZTD TEST ROW MAP - AUTO GENERATED
+// Tests must import TestRowMap from this file and never from src.
+// This file is synchronized with DDL using ztd-config.
+
+import type { FixtureRow, TableFixture, TableSchemaDefinition } from '@rawsql-ts/testkit-core';
+export interface TestRowMap {
+  'public.sessions': PublicSessionsTestRow;
+  'public.users': PublicUsersTestRow;
+}
+
+export interface PublicSessionsTestRow extends FixtureRow {
+  id: number;
+  user_id: number;
+  expires_at: string;
+}
+
+export interface PublicUsersTestRow extends FixtureRow {
+  id: number;
+  email: string;
+  score: string | null;
+}
+
+export type TestRow<K extends keyof TestRowMap> = TestRowMap[K];
+export type ZtdRowShapes = TestRowMap;
+export type ZtdTableName = keyof TestRowMap;
+
+export interface ZtdConfig {
+  tables: ZtdTableName[];
+}
+
+export function tableFixture<K extends ZtdTableName>(
+  tableName: K,
+  rows: ZtdRowShapes[K][],
+  schema?: TableSchemaDefinition
+): TableFixture {
+  return { tableName, rows, schema };
+}
+"
+`;
+
 exports[`ztd-config CLI produces the expected TypeScript snapshot 1`] = `
 "// ZTD TEST ROW MAP - AUTO GENERATED
 // Tests must import TestRowMap from this file and never from src.

--- a/playgrounds/ztd-playground/AGENTS.md
+++ b/playgrounds/ztd-playground/AGENTS.md
@@ -12,7 +12,7 @@ This playground exists to validate the ZTD development loop end-to-end against a
 - Do not hand-edit `ztd-config.ts`; regenerate it with:
 
 ```bash
-pnpm --filter ztd-playground exec ztd ztd-config
+pnpm --filter ztd-playground exec ztd gen-config
 ```
 
 ## 3. `ztd-config.ts` defines typed fixtures

--- a/playgrounds/ztd-playground/README.md
+++ b/playgrounds/ztd-playground/README.md
@@ -16,7 +16,7 @@ DDL ➜ `ztd-config.ts` ➜ type definitions ➜ fixtures ➜ ZTD rewrite ➜ te
 ## Postgres execution
 
 - Use `tests/test-utils.ts` to create a `@rawsql-ts/pg-testkit` client so fixtures are rewritten into Postgres `SELECT` queries rather than touching the real schema.
-- `DATABASE_URL` must point to a live Postgres database before running tests or the helper will throw a clear error. The connection is shared across the suite, and the helper keeps the same `pg.Client` open without issuing any DDL.
+- `DATABASE_URL` should point to a live Postgres database before running tests so the helper can reuse a persistent connection. When the env var is missing and a container runtime exists, the helper spins up a disposable `postgres:16-alpine` container via `@testcontainers`, still shares the same `pg.Client`, and never issues DDL. If no runtime is available, the helper raises a clear error that points back to this README so you can configure `DATABASE_URL`.
 - Because ZTD never creates tables, the same Postgres database can be reused safely even when the tests run in parallel.
 
 ## Sample domain


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lightweight `gen-config` command as an alternative to `ztd-config` for fixtures-only setups, supporting command-line option overrides.

* **Documentation**
  * Updated CLI and playground documentation with `gen-config` command guidance and clarified DATABASE_URL behavior with automatic container fallback support.

* **Tests**
  * Added test coverage for the new `gen-config` command.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->