### PR TITLE
fix: add fixed package group for ci publish

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,6 +2,25 @@
   "$schema": "https://unpkg.com/@changesets/config/schema.json",
   "changelog": ["@changesets/changelog-github", { "repo": "mk3008/rawsql-ts" }],
   "commit": false,
+  "fixed": [
+    [
+      "rawsql-ts",
+      "@rawsql-ts/adapter-node-pg",
+      "@rawsql-ts/ddl-docs-cli",
+      "@rawsql-ts/ddl-docs-vitepress",
+      "@rawsql-ts/executor",
+      "@rawsql-ts/shared-binder",
+      "@rawsql-ts/sql-contract",
+      "@rawsql-ts/sql-contract-zod",
+      "@rawsql-ts/sql-grep-core",
+      "@rawsql-ts/test-evidence-core",
+      "@rawsql-ts/test-evidence-renderer-md",
+      "@rawsql-ts/testkit-core",
+      "@rawsql-ts/testkit-postgres",
+      "@rawsql-ts/testkit-sqlite",
+      "@rawsql-ts/ztd-cli"
+    ]
+  ],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
## Summary
- add a fixed changesets group for packages published by the manual publish workflow
- include all current public workspace packages so ci-publish.mjs can resolve the publish set

## Verification
- node -e "const fs=require('fs'); const cfg=JSON.parse(fs.readFileSync('repos/rawsql-ts/tmp/rawsql-ts-publish-fixed/.changeset/config.json','utf8')); if(!Array.isArray(cfg.fixed)||!Array.isArray(cfg.fixed[0])||cfg.fixed[0].length===0) throw new Error('fixed missing'); console.log('fixed-count='+cfg.fixed[0].length);"
- node -e "const fs=require('fs'); const path=require('path'); const root='repos/rawsql-ts/tmp/rawsql-ts-publish-fixed'; const cfg=JSON.parse(fs.readFileSync(path.join(root,'.changeset/config.json'),'utf8')); const fixed=[...(cfg.fixed?.[0]||[])].sort(); const walk=(dir)=>fs.readdirSync(dir,{withFileTypes:true}).flatMap(d=>{const p=path.join(dir,d.name); if(d.isDirectory()) return walk(p); if(d.name==='package.json') return [p]; return [];}); const packages=walk(path.join(root,'packages')).map(p=>JSON.parse(fs.readFileSync(p,'utf8'))).filter(p=>p.name&&!p.private).map(p=>p.name).sort(); const missing=packages.filter(x=>!fixed.includes(x)); const extra=fixed.filter(x=>!packages.includes(x)); console.log(JSON.stringify({packages:packages.length,fixed:fixed.length,missing,extra},null,2)); if(missing.length||extra.length) process.exit(1);"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration to ensure coordinated updates across related packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->