### PR TITLE
fix: add ztd cli repository metadata

### DIFF
--- a/packages/ztd-cli/package.json
+++ b/packages/ztd-cli/package.json
@@ -23,6 +23,11 @@
   ],
   "author": "msugiura",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mk3008/rawsql-ts.git",
+    "directory": "packages/ztd-cli"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- add repository metadata to @rawsql-ts/ztd-cli package.json
- align the published package metadata with the GitHub provenance bundle used by npm Trusted Publishing

## Why
- run 23081487385 failed when publishing @rawsql-ts/ztd-cli with npm E422
- npm reported that provenance expected repository https://github.com/mk3008/rawsql-ts, but the packed package metadata exposed an empty repository.url

## Verification
- gh run view 23081487385 --repo mk3008/rawsql-ts --log-failed
- npm pack --dry-run (packages/ztd-cli)
- pre-commit hook during git commit: ztd-cli tests, build, and lint all passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration metadata to include repository information for improved package management and distribution tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->