### PR TITLE
fix(core): indent RETURNING lists

### DIFF
--- a/.changeset/returning-list-indentation.md
+++ b/.changeset/returning-list-indentation.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": patch
+---
+RETURNING list indentation
+- RETURNING clause items now format on their own indented lines in multiline output, matching SELECT list layout.

--- a/packages/core/src/transformers/SqlPrinter.ts
+++ b/packages/core/src/transformers/SqlPrinter.ts
@@ -184,6 +184,7 @@ export class SqlPrinter {
         this.indentIncrementContainers = new Set(
             options?.indentIncrementContainerTypes ?? [
                 SqlPrintTokenContainerType.SelectClause,
+                SqlPrintTokenContainerType.ReturningClause,
                 SqlPrintTokenContainerType.FromClause,
                 SqlPrintTokenContainerType.WhereClause,
                 SqlPrintTokenContainerType.GroupByClause,
@@ -1512,6 +1513,9 @@ export class SqlPrinter {
             // Ensure EXPLAIN targets print header comments on a dedicated line.
             return true;
         }
+        if (parentType === SqlPrintTokenContainerType.ReturningClause) {
+            return true;
+        }
         return false;
     }
 
@@ -1522,7 +1526,8 @@ export class SqlPrinter {
         if (
             parentType === SqlPrintTokenContainerType.InsertClause ||
             parentType === SqlPrintTokenContainerType.MergeInsertAction ||
-            parentType === SqlPrintTokenContainerType.SelectClause
+            parentType === SqlPrintTokenContainerType.SelectClause ||
+            parentType === SqlPrintTokenContainerType.ReturningClause
         ) {
             return currentLevel + 1;
         }
@@ -1539,8 +1544,6 @@ export class SqlPrinter {
     private isOnelineMode(): boolean {
         return this.newline === ' ';
     }
-
-
 
     /**
      * Handles CTE tokens with one-liner formatting.
@@ -1626,7 +1629,8 @@ export class SqlPrinter {
         }
         if (
             parentType === SqlPrintTokenContainerType.InsertClause ||
-            parentType === SqlPrintTokenContainerType.MergeInsertAction
+            parentType === SqlPrintTokenContainerType.MergeInsertAction ||
+            parentType === SqlPrintTokenContainerType.ReturningClause
         ) {
             return !this.isInsertClauseOneline(parentType);
         }

--- a/packages/core/tests/transformers/SqlFormatter.returning.test.ts
+++ b/packages/core/tests/transformers/SqlFormatter.returning.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { DeleteQueryParser } from '../../src/parsers/DeleteQueryParser';
+import { InsertQueryParser } from '../../src/parsers/InsertQueryParser';
+import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
+import { UpdateQueryParser } from '../../src/parsers/UpdateQueryParser';
+import { SqlFormatter } from '../../src/transformers/SqlFormatter';
+
+const formatterOptions = {
+    indentSize: 4,
+    indentChar: ' ',
+    newline: '\n',
+    keywordCase: 'upper',
+    commaBreak: 'before',
+    identifierEscape: 'none',
+} as const;
+
+const indent = ' '.repeat(4);
+
+const createFormatter = () => new SqlFormatter(formatterOptions);
+
+describe('SqlFormatter RETURNING indentation', () => {
+    it('indents INSERT RETURNING lists like SELECT lists', () => {
+        const query = InsertQueryParser.parse(
+            "INSERT INTO users (id, name, email) VALUES (1, 'Alice', 'alice@example.com') RETURNING id, name, email"
+        );
+
+        const formattedSql = createFormatter().format(query).formattedSql;
+
+        const expected = [
+            'INSERT INTO users(',
+            `${indent}id`,
+            `${indent}, name`,
+            `${indent}, email`,
+            ')',
+            'VALUES',
+            `${indent}(1, 'Alice', 'alice@example.com')`,
+            'RETURNING',
+            `${indent}id`,
+            `${indent}, name`,
+            `${indent}, email`,
+        ].join('\n');
+
+        expect(formattedSql).toBe(expected);
+    });
+
+    it('indents UPDATE RETURNING with a single item', () => {
+        const query = UpdateQueryParser.parse(
+            "UPDATE users SET name = 'Alice' RETURNING id"
+        );
+
+        const formattedSql = createFormatter().format(query).formattedSql;
+
+        const expected = [
+            'UPDATE users',
+            'SET',
+            `${indent}name = 'Alice'`,
+            'RETURNING',
+            `${indent}id`,
+        ].join('\n');
+
+        expect(formattedSql).toBe(expected);
+    });
+
+    it('indents DELETE RETURNING * on its own line', () => {
+        const query = DeleteQueryParser.parse('DELETE FROM users RETURNING *');
+
+        const formattedSql = createFormatter().format(query).formattedSql;
+
+        const expected = [
+            'DELETE FROM users',
+            'RETURNING',
+            `${indent}*`,
+        ].join('\n');
+
+        expect(formattedSql).toBe(expected);
+    });
+
+    it('indents RETURNING expressions inside WITH clauses', () => {
+        const sql = `
+            WITH inserted_users AS (
+                INSERT INTO users (name, email)
+                VALUES ('Alice', 'alice@example.com')
+                RETURNING lower(name) AS lower_name, CAST(email AS text) AS email_text
+            )
+            SELECT * FROM inserted_users
+        `;
+
+        const query = SelectQueryParser.parse(sql);
+        const formattedSql = createFormatter().format(query).formattedSql;
+
+        const expectedReturningBlock = [
+            `${indent.repeat(2)}RETURNING`,
+            `${indent.repeat(3)}lower(name) AS lower_name`,
+            `${indent.repeat(3)}, cast(email as text) AS email_text`,
+        ].join('\n');
+
+        expect(formattedSql).toContain(expectedReturningBlock);
+    });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * RETURNING clause items now format on separate indented lines in multiline output, consistent with SELECT list layout for INSERT, UPDATE, DELETE, and WITH queries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->