### PR TITLE
fix: release only affected packages from changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,25 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config/schema.json",
   "changelog": ["@changesets/changelog-github", { "repo": "mk3008/rawsql-ts" }],
   "commit": false,
-  "fixed": [
-    [
-      "rawsql-ts",
-      "@rawsql-ts/adapter-node-pg",
-      "@rawsql-ts/ddl-docs-cli",
-      "@rawsql-ts/ddl-docs-vitepress",
-      "@rawsql-ts/executor",
-      "@rawsql-ts/shared-binder",
-      "@rawsql-ts/sql-contract",
-      "@rawsql-ts/sql-contract-zod",
-      "@rawsql-ts/sql-grep-core",
-      "@rawsql-ts/test-evidence-core",
-      "@rawsql-ts/test-evidence-renderer-md",
-      "@rawsql-ts/testkit-core",
-      "@rawsql-ts/testkit-postgres",
-      "@rawsql-ts/testkit-sqlite",
-      "@rawsql-ts/ztd-cli"
-    ]
-  ],
+  "fixed": [],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
## Summary
- remove the workspace-wide Changesets fixed group
- let release PRs version only packages directly affected by changesets and normal dependency propagation
- stop release PRs from bumping unrelated packages to the same version

## Why
- release PR #567 currently bumps nearly every package to 2.0.0 even though the underlying change only affects @rawsql-ts/ztd-cli
- the current behavior comes from .changeset/config.json, not from the GitHub Actions workflow itself
- the workspace-wide fixed group was reintroduced recently, so the release plan should be narrowed back to related packages only

## Verification
- pnpm changeset status --output tmp/changeset-status.json
  - verified with a temporary ztd-cli-only changeset that the release plan includes only @rawsql-ts/ztd-cli
- pre-commit hook during git commit
  - ztd-cli typecheck, tests, build, and lint passed

## Follow-up after merge
- close or regenerate release PR #567 so it picks up the new Changesets config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release and dependency management configuration to adjust internal dependency update handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->