### PR TITLE
fix(ci): skip hooks in docs api commit

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-﻿name: Docs
+name: Docs
 
 on:
   push:
@@ -65,7 +65,7 @@ jobs:
             echo "docs/api is already up to date"
             exit 0
           fi
-          git commit -m "docs: refresh API reference [skip ci]"
+          git commit --no-verify -m "docs: refresh API reference [skip ci]"
           if git push; then
             echo "docs: pushed API reference updates"
           else


### PR DESCRIPTION
## Summary
- skip Husky hooks when the Docs workflow auto-commits regenerated API docs
- prevent the docs job from failing on unrelated workspace checks during CI commits

## Verification
- gh run view 22755748464 --repo mk3008/rawsql-ts
- git diff --check -- .github/workflows/docs.yml


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation generation workflow process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->