### PR TITLE
ci: focus shared binder validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,8 @@ jobs:
       if: matrix.node-version == '20.x'
       run: |
         pnpm -r --if-present --filter @rawsql-ts/test-evidence-core --filter @rawsql-ts/test-evidence-renderer-md --filter @rawsql-ts/shared-binder --filter @rawsql-ts/testkit-core --filter @rawsql-ts/testkit-postgres --filter @rawsql-ts/testkit-sqlite --filter @rawsql-ts/adapter-node-pg --filter @rawsql-ts/ztd-cli --filter @rawsql-ts/sql-contract --filter @rawsql-ts/sql-contract-zod run build
-        pnpm -r --if-present --filter @rawsql-ts/test-evidence-core --filter @rawsql-ts/test-evidence-renderer-md --filter @rawsql-ts/shared-binder --filter @rawsql-ts/testkit-core --filter @rawsql-ts/testkit-postgres --filter @rawsql-ts/testkit-sqlite --filter @rawsql-ts/adapter-node-pg --filter @rawsql-ts/sql-contract --filter @rawsql-ts/sql-contract-zod run test
+        pnpm -r --if-present --filter @rawsql-ts/test-evidence-core --filter @rawsql-ts/test-evidence-renderer-md --filter @rawsql-ts/testkit-core --filter @rawsql-ts/testkit-postgres --filter @rawsql-ts/testkit-sqlite --filter @rawsql-ts/adapter-node-pg --filter @rawsql-ts/sql-contract --filter @rawsql-ts/sql-contract-zod run test
+        pnpm --filter @rawsql-ts/shared-binder run test:consumer-validation
         pnpm --filter @rawsql-ts/ztd-cli run test:consumer-validation
 
   benchmark:

--- a/packages/_shared/binder/package.json
+++ b/packages/_shared/binder/package.json
@@ -19,7 +19,8 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "test": "vitest run",
+    "test": "vitest run --config vitest.config.ts",
+    "test:consumer-validation": "vitest run --config vitest.config.ts",
     "lint": "eslint src --ext .ts",
     "prepack": "node -e \"const fs=require('fs');const cp=require('child_process');const npm=process.platform==='win32'?'npm.cmd':'npm';if(!fs.existsSync('dist/index.js')){process.exit(cp.spawnSync(npm,['run','build'],{stdio:'inherit'}).status??1)}\"",
     "release": "npm run lint && npm run test && npm run build && node -e \"require('fs').mkdirSync('../../../tmp', { recursive: true })\" && pnpm pack --out ../../../tmp/rawsql-ts-shared-binder.tgz && pnpm publish --access public"

--- a/packages/_shared/binder/tests/compileNamedParameters.unit.test.ts
+++ b/packages/_shared/binder/tests/compileNamedParameters.unit.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'vitest'
+import { compileNamedParameters } from '../src'
+
+describe('compileNamedParameters', () => {
+  test('ignores named markers inside string literals', () => {
+    const sql = "select ':name' as literal, :id as value"
+    const compiled = compileNamedParameters(sql, { id: 1, name: 'ignored' }, 'pg-indexed')
+
+    expect(compiled.sql).toBe("select ':name' as literal, $1 as value")
+    expect(compiled.values).toEqual([1])
+  })
+
+  test('ignores named markers inside comments', () => {
+    const sql = `
+      select :id as value
+      -- :ignored
+      /* :also_ignored */
+    `
+    const compiled = compileNamedParameters(sql, { id: 2 }, 'pg-indexed')
+
+    expect(compiled.sql).toMatch(/select\s+\$1\s+as\s+value/i)
+    expect(compiled.sql).toContain('-- :ignored')
+    expect(compiled.sql).toContain('/* :also_ignored */')
+    expect(compiled.values).toEqual([2])
+  })
+
+  test('preserves postgres cast operator', () => {
+    const sql = 'select :id::text as value'
+    const compiled = compileNamedParameters(sql, { id: 3 }, 'pg-indexed')
+
+    expect(compiled.sql).toBe('select $1::text as value')
+    expect(compiled.values).toEqual([3])
+  })
+
+  test('ignores dollar-quoted strings', () => {
+    const sql = "select $$:ignored$$ as literal, :id as value"
+    const compiled = compileNamedParameters(sql, { id: 4, ignored: 'nope' }, 'pg-indexed')
+
+    expect(compiled.sql).toBe("select $$:ignored$$ as literal, $1 as value")
+    expect(compiled.values).toEqual([4])
+  })
+
+  test('throws when a named parameter is missing', () => {
+    const sql = 'select :missing as value'
+    expect(() => compileNamedParameters(sql, {}, 'pg-indexed')).toThrowError(
+      'Missing value for named parameter ":missing".',
+    )
+  })
+
+  test('allows duplicate named parameters', () => {
+    const sql = 'select :id as first, :id as second'
+    const compiled = compileNamedParameters(sql, { id: 10 }, 'pg-indexed')
+
+    expect(compiled.sql).toBe('select $1 as first, $2 as second')
+    expect(compiled.values).toEqual([10, 10])
+    expect(compiled.orderedNames).toEqual(['id', 'id'])
+  })
+
+  test('allows extra params keys', () => {
+    const sql = 'select :id as value'
+    const compiled = compileNamedParameters(sql, { id: 1, extra: 'ok' }, 'pg-indexed')
+
+    expect(compiled.sql).toBe('select $1 as value')
+    expect(compiled.values).toEqual([1])
+  })
+
+  test('throws when sql has no named parameters', () => {
+    expect(() => compileNamedParameters('select 1', {}, 'pg-indexed')).toThrowError(
+      'No named parameters found in SQL.',
+    )
+  })
+})

--- a/packages/_shared/binder/vitest.config.ts
+++ b/packages/_shared/binder/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config'
+import { resolve } from 'node:path'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    exclude: ['dist/**', 'node_modules/**', 'tmp/**'],
+    root: resolve(__dirname),
+    testTimeout: 30000,
+  },
+})


### PR DESCRIPTION
## Summary
- add a local `vitest.config.ts` and direct unit tests for `@rawsql-ts/shared-binder`
- stop the Node 20 consumer-validation step from invoking shared-binder through the recursive workspace `run test` path
- run a dedicated `test:consumer-validation` script for shared-binder, similar to the focused ztd-cli evidence subset

## Why
After the previous CI optimization, the remaining dominant bottleneck was `packages/_shared/binder test`, which was effectively discovering the root workspace Vitest suite and running most of the monorepo. This PR narrows shared-binder to a package-local test scope while preserving direct binder coverage.

## Verification
- `pnpm --filter @rawsql-ts/shared-binder run test:consumer-validation`
- `pnpm --filter @rawsql-ts/adapter-node-pg exec vitest run tests/binder-constraints.test.ts`
- `pnpm --filter @rawsql-ts/ztd-cli run test:consumer-validation`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests covering edge cases and error handling for parameter compilation functionality.

* **Chores**
  * Reorganized CI test execution to improve test isolation and consistency.
  * Updated test configuration for enhanced test execution management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->