### PR TITLE
fix(ci): build dependencies before refresh workflow

### DIFF
--- a/.github/workflows/refresh-demo-bundle.yml
+++ b/.github/workflows/refresh-demo-bundle.yml
@@ -28,6 +28,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Build rawsql-ts package
+        run: pnpm --filter rawsql-ts build
+
+      - name: Build testkit-core package
+        run: pnpm --filter @rawsql-ts/testkit-core build
+
+      - name: Build ztd-cli package
+        run: pnpm --filter @rawsql-ts/ztd-cli build
+
       - name: Build rawsql-ts browser output
         run: pnpm --filter rawsql-ts build:browser
 


### PR DESCRIPTION
## Summary
- build rawsql-ts, testkit-core, and ztd-cli before the demo refresh steps so their declaration files exist
- keep the Corepack/pnpm activation and perms tweaks previously added so pnpm installs succeed and the PR step has push rights

## Testing
- pnpm --filter rawsql-ts build
- pnpm --filter @rawsql-ts/testkit-core build
- pnpm --filter @rawsql-ts/ztd-cli build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline to optimize the package build sequence.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->