### PR TITLE
ci: prevent release-pr workflow from failing on husky hooks

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -9,12 +9,16 @@ permissions:
 jobs:
   release_pr:
     runs-on: ubuntu-latest
+    env:
+      # Disable git hooks (e.g. husky) so the Changesets commit can't fail in CI.
+      HUSKY: 0
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: 'pnpm'
 
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
@@ -25,5 +29,6 @@ jobs:
           version: pnpm changeset version
           commit: "chore(release): version packages"
           title: "chore(release): version packages"
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI workflow with pnpm cache enablement for faster builds.
  * Refined release process configuration to improve reliability during automated releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->