### PR TITLE
fix(ztd-cli): improve pnpm resolution on Windows

### DIFF
--- a/.changeset/bright-taxis-argue.md
+++ b/.changeset/bright-taxis-argue.md
@@ -1,0 +1,5 @@
+---
+"@rawsql-ts/ztd-cli": patch
+---
+
+Improve Windows package manager resolution during `ztd init` dependency installation.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows package manager resolution during `ztd init` dependency installation.
  * Added retry logic for package manager execution to handle edge cases.
  * Enhanced executable resolution for common package manager wrappers on Windows.
  * Added support for `ZTD_PACKAGE_MANAGER_PATH` environment variable to override package manager path resolution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->