### PR TITLE
docs: explain ztd-cli telemetry philosophy

### DIFF
--- a/docs/guide/feature-index.md
+++ b/docs/guide/feature-index.md
@@ -65,6 +65,7 @@ An at-a-glance index of easy-to-miss but important capabilities across the rawsq
 | ztd-cli measurement inventory | [guide/ztd-cli-measurement-inventory](./ztd-cli-measurement-inventory.md) | Audit current timing/profiling surfaces before adding OpenTelemetry |
 | ztd-cli telemetry policy | [guide/ztd-cli-telemetry-policy](./ztd-cli-telemetry-policy.md) | Event schema, redaction rules, and safe export boundaries for CLI telemetry |
 | ztd-cli telemetry export modes | [guide/ztd-cli-telemetry-export-modes](./ztd-cli-telemetry-export-modes.md) | Choose local debug, CI artifact, or OTLP export without changing command behavior |
+| ztd-cli telemetry philosophy | [guide/ztd-cli-telemetry-philosophy](./ztd-cli-telemetry-philosophy.md) | Why telemetry exists, why it stays opt-in, and which goals are explicitly out of scope |
 | Validation (Zod) | [recipes/validation-zod](../recipes/validation-zod.md) | Wire Zod schemas |
 | Validation (ArkType) | [recipes/validation-arktype](../recipes/validation-arktype.md) | Wire ArkType schemas |
 | SQL catalog recipe | [recipes/sql-contract](../recipes/sql-contract.md) | Catalog executor patterns |

--- a/docs/guide/ztd-cli-telemetry-philosophy.md
+++ b/docs/guide/ztd-cli-telemetry-philosophy.md
@@ -1,0 +1,63 @@
+---
+title: ztd-cli Telemetry Philosophy
+---
+
+# ztd-cli Telemetry Philosophy
+
+`ztd-cli` telemetry exists to help maintainers and advanced users inspect command behavior during investigation, dogfooding, and performance work. It is intentionally **not** part of the default happy path.
+
+## Why telemetry exists
+
+Telemetry is useful when you need to answer questions like these:
+
+- Which command phase is slow or unexpectedly failing?
+- Which fallback or output-selection path was taken?
+- How does a local dogfooding build behave compared with a published package?
+- Can we inspect command traces in a collector without adding a mandatory backend dependency?
+
+That is the scope. `ztd-cli` telemetry is for investigation and optimization, not for everyday usage requirements.
+
+## When to enable it
+
+Enable telemetry when you are:
+
+- Investigating a command failure or performance regression
+- Dogfooding new CLI behavior before release
+- Capturing CI artifacts for command-level trace review
+- Pointing a local collector or Jaeger instance at OTLP output for short-lived inspection
+
+Leave it off for normal published-package usage, happy-path setup, and standard project scaffolding.
+
+## Why it is disabled by default
+
+Telemetry stays opt-in because `ztd-cli` is a published CLI first.
+
+- The default flow should not require a backend, collector, or trace viewer.
+- Normal users should not have to think about exporters just to scaffold or regenerate files.
+- Published-package consumers must be able to ignore telemetry completely.
+- Optional embedding or exporter integration must not become a hidden runtime requirement.
+
+This is especially important for an AI-first operating model: structured traces are valuable during investigation, but they should remain an explicit tool rather than ambient background reporting.
+
+## Non-goals
+
+Telemetry is **not** intended to become:
+
+- An always-on production reporting channel
+- A mandatory dependency for published-package consumers
+- A replacement for normal CLI output, docs, or error messages
+- A blanket raw-log export path
+- A full logs-and-metrics framework by default
+
+Logs and metrics are intentionally deferred unless there is a concrete justification that fits the same safety and opt-in posture.
+
+## Security and privacy caveats
+
+Telemetry must preserve the same narrow boundary in every export mode.
+
+- SQL text, bind values, credentials, DSNs, and filesystem dumps must not be exported.
+- Large or highly variable payloads should be truncated instead of emitted verbatim.
+- Structured spans and decision events are preferred over raw logs because they are easier to sanitize and reason about.
+- If a new telemetry signal cannot be made low-cardinality and safe, it should not be added.
+
+See [ztd-cli telemetry policy](./ztd-cli-telemetry-policy.md) for the concrete schema and redaction rules, and [ztd-cli telemetry export modes](./ztd-cli-telemetry-export-modes.md) for local, CI, and OTLP usage.

--- a/packages/ztd-cli/README.md
+++ b/packages/ztd-cli/README.md
@@ -601,6 +601,11 @@ ztd model-gen src/sql/users/list_users.sql \
 
 Use DDL such as `CREATE TABLE public.users (...)` in `ztd/ddl/public.sql`, keep the SQL unqualified (`select user_id from users`), and set `ddl.defaultSchema` / `ddl.searchPath` in `ztd.config.json` to the schema order you expect.
 
+## Telemetry Philosophy
+
+`ztd-cli` telemetry is opt-in investigation tooling for dogfooding, debugging, and optimization. It is intentionally outside the default happy path, it must not become mandatory for published-package usage, and production embedding/export stays optional and off by default.
+
+Read the full guidance in [ztd-cli Telemetry Philosophy](../../docs/guide/ztd-cli-telemetry-philosophy.md), [ztd-cli Telemetry Policy](../../docs/guide/ztd-cli-telemetry-policy.md), and [ztd-cli Telemetry Export Modes](../../docs/guide/ztd-cli-telemetry-export-modes.md).
 ## Further Reading
 
 - Local-source quick start:
@@ -629,4 +634,3 @@ This mode emits `src/local/sql-contract.ts`, links `@rawsql-ts/sql-contract` via
 ## License
 
 MIT
-


### PR DESCRIPTION
## Summary
- add a guide that explains why ztd-cli telemetry exists and why it stays opt-in
- document non-goals and privacy/security caveats for telemetry usage
- add README and feature index links so the philosophy is discoverable

Closes #521

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added comprehensive documentation on telemetry philosophy, detailing opt-in behavior, security, privacy considerations, and related guidance.
* Updated the README with a new Telemetry Philosophy section.
* Added telemetry documentation to the feature index for easy reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->