### PR TITLE
feat: add ztd-cli telemetry export modes

### DIFF
--- a/docs/guide/feature-index.md
+++ b/docs/guide/feature-index.md
@@ -64,6 +64,7 @@ An at-a-glance index of easy-to-miss but important capabilities across the rawsq
 | ztd describe schema | [guide/ztd-cli-describe-schema](./ztd-cli-describe-schema.md) | Contract details for `ztd describe` JSON payloads |
 | ztd-cli measurement inventory | [guide/ztd-cli-measurement-inventory](./ztd-cli-measurement-inventory.md) | Audit current timing/profiling surfaces before adding OpenTelemetry |
 | ztd-cli telemetry policy | [guide/ztd-cli-telemetry-policy](./ztd-cli-telemetry-policy.md) | Event schema, redaction rules, and safe export boundaries for CLI telemetry |
+| ztd-cli telemetry export modes | [guide/ztd-cli-telemetry-export-modes](./ztd-cli-telemetry-export-modes.md) | Choose local debug, CI artifact, or OTLP export without changing command behavior |
 | Validation (Zod) | [recipes/validation-zod](../recipes/validation-zod.md) | Wire Zod schemas |
 | Validation (ArkType) | [recipes/validation-arktype](../recipes/validation-arktype.md) | Wire ArkType schemas |
 | SQL catalog recipe | [recipes/sql-contract](../recipes/sql-contract.md) | Catalog executor patterns |

--- a/docs/guide/ztd-cli-telemetry-export-modes.md
+++ b/docs/guide/ztd-cli-telemetry-export-modes.md
@@ -1,0 +1,63 @@
+---
+title: ztd-cli Telemetry Export Modes
+---
+
+# ztd-cli Telemetry Export Modes
+
+`ztd-cli` keeps telemetry opt-in, but once enabled it can export spans in formats that work for local debugging, CI artifacts, and OTLP-compatible collectors.
+
+## Modes
+
+| Mode | Use case | Output |
+|------|----------|--------|
+| `console` | Default local inspection | JSONL envelopes on `stderr` |
+| `debug` | Human-readable local debugging | formatted text lines on `stderr` |
+| `file` | CI artifacts or post-run summaries | JSONL file |
+| `otlp` | Jaeger / collector inspection | OTLP/HTTP traces |
+
+## CLI examples
+
+### Default console export
+
+```bash
+ztd --telemetry query uses table public.users
+```
+
+### Human-readable local debug output
+
+```bash
+ztd --telemetry --telemetry-export debug query uses table public.users
+```
+
+### CI-friendly JSONL artifact
+
+```bash
+ztd --telemetry --telemetry-export file --telemetry-file tmp/telemetry/ztd-cli.telemetry.jsonl query uses table public.users
+```
+
+Archive `tmp/telemetry/ztd-cli.telemetry.jsonl` with the CI system's normal artifact upload step.
+
+### OTLP/HTTP export for Jaeger or a collector
+
+```bash
+ztd --telemetry --telemetry-export otlp --telemetry-endpoint http://127.0.0.1:4318/v1/traces query uses table public.users
+```
+
+If `--telemetry-endpoint` is omitted, `ztd-cli` defaults to `http://127.0.0.1:4318/v1/traces`.
+
+## Environment variables
+
+| Variable | Purpose |
+|----------|---------|
+| `ZTD_CLI_TELEMETRY` | Enable telemetry when set to a truthy value |
+| `ZTD_CLI_TELEMETRY_EXPORT` | Select `console`, `debug`, `file`, or `otlp` |
+| `ZTD_CLI_TELEMETRY_FILE` | Override the JSONL artifact path for `file` mode |
+| `ZTD_CLI_TELEMETRY_OTLP_ENDPOINT` | Override the OTLP/HTTP traces endpoint |
+
+## Design notes
+
+- Telemetry stays no-op unless explicitly enabled.
+- `console` and `debug` keep local inspection simple without requiring a backend.
+- `file` mode exists so CI can archive telemetry output without standing up a collector.
+- `otlp` mode is intentionally minimal and collector-friendly, so local Jaeger / OpenTelemetry setups can inspect the same spans.
+- Redaction and truncation rules from the telemetry policy still apply in every mode.

--- a/packages/ztd-cli/src/index.ts
+++ b/packages/ztd-cli/src/index.ts
@@ -17,6 +17,7 @@ import {
   configureTelemetry,
   emitDecisionEvent,
   finishCommandSpan,
+  flushTelemetry,
   recordException,
 } from './utils/telemetry';
 
@@ -39,15 +40,31 @@ export function buildProgram(): Command {
   const program = new Command();
   program.name('ztd').description('Zero Table Dependency scaffolding and DDL helpers');
   program.option('--output <format>', 'Global output format (text|json)', 'text');
-  program.option('--telemetry', 'Enable internal telemetry events on stderr');
+  program.option('--telemetry', 'Enable internal telemetry events');
+  program.option('--telemetry-export <mode>', 'Telemetry export mode (console|debug|file|otlp)');
+  program.option('--telemetry-file <path>', 'Write JSONL telemetry to a file when telemetry export mode is file');
+  program.option('--telemetry-endpoint <url>', 'OTLP/HTTP traces endpoint when telemetry export mode is otlp');
   program.hook('preAction', (_rootCommand: Command, actionCommand: Command) => {
-    const options = actionCommand.optsWithGlobals() as { output?: string; telemetry?: boolean };
+    const options = actionCommand.optsWithGlobals() as {
+      output?: string;
+      telemetry?: boolean;
+      telemetryExport?: string;
+      telemetryFile?: string;
+      telemetryEndpoint?: string;
+    };
     setAgentOutputFormat(options.output);
 
-    // Preserve env-based opt-in when the CLI flag was not provided explicitly.
+    // Preserve env-based opt-in when CLI flags were not provided explicitly.
     const telemetryOptionSource = actionCommand.getOptionValueSource('telemetry');
+    const telemetryExportSource = actionCommand.getOptionValueSource('telemetryExport');
+    const telemetryFileSource = actionCommand.getOptionValueSource('telemetryFile');
+    const telemetryEndpointSource = actionCommand.getOptionValueSource('telemetryEndpoint');
+
     configureTelemetry({
       enabled: telemetryOptionSource === 'default' ? undefined : options.telemetry,
+      exportMode: telemetryExportSource === 'default' ? undefined : options.telemetryExport,
+      filePath: telemetryFileSource === 'default' ? undefined : options.telemetryFile,
+      otlpEndpoint: telemetryEndpointSource === 'default' ? undefined : options.telemetryEndpoint,
     });
 
     const commandPath = getCommandPath(actionCommand);
@@ -84,6 +101,7 @@ Getting started:
   $ ztd lint <path>            Lint SQL files against the schema
   $ ztd query uses table public.users
   $ ztd query uses column public.users.email --format json
+  $ ztd --telemetry --telemetry-export debug query uses table public.users
 
 Common workflow:
   1. ztd init                  Scaffold the project
@@ -103,13 +121,15 @@ Documentation: https://github.com/mk3008/rawsql-ts`);
 export async function main(argv: string[] = process.argv): Promise<void> {
   const program = buildProgram();
   await program.parseAsync(argv);
+  await flushTelemetry();
 }
 
-function handleFatalError(error: unknown): never {
+async function handleFatalError(error: unknown): Promise<never> {
   // Keep a terminal root exception alongside child span failures so exporters can correlate
   // the failing phase with the overall command outcome without inferring it from child spans.
   recordException(error, { scope: 'command-root' });
   finishCommandSpan('error');
+  await flushTelemetry();
   console.error(error instanceof Error ? error.message : error);
   if (error instanceof CheckContractRuntimeError || error instanceof TestEvidenceRuntimeError) {
     process.exit(2);

--- a/packages/ztd-cli/src/utils/telemetry.ts
+++ b/packages/ztd-cli/src/utils/telemetry.ts
@@ -1,13 +1,24 @@
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve as resolvePath } from 'node:path';
 import { performance } from 'node:perf_hooks';
+import { randomBytes } from 'node:crypto';
 
 export type TelemetryAttributeValue = string | number | boolean | null;
 export type TelemetryAttributes = Record<string, TelemetryAttributeValue | undefined>;
 export type TelemetryStatus = 'ok' | 'error';
+export type TelemetryExportMode = 'console' | 'debug' | 'file' | 'otlp';
 
 const TELEMETRY_ENABLED_ENV = 'ZTD_CLI_TELEMETRY';
+const TELEMETRY_EXPORT_ENV = 'ZTD_CLI_TELEMETRY_EXPORT';
+const TELEMETRY_FILE_ENV = 'ZTD_CLI_TELEMETRY_FILE';
+const TELEMETRY_OTLP_ENDPOINT_ENV = 'ZTD_CLI_TELEMETRY_OTLP_ENDPOINT';
 const DEFAULT_SCHEMA_VERSION = 1;
+const DEFAULT_OTLP_HTTP_ENDPOINT = 'http://127.0.0.1:4318/v1/traces';
+const DEFAULT_FILE_EXPORT_PATH = 'tmp/telemetry/ztd-cli.telemetry.jsonl';
 const MAX_ATTRIBUTE_STRING_LENGTH = 160;
 const REDACTED_VALUE = '[REDACTED]';
+const OTLP_STATUS_OK = 1;
+const OTLP_STATUS_ERROR = 2;
 
 export const TELEMETRY_DECISION_EVENT_SCHEMA = {
   'command.selected': {
@@ -68,6 +79,31 @@ interface TelemetrySink {
   startSpan(name: string, parentSpanId?: string, attributes?: TelemetryAttributes): TelemetrySpan;
   emitDecisionEvent(name: TelemetryDecisionEventName, spanId?: string, attributes?: TelemetryAttributes): void;
   emitException(error: unknown, spanId?: string, attributes?: TelemetryAttributes): void;
+  flush(): Promise<void>;
+}
+
+interface TelemetryEnvelopeBase {
+  schemaVersion: number;
+  type: 'telemetry';
+  timestamp: string;
+}
+
+type TelemetryEnvelope = TelemetryEnvelopeBase & Record<string, unknown>;
+
+interface OtlpSpanEventRecord {
+  timeUnixNano: string;
+  name: string;
+  attributes: Array<Record<string, unknown>>;
+}
+
+interface ActiveOtlpSpanRecord {
+  traceId: string;
+  spanId: string;
+  parentSpanId?: string;
+  name: string;
+  startTimeUnixNano: string;
+  attributes: Array<Record<string, unknown>>;
+  events: OtlpSpanEventRecord[];
 }
 
 class NoopTelemetrySpan implements TelemetrySpan {
@@ -94,10 +130,16 @@ class NoopTelemetrySink implements TelemetrySink {
   emitException(): void {
     return;
   }
+
+  async flush(): Promise<void> {
+    return;
+  }
 }
 
-class StderrTelemetrySink implements TelemetrySink {
+class JsonLinesTelemetrySink implements TelemetrySink {
   private nextSpanId = 1;
+
+  constructor(private readonly writeLine: (line: string) => void) {}
 
   startSpan(name: string, parentSpanId?: string, attributes?: TelemetryAttributes): TelemetrySpan {
     const spanId = `span-${this.nextSpanId++}`;
@@ -148,15 +190,184 @@ class StderrTelemetrySink implements TelemetrySink {
     });
   }
 
+  async flush(): Promise<void> {
+    return;
+  }
+
   private write(payload: Record<string, unknown>): void {
-    process.stderr.write(
-      `${JSON.stringify({
-        schemaVersion: DEFAULT_SCHEMA_VERSION,
-        type: 'telemetry',
-        timestamp: new Date().toISOString(),
-        ...payload,
-      })}\n`,
-    );
+    this.writeLine(JSON.stringify(buildTelemetryEnvelope(payload)));
+  }
+}
+
+class DebugTelemetrySink implements TelemetrySink {
+  private nextSpanId = 1;
+
+  startSpan(name: string, parentSpanId?: string, attributes?: TelemetryAttributes): TelemetrySpan {
+    const spanId = `span-${this.nextSpanId++}`;
+    const startedAt = performance.now();
+    this.write('span-start', name, spanId, parentSpanId, sanitizeAttributes(attributes));
+
+    return {
+      id: spanId,
+      end: (status: TelemetryStatus) => {
+        this.write('span-end', name, spanId, parentSpanId, {
+          status,
+          durationMs: roundDuration(performance.now() - startedAt),
+        });
+      },
+      recordException: (error: unknown, exceptionAttributes?: TelemetryAttributes) => {
+        this.emitException(error, spanId, exceptionAttributes);
+      },
+    };
+  }
+
+  emitDecisionEvent(name: TelemetryDecisionEventName, spanId?: string, attributes?: TelemetryAttributes): void {
+    const schema = TELEMETRY_DECISION_EVENT_SCHEMA[name];
+    this.write('decision', name, spanId, undefined, sanitizeAttributes(attributes, schema.allowedAttributes));
+  }
+
+  emitException(error: unknown, spanId?: string, attributes?: TelemetryAttributes): void {
+    this.write('exception', normalizeError(error).message as string, spanId, undefined, sanitizeAttributes(attributes));
+  }
+
+  async flush(): Promise<void> {
+    return;
+  }
+
+  private write(kind: string, label: string, spanId?: string, parentSpanId?: string, data: Record<string, unknown> = {}): void {
+    const summary = JSON.stringify(data);
+    const suffix = summary === '{}' ? '' : ` ${summary}`;
+    const parent = parentSpanId ? ` parent=${parentSpanId}` : '';
+    process.stderr.write(`[telemetry] ${kind} ${label} span=${spanId ?? 'none'}${parent}${suffix}\n`);
+  }
+}
+
+class OtlpHttpTelemetrySink implements TelemetrySink {
+  private readonly activeSpans = new Map<string, ActiveOtlpSpanRecord>();
+  private readonly pendingExports = new Set<Promise<void>>();
+
+  constructor(private readonly endpoint: string) {}
+
+  startSpan(name: string, parentSpanId?: string, attributes?: TelemetryAttributes): TelemetrySpan {
+    const parentSpan = parentSpanId ? this.activeSpans.get(parentSpanId) : undefined;
+    const spanId = randomBytes(8).toString('hex');
+    const spanRecord: ActiveOtlpSpanRecord = {
+      traceId: parentSpan?.traceId ?? randomBytes(16).toString('hex'),
+      spanId,
+      parentSpanId,
+      name,
+      startTimeUnixNano: currentTimeUnixNano(),
+      attributes: toOtlpAttributes(sanitizeAttributes(attributes)),
+      events: [],
+    };
+    this.activeSpans.set(spanId, spanRecord);
+
+    return {
+      id: spanId,
+      end: (status: TelemetryStatus) => {
+        this.endSpan(spanId, status);
+      },
+      recordException: (error: unknown, exceptionAttributes?: TelemetryAttributes) => {
+        this.emitException(error, spanId, exceptionAttributes);
+      },
+    };
+  }
+
+  emitDecisionEvent(name: TelemetryDecisionEventName, spanId?: string, attributes?: TelemetryAttributes): void {
+    const spanRecord = spanId ? this.activeSpans.get(spanId) : undefined;
+    if (!spanRecord) {
+      return;
+    }
+
+    const schema = TELEMETRY_DECISION_EVENT_SCHEMA[name];
+    spanRecord.events.push({
+      timeUnixNano: currentTimeUnixNano(),
+      name,
+      attributes: toOtlpAttributes(sanitizeAttributes(attributes, schema.allowedAttributes)),
+    });
+  }
+
+  emitException(error: unknown, spanId?: string, attributes?: TelemetryAttributes): void {
+    const spanRecord = spanId ? this.activeSpans.get(spanId) : undefined;
+    if (!spanRecord) {
+      return;
+    }
+
+    const normalized = normalizeError(error);
+    spanRecord.events.push({
+      timeUnixNano: currentTimeUnixNano(),
+      name: 'exception',
+      attributes: [
+        ...toOtlpAttributes({
+          'exception.type': String(normalized.name ?? 'UnknownError'),
+          'exception.message': String(normalized.message ?? ''),
+        }),
+        ...toOtlpAttributes(sanitizeAttributes(attributes)),
+      ],
+    });
+  }
+
+  async flush(): Promise<void> {
+    await Promise.allSettled([...this.pendingExports]);
+  }
+
+  private endSpan(spanId: string, status: TelemetryStatus): void {
+    const spanRecord = this.activeSpans.get(spanId);
+    if (!spanRecord) {
+      return;
+    }
+    this.activeSpans.delete(spanId);
+
+    const payload = {
+      resourceSpans: [
+        {
+          resource: {
+            attributes: toOtlpAttributes({
+              'service.name': 'ztd-cli',
+              'telemetry.export.mode': 'otlp',
+            }),
+          },
+          scopeSpans: [
+            {
+              scope: {
+                name: '@rawsql-ts/ztd-cli',
+              },
+              spans: [
+                {
+                  traceId: spanRecord.traceId,
+                  spanId: spanRecord.spanId,
+                  parentSpanId: spanRecord.parentSpanId,
+                  name: spanRecord.name,
+                  kind: 1,
+                  startTimeUnixNano: spanRecord.startTimeUnixNano,
+                  endTimeUnixNano: currentTimeUnixNano(),
+                  attributes: spanRecord.attributes,
+                  events: spanRecord.events,
+                  status: {
+                    code: status === 'ok' ? OTLP_STATUS_OK : OTLP_STATUS_ERROR,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const exportPromise = fetch(this.endpoint, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    })
+      .then(() => undefined)
+      .catch(() => undefined)
+      .finally(() => {
+        this.pendingExports.delete(exportPromise);
+      });
+
+    this.pendingExports.add(exportPromise);
   }
 }
 
@@ -164,6 +375,7 @@ const NOOP_SINK = new NoopTelemetrySink();
 
 let telemetrySink: TelemetrySink = NOOP_SINK;
 let telemetryEnabled = false;
+let telemetryExportMode: TelemetryExportMode = 'console';
 const spanStack: TelemetrySpan[] = [];
 
 export function resolveTelemetryEnabled(explicit?: boolean | string | undefined): boolean {
@@ -178,18 +390,55 @@ export function resolveTelemetryEnabled(explicit?: boolean | string | undefined)
   return isTruthy(process.env[TELEMETRY_ENABLED_ENV]);
 }
 
+export function resolveTelemetryExportMode(explicit?: TelemetryExportMode | string | undefined): TelemetryExportMode {
+  return normalizeTelemetryExportMode(explicit ?? process.env[TELEMETRY_EXPORT_ENV]);
+}
+
+export function resolveTelemetryFilePath(explicit?: string | undefined): string {
+  return explicit ?? process.env[TELEMETRY_FILE_ENV] ?? DEFAULT_FILE_EXPORT_PATH;
+}
+
+export function resolveTelemetryOtlpEndpoint(explicit?: string | undefined): string {
+  return explicit ?? process.env[TELEMETRY_OTLP_ENDPOINT_ENV] ?? DEFAULT_OTLP_HTTP_ENDPOINT;
+}
+
 export function setTelemetryEnabled(enabled: boolean): void {
   process.env[TELEMETRY_ENABLED_ENV] = enabled ? '1' : '0';
 }
 
-export function configureTelemetry(options: { enabled?: boolean | string } = {}): void {
+export function configureTelemetry(options: {
+  enabled?: boolean | string;
+  exportMode?: TelemetryExportMode | string;
+  filePath?: string;
+  otlpEndpoint?: string;
+} = {}): void {
   telemetryEnabled = resolveTelemetryEnabled(options.enabled);
-  telemetrySink = telemetryEnabled ? new StderrTelemetrySink() : NOOP_SINK;
+  telemetryExportMode = resolveTelemetryExportMode(options.exportMode);
+
+  if (!telemetryEnabled) {
+    telemetrySink = NOOP_SINK;
+    spanStack.length = 0;
+    return;
+  }
+
+  telemetrySink = createTelemetrySink({
+    exportMode: telemetryExportMode,
+    filePath: resolveTelemetryFilePath(options.filePath),
+    otlpEndpoint: resolveTelemetryOtlpEndpoint(options.otlpEndpoint),
+  });
   spanStack.length = 0;
 }
 
 export function isTelemetryEnabled(): boolean {
   return telemetryEnabled;
+}
+
+export function getTelemetryExportMode(): TelemetryExportMode {
+  return telemetryExportMode;
+}
+
+export async function flushTelemetry(): Promise<void> {
+  await telemetrySink.flush();
 }
 
 export function beginCommandSpan(commandName: string, attributes: TelemetryAttributes = {}): void {
@@ -283,6 +532,41 @@ export function recordException(error: unknown, attributes: TelemetryAttributes 
   telemetrySink.emitException(error, undefined, attributes);
 }
 
+function createTelemetrySink(options: {
+  exportMode: TelemetryExportMode;
+  filePath: string;
+  otlpEndpoint: string;
+}): TelemetrySink {
+  switch (options.exportMode) {
+    case 'console':
+      return new JsonLinesTelemetrySink((line) => {
+        process.stderr.write(`${line}\n`);
+      });
+    case 'debug':
+      return new DebugTelemetrySink();
+    case 'file': {
+      const absoluteFile = resolvePath(process.cwd(), options.filePath);
+      mkdirSync(dirname(absoluteFile), { recursive: true });
+      return new JsonLinesTelemetrySink((line) => {
+        appendFileSync(absoluteFile, `${line}\n`, 'utf8');
+      });
+    }
+    case 'otlp':
+      return new OtlpHttpTelemetrySink(options.otlpEndpoint);
+    default:
+      return NOOP_SINK;
+  }
+}
+
+function buildTelemetryEnvelope(payload: Record<string, unknown>): TelemetryEnvelope {
+  return {
+    schemaVersion: DEFAULT_SCHEMA_VERSION,
+    type: 'telemetry',
+    timestamp: new Date().toISOString(),
+    ...payload,
+  };
+}
+
 function getCurrentSpan(): TelemetrySpan | undefined {
   return spanStack[spanStack.length - 1];
 }
@@ -301,6 +585,18 @@ function isTruthy(value: string | undefined): boolean {
 
   const normalized = value.trim().toLowerCase();
   return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
+}
+
+function normalizeTelemetryExportMode(value: string | undefined): TelemetryExportMode {
+  switch ((value ?? 'console').trim().toLowerCase()) {
+    case 'console':
+    case 'debug':
+    case 'file':
+    case 'otlp':
+      return (value ?? 'console').trim().toLowerCase() as TelemetryExportMode;
+    default:
+      return 'console';
+  }
 }
 
 function sanitizeAttributes(
@@ -379,6 +675,30 @@ function looksSensitive(value: string): boolean {
     /\b(?:bearer|basic)\s+[A-Za-z0-9._~+\/=:-]{8,}\b/iu,
     /\b(?:select|insert|update|delete|create|alter|drop|with)\b[\s\S]{0,120}\b(?:from|into|table|view|where|values|set)\b/iu,
   ].some((pattern) => pattern.test(normalized));
+}
+
+function toOtlpAttributes(attributes: Record<string, TelemetryAttributeValue>): Array<Record<string, unknown>> {
+  return Object.entries(attributes).map(([key, value]) => ({
+    key,
+    value: toOtlpAnyValue(value),
+  }));
+}
+
+function toOtlpAnyValue(value: TelemetryAttributeValue): Record<string, unknown> {
+  if (value === null) {
+    return { stringValue: 'null' };
+  }
+  if (typeof value === 'boolean') {
+    return { boolValue: value };
+  }
+  if (typeof value === 'number') {
+    return Number.isInteger(value) ? { intValue: value } : { doubleValue: value };
+  }
+  return { stringValue: value };
+}
+
+function currentTimeUnixNano(): string {
+  return (BigInt(Date.now()) * BigInt(1000000)).toString();
 }
 
 function roundDuration(value: number): number {

--- a/packages/ztd-cli/tests/commandTelemetry.unit.test.ts
+++ b/packages/ztd-cli/tests/commandTelemetry.unit.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { afterEach, expect, test, vi } from 'vitest';
 
@@ -35,6 +35,8 @@ import { configureTelemetry } from '../src/utils/telemetry';
 
 const originalProjectRoot = process.env.ZTD_PROJECT_ROOT;
 const originalTelemetry = process.env.ZTD_CLI_TELEMETRY;
+const originalTelemetryExport = process.env.ZTD_CLI_TELEMETRY_EXPORT;
+const originalTelemetryFile = process.env.ZTD_CLI_TELEMETRY_FILE;
 
 function createWorkspace(prefix: string): string {
   const tmpRoot = path.join(process.cwd(), 'tmp');
@@ -74,6 +76,18 @@ afterEach(() => {
     delete process.env.ZTD_CLI_TELEMETRY;
   } else {
     process.env.ZTD_CLI_TELEMETRY = originalTelemetry;
+  }
+
+  if (originalTelemetryExport === undefined) {
+    delete process.env.ZTD_CLI_TELEMETRY_EXPORT;
+  } else {
+    process.env.ZTD_CLI_TELEMETRY_EXPORT = originalTelemetryExport;
+  }
+
+  if (originalTelemetryFile === undefined) {
+    delete process.env.ZTD_CLI_TELEMETRY_FILE;
+  } else {
+    process.env.ZTD_CLI_TELEMETRY_FILE = originalTelemetryFile;
   }
 
   configureTelemetry({ enabled: false });
@@ -116,6 +130,60 @@ test('query uses emits stable phase spans through the real CLI path', async () =
       expect.objectContaining({ kind: 'span-start', spanName: 'spec-discovery' }),
       expect.objectContaining({ kind: 'span-start', spanName: 'impact-aggregation' }),
       expect.objectContaining({ kind: 'span-start', spanName: 'render-query-usage-output' }),
+      expect.objectContaining({ kind: 'span-end', spanName: 'query uses table', status: 'ok' }),
+    ]),
+  );
+});
+
+test('query uses can export telemetry to a CI-friendly artifact file through the real CLI path', async () => {
+  const workspace = createWorkspace('query-telemetry-file');
+  const specsDir = path.join(workspace, 'src', 'catalog', 'specs');
+  const sqlDir = path.join(workspace, 'src', 'sql');
+  const telemetryFile = path.join(workspace, 'artifacts', 'query-uses.telemetry.jsonl');
+  mkdirSync(specsDir, { recursive: true });
+  mkdirSync(sqlDir, { recursive: true });
+
+  writeFileSync(
+    path.join(specsDir, 'users.spec.json'),
+    JSON.stringify({ id: 'catalog.users', sqlFile: '../../sql/users.sql', params: { shape: 'named' } }, null, 2),
+    'utf8',
+  );
+  writeFileSync(path.join(sqlDir, 'users.sql'), 'SELECT email FROM public.users;', 'utf8');
+
+  process.env.ZTD_PROJECT_ROOT = workspace;
+  const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+  const program = buildProgram();
+  program.exitOverride();
+  await program.parseAsync(
+    [
+      'node',
+      'ztd',
+      '--telemetry',
+      '--telemetry-export',
+      'file',
+      '--telemetry-file',
+      telemetryFile,
+      'query',
+      'uses',
+      'table',
+      'public.users',
+      '--format',
+      'json',
+    ],
+    { from: 'node' },
+  );
+
+  logSpy.mockRestore();
+
+  expect(existsSync(telemetryFile)).toBe(true);
+  const payloads = readFileSync(telemetryFile, 'utf8')
+    .trim()
+    .split(/\r?\n/)
+    .map((line) => JSON.parse(line));
+  expect(payloads).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ kind: 'span-start', spanName: 'query uses table' }),
       expect.objectContaining({ kind: 'span-end', spanName: 'query uses table', status: 'ok' }),
     ]),
   );

--- a/packages/ztd-cli/tests/telemetry.unit.test.ts
+++ b/packages/ztd-cli/tests/telemetry.unit.test.ts
@@ -1,24 +1,58 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
 import { afterEach, expect, test, vi } from 'vitest';
 import {
   beginCommandSpan,
   configureTelemetry,
   emitDecisionEvent,
   finishCommandSpan,
+  flushTelemetry,
+  getTelemetryExportMode,
   recordException,
+  resolveTelemetryExportMode,
   setTelemetryEnabled,
   withSpan,
   withSpanSync,
 } from '../src/utils/telemetry';
 
 const originalTelemetry = process.env.ZTD_CLI_TELEMETRY;
+const originalTelemetryExport = process.env.ZTD_CLI_TELEMETRY_EXPORT;
+const originalTelemetryFile = process.env.ZTD_CLI_TELEMETRY_FILE;
+const originalTelemetryEndpoint = process.env.ZTD_CLI_TELEMETRY_OTLP_ENDPOINT;
 
-afterEach(() => {
+function createWorkspace(prefix: string): string {
+  const tmpRoot = path.join(process.cwd(), 'tmp');
+  mkdirSync(tmpRoot, { recursive: true });
+  return mkdtempSync(path.join(tmpRoot, prefix + '-'));
+}
+
+afterEach(async () => {
   if (originalTelemetry === undefined) {
     delete process.env.ZTD_CLI_TELEMETRY;
   } else {
     process.env.ZTD_CLI_TELEMETRY = originalTelemetry;
   }
+
+  if (originalTelemetryExport === undefined) {
+    delete process.env.ZTD_CLI_TELEMETRY_EXPORT;
+  } else {
+    process.env.ZTD_CLI_TELEMETRY_EXPORT = originalTelemetryExport;
+  }
+
+  if (originalTelemetryFile === undefined) {
+    delete process.env.ZTD_CLI_TELEMETRY_FILE;
+  } else {
+    process.env.ZTD_CLI_TELEMETRY_FILE = originalTelemetryFile;
+  }
+
+  if (originalTelemetryEndpoint === undefined) {
+    delete process.env.ZTD_CLI_TELEMETRY_OTLP_ENDPOINT;
+  } else {
+    process.env.ZTD_CLI_TELEMETRY_OTLP_ENDPOINT = originalTelemetryEndpoint;
+  }
+
   configureTelemetry({ enabled: false });
+  await flushTelemetry();
   vi.restoreAllMocks();
 });
 
@@ -34,11 +68,12 @@ test('telemetry is a no-op by default', async () => {
   await withSpan('phase', async () => undefined);
   recordException(new Error('ignored'));
   finishCommandSpan('ok');
+  await flushTelemetry();
 
   expect(writeSpy).not.toHaveBeenCalled();
 });
 
-test('telemetry emits root spans, child spans, decision events, and exceptions when enabled', async () => {
+test('telemetry defaults to console export when enabled without an explicit export mode', async () => {
   const lines: string[] = [];
   vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: string | Uint8Array) => {
     lines.push(String(chunk).trim());
@@ -47,6 +82,8 @@ test('telemetry emits root spans, child spans, decision events, and exceptions w
 
   setTelemetryEnabled(true);
   configureTelemetry();
+  expect(getTelemetryExportMode()).toBe('console');
+
   beginCommandSpan('ztd-config', { outputFormat: 'json' });
   emitDecisionEvent('command.selected', { command: 'ztd-config' });
   await expect(withSpan('generate', async () => {
@@ -55,6 +92,7 @@ test('telemetry emits root spans, child spans, decision events, and exceptions w
   })).rejects.toThrow('boom');
   recordException(new Error('root failure'), { scope: 'command-root' });
   finishCommandSpan('error');
+  await flushTelemetry();
 
   const payloads = lines.filter(Boolean).map((line) => JSON.parse(line));
   expect(payloads).toEqual(
@@ -66,6 +104,76 @@ test('telemetry emits root spans, child spans, decision events, and exceptions w
       expect.objectContaining({ type: 'telemetry', kind: 'span-end', spanName: 'ztd-config', status: 'error' }),
     ]),
   );
+});
+
+test('debug export emits human-readable telemetry lines for local inspection', async () => {
+  const lines: string[] = [];
+  vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: string | Uint8Array) => {
+    lines.push(String(chunk));
+    return true;
+  }) as typeof process.stderr.write);
+
+  configureTelemetry({ enabled: true, exportMode: 'debug' });
+  beginCommandSpan('query uses table');
+  emitDecisionEvent('command.selected', { command: 'query uses table' });
+  finishCommandSpan('ok');
+  await flushTelemetry();
+
+  const serialized = lines.join('');
+  expect(serialized).toContain('[telemetry] span-start query uses table');
+  expect(serialized).toContain('[telemetry] decision command.selected');
+  expect(serialized).toContain('[telemetry] span-end query uses table');
+  expect(() => JSON.parse(serialized)).toThrow();
+});
+
+test('file export writes JSONL telemetry that CI can archive', async () => {
+  const workspace = createWorkspace('telemetry-file');
+  const filePath = path.join(workspace, 'artifacts', 'telemetry.jsonl');
+
+  configureTelemetry({ enabled: true, exportMode: 'file', filePath });
+  beginCommandSpan('ddl diff');
+  await withSpan('collect-local-ddl', async () => undefined, { localFileCount: 2 });
+  finishCommandSpan('ok');
+  await flushTelemetry();
+
+  expect(existsSync(filePath)).toBe(true);
+  const payloads = readFileSync(filePath, 'utf8')
+    .trim()
+    .split(/\r?\n/)
+    .map((line) => JSON.parse(line));
+  expect(payloads).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ kind: 'span-start', spanName: 'ddl diff' }),
+      expect.objectContaining({ kind: 'span-start', spanName: 'collect-local-ddl' }),
+      expect.objectContaining({ kind: 'span-end', spanName: 'ddl diff', status: 'ok' }),
+    ]),
+  );
+});
+
+test('otlp export posts completed spans to an OTLP HTTP endpoint', async () => {
+  const fetchSpy = vi.fn(async () => ({ ok: true }));
+  vi.stubGlobal('fetch', fetchSpy);
+
+  configureTelemetry({ enabled: true, exportMode: 'otlp', otlpEndpoint: 'http://127.0.0.1:4318/v1/traces' });
+  beginCommandSpan('model-gen');
+  emitDecisionEvent('model-gen.probe-mode', { probeMode: 'live' });
+  await withSpan('probe-client-connect', async () => undefined, { probeMode: 'live' });
+  finishCommandSpan('ok');
+  await flushTelemetry();
+
+  expect(fetchSpy).toHaveBeenCalled();
+  const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+  expect(url).toBe('http://127.0.0.1:4318/v1/traces');
+  const body = JSON.parse(String(init.body));
+  expect(body.resourceSpans[0].scopeSpans[0].spans[0]).toEqual(
+    expect.objectContaining({
+      name: 'probe-client-connect',
+      traceId: expect.any(String),
+      spanId: expect.any(String),
+      parentSpanId: expect.any(String),
+    }),
+  );
+  expect(body.resourceSpans[0].scopeSpans[0].spans[0].events).toEqual([]);
 });
 
 test('decision events keep only schema-approved attributes and redact sensitive payloads', async () => {
@@ -101,6 +209,7 @@ test('decision events keep only schema-approved attributes and redact sensitive 
     filesystemDump,
   });
   finishCommandSpan('error');
+  await flushTelemetry();
 
   const serialized = lines.join('\n');
   expect(serialized).not.toContain(dsn);
@@ -167,6 +276,7 @@ test('authorization-style secrets are redacted by key and value detectors', asyn
     apiKey,
   });
   finishCommandSpan('error');
+  await flushTelemetry();
 
   const serialized = lines.join('\n');
   expect(serialized).not.toContain(apiKey);
@@ -225,6 +335,7 @@ test('benign oversized and multiline attributes use truncation without redaction
     preview: longNote,
   });
   finishCommandSpan('ok');
+  await flushTelemetry();
 
   const payloads = lines.filter(Boolean).map((line) => JSON.parse(line));
   expect(payloads).toEqual(
@@ -246,7 +357,7 @@ test('benign oversized and multiline attributes use truncation without redaction
   expect(serialized).not.toContain('[REDACTED]');
 });
 
-test('withSpanSync emits synchronous child span lifecycle when enabled', () => {
+test('withSpanSync emits synchronous child span lifecycle when enabled', async () => {
   const lines: string[] = [];
   vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: string | Uint8Array) => {
     lines.push(String(chunk).trim());
@@ -258,6 +369,7 @@ test('withSpanSync emits synchronous child span lifecycle when enabled', () => {
   beginCommandSpan('ddl diff');
   const value = withSpanSync('compute-diff-plan', () => 'ok', { localFileCount: 2 });
   finishCommandSpan('ok');
+  await flushTelemetry();
 
   expect(value).toBe('ok');
   const payloads = lines.filter(Boolean).map((line) => JSON.parse(line));
@@ -267,4 +379,9 @@ test('withSpanSync emits synchronous child span lifecycle when enabled', () => {
       expect.objectContaining({ kind: 'span-end', spanName: 'compute-diff-plan', status: 'ok' }),
     ]),
   );
+});
+
+test('telemetry export mode falls back to env configuration', () => {
+  process.env.ZTD_CLI_TELEMETRY_EXPORT = 'debug';
+  expect(resolveTelemetryExportMode(undefined)).toBe('debug');
 });


### PR DESCRIPTION
## Summary
- add console, debug, file, and otlp telemetry export modes for ztd-cli
- keep telemetry opt-in while making local inspection and CI artifacts straightforward
- document the export modes and add tests for local, CI-friendly, and OTLP paths

## Testing
- pnpm install --offline --ignore-scripts
- vitest run --config packages/ztd-cli/vitest.config.ts packages/ztd-cli/tests/telemetry.unit.test.ts packages/ztd-cli/tests/commandTelemetry.unit.test.ts
- vitepress build docs
- tsc -p packages/ztd-cli/tsconfig.json --noEmit (shows pre-existing unrelated ztd-cli errors outside this issue scope)

Closes #520