### PR TITLE
fix: normalize serial defaults

### DIFF
--- a/.changeset/serial-defaults-generated.md
+++ b/.changeset/serial-defaults-generated.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": patch
+---
+
+Ensure serial/serial8 pseudo-types are normalized before casts and that columns without explicit defaults get a deterministic `row_number() over ()` expression so RETURNING clauses work when the column is omitted.

--- a/packages/core/src/utils/serialTypeNormalization.ts
+++ b/packages/core/src/utils/serialTypeNormalization.ts
@@ -39,3 +39,25 @@ export function normalizeSerialPseudoType(typeName?: string): string | undefined
   segments.push(normalizedBase);
   return segments.join('.');
 }
+
+/**
+ * Returns true when the provided type name resolves to a known serial pseudo-type.
+ */
+export function isSerialPseudoType(typeName?: string): boolean {
+  if (!typeName) {
+    return false;
+  }
+
+  const trimmed = typeName.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  const segments = trimmed.split('.');
+  const base = segments.pop();
+  if (!base) {
+    return false;
+  }
+
+  return Boolean(SERIAL_PSEUDO_TYPE_MAP[base.toLowerCase()]);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of serial column defaults in queries with RETURNING clauses when columns are omitted.
  * Normalized serial pseudo-type resolution before type casts for consistent type handling.
  * Serial columns without explicit defaults now use deterministic expressions instead of sequence-based defaults.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->