### PR TITLE
fix(changesets): remove stale ignored workspace package

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,5 +6,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@rawsql-ts/ztd-playground"]
+  "ignore": []
 }


### PR DESCRIPTION
## Summary
- remove stale Changesets ignore entry for missing package @rawsql-ts/ztd-playground
- allow pnpm changeset version in Release PR workflow to pass config validation

## Verification
- HUSKY=0 pnpm changeset version (no longer fails on missing ignore package)
- pnpm changeset status
