### PR TITLE
fix(testkit-core): broaden table schema column types

### DIFF
--- a/.changeset/gentle-oranges-join.md
+++ b/.changeset/gentle-oranges-join.md
@@ -1,0 +1,5 @@
+---
+"@rawsql-ts/testkit-core": patch
+---
+
+Allow table schema column metadata to accept raw DDL type names alongside affinity values.

--- a/packages/testkit-core/src/types/index.ts
+++ b/packages/testkit-core/src/types/index.ts
@@ -6,9 +6,20 @@ import type {
 } from 'rawsql-ts';
 export type { TableDefinitionModel } from 'rawsql-ts';
 import type { TableNameResolver } from '../fixtures/TableNameResolver';
+import type { ColumnAffinity } from '../fixtures/ColumnAffinity';
 
+/**
+ * Declared column type tokens for schema metadata. Accepts raw DDL type names
+ * and precomputed affinity values for compatibility.
+ */
+export type SchemaColumnType = string | ColumnAffinity;
+
+/**
+ * Minimal schema metadata used by fixtures when no full table model is
+ * available.
+ */
 export interface TableSchemaDefinition {
-  columns: Record<string, string>;
+  columns: Record<string, SchemaColumnType>;
 }
 
 export interface SchemaRegistry {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Table schema column definitions now accept raw DDL type names alongside existing values, providing greater flexibility in schema specification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->