### PR TITLE
fix(ztd-cli): parse `$1, $2` positional params correctly

### DIFF
--- a/.changeset/twelve-weeks-turn.md
+++ b/.changeset/twelve-weeks-turn.md
@@ -1,0 +1,10 @@
+---
+"rawsql-ts": minor
+---
+
+Fixed incorrect tokenization of Postgres-style positional parameters (`$1, $2`).
+
+The SQL Server MONEY literal detector mistakenly treated the comma after `$1` as part of a numeric literal.
+MONEY detection is now limited to cases where `,` or `.` is followed by a digit, allowing `$1, $2` to be tokenized correctly as parameter + comma + parameter.
+
+Added regression tests for positional parameters in the parser and token readers.

--- a/packages/core/tests/parameter.test.ts
+++ b/packages/core/tests/parameter.test.ts
@@ -28,6 +28,23 @@ test('tokenizes positional parameter in PostgreSQL', () => {
     expect(tokens[0].value).toBe('$1');
 });
 
+test('tokenizes PostgreSQL positional params separated by commas', () => {
+    // Arrange
+    const tokenizer = new SqlTokenizer('$1, $2');
+
+    // Act
+    const tokens = tokenizer.readLexmes();
+
+    // Assert
+    expect(tokens.length).toBe(3);
+    expect(tokens[0].type).toBe(TokenType.Parameter);
+    expect(tokens[0].value).toBe('$1');
+    expect(tokens[1].type).toBe(TokenType.Comma);
+    expect(tokens[1].value).toBe(',');
+    expect(tokens[2].type).toBe(TokenType.Parameter);
+    expect(tokens[2].value).toBe('$2');
+});
+
 test('tokenizes unnamed parameter in MySQL', () => {
     // Arrange
     const tokenizer = new SqlTokenizer('?');

--- a/packages/core/tests/parsers/SqlParser.test.ts
+++ b/packages/core/tests/parsers/SqlParser.test.ts
@@ -5,7 +5,7 @@ import { InsertQuery } from '../../src/models/InsertQuery';
 import { CreateTableQuery } from '../../src/models/CreateTableQuery';
 import { MergeQuery } from '../../src/models/MergeQuery';
 import { AnalyzeStatement, ExplainStatement } from '../../src/models/DDLStatements';
-import { RawString, IdentifierString } from '../../src/models/ValueComponent';
+import { RawString, IdentifierString, ParameterExpression } from '../../src/models/ValueComponent';
 
 describe('SqlParser', () => {
     test('parse returns a SelectQuery for single-statement input', () => {
@@ -18,6 +18,19 @@ describe('SqlParser', () => {
             throw new Error('SqlParser.parse should return SimpleSelectQuery for SELECT statements');
         }
         expect(() => result.toSimpleQuery()).not.toThrow();
+    });
+
+    test('parse supports PostgreSQL positional parameters in select list', () => {
+        const result = SqlParser.parse('select $1, $2');
+
+        expect(result).toBeInstanceOf(SimpleSelectQuery);
+        if (!(result instanceof SimpleSelectQuery)) {
+            throw new Error('SqlParser.parse should return SimpleSelectQuery for SELECT statements');
+        }
+
+        expect(result.selectClause.items).toHaveLength(2);
+        expect(result.selectClause.items[0].value).toBeInstanceOf(ParameterExpression);
+        expect(result.selectClause.items[1].value).toBeInstanceOf(ParameterExpression);
     });
 
     test('parse returns an InsertQuery for INSERT statements', () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tokenization of PostgreSQL-style positional parameters ($1, $2) that were being incorrectly identified as SQL Server monetary literals, preventing proper parsing when parameters appeared adjacent to commas
* **Tests**
  * Added regression tests for PostgreSQL positional parameter tokenization and SELECT query parsing
* **Chores**
  * Minor changelog entry for rawsql-ts

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->