### PR TITLE
fix: skip prepack rebuilds in ci publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -103,8 +103,7 @@ jobs:
           NPM_CONFIG_PROVENANCE: "true"
           RAWSQL_PUBLISH_AUTH: "oidc"
           RAWSQL_PUBLISH_OIDC_FALLBACK_TO_TOKEN: "1"
-          # Keep the npm token out of the default npm environment and only expose it when ci-publish.mjs retries explicitly.
-          RAWSQL_PUBLISH_FALLBACK_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
         run: |
-          # Prevent token-based auth from overriding OIDC Trusted Publishing.
-          env -u NODE_AUTH_TOKEN node ./scripts/ci-publish.mjs
+          # Preserve the existing npm token under a separate name so ci-publish.mjs can use it only for explicit retries.
+          # Then drop NODE_AUTH_TOKEN from the live environment to keep the primary publish path on OIDC.
+          RAWSQL_PUBLISH_FALLBACK_TOKEN="${NODE_AUTH_TOKEN:-}" env -u NODE_AUTH_TOKEN node ./scripts/ci-publish.mjs

--- a/scripts/ci-publish.mjs
+++ b/scripts/ci-publish.mjs
@@ -471,7 +471,8 @@ function npmPackageVersionExists(packageName, version) {
 }
 
 function publishWithNpm(packageDir, publishAuth, opts) {
-  const args = ["publish", "--registry", NPM_PUBLIC_REGISTRY, "--access", "public"];
+  // CI already builds publish artifacts up front, so skip lifecycle rebuilds during npm publish.
+  const args = ["publish", "--ignore-scripts", "--registry", NPM_PUBLIC_REGISTRY, "--access", "public"];
 
   if (publishAuth === "oidc") {
     // OIDC Trusted Publishing requires provenance.
@@ -508,7 +509,9 @@ function publishWithNpm(packageDir, publishAuth, opts) {
         process.env.NPM_CONFIG_USERCONFIG = ensureTokenUserConfig(opts.workspaceRoot);
 
         try {
-          runWithOutput(NPM, ["publish", "--registry", NPM_PUBLIC_REGISTRY, "--access", "public"], { cwd: packageDir });
+          runWithOutput(NPM, ["publish", "--ignore-scripts", "--registry", NPM_PUBLIC_REGISTRY, "--access", "public"], {
+            cwd: packageDir,
+          });
           return;
         } catch (fallbackError) {
           const fallbackMessage = fallbackError instanceof Error ? fallbackError.message : String(fallbackError);


### PR DESCRIPTION
## Summary
- skip package lifecycle rebuilds during CI publish because the workflow already builds publish artifacts first
- preserve the current NODE_AUTH_TOKEN as RAWSQL_PUBLISH_FALLBACK_TOKEN at shell runtime before unsetting NODE_AUTH_TOKEN

## Why
- run 23081056555 still executed on main commit 51dbac57, before commit 073ccbab was merged
- the failure is the same prepack-triggered ddl-docs-cli build error that the follow-up branch commit addresses

## Verification
- gh run view 23081056555 --repo mk3008/rawsql-ts --log-failed
- node --check repos/rawsql-ts/tmp/rawsql-ts-publish-fixed/scripts/ci-publish.mjs
- Select-String -Path repos/rawsql-ts/tmp/rawsql-ts-publish-fixed/scripts/ci-publish.mjs -Pattern '--ignore-scripts|CI already builds publish artifacts up front' -Context 0,2
- Select-String -Path repos/rawsql-ts/tmp/rawsql-ts-publish-fixed/.github/workflows/publish.yml -Pattern 'RAWSQL_PUBLISH_OIDC_FALLBACK_TO_TOKEN|RAWSQL_PUBLISH_FALLBACK_TOKEN="\$\{NODE_AUTH_TOKEN:-\}" env -u NODE_AUTH_TOKEN node ./scripts/ci-publish.mjs' -Context 0,1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced publish workflow security with OIDC-only publishing by default and secure token handling for fallback scenarios.
  * Optimized package publishing by skipping unnecessary lifecycle scripts during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->