### PR TITLE
ci(docs): build workspace packages before docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,6 +46,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build workspace packages
+        run: |
+          pnpm --filter rawsql-ts run build
+          pnpm --filter @rawsql-ts/testkit-core run build
+          pnpm --filter @rawsql-ts/ztd-cli run build
+
       - name: Build documentation
         run: pnpm run docs:build
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation build workflow to rebuild workspace packages before generating documentation, ensuring consistency and completeness of the documentation build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->