### PR TITLE
fix: enable token fallback for first publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,6 +102,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
           RAWSQL_PUBLISH_AUTH: "oidc"
+          RAWSQL_PUBLISH_OIDC_FALLBACK_TO_TOKEN: "1"
+          # Keep the npm token out of the default npm environment and only expose it when ci-publish.mjs retries explicitly.
+          RAWSQL_PUBLISH_FALLBACK_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
         run: |
           # Prevent token-based auth from overriding OIDC Trusted Publishing.
           env -u NODE_AUTH_TOKEN node ./scripts/ci-publish.mjs

--- a/scripts/ci-publish.mjs
+++ b/scripts/ci-publish.mjs
@@ -8,6 +8,7 @@ const PNPM = "pnpm";
 const NPM = "npm";
 const GIT = "git";
 const GH = "gh";
+const FALLBACK_TOKEN_ENV = "RAWSQL_PUBLISH_FALLBACK_TOKEN";
 
 // Always target the public npm registry explicitly to avoid .npmrc/env quirks.
 const NPM_PUBLIC_REGISTRY = "https://registry.npmjs.org";
@@ -318,14 +319,21 @@ function ensureTokenUserConfig(workspaceRoot) {
   return tokenUserConfig;
 }
 
+function getPreservedPublishToken() {
+  return process.env[FALLBACK_TOKEN_ENV] || process.env.NODE_AUTH_TOKEN || "";
+}
+
 function sanitizeOidcEnvironment(publishAuth, workspaceRoot) {
   if (publishAuth !== "oidc") return;
 
-  // npm can prefer token-based auth when NODE_AUTH_TOKEN exists, which can break OIDC Trusted Publishing.
-  // Remove it proactively so downstream npm commands run in a clean OIDC environment.
+  // Remove auth tokens from the live environment so OIDC attempts stay pure until an explicit fallback retry.
   if (process.env.NODE_AUTH_TOKEN) {
     console.warn("[publish] warning: NODE_AUTH_TOKEN is set; removing it to avoid token-based auth overriding OIDC.");
     delete process.env.NODE_AUTH_TOKEN;
+  }
+  if (process.env[FALLBACK_TOKEN_ENV]) {
+    console.warn(`[publish] warning: ${FALLBACK_TOKEN_ENV} is set; removing it until token fallback is needed.`);
+    delete process.env[FALLBACK_TOKEN_ENV];
   }
 
   // Ensure npm doesn't pick up token auth from user-level config written by actions/setup-node or pre-existing runner config.
@@ -530,8 +538,8 @@ function publishWithNpm(packageDir, publishAuth, opts) {
         `  4) npm >= 11.5.1 and registry is ${NPM_PUBLIC_REGISTRY}`,
         "  5) npm publish includes --provenance (this script adds it in oidc mode)",
         opts?.allowTokenFallback === true
-          ? "  6) (fallback enabled) ensure a valid NODE_AUTH_TOKEN is available for token auth retry"
-          : "  6) (optional) enable RAWSQL_PUBLISH_OIDC_FALLBACK_TO_TOKEN=1 to retry with NODE_AUTH_TOKEN",
+          ? `  6) (fallback enabled) ensure a valid ${FALLBACK_TOKEN_ENV} or NODE_AUTH_TOKEN is available for token auth retry`
+          : `  6) (optional) enable RAWSQL_PUBLISH_OIDC_FALLBACK_TO_TOKEN=1 and provide ${FALLBACK_TOKEN_ENV} for token retry`,
       ].join("\n");
 
       throw new Error([hint, `---\n${message}`].join("\n"));
@@ -590,7 +598,7 @@ async function main() {
   const dryRun = process.env.RAWSQL_CI_DRY_RUN === "1";
   const publishAuth = detectPublishAuth();
 
-  const preservedNodeAuthToken = process.env.NODE_AUTH_TOKEN || "";
+  const preservedNodeAuthToken = getPreservedPublishToken();
   const allowTokenFallback = process.env.RAWSQL_PUBLISH_OIDC_FALLBACK_TO_TOKEN === "1";
 
   sanitizeOidcEnvironment(publishAuth, workspaceRoot);


### PR DESCRIPTION
## Summary
- preserve a dedicated fallback npm token for packages that cannot use Trusted Publishing yet
- enable the manual publish workflow to retry with token auth only after an OIDC publish attempt fails
- keep the default OIDC path clean by removing token-bearing env vars until fallback is explicitly needed

## Why
- run 23080641536 failed on @rawsql-ts/ddl-docs-cli with ENEEDAUTH after OIDC publish
- the workflow previously removed NODE_AUTH_TOKEN before starting ci-publish.mjs, so the existing fallback path could never access a token even when enabled

## Verification
- node --check repos/rawsql-ts/tmp/rawsql-ts-publish-fixed/scripts/ci-publish.mjs
- Select-String -Path repos/rawsql-ts/tmp/rawsql-ts-publish-fixed/.github/workflows/publish.yml -Pattern 'RAWSQL_PUBLISH_OIDC_FALLBACK_TO_TOKEN|RAWSQL_PUBLISH_FALLBACK_TOKEN|env -u NODE_AUTH_TOKEN node ./scripts/ci-publish.mjs'
- Select-String -Path repos/rawsql-ts/tmp/rawsql-ts-publish-fixed/scripts/ci-publish.mjs -Pattern 'FALLBACK_TOKEN_ENV|getPreservedPublishToken|RAWSQL_PUBLISH_OIDC_FALLBACK_TO_TOKEN' -Context 0,2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated publishing workflow with enhanced OIDC token management and configuration
  * Introduced fallback authentication mechanism to ensure consistent and reliable package publication across different deployment scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->