### PR TITLE
ci: make manual publish workflow OIDC-compatible via npm + gh releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,19 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - run: corepack enable
+
+      - name: Export NODE_AUTH_TOKEN when provided
+        shell: bash
+        run: |
+          TOKEN="${{ secrets.NPM_TOKEN }}"
+          if [ -z "${TOKEN}" ]; then
+            TOKEN="${{ secrets.NODE_AUTH_TOKEN }}"
+          fi
+
+          if [ -n "${TOKEN}" ]; then
+            echo "NODE_AUTH_TOKEN=${TOKEN}" >> "${GITHUB_ENV}"
+          fi
+
       - run: pnpm install --frozen-lockfile
 
       - name: Update npm for OIDC
@@ -41,8 +54,6 @@ jobs:
 
       - name: Verify npm authentication (token path)
         shell: bash
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN || secrets.NODE_AUTH_TOKEN }}
         run: |
           if [ -z "${NODE_AUTH_TOKEN}" ]; then
             echo "NODE_AUTH_TOKEN is not set; assuming npm Trusted Publishing (OIDC)."
@@ -55,11 +66,14 @@ jobs:
       - name: Build publish artifacts (dist/)
         run: pnpm build:publish
 
-      - name: Publish to npm and create GitHub Release
-        uses: changesets/action@v1
-        with:
-          publish: pnpm changeset publish
-          createGithubReleases: true
+      - name: Configure git identity for tags
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Publish to npm (OIDC-compatible), tag, and create GitHub Releases
+        shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN || secrets.NODE_AUTH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node ./scripts/ci-publish.mjs

--- a/scripts/ci-publish.mjs
+++ b/scripts/ci-publish.mjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const IS_WINDOWS = process.platform === "win32";
+const PNPM = "pnpm";
+const NPM = "npm";
+const GIT = "git";
+const GH = "gh";
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    stdio: "inherit",
+    shell: IS_WINDOWS,
+    ...options,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (typeof result.status === "number" && result.status !== 0) {
+    throw new Error(`${command} ${args.join(" ")} failed with exit code ${result.status}`);
+  }
+}
+
+function tryRun(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    stdio: "ignore",
+    shell: IS_WINDOWS,
+    ...options,
+  });
+
+  if (result.error) {
+    return { ok: false, status: null };
+  }
+  return { ok: result.status === 0, status: result.status };
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function ensureDir(dirPath) {
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true });
+  }
+}
+
+function getFixedPackageNames(workspaceRoot) {
+  const configPath = path.join(workspaceRoot, ".changeset", "config.json");
+  const config = readJson(configPath);
+
+  // The repo uses a fixed group, so we treat the first entry as the publish set.
+  const fixedGroups = Array.isArray(config.fixed) ? config.fixed : [];
+  const fixedGroup = fixedGroups[0];
+  if (!Array.isArray(fixedGroup) || fixedGroup.length === 0) {
+    throw new Error(`No fixed group found in ${configPath}`);
+  }
+  return fixedGroup;
+}
+
+function getWorkspacePackageDirByName() {
+  // Use pnpm itself to resolve workspace package locations reliably.
+  const raw = execFileSync(PNPM, ["-r", "list", "--depth", "-1", "--json"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"],
+    shell: IS_WINDOWS,
+  });
+  const items = JSON.parse(raw);
+
+  const map = new Map();
+  for (const item of items) {
+    if (!item?.name || !item?.path) continue;
+    map.set(item.name, item.path);
+  }
+  return map;
+}
+
+function npmPackageVersionExists(packageName, version) {
+  // Public registry lookup; this should not require any credentials.
+  const view = tryRun(NPM, ["view", `${packageName}@${version}`, "version"]);
+  return view.ok;
+}
+
+function publishWithNpm(packageDir) {
+  const args = ["publish", "--access", "public"];
+
+  // When publishing via npm Trusted Publishing (OIDC), npm requires --provenance.
+  // Keep the token-based path compatible by not forcing provenance when NODE_AUTH_TOKEN is present.
+  if (!process.env.NODE_AUTH_TOKEN) {
+    args.push("--provenance");
+  }
+
+  run(NPM, args, { cwd: packageDir });
+}
+
+function gitTagExists(tagName) {
+  return tryRun(GIT, ["rev-parse", "-q", "--verify", `refs/tags/${tagName}`]).ok;
+}
+
+function createAnnotatedGitTag(tagName) {
+  run(GIT, ["tag", "-a", tagName, "-m", tagName]);
+}
+
+function pushAllTags() {
+  run(GIT, ["push", "--tags"]);
+}
+
+function ghReleaseExists(tagName) {
+  return tryRun(GH, ["release", "view", tagName]).ok;
+}
+
+function sanitizeFilename(input) {
+  return input.replace(/[^a-zA-Z0-9._-]+/g, "_");
+}
+
+function extractChangelogSection(changelogMarkdown, version) {
+  const lines = changelogMarkdown.split(/\r?\n/);
+  const header = `## ${version}`;
+
+  const startIndex = lines.findIndex((line) => line.trim() === header);
+  if (startIndex === -1) return null;
+
+  const content = [];
+  for (let i = startIndex + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line.startsWith("## ")) break;
+    content.push(line);
+  }
+
+  // Trim leading/trailing empty lines to keep notes compact.
+  while (content.length > 0 && content[0].trim() === "") content.shift();
+  while (content.length > 0 && content[content.length - 1].trim() === "") content.pop();
+
+  return content.join("\n");
+}
+
+function createGitHubRelease(tagName, notesFilePath) {
+  run(GH, ["release", "create", tagName, "--title", tagName, "--notes-file", notesFilePath]);
+}
+
+function main() {
+  const workspaceRoot = process.cwd();
+  const dryRun = process.env.RAWSQL_CI_DRY_RUN === "1";
+  const fixedPackageNames = getFixedPackageNames(workspaceRoot);
+  const dirByName = getWorkspacePackageDirByName();
+
+  const tmpNotesDir = path.join(workspaceRoot, "tmp", "release-notes");
+  ensureDir(tmpNotesDir);
+
+  const packages = [];
+  for (const packageName of fixedPackageNames) {
+    const packageDir = dirByName.get(packageName);
+    if (!packageDir) {
+      throw new Error(`Workspace package directory not found for "${packageName}"`);
+    }
+
+    const pkgJsonPath = path.join(packageDir, "package.json");
+    const pkg = readJson(pkgJsonPath);
+    if (pkg.private) {
+      continue;
+    }
+
+    packages.push({
+      name: pkg.name,
+      version: pkg.version,
+      dir: packageDir,
+      changelogPath: path.join(packageDir, "CHANGELOG.md"),
+    });
+  }
+
+  const publishedNow = [];
+  for (const pkg of packages) {
+    const exists = npmPackageVersionExists(pkg.name, pkg.version);
+    if (exists) {
+      console.log(`[publish] ${pkg.name}@${pkg.version} already exists; skipping`);
+      continue;
+    }
+
+    if (dryRun) {
+      console.log(`[publish] (dry-run) would publish ${pkg.name}@${pkg.version}`);
+      continue;
+    }
+
+    console.log(`[publish] publishing ${pkg.name}@${pkg.version}`);
+    publishWithNpm(pkg.dir);
+    publishedNow.push(`${pkg.name}@${pkg.version}`);
+  }
+
+  // Create tags for the current versions so GitHub releases can attach to them.
+  for (const pkg of packages) {
+    const tagName = `${pkg.name}@${pkg.version}`;
+    if (gitTagExists(tagName)) {
+      console.log(`[tag] ${tagName} already exists; skipping`);
+      continue;
+    }
+
+    if (dryRun) {
+      console.log(`[tag] (dry-run) would create ${tagName}`);
+      continue;
+    }
+
+    console.log(`[tag] creating ${tagName}`);
+    createAnnotatedGitTag(tagName);
+  }
+
+  // Push tags so releases can be created on the remote.
+  if (!dryRun) {
+    pushAllTags();
+  } else {
+    console.log("[tag] (dry-run) would push tags");
+  }
+
+  // Create GitHub releases per package/tag, using the package CHANGELOG section when available.
+  for (const pkg of packages) {
+    const tagName = `${pkg.name}@${pkg.version}`;
+    if (dryRun) {
+      console.log(`[release] (dry-run) would create ${tagName}`);
+      continue;
+    }
+    if (ghReleaseExists(tagName)) {
+      console.log(`[release] ${tagName} already exists; skipping`);
+      continue;
+    }
+
+    let notes = `Release ${tagName}\n`;
+    if (fs.existsSync(pkg.changelogPath)) {
+      const changelog = fs.readFileSync(pkg.changelogPath, "utf8");
+      const section = extractChangelogSection(changelog, pkg.version);
+      if (section) {
+        // Use the version section as release notes to stay aligned with Changesets output.
+        notes = section;
+      }
+    }
+
+    const notesFile = path.join(tmpNotesDir, `${sanitizeFilename(tagName)}.md`);
+    fs.writeFileSync(notesFile, notes, "utf8");
+
+    console.log(`[release] creating ${tagName}`);
+    createGitHubRelease(tagName, notesFile);
+  }
+
+  if (publishedNow.length === 0) {
+    console.log("[publish] no packages were published (all versions already exist)");
+  } else {
+    console.log(`[publish] published: ${publishedNow.join(", ")}`);
+  }
+}
+
+main();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the publish workflow to support OIDC-compatible authentication for npm.
  * Enhanced the publishing pipeline to automatically create git tags and GitHub releases for published packages.
  * Added support for dry-run mode in the publishing process for safer testing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->