### PR TITLE
chore(ztd-cli): add npm view diagnostics for OIDC publish auth failures

### DIFF
--- a/docs/oidc-publish-troubleshooting.md
+++ b/docs/oidc-publish-troubleshooting.md
@@ -7,6 +7,7 @@ When publishing fails, the most important clue is **which authentication path np
 - GitHub context (`GITHUB_*`) and OIDC availability (`ACTIONS_ID_TOKEN_REQUEST_*`)
 - A small, safe subset of OIDC token **claims** (not the token)
 - Minimal npm auth diagnostics (`npm whoami`, `npm config get userconfig`, etc.)
+- On OIDC auth-related failures, a small `npm view` summary (latest version + dist-tags) to confirm the package exists on the public registry
 
 ## Common failure modes
 
@@ -22,6 +23,7 @@ Most likely causes:
 
 What to do:
 - Check the OIDC claim logs in the workflow output (issuer, audience, subject, repository, ref, workflow).
+- Check `npm view diagnostics` in the logs. If `npm view` succeeds but `npm publish` fails with `ENEEDAUTH`, it strongly suggests a Trusted Publisher configuration mismatch rather than a missing package.
 - Update npm Trusted Publishers configuration to match the workflow context.
 
 ### Token fallback fails with "Access token expired or revoked"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced OIDC publish workflow with automatic diagnostic output displaying package registry information when authentication failures occur.

* **Documentation**
  * Expanded OIDC publish troubleshooting guide with diagnostic verification steps and guidance for resolving authentication issues during publication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->