### PR TITLE
fix(rewriter): handle duplicate table sources

### DIFF
--- a/.changeset/fix-self-join-rewrite.md
+++ b/.changeset/fix-self-join-rewrite.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": patch
+"@rawsql-ts/testkit-core": patch
+---
+Fix fixture rewriting for self-joins by handling repeated table sources.

--- a/packages/core/tests/transformers/TableSourceCollector.test.ts
+++ b/packages/core/tests/transformers/TableSourceCollector.test.ts
@@ -251,6 +251,25 @@ describe('TableSourceCollector', () => {
         expect(tableNames.sort()).toEqual(['orders', 'premium_users', 'status_codes', 'users'].sort());
     });
 
+    test('collects duplicate table sources when dedupe is disabled', () => {
+        // Arrange
+        const sql = `
+            SELECT c.category_id, p.category_id
+            FROM public.category c
+            LEFT JOIN public.category p ON c.parent_id = p.category_id
+        `;
+        const query = SelectQueryParser.parse(sql);
+        const collector = new TableSourceCollector(true, false);
+
+        // Act
+        collector.visit(query);
+        const tableSources = collector.getTableSources();
+
+        // Assert
+        expect(tableSources.length).toBe(2);
+        expect(tableSources.map(ts => ts.table.name)).toEqual(['category', 'category']);
+    });
+
     test('collects table sources from complex query with various clauses when selectableOnly is false', () => {
         // Arrange
         const sql = `
@@ -783,3 +802,4 @@ order by
         }).not.toThrow();
     });
 });
+

--- a/packages/testkit-core/src/rewriter/ResultSelectRewriter.ts
+++ b/packages/testkit-core/src/rewriter/ResultSelectRewriter.ts
@@ -337,7 +337,8 @@ export class ResultSelectRewriter {
       return;
     }
 
-    const collector = new TableSourceCollector(false);
+    // Collect every table occurrence so self-joins rewrite each source.
+    const collector = new TableSourceCollector(false, false);
     for (const source of collector.collect(component)) {
       const referencedName = this.getPrimaryKey(source.getSourceName());
       const alias = fixtureAliasMap.get(referencedName);

--- a/packages/testkit-core/tests/ResultSelectRewriter.test.ts
+++ b/packages/testkit-core/tests/ResultSelectRewriter.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { DefaultFixtureProvider } from '../src/fixtures/FixtureProvider';
+import { TableNameResolver } from '../src/fixtures/TableNameResolver';
+import { ResultSelectRewriter } from '../src/rewriter/ResultSelectRewriter';
+import type { TableDefinitionModel, TableRowsFixture } from '../src/types';
+
+const tableDefinitions: TableDefinitionModel[] = [
+  {
+    name: 'public.category',
+    columns: [
+      { name: 'category_id', typeName: 'INTEGER' },
+      { name: 'parent_id', typeName: 'INTEGER' },
+      { name: 'name', typeName: 'TEXT' },
+    ],
+  },
+];
+
+const baseRows: TableRowsFixture[] = [
+  {
+    tableName: 'public.category',
+    rows: [
+      { category_id: 1, parent_id: null, name: 'Root' },
+      { category_id: 2, parent_id: 1, name: 'Child' },
+    ],
+  },
+];
+
+describe('ResultSelectRewriter', () => {
+  it('rewrites every occurrence of the same table in joins', () => {
+    const resolver = new TableNameResolver({ defaultSchema: 'public' });
+    const fixtures = new DefaultFixtureProvider(
+      tableDefinitions,
+      baseRows,
+      resolver
+    );
+    const rewriter = new ResultSelectRewriter(
+      fixtures,
+      'error',
+      undefined,
+      resolver
+    );
+
+    const sql = `
+      select
+        c.category_id as "categoryId",
+        c.parent_id as "parentId",
+        p.name as "parentName",
+        c.name as "name"
+      from
+        public.category c
+        left join public.category p on c.parent_id = p.category_id
+      order by
+        c.category_id;
+    `;
+    const result = rewriter.rewrite(sql);
+    const normalized = result.sql.toLowerCase();
+
+    expect(normalized).not.toContain('public.category');
+    expect(normalized).toContain('public_category');
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed fixture rewriting to correctly handle self-joins where the same table is referenced multiple times in a query. Fixtures now properly disambiguate repeated table sources for accurate test fixture generation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->