### PR TITLE
fix(ztd-cli): improve watch reliability on Windows

### DIFF
--- a/.changeset/ztd-config-watch-windows.md
+++ b/.changeset/ztd-config-watch-windows.md
@@ -1,0 +1,7 @@
+---
+"@rawsql-ts/ztd-cli": patch
+---
+
+Reliable DDL watch updates on Windows
+- ztd-config --watch now detects DDL edits under configured directories on Windows.
+- Generated test row maps stay in sync without manual reruns.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `ztd-config --watch` now reliably detects DDL file changes within configured directories on Windows
  * Generated test row maps automatically remain synchronized without requiring manual reruns

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->