### PR TITLE
feat(ztd-cli): auto-install template dependencies during init

### DIFF
--- a/.changeset/ztd-init-installs-template-deps.md
+++ b/.changeset/ztd-init-installs-template-deps.md
@@ -1,0 +1,7 @@
+---
+"@rawsql-ts/ztd-cli": patch
+---
+
+Make `ztd init` produce a self-consistent scaffold by installing the devDependencies referenced by the generated templates.
+
+Postgres remains the default, so `@rawsql-ts/pg-testkit` is automatically added when it is not already declared.

--- a/packages/ztd-cli/README.md
+++ b/packages/ztd-cli/README.md
@@ -16,6 +16,8 @@ For actual test execution:
 pnpm add -D @rawsql-ts/pg-testkit
 ```
 
+If you run `npx ztd init`, the CLI will automatically add and install the devDependencies referenced by the generated templates (Postgres defaults to `@rawsql-ts/pg-testkit`).
+
 Then use the CLI through `npx ztd` or the installed `ztd` bin.
 
 ## Getting Started (Fast Path)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `ztd init` now automatically installs devDependencies referenced by generated templates, ensuring a self-consistent project scaffold immediately after initialization.
  * Automatic package manager detection installs required dependencies without manual intervention.

* **Documentation**
  * Updated CLI documentation to reflect automatic dependency installation behavior.

* **Tests**
  * Added test coverage for template dependency installation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->