### PR TITLE
ci: narrow consumer validation coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,8 @@ jobs:
       if: matrix.node-version == '20.x'
       run: |
         pnpm -r --if-present --filter @rawsql-ts/test-evidence-core --filter @rawsql-ts/test-evidence-renderer-md --filter @rawsql-ts/shared-binder --filter @rawsql-ts/testkit-core --filter @rawsql-ts/testkit-postgres --filter @rawsql-ts/testkit-sqlite --filter @rawsql-ts/adapter-node-pg --filter @rawsql-ts/ztd-cli --filter @rawsql-ts/sql-contract --filter @rawsql-ts/sql-contract-zod run build
-        pnpm -r --if-present --filter @rawsql-ts/test-evidence-core --filter @rawsql-ts/test-evidence-renderer-md --filter @rawsql-ts/shared-binder --filter @rawsql-ts/testkit-core --filter @rawsql-ts/testkit-postgres --filter @rawsql-ts/testkit-sqlite --filter @rawsql-ts/adapter-node-pg --filter @rawsql-ts/ztd-cli --filter @rawsql-ts/sql-contract --filter @rawsql-ts/sql-contract-zod run test
+        pnpm -r --if-present --filter @rawsql-ts/test-evidence-core --filter @rawsql-ts/test-evidence-renderer-md --filter @rawsql-ts/shared-binder --filter @rawsql-ts/testkit-core --filter @rawsql-ts/testkit-postgres --filter @rawsql-ts/testkit-sqlite --filter @rawsql-ts/adapter-node-pg --filter @rawsql-ts/sql-contract --filter @rawsql-ts/sql-contract-zod run test
+        pnpm --filter @rawsql-ts/ztd-cli run test:consumer-validation
 
   benchmark:
     runs-on: ubuntu-latest

--- a/packages/ztd-cli/package.json
+++ b/packages/ztd-cli/package.json
@@ -11,7 +11,8 @@
     "build": "pnpm --filter @rawsql-ts/test-evidence-core run build && pnpm --filter @rawsql-ts/test-evidence-renderer-md run build && pnpm --filter @rawsql-ts/testkit-core run build && tsc -p tsconfig.json",
     "test": "vitest run --config vitest.config.ts",
     "lint": "eslint src --ext .ts",
-    "release": "npm run lint && npm run test && npm run build && node -e \"require('fs').mkdirSync('../../tmp', { recursive: true })\" && pnpm pack --out ../../tmp/rawsql-ts-ztd-cli.tgz && pnpm publish --access public"
+    "release": "npm run lint && npm run test && npm run build && node -e \"require('fs').mkdirSync('../../tmp', { recursive: true })\" && pnpm pack --out ../../tmp/rawsql-ts-ztd-cli.tgz && pnpm publish --access public",
+    "test:consumer-validation": "vitest run --config vitest.config.ts tests/testEvidence.unit.test.ts tests/testEvidence.cli.test.ts tests/sqlCatalog.evidence.test.ts tests/testCaseCatalog.evidence.test.ts"
   },
   "keywords": [
     "rawsql-ts",


### PR DESCRIPTION
## Summary
- narrow the Node 20 consumer-validation lane to a focused `@rawsql-ts/ztd-cli` evidence subset
- keep build coverage for the same packages while avoiding the full ztd-cli suite in the heavy CI step
- add a reusable `test:consumer-validation` script for local and CI verification

## Why
The merged perf-evidence work exposed that `build-and-test (20.x)` spent most of its time inside `Validate test-evidence boundaries and consumers`, largely because it ran the full `@rawsql-ts/ztd-cli` suite. This PR keeps the consumer/boundary intent of that step, but removes the overbroad ztd-cli cost.

## Verification
- `pnpm --filter @rawsql-ts/ztd-cli run test:consumer-validation`
- `git diff --check -- .github/workflows/ci.yml packages/ztd-cli/package.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD testing infrastructure by introducing a dedicated consumer validation test step for improved test coverage organization and validation boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->