### PR TITLE
feat: add ztd-cli telemetry abstraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,4 +202,5 @@ playgrounds/ztd-playground/
 DOGFOOD_LOG.txt
 DOGFOOD_REPORT.md
 tmp/dogfood-runs/
+.codex/CONTINUITY.md
 

--- a/packages/ztd-cli/src/commands/ztdConfigCommand.ts
+++ b/packages/ztd-cli/src/commands/ztdConfigCommand.ts
@@ -17,8 +17,51 @@ import { runGenerateZtdConfig, type ZtdConfigGenerationOptions } from './ztdConf
 import { ensureDirectory } from '../utils/fs';
 import { emitDiagnostic, isJsonOutput, parseJsonPayload, writeCommandEnvelope } from '../utils/agentCli';
 import { validateProjectPath, validateResourceIdentifier } from '../utils/agentSafety';
+import { emitDecisionEvent, withSpan } from '../utils/telemetry';
 
 const WATCH_DEBOUNCE_MS = 150;
+
+type ZtdConfigCommandOptions = {
+  ddlDir: string[];
+  extensions: string[];
+  out?: string;
+  defaultSchema?: string;
+  searchPath?: string[];
+  watch: boolean;
+  quiet: boolean;
+  dryRun: boolean;
+  json?: string;
+};
+
+function normalizeZtdConfigCommandOptions(options: Record<string, unknown>): ZtdConfigCommandOptions {
+  const ddlDir = typeof options.ddlDir === 'string'
+    ? collectDirectories(options.ddlDir, [])
+    : Array.isArray(options.ddlDir)
+      ? options.ddlDir.filter((entry): entry is string => typeof entry === 'string')
+      : [];
+  const extensions = typeof options.extensions === 'string'
+    ? parseExtensions(options.extensions)
+    : Array.isArray(options.extensions)
+      ? options.extensions.filter((entry): entry is string => typeof entry === 'string')
+      : DEFAULT_EXTENSIONS;
+  const searchPath = typeof options.searchPath === 'string'
+    ? parseCsvList(options.searchPath)
+    : Array.isArray(options.searchPath)
+      ? options.searchPath.filter((entry): entry is string => typeof entry === 'string')
+      : undefined;
+
+  return {
+    ddlDir,
+    extensions,
+    out: typeof options.out === 'string' ? options.out : undefined,
+    defaultSchema: typeof options.defaultSchema === 'string' ? options.defaultSchema : undefined,
+    searchPath,
+    watch: Boolean(options.watch),
+    quiet: Boolean(options.quiet),
+    dryRun: Boolean(options.dryRun),
+    json: typeof options.json === 'string' ? options.json : undefined,
+  };
+}
 
 function renderZtdLayoutGeneratedFile(config: ZtdProjectConfig): string {
   // Derive the canonical ztd root directory from the configured DDL path.
@@ -64,104 +107,133 @@ export function registerZtdConfigCommand(program: Command): void {
     .option('--quiet', 'Suppress next-step hints after generation', false)
     .option('--dry-run', 'Validate inputs and render outputs without writing files', false)
     .option('--json <payload>', 'Pass command options as a JSON object')
-    .action(async (options) => {
-      const merged = options.json ? resolveZtdConfigCommandOptions(options as Record<string, unknown>) : options;
-      if (merged.watch && merged.dryRun) {
-        throw new Error('--watch cannot be combined with --dry-run.');
-      }
+    .action(async (options: Record<string, unknown>) => {
+      const commandState = await withSpan('resolve-command-state', async () => {
+        const merged = options.json ? resolveZtdConfigCommandOptions(options) : normalizeZtdConfigCommandOptions(options);
+        if (merged.watch && merged.dryRun) {
+          emitDecisionEvent('watch.invalid-with-dry-run');
+          throw new Error('--watch cannot be combined with --dry-run.');
+        }
 
-      const projectConfig = loadZtdProjectConfig();
-      const directories = normalizeDirectoryList(merged.ddlDir as string[], projectConfig.ddlDir ?? DEFAULT_DDL_DIRECTORY);
-      const extensions = resolveExtensions(merged.extensions as string[], DEFAULT_EXTENSIONS);
-      const defaultOut = path.join(
-        projectConfig.testsDir ?? DEFAULT_TESTS_DIRECTORY,
-        'generated',
-        'ztd-row-map.generated.ts'
-      );
-      const output = merged.out ?? defaultOut;
-      const layoutOut = path.join(path.dirname(output), 'ztd-layout.generated.ts');
+        const projectConfig = loadZtdProjectConfig();
+        const directories = normalizeDirectoryList(merged.ddlDir, projectConfig.ddlDir ?? DEFAULT_DDL_DIRECTORY);
+        const extensions = resolveExtensions(merged.extensions, DEFAULT_EXTENSIONS);
+        const defaultOut = path.join(
+          projectConfig.testsDir ?? DEFAULT_TESTS_DIRECTORY,
+          'generated',
+          'ztd-row-map.generated.ts'
+        );
+        const output = merged.out ?? defaultOut;
+        const layoutOut = path.join(path.dirname(output), 'ztd-layout.generated.ts');
 
-      const ddlOverrides: ZtdProjectConfig['ddl'] = { ...projectConfig.ddl };
-      let shouldUpdateConfig = false;
+        const ddlOverrides: ZtdProjectConfig['ddl'] = { ...projectConfig.ddl };
+        let shouldUpdateConfig = false;
 
-      if (merged.defaultSchema) {
-        ddlOverrides.defaultSchema = validateResourceIdentifier(merged.defaultSchema, '--default-schema');
-        shouldUpdateConfig = true;
-      }
+        if (merged.defaultSchema) {
+          ddlOverrides.defaultSchema = validateResourceIdentifier(merged.defaultSchema, '--default-schema');
+          shouldUpdateConfig = true;
+        }
 
-      if (merged.searchPath && merged.searchPath.length > 0) {
-        ddlOverrides.searchPath = merged.searchPath.map((entry: string) => validateResourceIdentifier(entry, '--search-path'));
-        shouldUpdateConfig = true;
-      }
+        if (merged.searchPath && merged.searchPath.length > 0) {
+          ddlOverrides.searchPath = merged.searchPath.map((entry) => validateResourceIdentifier(entry, '--search-path'));
+          shouldUpdateConfig = true;
+        }
 
-      const validatedOutput = validateProjectPath(output, '--out');
-      const validatedLayoutOut = validateProjectPath(layoutOut, 'generated layout output');
+        const validatedOutput = validateProjectPath(output, '--out');
+        const validatedLayoutOut = validateProjectPath(layoutOut, 'generated layout output');
+        const generationOptions: ZtdConfigGenerationOptions = {
+          directories,
+          extensions,
+          out: validatedOutput,
+          defaultSchema: ddlOverrides.defaultSchema,
+          searchPath: ddlOverrides.searchPath,
+          ddlLint: projectConfig.ddlLint,
+          dryRun: merged.dryRun
+        };
+        const layoutConfig: ZtdProjectConfig = { ...projectConfig, ddl: ddlOverrides };
 
-      if (shouldUpdateConfig && !merged.dryRun) {
-        writeZtdProjectConfig(process.cwd(), { ddl: ddlOverrides });
-        emitDiagnostic({ code: 'ztd-config.config-updated', message: 'ztd.config.json ddl schema settings updated.' });
-      }
+        emitDecisionEvent('command.options.resolved', {
+          dryRun: merged.dryRun,
+          watch: merged.watch,
+          quiet: merged.quiet,
+          shouldUpdateConfig,
+          jsonPayload: Boolean(options.json),
+        });
 
-      const generationOptions: ZtdConfigGenerationOptions = {
-        directories,
-        extensions,
-        out: validatedOutput,
-        defaultSchema: ddlOverrides.defaultSchema,
-        searchPath: ddlOverrides.searchPath,
-        ddlLint: projectConfig.ddlLint,
-        dryRun: Boolean(merged.dryRun)
-      };
+        return {
+          merged,
+          shouldUpdateConfig,
+          ddlOverrides,
+          validatedOutput,
+          validatedLayoutOut,
+          generationOptions,
+          layoutConfig,
+        };
+      }, {
+        command: 'ztd-config',
+      });
 
-      const generation = await runGenerateZtdConfig(generationOptions);
-      const layoutConfig: ZtdProjectConfig = { ...projectConfig, ddl: ddlOverrides };
-      if (!merged.dryRun) {
-        writeZtdLayoutFile(validatedLayoutOut, layoutConfig);
-      }
-
-      if (isJsonOutput()) {
-        writeCommandEnvelope('ztd-config', {
-          schemaVersion: 1,
-          dryRun: Boolean(merged.dryRun),
-          configUpdated: shouldUpdateConfig && !merged.dryRun,
-          outputs: [
-            { path: validatedOutput, bytes: generation.rendered.length, written: !merged.dryRun },
-            { path: validatedLayoutOut, written: !merged.dryRun }
-          ],
-          tables: generation.tables.map((table) => ({ name: table.name, columns: table.columns.length }))
+      if (commandState.shouldUpdateConfig && !commandState.merged.dryRun) {
+        await withSpan('persist-project-config', async () => {
+          writeZtdProjectConfig(process.cwd(), { ddl: commandState.ddlOverrides });
+          emitDiagnostic({ code: 'ztd-config.config-updated', message: 'ztd.config.json ddl schema settings updated.' });
+          emitDecisionEvent('config.updated');
         });
       }
 
-      if (merged.watch) {
-        console.log(`[watch] Initial generation complete: ${generationOptions.out}`);
-        await watchZtdConfig(generationOptions, validatedLayoutOut, layoutConfig);
-      } else if (!merged.quiet) {
-        if (merged.dryRun) {
-          emitDiagnostic({
-            code: 'ztd-config.dry-run',
-            message: `Dry-run validated generation for ${validatedOutput} and ${validatedLayoutOut}.`
-          });
-        } else {
-          emitDiagnostic({ code: 'ztd-config.next-steps', message: 'Next: run vitest, ztd lint, and ztd check-contract.' });
-        }
+      const generation = await withSpan('generate-ztd-config', async () => {
+        return await runGenerateZtdConfig(commandState.generationOptions);
+      }, {
+        dryRun: commandState.merged.dryRun,
+        directoryCount: commandState.generationOptions.directories.length,
+      });
+
+      if (!commandState.merged.dryRun) {
+        await withSpan('write-layout-file', async () => {
+          writeZtdLayoutFile(commandState.validatedLayoutOut, commandState.layoutConfig);
+        });
       }
+
+      await withSpan('emit-command-output', async () => {
+        if (isJsonOutput()) {
+          writeCommandEnvelope('ztd-config', {
+            schemaVersion: 1,
+            dryRun: commandState.merged.dryRun,
+            configUpdated: commandState.shouldUpdateConfig && !commandState.merged.dryRun,
+            outputs: [
+              { path: commandState.validatedOutput, bytes: generation.rendered.length, written: !commandState.merged.dryRun },
+              { path: commandState.validatedLayoutOut, written: !commandState.merged.dryRun }
+            ],
+            tables: generation.tables.map((table) => ({ name: table.name, columns: table.columns.length }))
+          });
+          emitDecisionEvent('output.json-envelope');
+        }
+
+        if (commandState.merged.watch) {
+          console.log(`[watch] Initial generation complete: ${commandState.generationOptions.out}`);
+          emitDecisionEvent('watch.enabled');
+          await watchZtdConfig(commandState.generationOptions, commandState.validatedLayoutOut, commandState.layoutConfig);
+        } else if (!commandState.merged.quiet) {
+          if (commandState.merged.dryRun) {
+            emitDiagnostic({
+              code: 'ztd-config.dry-run',
+              message: `Dry-run validated generation for ${commandState.validatedOutput} and ${commandState.validatedLayoutOut}.`
+            });
+            emitDecisionEvent('output.dry-run-diagnostic');
+          } else {
+            emitDiagnostic({ code: 'ztd-config.next-steps', message: 'Next: run vitest, ztd lint, and ztd check-contract.' });
+            emitDecisionEvent('output.next-steps-diagnostic');
+          }
+        } else {
+          emitDecisionEvent('output.quiet-suppressed');
+        }
+      });
     });
 }
 
-export function resolveZtdConfigCommandOptions(options: Record<string, unknown>): Record<string, unknown> {
+export function resolveZtdConfigCommandOptions(options: Record<string, unknown>): ZtdConfigCommandOptions {
   const payload = parseJsonPayload<Record<string, unknown>>(String(options.json), '--json');
-  const merged = { ...options, ...payload };
-
-  if (typeof merged.ddlDir === 'string') {
-    merged.ddlDir = collectDirectories(merged.ddlDir, []);
-  }
-  if (typeof merged.extensions === 'string') {
-    merged.extensions = parseExtensions(merged.extensions);
-  }
-  if (typeof merged.searchPath === 'string') {
-    merged.searchPath = parseCsvList(merged.searchPath);
-  }
-
-  return merged;
+  return normalizeZtdConfigCommandOptions({ ...options, ...payload });
 }
 
 async function watchZtdConfig(

--- a/packages/ztd-cli/src/index.ts
+++ b/packages/ztd-cli/src/index.ts
@@ -12,14 +12,56 @@ import { registerQueryCommands } from './commands/query';
 import { TestEvidenceRuntimeError, registerTestEvidenceCommand } from './commands/testEvidence';
 import { registerZtdConfigCommand } from './commands/ztdConfigCommand';
 import { setAgentOutputFormat } from './utils/agentCli';
+import {
+  beginCommandSpan,
+  configureTelemetry,
+  emitDecisionEvent,
+  finishCommandSpan,
+  recordException,
+} from './utils/telemetry';
 
-async function main(): Promise<void> {
+function getCommandPath(command: Command): string {
+  const segments: string[] = [];
+  let current: Command | null = command;
+
+  while (current) {
+    const name = current.name();
+    if (name && name !== 'ztd') {
+      segments.unshift(name);
+    }
+    current = current.parent ?? null;
+  }
+
+  return segments.join(' ');
+}
+
+export function buildProgram(): Command {
   const program = new Command();
   program.name('ztd').description('Zero Table Dependency scaffolding and DDL helpers');
   program.option('--output <format>', 'Global output format (text|json)', 'text');
-  program.hook('preAction', (rootCommand) => {
-    const options = rootCommand.optsWithGlobals() as { output?: string };
+  program.option('--telemetry', 'Enable internal telemetry events on stderr');
+  program.hook('preAction', (_rootCommand: Command, actionCommand: Command) => {
+    const options = actionCommand.optsWithGlobals() as { output?: string; telemetry?: boolean };
     setAgentOutputFormat(options.output);
+
+    // Preserve env-based opt-in when the CLI flag was not provided explicitly.
+    const telemetryOptionSource = actionCommand.getOptionValueSource('telemetry');
+    configureTelemetry({
+      enabled: telemetryOptionSource === 'default' ? undefined : options.telemetry,
+    });
+
+    const commandPath = getCommandPath(actionCommand);
+    beginCommandSpan(commandPath, {
+      outputFormat: options.output ?? 'text',
+      telemetryEnabled: telemetryOptionSource === 'default'
+        ? undefined
+        : Boolean(options.telemetry),
+    });
+    emitDecisionEvent('command.selected', { command: commandPath });
+  });
+  program.hook('postAction', (_rootCommand: Command, actionCommand: Command) => {
+    emitDecisionEvent('command.completed', { command: getCommandPath(actionCommand) });
+    finishCommandSpan('ok');
   });
 
   registerInitCommand(program);
@@ -55,13 +97,26 @@ After schema changes:
 
 Documentation: https://github.com/mk3008/rawsql-ts`);
 
-  await program.parseAsync(process.argv);
+  return program;
 }
 
-main().catch((error) => {
+export async function main(argv: string[] = process.argv): Promise<void> {
+  const program = buildProgram();
+  await program.parseAsync(argv);
+}
+
+function handleFatalError(error: unknown): never {
+  // Keep a terminal root exception alongside child span failures so exporters can correlate
+  // the failing phase with the overall command outcome without inferring it from child spans.
+  recordException(error, { scope: 'command-root' });
+  finishCommandSpan('error');
   console.error(error instanceof Error ? error.message : error);
   if (error instanceof CheckContractRuntimeError || error instanceof TestEvidenceRuntimeError) {
     process.exit(2);
   }
   process.exit(1);
-});
+}
+
+if (require.main === module) {
+  void main().catch(handleFatalError);
+}

--- a/packages/ztd-cli/src/utils/telemetry.ts
+++ b/packages/ztd-cli/src/utils/telemetry.ts
@@ -1,0 +1,260 @@
+import { performance } from 'node:perf_hooks';
+
+export type TelemetryAttributeValue = string | number | boolean | null;
+export type TelemetryAttributes = Record<string, TelemetryAttributeValue | undefined>;
+export type TelemetryStatus = 'ok' | 'error';
+
+const TELEMETRY_ENABLED_ENV = 'ZTD_CLI_TELEMETRY';
+const DEFAULT_SCHEMA_VERSION = 1;
+
+interface TelemetrySpan {
+  id: string;
+  end(status: TelemetryStatus): void;
+  recordException(error: unknown, attributes?: TelemetryAttributes): void;
+}
+
+interface TelemetrySink {
+  startSpan(name: string, parentSpanId?: string, attributes?: TelemetryAttributes): TelemetrySpan;
+  emitDecisionEvent(name: string, spanId?: string, attributes?: TelemetryAttributes): void;
+  emitException(error: unknown, spanId?: string, attributes?: TelemetryAttributes): void;
+}
+
+class NoopTelemetrySpan implements TelemetrySpan {
+  id = 'noop';
+
+  end(): void {
+    return;
+  }
+
+  recordException(): void {
+    return;
+  }
+}
+
+class NoopTelemetrySink implements TelemetrySink {
+  startSpan(): TelemetrySpan {
+    return new NoopTelemetrySpan();
+  }
+
+  emitDecisionEvent(): void {
+    return;
+  }
+
+  emitException(): void {
+    return;
+  }
+}
+
+class StderrTelemetrySink implements TelemetrySink {
+  private nextSpanId = 1;
+
+  startSpan(name: string, parentSpanId?: string, attributes?: TelemetryAttributes): TelemetrySpan {
+    const spanId = `span-${this.nextSpanId++}`;
+    const startedAt = performance.now();
+
+    this.write({
+      kind: 'span-start',
+      spanId,
+      parentSpanId,
+      spanName: name,
+      attributes: sanitizeAttributes(attributes),
+    });
+
+    return {
+      id: spanId,
+      end: (status: TelemetryStatus) => {
+        this.write({
+          kind: 'span-end',
+          spanId,
+          parentSpanId,
+          spanName: name,
+          status,
+          durationMs: roundDuration(performance.now() - startedAt),
+        });
+      },
+      recordException: (error: unknown, exceptionAttributes?: TelemetryAttributes) => {
+        this.emitException(error, spanId, exceptionAttributes);
+      },
+    };
+  }
+
+  emitDecisionEvent(name: string, spanId?: string, attributes?: TelemetryAttributes): void {
+    this.write({
+      kind: 'decision',
+      eventName: name,
+      spanId,
+      attributes: sanitizeAttributes(attributes),
+    });
+  }
+
+  emitException(error: unknown, spanId?: string, attributes?: TelemetryAttributes): void {
+    this.write({
+      kind: 'exception',
+      spanId,
+      error: normalizeError(error),
+      attributes: sanitizeAttributes(attributes),
+    });
+  }
+
+  private write(payload: Record<string, unknown>): void {
+    process.stderr.write(
+      `${JSON.stringify({
+        schemaVersion: DEFAULT_SCHEMA_VERSION,
+        type: 'telemetry',
+        timestamp: new Date().toISOString(),
+        ...payload,
+      })}\n`,
+    );
+  }
+}
+
+const NOOP_SINK = new NoopTelemetrySink();
+
+let telemetrySink: TelemetrySink = NOOP_SINK;
+let telemetryEnabled = false;
+const spanStack: TelemetrySpan[] = [];
+
+export function resolveTelemetryEnabled(explicit?: boolean | string | undefined): boolean {
+  if (typeof explicit === 'boolean') {
+    return explicit;
+  }
+
+  if (typeof explicit === 'string') {
+    return isTruthy(explicit);
+  }
+
+  return isTruthy(process.env[TELEMETRY_ENABLED_ENV]);
+}
+
+export function setTelemetryEnabled(enabled: boolean): void {
+  process.env[TELEMETRY_ENABLED_ENV] = enabled ? '1' : '0';
+}
+
+export function configureTelemetry(options: { enabled?: boolean | string } = {}): void {
+  telemetryEnabled = resolveTelemetryEnabled(options.enabled);
+  telemetrySink = telemetryEnabled ? new StderrTelemetrySink() : NOOP_SINK;
+  spanStack.length = 0;
+}
+
+export function isTelemetryEnabled(): boolean {
+  return telemetryEnabled;
+}
+
+export function beginCommandSpan(commandName: string, attributes: TelemetryAttributes = {}): void {
+  if (!telemetryEnabled) {
+    return;
+  }
+
+  spanStack.length = 0;
+  const rootSpan = telemetrySink.startSpan(commandName, undefined, {
+    ...attributes,
+    scope: 'command-root',
+  });
+  spanStack.push(rootSpan);
+}
+
+export function finishCommandSpan(status: TelemetryStatus = 'ok'): void {
+  if (!telemetryEnabled) {
+    return;
+  }
+
+  while (spanStack.length > 1) {
+    spanStack.pop()?.end(status);
+  }
+
+  spanStack.pop()?.end(status);
+}
+
+export async function withSpan<T>(name: string, fn: () => Promise<T> | T, attributes: TelemetryAttributes = {}): Promise<T> {
+  if (!telemetryEnabled) {
+    return await fn();
+  }
+
+  const parentSpanId = getCurrentSpan()?.id;
+  const span = telemetrySink.startSpan(name, parentSpanId, attributes);
+  spanStack.push(span);
+
+  try {
+    const result = await fn();
+    span.end('ok');
+    return result;
+  } catch (error) {
+    span.recordException(error);
+    span.end('error');
+    throw error;
+  } finally {
+    removeSpan(span.id);
+  }
+}
+
+export function emitDecisionEvent(name: string, attributes: TelemetryAttributes = {}): void {
+  if (!telemetryEnabled) {
+    return;
+  }
+
+  telemetrySink.emitDecisionEvent(name, getCurrentSpan()?.id, attributes);
+}
+
+export function recordException(error: unknown, attributes: TelemetryAttributes = {}): void {
+  if (!telemetryEnabled) {
+    return;
+  }
+
+  const currentSpan = getCurrentSpan();
+  if (currentSpan) {
+    currentSpan.recordException(error, attributes);
+    return;
+  }
+
+  telemetrySink.emitException(error, undefined, attributes);
+}
+
+function getCurrentSpan(): TelemetrySpan | undefined {
+  return spanStack[spanStack.length - 1];
+}
+
+function removeSpan(spanId: string): void {
+  const index = spanStack.findIndex((span) => span.id === spanId);
+  if (index >= 0) {
+    spanStack.splice(index, 1);
+  }
+}
+
+function isTruthy(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
+}
+
+function sanitizeAttributes(attributes: TelemetryAttributes = {}): Record<string, TelemetryAttributeValue> {
+  const sanitized: Record<string, TelemetryAttributeValue> = {};
+  for (const [key, value] of Object.entries(attributes)) {
+    if (value === undefined) {
+      continue;
+    }
+    sanitized[key] = value;
+  }
+  return sanitized;
+}
+
+function normalizeError(error: unknown): Record<string, unknown> {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    };
+  }
+
+  return {
+    name: 'UnknownError',
+    message: String(error),
+  };
+}
+
+function roundDuration(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}

--- a/packages/ztd-cli/tests/telemetry.unit.test.ts
+++ b/packages/ztd-cli/tests/telemetry.unit.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import {
+  beginCommandSpan,
+  configureTelemetry,
+  emitDecisionEvent,
+  finishCommandSpan,
+  recordException,
+  setTelemetryEnabled,
+  withSpan,
+} from '../src/utils/telemetry';
+
+const originalTelemetry = process.env.ZTD_CLI_TELEMETRY;
+
+afterEach(() => {
+  if (originalTelemetry === undefined) {
+    delete process.env.ZTD_CLI_TELEMETRY;
+  } else {
+    process.env.ZTD_CLI_TELEMETRY = originalTelemetry;
+  }
+  configureTelemetry({ enabled: false });
+  vi.restoreAllMocks();
+});
+
+test('telemetry is a no-op by default', async () => {
+  const writeSpy = vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: string | Uint8Array) => {
+    void chunk;
+    return true;
+  }) as typeof process.stderr.write);
+
+  configureTelemetry({ enabled: false });
+  beginCommandSpan('ztd-config');
+  emitDecisionEvent('command.selected', { command: 'ztd-config' });
+  await withSpan('phase', async () => undefined);
+  recordException(new Error('ignored'));
+  finishCommandSpan('ok');
+
+  expect(writeSpy).not.toHaveBeenCalled();
+});
+
+test('telemetry emits root spans, child spans, decision events, and exceptions when enabled', async () => {
+  const lines: string[] = [];
+  vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: string | Uint8Array) => {
+    lines.push(String(chunk).trim());
+    return true;
+  }) as typeof process.stderr.write);
+
+  setTelemetryEnabled(true);
+  configureTelemetry();
+  beginCommandSpan('ztd-config', { outputFormat: 'json' });
+  emitDecisionEvent('command.selected', { command: 'ztd-config' });
+  await expect(withSpan('generate', async () => {
+    emitDecisionEvent('generation.started', { dryRun: true });
+    throw new Error('boom');
+  })).rejects.toThrow('boom');
+  recordException(new Error('root failure'), { scope: 'command-root' });
+  finishCommandSpan('error');
+
+  const payloads = lines.filter(Boolean).map((line) => JSON.parse(line));
+  expect(payloads).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ type: 'telemetry', kind: 'span-start', spanName: 'ztd-config' }),
+      expect.objectContaining({ type: 'telemetry', kind: 'span-start', spanName: 'generate' }),
+      expect.objectContaining({ type: 'telemetry', kind: 'decision', eventName: 'generation.started' }),
+      expect.objectContaining({ type: 'telemetry', kind: 'exception', spanId: expect.any(String) }),
+      expect.objectContaining({ type: 'telemetry', kind: 'span-end', spanName: 'ztd-config', status: 'error' }),
+    ]),
+  );
+});

--- a/packages/ztd-cli/tests/ztdConfigCommand.telemetry.unit.test.ts
+++ b/packages/ztd-cli/tests/ztdConfigCommand.telemetry.unit.test.ts
@@ -1,0 +1,153 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { afterEach, expect, test, vi } from 'vitest';
+import { buildProgram } from '../src/index';
+import { configureTelemetry } from '../src/utils/telemetry';
+
+const originalOutput = process.env.ZTD_CLI_OUTPUT_FORMAT;
+const originalTelemetry = process.env.ZTD_CLI_TELEMETRY;
+
+function createWorkspace(prefix: string): string {
+  const tmpRoot = path.join(process.cwd(), 'tmp');
+  mkdirSync(tmpRoot, { recursive: true });
+  const root = mkdtempSync(path.join(tmpRoot, `${prefix}-`));
+  mkdirSync(path.join(root, 'ztd', 'ddl'), { recursive: true });
+  return root;
+}
+
+afterEach(() => {
+  if (originalOutput === undefined) {
+    delete process.env.ZTD_CLI_OUTPUT_FORMAT;
+  } else {
+    process.env.ZTD_CLI_OUTPUT_FORMAT = originalOutput;
+  }
+  if (originalTelemetry === undefined) {
+    delete process.env.ZTD_CLI_TELEMETRY;
+  } else {
+    process.env.ZTD_CLI_TELEMETRY = originalTelemetry;
+  }
+  configureTelemetry({ enabled: false });
+  vi.restoreAllMocks();
+});
+
+test('real CLI root wiring emits telemetry events for ztd-config when --telemetry is enabled', async () => {
+  const workspace = createWorkspace('ztd-config-telemetry');
+  const ddlDir = path.join(workspace, 'ztd', 'ddl');
+  const ddlFile = path.join(ddlDir, 'public.sql');
+  const outputFile = path.join(workspace, 'tests', 'generated', 'ztd-row-map.generated.ts');
+  const relativeDdlDir = path.relative(process.cwd(), ddlDir);
+  const relativeOutputFile = path.relative(process.cwd(), outputFile);
+
+  writeFileSync(
+    ddlFile,
+    `
+      CREATE TABLE public.users (
+        id serial PRIMARY KEY,
+        email text NOT NULL
+      );
+    `,
+    'utf8',
+  );
+
+  const stdout: string[] = [];
+  const stderrLines: string[] = [];
+  const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: string | Uint8Array) => {
+    stderrLines.push(String(chunk));
+    return true;
+  }) as typeof process.stderr.write);
+  const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: string | Uint8Array) => {
+    stdout.push(String(chunk));
+    return true;
+  }) as typeof process.stdout.write);
+
+  const program = buildProgram();
+  program.exitOverride();
+  await program.parseAsync(
+    ['node', 'ztd', '--telemetry', '--output', 'json', 'ztd-config', '--ddl-dir', relativeDdlDir, '--out', relativeOutputFile, '--dry-run'],
+    { from: 'node' },
+  );
+
+  stderrSpy.mockRestore();
+  stdoutSpy.mockRestore();
+
+  const envelope = JSON.parse(stdout.join(''));
+  expect(envelope).toMatchObject({
+    command: 'ztd-config',
+    ok: true,
+    data: {
+      dryRun: true,
+    },
+  });
+
+  const telemetryEvents = stderrLines
+    .join('')
+    .split(/\r?\n/)
+    .filter((line) => line.includes('"type":"telemetry"'))
+    .map((line) => JSON.parse(line));
+
+  expect(telemetryEvents).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ kind: 'span-start', spanName: 'ztd-config' }),
+      expect.objectContaining({ kind: 'span-start', spanName: 'resolve-command-state' }),
+      expect.objectContaining({ kind: 'span-start', spanName: 'generate-ztd-config' }),
+      expect.objectContaining({ kind: 'decision', eventName: 'output.json-envelope' }),
+      expect.objectContaining({ kind: 'span-end', spanName: 'ztd-config', status: 'ok' }),
+    ]),
+  );
+});
+
+test('real CLI root wiring enables telemetry from env when the flag is omitted', async () => {
+  const workspace = createWorkspace('ztd-config-telemetry-env');
+  const ddlDir = path.join(workspace, 'ztd', 'ddl');
+  const ddlFile = path.join(ddlDir, 'public.sql');
+  const outputFile = path.join(workspace, 'tests', 'generated', 'ztd-row-map.generated.ts');
+  const relativeDdlDir = path.relative(process.cwd(), ddlDir);
+  const relativeOutputFile = path.relative(process.cwd(), outputFile);
+
+  writeFileSync(
+    ddlFile,
+    `
+      CREATE TABLE public.accounts (
+        id serial PRIMARY KEY,
+        email text NOT NULL
+      );
+    `,
+    'utf8',
+  );
+
+  process.env.ZTD_CLI_TELEMETRY = '1';
+
+  const stderrLines: string[] = [];
+  const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: string | Uint8Array) => {
+    stderrLines.push(String(chunk));
+    return true;
+  }) as typeof process.stderr.write);
+  const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: string | Uint8Array) => {
+    void chunk;
+    return true;
+  }) as typeof process.stdout.write);
+
+  const program = buildProgram();
+  program.exitOverride();
+  await program.parseAsync(
+    ['node', 'ztd', '--output', 'json', 'ztd-config', '--ddl-dir', relativeDdlDir, '--out', relativeOutputFile, '--dry-run'],
+    { from: 'node' },
+  );
+
+  stderrSpy.mockRestore();
+  stdoutSpy.mockRestore();
+
+  const telemetryEvents = stderrLines
+    .join('')
+    .split(/\r?\n/)
+    .filter((line) => line.includes('"type":"telemetry"'))
+    .map((line) => JSON.parse(line));
+
+  expect(telemetryEvents).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ kind: 'span-start', spanName: 'ztd-config' }),
+      expect.objectContaining({ kind: 'decision', eventName: 'command.selected' }),
+      expect.objectContaining({ kind: 'span-end', spanName: 'ztd-config', status: 'ok' }),
+    ]),
+  );
+});


### PR DESCRIPTION
## Summary
- add a thin internal telemetry abstraction for ztd-cli with a default no-op runtime and stderr JSON sink
- instrument root command execution plus ztd-config command phases, decision events, and exception recording
- cover explicit flag enablement and env-based fallback with focused telemetry tests

## Testing
- .\\node_modules\\.bin\\vitest.cmd run --config packages/ztd-cli/vitest.config.ts packages/ztd-cli/tests/telemetry.unit.test.ts packages/ztd-cli/tests/describe.cli.test.ts packages/ztd-cli/tests/ztdConfigCommand.telemetry.unit.test.ts
- pnpm test (fails in existing unrelated cli/init suites during pre-commit; telemetry tests passed)

Closes #517