### PR TITLE
build(ztd-cli): prebuild test-evidence dependencies

### DIFF
--- a/.changeset/odd-olives-float.md
+++ b/.changeset/odd-olives-float.md
@@ -1,0 +1,5 @@
+---
+'@rawsql-ts/ztd-cli': patch
+---
+
+Fix the ztd-cli build pipeline so it builds the test-evidence workspace dependencies before compiling the CLI package.

--- a/packages/ztd-cli/package.json
+++ b/packages/ztd-cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "prepack": "node -e \"const fs=require('fs');const cp=require('child_process');const npm=process.platform==='win32'?'npm.cmd':'npm';if(!fs.existsSync('dist/index.js')){process.exit(cp.spawnSync(npm,['run','build'],{stdio:'inherit'}).status??1)}\"",
-    "build": "pnpm --filter @rawsql-ts/testkit-core run build && tsc -p tsconfig.json",
+    "build": "pnpm --filter @rawsql-ts/test-evidence-core run build && pnpm --filter @rawsql-ts/test-evidence-renderer-md run build && pnpm --filter @rawsql-ts/testkit-core run build && tsc -p tsconfig.json",
     "test": "vitest run",
     "lint": "eslint src --ext .ts",
     "release": "npm run lint && npm run test && npm run build && npm pack --dry-run && npm publish --access public"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the build pipeline to ensure all workspace dependencies are compiled in the correct order before the CLI package is built, resolving build failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->