### PR TITLE
feat: define ztd-cli telemetry event schema

### DIFF
--- a/docs/guide/feature-index.md
+++ b/docs/guide/feature-index.md
@@ -63,9 +63,9 @@ An at-a-glance index of easy-to-miss but important capabilities across the rawsq
 | ztd-cli Agent Interface | [guide/ztd-cli-agent-interface](./ztd-cli-agent-interface.md) | Machine-readable CLI usage for automation and AI agents |
 | ztd describe schema | [guide/ztd-cli-describe-schema](./ztd-cli-describe-schema.md) | Contract details for `ztd describe` JSON payloads |
 | ztd-cli measurement inventory | [guide/ztd-cli-measurement-inventory](./ztd-cli-measurement-inventory.md) | Audit current timing/profiling surfaces before adding OpenTelemetry |
+| ztd-cli telemetry policy | [guide/ztd-cli-telemetry-policy](./ztd-cli-telemetry-policy.md) | Event schema, redaction rules, and safe export boundaries for CLI telemetry |
 | Validation (Zod) | [recipes/validation-zod](../recipes/validation-zod.md) | Wire Zod schemas |
 | Validation (ArkType) | [recipes/validation-arktype](../recipes/validation-arktype.md) | Wire ArkType schemas |
 | SQL catalog recipe | [recipes/sql-contract](../recipes/sql-contract.md) | Catalog executor patterns |
 | Execution scope | [guide/execution-scope](./execution-scope.md) | Transaction and connection control |
 | ZTD Theory | [guide/ztd-theory](./ztd-theory.md) | Conceptual foundation |
-

--- a/docs/guide/ztd-cli-telemetry-policy.md
+++ b/docs/guide/ztd-cli-telemetry-policy.md
@@ -1,0 +1,75 @@
+---
+title: ztd-cli Telemetry Policy
+---
+
+# ztd-cli Telemetry Policy
+
+`ztd-cli` telemetry is intentionally narrow. The sink is useful only when it captures stable decision points and phase boundaries without leaking SQL text, DSNs, credentials, or other high-cardinality payloads.
+
+## Decision-event schema
+
+Decision events use a fixed schema. Adding a new event means updating the source schema in `packages/ztd-cli/src/utils/telemetry.ts`, documenting it here, and deciding which low-cardinality attributes are safe to export.
+
+| Event name | Category | When it fires | Allowed attributes |
+|------------|----------|---------------|--------------------|
+| `command.selected` | command lifecycle | A CLI command path is selected and root telemetry starts | `command` |
+| `command.completed` | command lifecycle | A CLI command path completes successfully | `command` |
+| `model-gen.probe-mode` | probe mode selected | `model-gen` decides between `live` and `ztd` probe mode | `probeMode` |
+| `watch.invalid-with-dry-run` | invalid option guard | `ztd-config` rejects `--watch` with `--dry-run` | none |
+| `command.options.resolved` | fallback activated / config planning | `ztd-config` resolves the option state that affects generation flow | `dryRun`, `watch`, `quiet`, `shouldUpdateConfig`, `jsonPayload` |
+| `config.updated` | config mutation | `ztd-config` persists ddl-related config overrides | none |
+| `output.json-envelope` | output mode selected | A command emits a machine-readable JSON envelope | none |
+| `watch.enabled` | watch activation | `ztd-config` enters watch mode after the first successful generation | none |
+| `output.dry-run-diagnostic` | output truncation / guidance selection | Dry-run guidance is emitted instead of writing files | none |
+| `output.next-steps-diagnostic` | guidance emission | Interactive next-step guidance is emitted | none |
+| `output.quiet-suppressed` | generated output suppressed | Quiet mode suppresses follow-up guidance | none |
+
+## Reserved event categories
+
+The current implementation already emits the events above and reserves the following categories for future additions when they become useful enough to keep stable:
+
+- `fallback activated`
+- `generated files excluded`
+- `probe mode selected`
+- `ambiguous resolution detected`
+- `parse recovery applied`
+- `output truncation applied`
+
+Future events in those categories should follow the same rules: low-cardinality names, explicit allowed attributes, and source plus docs updates in the same change.
+
+## Redaction policy
+
+The telemetry sink sanitizes span attributes, decision-event attributes, and exception payloads before writing JSON lines to `stderr`.
+
+### Never export
+
+- Raw SQL text
+- Bind values
+- Credentials, secrets, tokens, or auth material
+- DSNs / connection URLs
+- Full filesystem dumps or other multi-line directory snapshots
+- Highly variable large payloads
+- Exception stack traces
+
+### Allowed to export
+
+- Stable command names
+- Boolean toggles such as `dryRun` or `watch`
+- Small numeric counters such as `paramCount` or `directoryCount`
+- Stable mode names such as `probeMode`
+- Project-scoped file paths when they are not secrets and not bulk dumps
+
+### Sanitization behavior
+
+- Decision events drop attributes that are not listed in the schema.
+- Sensitive keys such as `sqlText`, `databaseUrl`, `bindValues`, or `password` are replaced with `[REDACTED]`.
+- Strings that look like SQL text, DSNs, or secret-bearing key-value pairs are replaced with `[REDACTED]` even if the key is generic.
+- Large or multi-line strings are replaced with `[TRUNCATED:<length>]` to avoid high-cardinality exports.
+- Exceptions keep a sanitized `name` and `message`, but do not export stacks.
+
+## Testing expectation
+
+Telemetry changes should ship with tests that capture stderr payloads directly and verify both of these constraints:
+
+1. Expected decision events and phase spans are still emitted.
+2. Sensitive fields are absent or redacted in the exported JSON.

--- a/packages/ztd-cli/src/utils/telemetry.ts
+++ b/packages/ztd-cli/src/utils/telemetry.ts
@@ -6,6 +6,57 @@ export type TelemetryStatus = 'ok' | 'error';
 
 const TELEMETRY_ENABLED_ENV = 'ZTD_CLI_TELEMETRY';
 const DEFAULT_SCHEMA_VERSION = 1;
+const MAX_ATTRIBUTE_STRING_LENGTH = 160;
+const REDACTED_VALUE = '[REDACTED]';
+
+export const TELEMETRY_DECISION_EVENT_SCHEMA = {
+  'command.selected': {
+    summary: 'A command path was selected and root command telemetry started.',
+    allowedAttributes: ['command'],
+  },
+  'command.completed': {
+    summary: 'A command path completed successfully.',
+    allowedAttributes: ['command'],
+  },
+  'model-gen.probe-mode': {
+    summary: 'model-gen resolved whether probing should use live PostgreSQL or ZTD fixtures.',
+    allowedAttributes: ['probeMode'],
+  },
+  'watch.invalid-with-dry-run': {
+    summary: 'ztd-config rejected an invalid watch plus dry-run option combination.',
+    allowedAttributes: [],
+  },
+  'command.options.resolved': {
+    summary: 'ztd-config resolved high-level option state that influences generation flow.',
+    allowedAttributes: ['dryRun', 'watch', 'quiet', 'shouldUpdateConfig', 'jsonPayload'],
+  },
+  'config.updated': {
+    summary: 'ztd-config persisted ddl-related project configuration changes.',
+    allowedAttributes: [],
+  },
+  'output.json-envelope': {
+    summary: 'The command emitted a machine-readable JSON envelope.',
+    allowedAttributes: [],
+  },
+  'watch.enabled': {
+    summary: 'ztd-config switched into watch mode after the initial generation.',
+    allowedAttributes: [],
+  },
+  'output.dry-run-diagnostic': {
+    summary: 'The command emitted dry-run follow-up guidance instead of writing files.',
+    allowedAttributes: [],
+  },
+  'output.next-steps-diagnostic': {
+    summary: 'The command emitted next-step guidance for interactive use.',
+    allowedAttributes: [],
+  },
+  'output.quiet-suppressed': {
+    summary: 'The command intentionally suppressed follow-up guidance because quiet mode is active.',
+    allowedAttributes: [],
+  },
+} as const;
+
+export type TelemetryDecisionEventName = keyof typeof TELEMETRY_DECISION_EVENT_SCHEMA;
 
 interface TelemetrySpan {
   id: string;
@@ -15,7 +66,7 @@ interface TelemetrySpan {
 
 interface TelemetrySink {
   startSpan(name: string, parentSpanId?: string, attributes?: TelemetryAttributes): TelemetrySpan;
-  emitDecisionEvent(name: string, spanId?: string, attributes?: TelemetryAttributes): void;
+  emitDecisionEvent(name: TelemetryDecisionEventName, spanId?: string, attributes?: TelemetryAttributes): void;
   emitException(error: unknown, spanId?: string, attributes?: TelemetryAttributes): void;
 }
 
@@ -78,12 +129,13 @@ class StderrTelemetrySink implements TelemetrySink {
     };
   }
 
-  emitDecisionEvent(name: string, spanId?: string, attributes?: TelemetryAttributes): void {
+  emitDecisionEvent(name: TelemetryDecisionEventName, spanId?: string, attributes?: TelemetryAttributes): void {
+    const schema = TELEMETRY_DECISION_EVENT_SCHEMA[name];
     this.write({
       kind: 'decision',
       eventName: name,
       spanId,
-      attributes: sanitizeAttributes(attributes),
+      attributes: sanitizeAttributes(attributes, schema.allowedAttributes),
     });
   }
 
@@ -209,7 +261,7 @@ export function withSpanSync<T>(name: string, fn: () => T, attributes: Telemetry
   }
 }
 
-export function emitDecisionEvent(name: string, attributes: TelemetryAttributes = {}): void {
+export function emitDecisionEvent(name: TelemetryDecisionEventName, attributes: TelemetryAttributes = {}): void {
   if (!telemetryEnabled) {
     return;
   }
@@ -251,13 +303,20 @@ function isTruthy(value: string | undefined): boolean {
   return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
 }
 
-function sanitizeAttributes(attributes: TelemetryAttributes = {}): Record<string, TelemetryAttributeValue> {
+function sanitizeAttributes(
+  attributes: TelemetryAttributes = {},
+  allowedKeys?: readonly string[],
+): Record<string, TelemetryAttributeValue> {
   const sanitized: Record<string, TelemetryAttributeValue> = {};
   for (const [key, value] of Object.entries(attributes)) {
     if (value === undefined) {
       continue;
     }
-    sanitized[key] = value;
+    if (allowedKeys && !allowedKeys.includes(key)) {
+      continue;
+    }
+
+    sanitized[key] = sanitizeAttributeValue(key, value);
   }
   return sanitized;
 }
@@ -266,15 +325,60 @@ function normalizeError(error: unknown): Record<string, unknown> {
   if (error instanceof Error) {
     return {
       name: error.name,
-      message: error.message,
-      stack: error.stack,
+      message: sanitizeStringValue('message', error.message),
     };
   }
 
   return {
     name: 'UnknownError',
-    message: String(error),
+    message: sanitizeStringValue('message', String(error)),
   };
+}
+
+function sanitizeAttributeValue(key: string, value: TelemetryAttributeValue): TelemetryAttributeValue {
+  if (value === null || typeof value === 'number' || typeof value === 'boolean') {
+    return isSensitiveAttributeKey(key) ? REDACTED_VALUE : value;
+  }
+
+  return sanitizeStringValue(key, value);
+}
+
+// Telemetry safety policy intentionally distinguishes secrets from bulky but benign data. DSN detection covers both URL-style and libpq-style forms, while oversized or multiline values are truncated instead of redacted so exporters keep the boundary without leaking payload bodies.
+function sanitizeStringValue(key: string, value: string): string {
+  if (isSensitiveAttributeKey(key) || looksSensitive(value)) {
+    return REDACTED_VALUE;
+  }
+
+  if (value.includes('\n') || value.length > MAX_ATTRIBUTE_STRING_LENGTH) {
+    return `[TRUNCATED:${value.length}]`;
+  }
+
+  return value;
+}
+
+function isSensitiveAttributeKey(key: string): boolean {
+  return [
+    /(?:^|\.)(?:sql|sqlText|query|queryText|statement)$/iu,
+    /(?:dsn|databaseUrl|connectionUrl|url|uri)$/iu,
+    /(?:password|secret|credential|authorization|api(?:_|-)?key|access(?:_|-)?key|(?:auth|bearer|access|refresh|session)?token)$/iu,
+    /(?:bindValue|bindValues|paramValue|paramValues)$/iu,
+    /(?:stack|dump)$/iu,
+  ].some((pattern) => pattern.test(key));
+}
+
+function looksSensitive(value: string): boolean {
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    return false;
+  }
+
+  return [
+    /\b(?:postgres(?:ql)?|mysql|mssql|redis):\/\/\S+/iu,
+    /\b(?:host|hostaddr|port|dbname|db|user|password|passfile|service|sslmode|sslcert|sslkey|sslrootcert|target_session_attrs)\s*=\s*(?:"[^"]*"|'[^']*'|[^\s]+)/iu,
+    /\b(?:password|pwd|secret|token|api(?:key|_key)|access(?:key|_key)|authorization)\s*[=:]\s*\S+/iu,
+    /\b(?:bearer|basic)\s+[A-Za-z0-9._~+\/=:-]{8,}\b/iu,
+    /\b(?:select|insert|update|delete|create|alter|drop|with)\b[\s\S]{0,120}\b(?:from|into|table|view|where|values|set)\b/iu,
+  ].some((pattern) => pattern.test(normalized));
 }
 
 function roundDuration(value: number): number {

--- a/packages/ztd-cli/tests/telemetry.unit.test.ts
+++ b/packages/ztd-cli/tests/telemetry.unit.test.ts
@@ -50,7 +50,7 @@ test('telemetry emits root spans, child spans, decision events, and exceptions w
   beginCommandSpan('ztd-config', { outputFormat: 'json' });
   emitDecisionEvent('command.selected', { command: 'ztd-config' });
   await expect(withSpan('generate', async () => {
-    emitDecisionEvent('generation.started', { dryRun: true });
+    emitDecisionEvent('output.json-envelope');
     throw new Error('boom');
   })).rejects.toThrow('boom');
   recordException(new Error('root failure'), { scope: 'command-root' });
@@ -61,11 +61,189 @@ test('telemetry emits root spans, child spans, decision events, and exceptions w
     expect.arrayContaining([
       expect.objectContaining({ type: 'telemetry', kind: 'span-start', spanName: 'ztd-config' }),
       expect.objectContaining({ type: 'telemetry', kind: 'span-start', spanName: 'generate' }),
-      expect.objectContaining({ type: 'telemetry', kind: 'decision', eventName: 'generation.started' }),
+      expect.objectContaining({ type: 'telemetry', kind: 'decision', eventName: 'output.json-envelope' }),
       expect.objectContaining({ type: 'telemetry', kind: 'exception', spanId: expect.any(String) }),
       expect.objectContaining({ type: 'telemetry', kind: 'span-end', spanName: 'ztd-config', status: 'error' }),
     ]),
   );
+});
+
+test('decision events keep only schema-approved attributes and redact sensitive payloads', async () => {
+  const lines: string[] = [];
+  vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: string | Uint8Array) => {
+    lines.push(String(chunk).trim());
+    return true;
+  }) as typeof process.stderr.write);
+
+  const dsn = 'postgres://demo:secret@localhost:5432/app';
+  const libpqDsn = 'host=localhost port=5432 dbname=app user=demo password=secret';
+  const sql = 'SELECT email FROM public.users WHERE password = :password';
+  const filesystemDump = Array.from({ length: 20 }, (_, index) => `C:/tmp/file-${index}.sql`).join('\n');
+
+  setTelemetryEnabled(true);
+  configureTelemetry();
+  beginCommandSpan('model-gen', {
+    connectionUrl: dsn,
+    scope: 'command-root',
+  });
+  emitDecisionEvent('model-gen.probe-mode', {
+    probeMode: 'live',
+    sqlText: sql,
+    connectionUrl: dsn,
+  });
+  await withSpan('probe-client-connect', async () => undefined, {
+    databaseUrl: dsn,
+    sqlText: sql,
+    outFile: 'src/catalog/specs/generated/getSales.generated.ts',
+  });
+  recordException(new Error(`Probe failed for ${libpqDsn} while running ${sql}`), {
+    bindValues: '[1,"secret"]',
+    filesystemDump,
+  });
+  finishCommandSpan('error');
+
+  const serialized = lines.join('\n');
+  expect(serialized).not.toContain(dsn);
+  expect(serialized).not.toContain(libpqDsn);
+  expect(serialized).not.toContain(sql);
+  expect(serialized).not.toContain('secret');
+  expect(serialized).not.toContain(filesystemDump);
+
+  const payloads = lines.filter(Boolean).map((line) => JSON.parse(line));
+  expect(payloads).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        kind: 'decision',
+        eventName: 'model-gen.probe-mode',
+        attributes: { probeMode: 'live' },
+      }),
+      expect.objectContaining({
+        kind: 'span-start',
+        spanName: 'probe-client-connect',
+        attributes: {
+          databaseUrl: '[REDACTED]',
+          sqlText: '[REDACTED]',
+          outFile: 'src/catalog/specs/generated/getSales.generated.ts',
+        },
+      }),
+      expect.objectContaining({
+        kind: 'exception',
+        error: {
+          name: 'Error',
+          message: '[REDACTED]',
+        },
+        attributes: {
+          bindValues: '[REDACTED]',
+          filesystemDump: '[REDACTED]',
+        },
+      }),
+    ]),
+  );
+});
+
+test('authorization-style secrets are redacted by key and value detectors', async () => {
+  const lines: string[] = [];
+  vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: string | Uint8Array) => {
+    lines.push(String(chunk).trim());
+    return true;
+  }) as typeof process.stderr.write);
+
+  const apiKey = 'demoApiKey12345';
+  const accessKey = 'demoAccessKey67890';
+  const authorization = 'Bearer demo-token-abcdef12';
+
+  setTelemetryEnabled(true);
+  configureTelemetry();
+  beginCommandSpan('model-gen', {
+    apiKey,
+    scope: 'command-root',
+  });
+  await withSpan('probe-client-connect', async () => undefined, {
+    authorization,
+    accessKey,
+    note: authorization,
+  });
+  recordException(new Error(`authorization=${authorization}`), {
+    apiKey,
+  });
+  finishCommandSpan('error');
+
+  const serialized = lines.join('\n');
+  expect(serialized).not.toContain(apiKey);
+  expect(serialized).not.toContain(accessKey);
+  expect(serialized).not.toContain(authorization);
+
+  const payloads = lines.filter(Boolean).map((line) => JSON.parse(line));
+  expect(payloads).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        kind: 'span-start',
+        spanName: 'model-gen',
+        attributes: {
+          apiKey: '[REDACTED]',
+          scope: 'command-root',
+        },
+      }),
+      expect.objectContaining({
+        kind: 'span-start',
+        spanName: 'probe-client-connect',
+        attributes: {
+          authorization: '[REDACTED]',
+          accessKey: '[REDACTED]',
+          note: '[REDACTED]',
+        },
+      }),
+      expect.objectContaining({
+        kind: 'exception',
+        error: {
+          name: 'Error',
+          message: '[REDACTED]',
+        },
+        attributes: {
+          apiKey: '[REDACTED]',
+        },
+      }),
+    ]),
+  );
+});
+
+test('benign oversized and multiline attributes use truncation without redaction', async () => {
+  const lines: string[] = [];
+  vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: string | Uint8Array) => {
+    lines.push(String(chunk).trim());
+    return true;
+  }) as typeof process.stderr.write);
+
+  const multilineNote = ['phase summary', 'line two', 'line three'].join('\n');
+  const longNote = 'safe-output-'.repeat(20);
+
+  setTelemetryEnabled(true);
+  configureTelemetry();
+  beginCommandSpan('query uses table');
+  await withSpan('render-query-usage-output', async () => 'ok', {
+    summary: multilineNote,
+    preview: longNote,
+  });
+  finishCommandSpan('ok');
+
+  const payloads = lines.filter(Boolean).map((line) => JSON.parse(line));
+  expect(payloads).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        kind: 'span-start',
+        spanName: 'render-query-usage-output',
+        attributes: {
+          summary: `[TRUNCATED:${multilineNote.length}]`,
+          preview: `[TRUNCATED:${longNote.length}]`,
+        },
+      }),
+    ]),
+  );
+
+  const serialized = lines.join('\n');
+  expect(serialized).not.toContain(multilineNote);
+  expect(serialized).not.toContain(longNote);
+  expect(serialized).not.toContain('[REDACTED]');
 });
 
 test('withSpanSync emits synchronous child span lifecycle when enabled', () => {


### PR DESCRIPTION
## Summary
- define a fixed decision-event schema for ztd-cli telemetry
- redact SQL, DSNs, credentials, bind values, stacks, and large multiline payloads before stderr export
- document the telemetry event policy and add regression tests for sensitive-field redaction

## Testing
- pnpm install --offline --ignore-scripts
- vitest run --config packages/ztd-cli/vitest.config.ts packages/ztd-cli/tests/telemetry.unit.test.ts packages/ztd-cli/tests/commandTelemetry.unit.test.ts
- vitepress build docs

Closes #519

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ztd-cli Telemetry Policy (decision events, reserved categories, redaction rules, testing expectations).
  * Added feature-index entry and cleaned up a stray separator in the docs.

* **Improvements**
  * Strengthened telemetry sanitization, redaction, and attribute truncation; tightened validation of decision event names.

* **Tests**
  * Added tests covering event attribute filtering, redaction of sensitive data, and truncation of oversized/multiline attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->