### PR TITLE
fix(adapter-node-pg): rename binder dependency to publishable package name

### DIFF
--- a/.changeset/friendly-buses-beam.md
+++ b/.changeset/friendly-buses-beam.md
@@ -1,0 +1,5 @@
+---
+'@rawsql-ts/adapter-node-pg': patch
+---
+
+Rename the internal binder dependency to `@rawsql-ts/shared-binder` so npm publish accepts the package metadata.

--- a/packages/_shared/binder/README.md
+++ b/packages/_shared/binder/README.md
@@ -1,3 +1,3 @@
 # Binder (shared)
 
-Public surface: import from `@rawsql-ts/_shared/binder` only. Keep exports stable via `src/index.ts`.
+Public surface: import from `@rawsql-ts/shared-binder` only. Keep exports stable via `src/index.ts`.

--- a/packages/_shared/binder/package.json
+++ b/packages/_shared/binder/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rawsql-ts/_shared/binder",
+  "name": "@rawsql-ts/shared-binder",
   "version": "0.0.0",
   "private": true,
   "main": "dist/index.js",

--- a/packages/adapters/adapter-node-pg/package.json
+++ b/packages/adapters/adapter-node-pg/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@rawsql-ts/testkit-postgres": "workspace:^",
     "@rawsql-ts/testkit-core": "workspace:^",
-    "@rawsql-ts/_shared/binder": "workspace:^",
+    "@rawsql-ts/shared-binder": "workspace:^",
     "pg": "^8.13.1",
     "rawsql-ts": "workspace:^"
   },

--- a/packages/adapters/adapter-node-pg/src/driver/PgTestkitClient.ts
+++ b/packages/adapters/adapter-node-pg/src/driver/PgTestkitClient.ts
@@ -9,7 +9,7 @@ import {
   type PostgresTestkitClient,
   type Row,
 } from '@rawsql-ts/testkit-postgres';
-import { compileNamedParameters, type NamedParams } from '@rawsql-ts/_shared/binder';
+import { compileNamedParameters, type NamedParams } from '@rawsql-ts/shared-binder';
 import type { CountableResult } from '@rawsql-ts/testkit-core';
 import type {
   CreatePgTestkitClientOptions,

--- a/packages/adapters/adapter-node-pg/tests/binder-constraints.test.ts
+++ b/packages/adapters/adapter-node-pg/tests/binder-constraints.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { compileNamedParameters } from '@rawsql-ts/_shared/binder';
+import { compileNamedParameters } from '@rawsql-ts/shared-binder';
 
 describe('compileNamedParameters constraints', () => {
   test('ignores named markers inside string literals', () => {

--- a/packages/adapters/adapter-node-pg/tsconfig.build.json
+++ b/packages/adapters/adapter-node-pg/tsconfig.build.json
@@ -6,8 +6,8 @@
     "baseUrl": ".",
     "paths": {
       "@rawsql-ts/testkit-core": ["../../testkit-core/dist/index"],
-      "@rawsql-ts/_shared/binder": ["../../_shared/binder/dist"],
-      "@rawsql-ts/_shared/binder/*": ["../../_shared/binder/dist/*"]
+      "@rawsql-ts/shared-binder": ["../../_shared/binder/dist"],
+      "@rawsql-ts/shared-binder/*": ["../../_shared/binder/dist/*"]
     }
   },
   "include": ["src/**/*.ts"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,7 +167,7 @@ importers:
 
   packages/adapters/adapter-node-pg:
     dependencies:
-      '@rawsql-ts/_shared/binder':
+      '@rawsql-ts/shared-binder':
         specifier: workspace:^
         version: link:../../_shared/binder
       '@rawsql-ts/testkit-core':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -52,8 +52,8 @@
         "@rawsql-ts/ztd-cli": ["packages/ztd-cli/src"],
         "@rawsql-ts/sqlite-testkit": ["packages/drivers/sqlite-testkit/src"],
         "@rawsql-ts/adapter-node-pg": ["packages/adapters/adapter-node-pg/src"],
-        "@rawsql-ts/_shared/binder": ["packages/_shared/binder/src"],
-        "@rawsql-ts/_shared/binder/*": ["packages/_shared/binder/src/*"]
+        "@rawsql-ts/shared-binder": ["packages/_shared/binder/src"],
+        "@rawsql-ts/shared-binder/*": ["packages/_shared/binder/src/*"]
         },
         // "rootDir": "./",                                  /* Specify the root folder within your source files. */
         // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -39,8 +39,8 @@ export const integrationConfig = defineConfig({
             '@rawsql-ts/sql-contract': resolve(__dirname, 'packages/sql-contract/src'),
             '@rawsql-ts/adapter-node-pg': resolve(__dirname, 'packages/adapters/adapter-node-pg/src'),
             '@rawsql-ts/adapter-node-pg/*': resolve(__dirname, 'packages/adapters/adapter-node-pg/src/*'),
-            '@rawsql-ts/_shared/binder': resolve(__dirname, 'packages/_shared/binder/src'),
-            '@rawsql-ts/_shared/binder/*': resolve(__dirname, 'packages/_shared/binder/src/*'),
+            '@rawsql-ts/shared-binder': resolve(__dirname, 'packages/_shared/binder/src'),
+            '@rawsql-ts/shared-binder/*': resolve(__dirname, 'packages/_shared/binder/src/*'),
         },
     },
 })
@@ -67,8 +67,8 @@ export default defineConfig({
             '@rawsql-ts/sql-contract': resolve(__dirname, 'packages/sql-contract/src'),
             '@rawsql-ts/adapter-node-pg': resolve(__dirname, 'packages/adapters/adapter-node-pg/src'),
             '@rawsql-ts/adapter-node-pg/*': resolve(__dirname, 'packages/adapters/adapter-node-pg/src/*'),
-            '@rawsql-ts/_shared/binder': resolve(__dirname, 'packages/_shared/binder/src'),
-            '@rawsql-ts/_shared/binder/*': resolve(__dirname, 'packages/_shared/binder/src/*'),
+            '@rawsql-ts/shared-binder': resolve(__dirname, 'packages/_shared/binder/src'),
+            '@rawsql-ts/shared-binder/*': resolve(__dirname, 'packages/_shared/binder/src/*'),
         },
     },
 })


### PR DESCRIPTION
## Summary
- rename internal binder package name to `@rawsql-ts/shared-binder`
- update adapter dependency/import/path aliases to the new package name
- add a changeset for adapter-node-pg patch release

## Why
- npm publish rejects dependency names like `@scope/name/sub`
- this unblocks publishing `@rawsql-ts/adapter-node-pg`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized internal package dependencies for the Node.js PostgreSQL adapter to improve package distribution and publishing compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->