### PR TITLE
fix: publish npm-installable ztd cli packages

### DIFF
--- a/.changeset/green-birds-rhyme.md
+++ b/.changeset/green-birds-rhyme.md
@@ -1,0 +1,7 @@
+---
+"@rawsql-ts/ztd-cli": patch
+"@rawsql-ts/sql-grep-core": patch
+"@rawsql-ts/test-evidence-renderer-md": patch
+---
+
+Fix published package manifests so npm consumers do not receive `workspace:` dependency ranges when installing `@rawsql-ts/ztd-cli` and its internal runtime dependencies.

--- a/scripts/ci-publish.mjs
+++ b/scripts/ci-publish.mjs
@@ -506,9 +506,33 @@ function npmPackageExists(packageName) {
   );
 }
 
+function createPublishTarball(packageDir, workspaceRoot, packageName) {
+  const tarballDir = path.join(workspaceRoot, "tmp", "publish-tarballs", sanitizeFilename(packageName));
+
+  // Recreate the staging directory so each publish attempt uses a single, deterministic tarball.
+  fs.rmSync(tarballDir, { recursive: true, force: true });
+  ensureDir(tarballDir);
+
+  runWithOutput(PNPM, ["pack", "--pack-destination", tarballDir], { cwd: packageDir });
+
+  const tarballs = fs.readdirSync(tarballDir).filter((entry) => entry.endsWith(".tgz"));
+  if (tarballs.length !== 1) {
+    throw new Error(
+      `[publish] expected exactly one tarball for ${packageName}, found ${tarballs.length} in ${tarballDir}`,
+    );
+  }
+
+  return path.join(tarballDir, tarballs[0]);
+}
+
 function publishWithNpm(packageDir, publishAuth, opts) {
+  if (!opts?.workspaceRoot || !opts?.packageName) {
+    throw new Error("[publish] publishWithNpm requires workspaceRoot and packageName");
+  }
+
+  const tarballPath = createPublishTarball(packageDir, opts.workspaceRoot, opts.packageName);
   // CI already builds publish artifacts up front, so skip lifecycle rebuilds during npm publish.
-  const args = ["publish", "--ignore-scripts", "--registry", NPM_PUBLIC_REGISTRY, "--access", "public"];
+  const args = [tarballPath, "--ignore-scripts", "--registry", NPM_PUBLIC_REGISTRY, "--access", "public"];
 
   if (publishAuth === "oidc") {
     // OIDC Trusted Publishing requires provenance.
@@ -516,7 +540,7 @@ function publishWithNpm(packageDir, publishAuth, opts) {
   }
 
   try {
-    runWithOutput(NPM, args, { cwd: packageDir });
+    runWithOutput(NPM, ["publish", ...args], { cwd: packageDir });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     const c = classifyNpmFailure(message);
@@ -545,9 +569,7 @@ function publishWithNpm(packageDir, publishAuth, opts) {
         process.env.NPM_CONFIG_USERCONFIG = ensureTokenUserConfig(opts.workspaceRoot);
 
         try {
-          runWithOutput(NPM, ["publish", "--ignore-scripts", "--registry", NPM_PUBLIC_REGISTRY, "--access", "public"], {
-            cwd: packageDir,
-          });
+          runWithOutput(NPM, ["publish", ...args.filter((arg) => arg !== "--provenance")], { cwd: packageDir });
           return;
         } catch (fallbackError) {
           const fallbackMessage = fallbackError instanceof Error ? fallbackError.message : String(fallbackError);


### PR DESCRIPTION
## Summary
- publish workspace packages from normalized pnpm tarballs instead of raw package directories
- prevent workspace: dependency ranges from leaking into published npm manifests
- add patch releases for @rawsql-ts/ztd-cli, @rawsql-ts/sql-grep-core, and @rawsql-ts/test-evidence-renderer-md

## Why
- 
pm install -D @rawsql-ts/ztd-cli currently fails with EUNSUPPORTEDPROTOCOL
- the published @rawsql-ts/ztd-cli package depends on internal packages whose npm metadata still contains workspace: ranges
- CI publish was using 
pm publish directly from package directories, which bypassed pnpm's manifest normalization

## Verification
- reproduced the consumer failure with 
pm install -D @rawsql-ts/ztd-cli
- inspected npm metadata and confirmed leaked workspace: ranges in published internal dependencies
- packed local tarballs with pnpm and verified their manifests are normalized
- installed the normalized tarballs into a fresh npm project and confirmed install succeeds
- pre-commit hook during git commit: workspace typecheck, tests, build, and lint all passed

## Notes
- this PR fixes the publish path for future releases
- the included changeset bumps the affected packages so corrected npm manifests can be published

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed published package manifests to ensure correct dependency specifications are delivered to npm consumers.
  * Improved reliability of the package publishing process with enhanced artifact generation and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->