### PR TITLE
fix(core): relax values parser ci budget

### DIFF
--- a/packages/core/tests/parsers/ValuesQueryParser.test.ts
+++ b/packages/core/tests/parsers/ValuesQueryParser.test.ts
@@ -161,12 +161,15 @@ test('values clause with massive row count parses within time budget', () => {
     const rows = Array.from({ length: 20000 }, (_, index) => `(${index}, 'value_${index}')`);
     const sql = `values ${rows.join(', ')}`;
 
+    // Keep the local budget strict while allowing slower shared CI runners.
+    const maxDurationMs = process.env.CI ? 3500 : 2000;
+
     // Measure parsing latency so the regression stays detectable.
     const start = performance.now();
     const clause = ValuesQueryParser.parse(sql);
     const durationMs = performance.now() - start;
 
     expect(clause.tuples.length).toBe(20000);
-    expect(durationMs).toBeLessThan(2000);
+    expect(durationMs).toBeLessThan(maxDurationMs);
 });
 


### PR DESCRIPTION
## Summary
- keep the ValuesQueryParser stress test strict locally while allowing slower CI runners
- avoid flaky CI failures from the absolute 2s budget on shared GitHub runners

## Verification
- pnpm --filter "./packages/core" run test -- tests/parsers/ValuesQueryParser.test.ts
- gh run view 22756235722 --repo mk3008/rawsql-ts --log-failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated parsing performance test thresholds to account for environmental differences, improving test reliability across different execution environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->