### PR TITLE
chore(core): tighten money literal detection for parameters

### DIFF
--- a/.changeset/steady-otters-unwind.md
+++ b/.changeset/steady-otters-unwind.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": patch
+---
+
+Positional placeholders inside multi-row VALUES clauses are preserved instead of being reclassified as SQL Server MONEY literals so INSERT parsing works with repeated `$n` tokens.

--- a/packages/core/src/tokenReaders/SqlServerMoneyLiteralDetector.ts
+++ b/packages/core/src/tokenReaders/SqlServerMoneyLiteralDetector.ts
@@ -1,0 +1,69 @@
+import { CharLookupTable } from '../utils/charLookupTable';
+
+/**
+ * Detects SQL Server MONEY literals that start with `$` and that use thousands-group formatting.
+ * This helper coexists with parameter parsing so the tokenizer can decide whether to treat
+ * `$1,234` as a literal or keep `$1` as a positional parameter.
+ */
+export function looksLikeSqlServerMoneyLiteral(input: string, position: number): boolean {
+    const length = input.length;
+    if (position < 0 || position + 1 >= length) {
+        return false;
+    }
+
+    if (input[position] !== '$' || !CharLookupTable.isDigit(input[position + 1])) {
+        return false;
+    }
+
+    let pos = position + 1;
+
+    // Consume the initial run of digits that follows the dollar sign.
+    while (pos < length && CharLookupTable.isDigit(input[pos])) {
+        pos++;
+    }
+
+    // Allow dollar values with a decimal part (e.g. `$123.45`) without requiring commas.
+    if (pos < length && input[pos] === '.' && pos + 1 < length && CharLookupTable.isDigit(input[pos + 1])) {
+        return true;
+    }
+
+    let sawThousandsGroup = false;
+
+    // Consume contiguous comma + 3-digit groups, stopping if the comma is not followed by immediate digits.
+    while (pos < length && input[pos] === ',') {
+        const groupStart = pos + 1;
+
+        if (groupStart >= length || !CharLookupTable.isDigit(input[groupStart])) {
+            break;
+        }
+
+        const groupEnd = groupStart + 3;
+        for (let index = groupStart; index < groupEnd; index++) {
+            if (index >= length || !CharLookupTable.isDigit(input[index])) {
+                return false;
+            }
+        }
+
+        sawThousandsGroup = true;
+        pos = groupEnd;
+    }
+
+    if (!sawThousandsGroup) {
+        return false;
+    }
+
+    // Allow an optional decimal fraction after the thousands groups.
+    if (pos < length && input[pos] === '.') {
+        const decimalStart = pos + 1;
+        if (decimalStart >= length || !CharLookupTable.isDigit(input[decimalStart])) {
+            return false;
+        }
+
+        let decimalPos = decimalStart;
+        while (decimalPos < length && CharLookupTable.isDigit(input[decimalPos])) {
+            decimalPos++;
+        }
+    }
+
+    return true;
+}

--- a/packages/core/tests/tokenReaders/SqlServerMoneyLiteralDetector.test.ts
+++ b/packages/core/tests/tokenReaders/SqlServerMoneyLiteralDetector.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { looksLikeSqlServerMoneyLiteral } from '../../src/tokenReaders/SqlServerMoneyLiteralDetector';
+
+function detectDollarLiteral(input: string): boolean {
+    const dollarIndex = input.indexOf('$');
+    if (dollarIndex < 0) {
+        throw new Error('Test input must contain a $ symbol: ' + input);
+    }
+    return looksLikeSqlServerMoneyLiteral(input, dollarIndex);
+}
+
+describe('SqlServerMoneyLiteralDetector', () => {
+    it('accepts comma-formatted dollar amounts', () => {
+        expect(detectDollarLiteral('SELECT $1,234 FROM dual')).toBe(true);
+        expect(detectDollarLiteral('SELECT $1,234.56')).toBe(true);
+        expect(detectDollarLiteral('SELECT $1,234,567')).toBe(true);
+        expect(detectDollarLiteral('SELECT $1,234,567.89')).toBe(true);
+        expect(detectDollarLiteral('VALUES ($1,234, $2)')).toBe(true); // trailing comma after whitespace
+    });
+
+    it('rejects positional parameters that are not formatted as money', () => {
+        expect(detectDollarLiteral('VALUES ($1, $2)')).toBe(false);
+        expect(detectDollarLiteral('VALUES ($1,23)')).toBe(false);
+        expect(detectDollarLiteral('VALUES ($1,234,56)')).toBe(false);
+        expect(detectDollarLiteral('SELECT $1, 234')).toBe(false);
+        expect(detectDollarLiteral('SELECT $1')).toBe(false);
+    });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parsing of multi-row INSERT statements using positional parameters. Positional placeholders ($n) within VALUES clauses are now correctly preserved and no longer misidentified as SQL Server MONEY literals.

* **Tests**
  * Added comprehensive test coverage for multi-row INSERT queries with positional parameters and SQL Server MONEY literal detection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->