### PR TITLE
feat: add ZTD test documentation export

### DIFF
--- a/.changeset/issue-548-ztd-test-docs.md
+++ b/.changeset/issue-548-ztd-test-docs.md
@@ -1,0 +1,8 @@
+---
+'@rawsql-ts/ztd-cli': minor
+'@rawsql-ts/test-evidence-renderer-md': minor
+---
+
+Add ztd evidence test-doc to export human-readable Markdown test documentation from deterministic ZTD test assets.
+
+

--- a/packages/test-evidence-renderer-md/src/index.ts
+++ b/packages/test-evidence-renderer-md/src/index.ts
@@ -6,3 +6,5 @@ export {
   type DiffReportMarkdownMeta
 } from './reportMarkdown';
 export { renderSpecificationMarkdown, type SpecificationMarkdownOptions } from './specificationMarkdown';
+
+export { renderTestDocumentationMarkdown, type TestDocumentationMarkdownOptions } from './testDocumentationMarkdown';

--- a/packages/test-evidence-renderer-md/src/testDocumentationMarkdown.ts
+++ b/packages/test-evidence-renderer-md/src/testDocumentationMarkdown.ts
@@ -1,0 +1,213 @@
+import { SpecificationModel, type DiffCase, type DiffCatalog } from '@rawsql-ts/test-evidence-core';
+import { DefinitionLinkOptions, formatDefinitionMarkdown } from './definitionLink';
+
+export type TestDocumentationMarkdownOptions = {
+  definitionLinks?: DefinitionLinkOptions;
+  title?: string;
+};
+
+/**
+ * Render human-readable test documentation from the deterministic specification model.
+ * This projection is presentation-only and must never mutate or reinterpret the semantic model.
+ */
+export function renderTestDocumentationMarkdown(
+  model: SpecificationModel,
+  options?: TestDocumentationMarkdownOptions
+): string {
+  const definitionLinks = options?.definitionLinks;
+  const title = options?.title ?? 'ZTD Test Documentation';
+  const lines: string[] = [];
+
+  lines.push(`# ${title}`);
+  lines.push('');
+  lines.push(`- schemaVersion: ${model.schemaVersion}`);
+  lines.push(`- catalogs: ${model.totals.catalogs}`);
+  lines.push(`- functionCatalogs: ${model.totals.functionCatalogs}`);
+  lines.push(`- sqlCatalogs: ${model.totals.sqlCatalogs}`);
+  lines.push(`- tests: ${model.totals.tests}`);
+  lines.push('');
+
+  for (const catalog of [...model.catalogs].sort((a, b) => a.catalogId.localeCompare(b.catalogId))) {
+    lines.push(`## ${catalog.catalogId} - ${catalog.title}`);
+    lines.push(`- targetType: ${catalog.kind === 'sql' ? 'sql-catalog' : 'function-unit'}`);
+    lines.push(`- targetName: ${catalog.title}`);
+    lines.push(`- definition: ${formatDefinitionMarkdown(catalog.definition ?? '(unknown)', definitionLinks)}`);
+    lines.push(`- purpose: ${catalog.description ?? formatCatalogPurpose(catalog)}`);
+    lines.push(`- tests: ${catalog.cases.length}`);
+    if (catalog.kind === 'sql') {
+      lines.push(`- fixtures: ${(catalog.fixtures ?? []).join(', ') || '(none)'}`);
+    }
+    if (Array.isArray(catalog.refs) && catalog.refs.length > 0) {
+      lines.push('- refs:');
+      for (const ref of catalog.refs) {
+        lines.push(`  - [${ref.label}](${ref.url})`);
+      }
+    }
+    lines.push('');
+    lines.push('### Test Case List');
+    for (const testCase of [...catalog.cases].sort((a, b) => a.id.localeCompare(b.id))) {
+      lines.push(`- ${testCase.id}: ${testCase.title}`);
+    }
+    lines.push('');
+
+    for (const testCase of [...catalog.cases].sort((a, b) => a.id.localeCompare(b.id))) {
+      lines.push(`### ${testCase.id} - ${testCase.title}`);
+      lines.push(`- purpose: ${formatCasePurpose(testCase)}`);
+      lines.push(`- execution: ${formatExecutionSummary(catalog, testCase)}`);
+      lines.push(`- expectedSummary: ${formatExpectedSummary(testCase)}`);
+      lines.push(`- coverage: ${formatCoveragePerspective(testCase)}`);
+      if (Array.isArray(testCase.refs) && testCase.refs.length > 0) {
+        lines.push('- refs:');
+        for (const ref of testCase.refs) {
+          lines.push(`  - [${ref.label}](${ref.url})`);
+        }
+      }
+      lines.push('#### Input / Setup');
+      if (catalog.kind === 'sql') {
+        lines.push(`- fixtures: ${(catalog.fixtures ?? []).join(', ') || '(none)'}`);
+      }
+      lines.push('```json');
+      lines.push(stringifyStablePretty(testCase.input));
+      lines.push('```');
+      lines.push('#### Expected Result');
+      if (testCase.expected === 'throws') {
+        lines.push('```json');
+        lines.push(stringifyErrorPretty(testCase.error));
+        lines.push('```');
+      } else {
+        lines.push('```json');
+        lines.push(stringifyStablePretty(testCase.output));
+        lines.push('```');
+      }
+      lines.push('#### Notes / Assumptions');
+      lines.push(`- ${formatCaseNotes(testCase)}`);
+      lines.push('');
+    }
+  }
+
+  return lines.join('\n').trimEnd();
+}
+
+function formatCatalogPurpose(catalog: DiffCatalog): string {
+  if (catalog.kind === 'sql') {
+    return 'Executable SQL catalog coverage projected from deterministic ZTD test assets.';
+  }
+  return 'Executable unit-test coverage projected from deterministic ZTD test assets.';
+}
+
+function formatCasePurpose(testCase: DiffCase): string {
+  if (typeof testCase.focus === 'string' && testCase.focus.trim().length > 0) {
+    return testCase.focus.trim();
+  }
+  return testCase.title;
+}
+
+function formatExecutionSummary(catalog: DiffCatalog, testCase: DiffCase): string {
+  if (catalog.kind === 'sql') {
+    const fixtures = (catalog.fixtures ?? []).join(', ') || 'no fixtures';
+    return `Execute the SQL catalog with the documented parameters against fixtures: ${fixtures}.`;
+  }
+  if (testCase.expected === 'throws') {
+    return 'Execute the target unit with the arranged input and capture the thrown error contract.';
+  }
+  return 'Execute the target unit with the arranged input and compare the returned value.';
+}
+
+function formatExpectedSummary(testCase: DiffCase): string {
+  if (testCase.expected === 'throws') {
+    const name = testCase.error?.name ?? 'Error';
+    const message = testCase.error?.message ?? '(message unspecified)';
+    const match = testCase.error?.match ?? 'contains';
+    return `Throws ${name}; message ${match} \"${message}\".`;
+  }
+  if (Array.isArray(testCase.output)) {
+    return `Returns ${testCase.output.length} row(s).`;
+  }
+  return `Returns ${summarizeScalarOutput(testCase.output)}.`;
+}
+
+function summarizeScalarOutput(value: unknown): string {
+  if (value === null) {
+    return 'null';
+  }
+  if (Array.isArray(value)) {
+    return `${value.length} item(s)`;
+  }
+  if (typeof value === 'object') {
+    return 'an object value';
+  }
+  return JSON.stringify(value) ?? 'an unspecified value';
+}
+
+function formatCoveragePerspective(testCase: DiffCase): string {
+  const classification = classifyCoveragePerspective(testCase);
+  const tags = Array.isArray(testCase.tags) && testCase.tags.length > 0
+    ? `[${testCase.tags.join(', ')}]`
+    : '[]';
+  return `${classification}; tags=${tags}`;
+}
+
+function classifyCoveragePerspective(testCase: DiffCase): 'normal' | 'edge' | 'regression' | 'unspecified' {
+  const tags = new Set((testCase.tags ?? []).map((tag) => tag.toLowerCase()));
+  const text = `${testCase.id} ${testCase.title} ${testCase.focus ?? ''}`.toLowerCase();
+
+  if (text.includes('regression') || text.includes('bugfix') || text.includes('hotfix') || text.includes('issue')) {
+    return 'regression';
+  }
+  if (testCase.expected === 'throws' || tags.has('bva') || text.includes('boundary') || text.includes('edge')) {
+    return 'edge';
+  }
+  if (
+    text.includes('baseline') ||
+    text.includes('smoke') ||
+    text.includes('noop') ||
+    text.includes('normal') ||
+    tags.size > 0
+  ) {
+    return 'normal';
+  }
+  return 'unspecified';
+}
+
+function formatCaseNotes(testCase: DiffCase): string {
+  if (Array.isArray(testCase.refs) && testCase.refs.length > 0) {
+    return 'See refs for linked issue or design context.';
+  }
+  if (testCase.expected === 'throws') {
+    return 'Error matching remains part of the executable contract.';
+  }
+  return 'No extra assumptions were exported for this case.';
+}
+
+function stringifyStablePretty(value: unknown): string {
+  return JSON.stringify(sortDeep(value), null, 2) ?? 'null';
+}
+
+function stringifyErrorPretty(value: unknown): string {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return 'null';
+  }
+  const source = value as Record<string, unknown>;
+  return JSON.stringify(
+    {
+      name: source.name,
+      message: source.message,
+      match: source.match,
+    },
+    null,
+    2
+  ) ?? 'null';
+}
+
+function sortDeep(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sortDeep(item));
+  }
+  if (value !== null && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([key, nested]) => [key, sortDeep(nested)] as const);
+    return Object.fromEntries(entries);
+  }
+  return value;
+}

--- a/packages/test-evidence-renderer-md/tests/renderer.unit.test.ts
+++ b/packages/test-evidence-renderer-md/tests/renderer.unit.test.ts
@@ -12,7 +12,8 @@ import {
   renderDiffMarkdown,
   renderLegacyDiffMarkdown,
   renderDiffReportMarkdown,
-  renderSpecificationMarkdown
+  renderSpecificationMarkdown,
+  renderTestDocumentationMarkdown
 } from '../src';
 
 function createPreview(args: {
@@ -448,4 +449,55 @@ test('definition link rendering supports path and github modes', () => {
   expect(diffGithub).toContain(
     '[File](https://github.com/mk3008/rawsql-ts/blob/abc123/src/specs/sql/users.catalog.ts)'
   );
+});
+
+test('renderTestDocumentationMarkdown projects case purpose, execution, and coverage summaries', () => {
+  const preview = createPreview({
+    sqlCatalogs: [
+      {
+        id: 'sql.users',
+        title: 'users',
+        definitionPath: 'src/specs/sql/users.catalog.ts',
+        fixtures: ['users', 'orders'],
+        cases: [
+          { id: 'baseline', title: 'baseline', input: { active: 1 }, output: [{ id: 1 }] },
+          { id: 'regression-case', title: 'regression guard', input: { active: 0 }, output: [{ id: 2 }] }
+        ]
+      }
+    ],
+    functionCatalogs: [
+      {
+        id: 'unit.normalize-email',
+        title: 'normalizeEmail',
+        definitionPath: 'tests/specs/testCaseCatalogs.ts',
+        cases: [
+          {
+            id: 'rejects-invalid-input',
+            title: 'throws when @ is missing',
+            input: 'invalid-email',
+            expected: 'throws',
+            error: { name: 'Error', message: 'invalid email', match: 'contains' },
+            tags: ['validation', 'bva'],
+            focus: 'Rejects malformed input before normalization.'
+          }
+        ]
+      }
+    ]
+  });
+  const model = buildSpecificationModel(preview);
+  const markdown = renderTestDocumentationMarkdown(model);
+
+  expect(markdown).toContain('# ZTD Test Documentation');
+  expect(markdown).toContain('## sql.users - users');
+  expect(markdown).toContain('- execution: Execute the SQL catalog with the documented parameters against fixtures: orders, users.');
+  expect(markdown).toContain('- expectedSummary: Returns 1 row(s).');
+  expect(markdown).toContain('- coverage: regression; tags=[]');
+  expect(markdown).toContain('## unit.normalize-email - normalizeEmail');
+  expect(markdown).toContain('- purpose: Rejects malformed input before normalization.');
+  expect(markdown).toContain('- execution: Execute the target unit with the arranged input and capture the thrown error contract.');
+  expect(markdown).toContain('- expectedSummary: Throws Error; message contains "invalid email".');
+  expect(markdown).toContain('- coverage: edge; tags=[validation, bva]');
+  expect(markdown).toContain('#### Input / Setup');
+  expect(markdown).toContain('#### Expected Result');
+  expect(markdown).toContain('#### Notes / Assumptions');
 });

--- a/packages/ztd-cli/README.md
+++ b/packages/ztd-cli/README.md
@@ -16,6 +16,7 @@ CLI tool for scaffolding **Zero Table Dependency (ZTD)** projects and keeping DD
 - DDL diff against a live database
 - SQL linting with fixture-backed validation
 - Deterministic test specification evidence export (JSON / Markdown)
+- Human-readable test documentation export for ZTD test assets
 - Watch mode for continuous regeneration
 - Validator selection (Zod or ArkType) during init
 - Global machine-readable mode via `--output json`

--- a/packages/ztd-cli/package.json
+++ b/packages/ztd-cli/package.json
@@ -8,8 +8,8 @@
   },
   "scripts": {
     "prepack": "node -e \"const fs=require('fs');const cp=require('child_process');const npm=process.platform==='win32'?'npm.cmd':'npm';if(!fs.existsSync('dist/index.js')){process.exit(cp.spawnSync(npm,['run','build'],{stdio:'inherit'}).status??1)}\"",
-    "build": "pnpm --filter @rawsql-ts/sql-grep-core run build && pnpm --filter @rawsql-ts/test-evidence-core run build && pnpm --filter @rawsql-ts/test-evidence-renderer-md run build && pnpm --filter @rawsql-ts/testkit-core run build && tsc -p tsconfig.json",
-    "test": "vitest run --config vitest.config.ts",
+    "build": "pnpm --filter rawsql-ts run build && pnpm --filter @rawsql-ts/sql-grep-core run build && pnpm --filter @rawsql-ts/test-evidence-core run build && pnpm --filter @rawsql-ts/test-evidence-renderer-md run build && pnpm --filter @rawsql-ts/testkit-core run build && tsc -p tsconfig.json",
+    "test": "pnpm --filter @rawsql-ts/adapter-node-pg run build && vitest run --config vitest.config.ts",
     "lint": "eslint src --ext .ts",
     "release": "npm run lint && npm run test && npm run build && node -e \"require('fs').mkdirSync('../../tmp', { recursive: true })\" && pnpm pack --out ../../tmp/rawsql-ts-ztd-cli.tgz && pnpm publish --access public",
     "test:consumer-validation": "vitest run --config vitest.config.ts tests/testEvidence.unit.test.ts tests/testEvidence.cli.test.ts tests/sqlCatalog.evidence.test.ts tests/testCaseCatalog.evidence.test.ts"

--- a/packages/ztd-cli/src/commands/testEvidence.ts
+++ b/packages/ztd-cli/src/commands/testEvidence.ts
@@ -15,6 +15,7 @@ import {
 import {
   renderDiffMarkdown,
   renderSpecificationMarkdown,
+  renderTestDocumentationMarkdown,
   type DefinitionLinkOptions,
   type RemovedDetailLevel
 } from '@rawsql-ts/test-evidence-renderer-md';
@@ -186,6 +187,14 @@ interface TestEvidencePrCommandOptions {
   limit?: string;
 }
 
+interface TestDocCommandOptions {
+  out?: string;
+  specsDir?: string;
+  testsDir?: string;
+  specModule?: string;
+  json?: string;
+}
+
 interface TestCaseCatalogDocumentLike {
   catalogs?: unknown;
 }
@@ -280,6 +289,36 @@ export function registerTestEvidenceCommand(program: Command): void {
           report,
           format,
           outDir: path.resolve(process.cwd(), String(merged.outDir)),
+          sourceRootDir
+        });
+        process.exitCode = resolveTestEvidenceExitCode({ result: report });
+      } catch (error) {
+        process.exitCode = resolveTestEvidenceExitCode({ error });
+        console.error(error instanceof Error ? error.message : String(error));
+      }
+    });
+  evidenceCommand
+    .command('test-doc')
+    .description('Generate human-readable Markdown test documentation from ZTD test assets')
+    .option('--out <path>', 'Output markdown path', '.ztd/test-evidence/test-documentation.md')
+    .option('--specs-dir <path>', 'Override SQL catalog specs directory (default: src/catalog/specs)')
+    .option('--tests-dir <path>', 'Override tests directory (default: tests)')
+    .option('--spec-module <path>', 'Explicit evidence module path (default: tests/specs/index)')
+    .option('--json <payload>', 'Pass test-doc options as a JSON object')
+    .action((options: TestDocCommandOptions) => {
+      try {
+        const merged = options.json ? { ...options, ...parseJsonPayload<Record<string, unknown>>(options.json, '--json') } : options;
+        const report = runTestEvidenceSpecification({
+          mode: 'specification',
+          rootDir: process.env.ZTD_PROJECT_ROOT,
+          specsDir: merged.specsDir as string | undefined,
+          testsDir: merged.testsDir as string | undefined,
+          specModule: merged.specModule as string | undefined
+        });
+        const sourceRootDir = path.resolve(process.env.ZTD_PROJECT_ROOT ?? process.cwd());
+        writeTestDocumentationArtifact({
+          report,
+          outPath: path.resolve(process.cwd(), String(merged.out ?? '.ztd/test-evidence/test-documentation.md')),
           sourceRootDir
         });
         process.exitCode = resolveTestEvidenceExitCode({ result: report });
@@ -1592,4 +1631,41 @@ function sortDeep(value: unknown): unknown {
     return Object.fromEntries(entries);
   }
   return value;
+}
+
+
+
+
+
+
+
+
+/**
+ * Render deterministic Markdown focused on human-readable test intent.
+ */
+export function formatTestDocumentationOutput(
+  report: TestSpecificationEvidence,
+  context?: { markdownPath?: string; sourceRootDir?: string }
+): string {
+  const model = buildSpecificationModel(report as TestEvidencePreviewJson);
+  return `${renderTestDocumentationMarkdown(model, {
+    definitionLinks: resolveDefinitionLinkOptions(context)
+  })}\n`;
+}
+
+function writeTestDocumentationArtifact(args: {
+  report: TestSpecificationEvidence;
+  outPath: string;
+  sourceRootDir: string;
+}): void {
+  mkdirSync(path.dirname(args.outPath), { recursive: true });
+  writeFileSync(
+    args.outPath,
+    formatTestDocumentationOutput(args.report, {
+      markdownPath: args.outPath,
+      sourceRootDir: args.sourceRootDir
+    }),
+    'utf8'
+  );
+  console.log(`wrote: ${args.outPath}`);
 }

--- a/packages/ztd-cli/src/perf/benchmark.ts
+++ b/packages/ztd-cli/src/perf/benchmark.ts
@@ -1822,11 +1822,13 @@ function isPerfPipelineAnalysis(value: unknown): value is PerfPipelineAnalysis {
     return false;
   }
   const analysis = value as Record<string, unknown>;
+  // Older saved summaries may not include scalar_filter_candidates.
+  // Treat the field as optional so perf diff remains backward-compatible.
   return typeof analysis.query_type === 'string'
     && typeof analysis.cte_count === 'number'
     && typeof analysis.should_consider_pipeline === 'boolean'
     && isPerfPipelineCandidateArray(analysis.candidate_ctes)
-    && isStringArray(analysis.scalar_filter_candidates)
+    && (analysis.scalar_filter_candidates === undefined || isStringArray(analysis.scalar_filter_candidates))
     && isStringArray(analysis.notes);
 }
 

--- a/packages/ztd-cli/tests/perfBenchmark.unit.test.ts
+++ b/packages/ztd-cli/tests/perfBenchmark.unit.test.ts
@@ -709,6 +709,34 @@ test('loadPerfBenchmarkReport accepts decomposed summaries with strategy metadat
   expect(loaded.executed_statements[0]).toMatchObject({ role: 'materialize', target: 'base_sales' });
 });
 
+test('loadPerfBenchmarkReport accepts legacy summaries without scalar filter candidates', () => {
+  const workspace = createTempDir('perf-benchmark-legacy-summary');
+  const summary = makePerfReport({
+    run_id: 'run_legacy',
+    pipeline_analysis: {
+      query_type: 'SELECT',
+      cte_count: 1,
+      should_consider_pipeline: true,
+      candidate_ctes: [
+        {
+          name: 'base_sales',
+          downstream_references: 2,
+          reasons: ['referenced by multiple downstream consumers']
+        }
+      ],
+      notes: ['legacy summary fixture']
+    } as PerfBenchmarkReport['pipeline_analysis']
+  });
+
+  writeFileSync(path.join(workspace, 'summary.json'), JSON.stringify(summary, null, 2), 'utf8');
+
+  const loaded = loadPerfBenchmarkReport(workspace);
+
+  expect(loaded.run_id).toBe('run_legacy');
+  expect(loaded.pipeline_analysis.candidate_ctes).toHaveLength(1);
+  expect(loaded.pipeline_analysis.notes).toEqual(['legacy summary fixture']);
+});
+
 test('diffPerfBenchmarkReports emits statement deltas for decomposed multi-statement runs', () => {
   const workspace = createTempDir('perf-benchmark-decomposed-diff');
   const baselineDir = path.join(workspace, 'run_001');

--- a/packages/ztd-cli/tests/testEvidence.cli.test.ts
+++ b/packages/ztd-cli/tests/testEvidence.cli.test.ts
@@ -218,3 +218,25 @@ test('resolveTestEvidenceExitCode maps success and runtime failures', () => {
   expect(resolveTestEvidenceExitCode({ error: new TestEvidenceRuntimeError('bad config') })).toBe(2);
 });
 
+
+test('CLI: evidence test-doc writes a human-readable markdown artifact', async () => {
+  const root = createWorkspace('evidence-cli-test-doc');
+  writeSpecModule(root);
+
+  process.env.ZTD_PROJECT_ROOT = root;
+  const outFile = path.join(root, 'artifacts', 'test-documentation.md');
+  const program = createProgram();
+  await program.parseAsync(['evidence', 'test-doc', '--out', outFile], { from: 'user' });
+
+  expect(process.exitCode).toBe(0);
+  const markdown = readFileSync(outFile, 'utf8');
+  expect(markdown).toContain('# ZTD Test Documentation');
+  expect(markdown).toContain('## unit.users - users');
+  expect(markdown).toContain('- purpose: Ensures user listing behavior remains deterministic.');
+  expect(markdown).toContain('## sql.active-orders - active orders');
+  expect(markdown).toContain('- targetType: sql-catalog');
+  expect(markdown).toContain('- execution: Execute the SQL catalog with the documented parameters against fixtures: users.');
+  expectDefinitionLinkPathOrGithub(markdown, 'tests/specs/users.catalog.ts');
+  expectDefinitionLinkPathOrGithub(markdown, 'src/specs/sql/activeOrders.catalog.ts');
+});
+

--- a/packages/ztd-cli/tests/testEvidence.unit.test.ts
+++ b/packages/ztd-cli/tests/testEvidence.unit.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { expect, test } from 'vitest';
 import {
   applyEvidenceOutputControls,
+  formatTestDocumentationOutput,
   formatTestEvidenceOutput,
   runTestEvidenceSpecification,
   TestEvidenceRuntimeError
@@ -281,5 +282,28 @@ test('runTestEvidenceSpecification normalizes tags vocabulary and keeps catalog 
   ]);
   expect(report.testCaseCatalogs[0]?.cases[0]?.tags).toEqual(['validation', 'ep']);
   expect(report.testCaseCatalogs[0]?.cases[0]?.focus).toBe('Ensures tags are normalized into two axes.');
+});
+
+
+test('formatTestDocumentationOutput emits human-readable test intent sections', () => {
+  const root = createWorkspace('evidence-test-doc');
+  writeSpecModule(root, { testCaseIds: ['works'], includeSqlCase: true });
+
+  const report = runTestEvidenceSpecification({ mode: 'specification', rootDir: root });
+  const markdown = withoutGitHubEnv(() => formatTestDocumentationOutput(report));
+
+  expect(markdown).toContain('# ZTD Test Documentation');
+  expect(markdown).toContain('## sql.active-orders - active orders');
+  expect(markdown).toContain('- targetType: sql-catalog');
+  expect(markdown).toContain('- execution: Execute the SQL catalog with the documented parameters against fixtures: users.');
+  expect(markdown).toContain('- expectedSummary: Returns 1 row(s).');
+  expect(markdown).toContain('## unit.users - User behavior');
+  expect(markdown).toContain('- targetType: function-unit');
+  expect(markdown).toContain('- purpose: Ensures works behavior remains stable.');
+  expect(markdown).toContain('- coverage: normal; tags=[invariant, state]');
+  expect(markdown).toContain('### Test Case List');
+  expect(markdown).toContain('#### Input / Setup');
+  expect(markdown).toContain('#### Expected Result');
+  expect(markdown).toContain('#### Notes / Assumptions');
 });
 


### PR DESCRIPTION
## Summary
- add ztd evidence test-doc to generate human-readable Markdown test documentation from ZTD test assets
- add a Markdown renderer projection and focused tests for CLI/output behavior
- make perf summary loading backward-compatible for legacy saved evidence and ensure ztd-cli build/test scripts pass from a clean state

## Verification
- pnpm --filter @rawsql-ts/ztd-cli exec tsc --noEmit -p tsconfig.json
- pnpm --filter @rawsql-ts/ztd-cli lint
- pnpm --filter @rawsql-ts/ztd-cli build
- pnpm --filter @rawsql-ts/ztd-cli test
- git commit (pre-commit ran workspace typecheck/test/build/lint)
