### PR TITLE
fix(docs): replace dead readme links

### DIFF
--- a/docs/guide/feature-index.md
+++ b/docs/guide/feature-index.md
@@ -53,8 +53,8 @@ An at-a-glance index of easy-to-miss but important capabilities across the rawsq
 
 | Guide | Path | When to read |
 |-------|------|-------------|
-| Happy Path Quickstart | [ztd-cli README](../../packages/ztd-cli/README.md#happy-path-quickstart) | First-time setup |
-| After DDL Changes | [ztd-cli README](../../packages/ztd-cli/README.md#after-ddlschema-changes) | Schema evolution workflow |
+| Happy Path Quickstart | [ztd-cli README](https://github.com/mk3008/rawsql-ts/blob/main/packages/ztd-cli/README.md#happy-path-quickstart) | First-time setup |
+| After DDL Changes | [ztd-cli README](https://github.com/mk3008/rawsql-ts/blob/main/packages/ztd-cli/README.md#after-ddlschema-changes) | Schema evolution workflow |
 | Mapping vs Validation pipeline | [recipes/mapping-vs-validation](../recipes/mapping-vs-validation.md) | Avoid coerce/validator conflicts |
 | Postgres Pitfalls | [guide/postgres-pitfalls](./postgres-pitfalls.md) | Postgres-specific quirks |
 | Spec-Change Scenarios | [guide/spec-change-scenarios](./spec-change-scenarios.md) | Quick reference for common changes |

--- a/docs/guide/postgres-pitfalls.md
+++ b/docs/guide/postgres-pitfalls.md
@@ -80,6 +80,6 @@ PostgreSQL uses `search_path` to resolve unqualified table names. ZTD's `ztd.con
 
 ## Further reading
 
-- [sql-contract README](../../packages/sql-contract/README.md) — DBMS differences section
+- [sql-contract README](https://github.com/mk3008/rawsql-ts/blob/main/packages/sql-contract/README.md) — DBMS differences section
 - [Mapping vs validation pipeline](../recipes/mapping-vs-validation.md) — how coercions and validators interact
-- [Happy Path Quickstart](../../packages/ztd-cli/README.md#happy-path-quickstart) — end-to-end setup guide
+- [Happy Path Quickstart](https://github.com/mk3008/rawsql-ts/blob/main/packages/ztd-cli/README.md#happy-path-quickstart) — end-to-end setup guide

--- a/docs/guide/spec-change-scenarios.md
+++ b/docs/guide/spec-change-scenarios.md
@@ -88,5 +88,5 @@ Condensed scenarios covering common specification and schema changes, what steps
 
 ## Further reading
 
-- [After DDL/Schema Changes](../../packages/ztd-cli/README.md#after-ddlschema-changes) — standard workflow steps
+- [After DDL/Schema Changes](https://github.com/mk3008/rawsql-ts/blob/main/packages/ztd-cli/README.md#after-ddlschema-changes) — standard workflow steps
 - [ZTD Theory](./ztd-theory.md) — conceptual foundation


### PR DESCRIPTION
## Summary
- replace VitePress-dead relative README links in guide pages with GitHub URLs
- unblock the Docs workflow build triggered by dead link checks

## Verification
- pnpm run docs:build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated five documentation hyperlinks in guide files to use absolute GitHub URLs instead of relative paths. This ensures links remain functional when documentation is viewed outside the repository context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->