### PR TITLE
fix: guard publish job runtime setup

### DIFF
--- a/.github/actions/setup-publish-runtime/action.yml
+++ b/.github/actions/setup-publish-runtime/action.yml
@@ -1,0 +1,89 @@
+name: "Setup Publish Runtime"
+description: "Initialize a self-contained runtime for publish workflow jobs and fail fast when required tools/files are missing."
+
+inputs:
+  node-version:
+    description: "Node.js version to install"
+    required: false
+    default: "22"
+  use-pnpm:
+    description: "Whether this job needs pnpm on PATH"
+    required: false
+    default: "true"
+  install-dependencies:
+    description: "Whether to run pnpm install --frozen-lockfile"
+    required: false
+    default: "false"
+  update-npm:
+    description: "Whether to upgrade npm for Trusted Publishing requirements"
+    required: false
+    default: "false"
+  registry-url:
+    description: "Registry URL passed to setup-node"
+    required: false
+    default: "https://registry.npmjs.org"
+  required-commands:
+    description: "Comma-separated command list validated by verify-runtime-prereqs.mjs"
+    required: false
+    default: "node,npm"
+  required-files:
+    description: "Comma-separated relative file paths validated by verify-runtime-prereqs.mjs"
+    required: false
+    default: ""
+  label:
+    description: "Human-readable label for runtime diagnostics"
+    required: false
+    default: "publish-job"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup pnpm
+      if: ${{ inputs.use-pnpm == 'true' }}
+      uses: pnpm/action-setup@v4
+      with:
+        run_install: false
+
+    - name: Setup Node with pnpm cache
+      if: ${{ inputs.use-pnpm == 'true' }}
+      uses: actions/setup-node@v5
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: "pnpm"
+        registry-url: ${{ inputs.registry-url }}
+
+    - name: Setup Node without pnpm cache
+      if: ${{ inputs.use-pnpm != 'true' }}
+      uses: actions/setup-node@v5
+      with:
+        node-version: ${{ inputs.node-version }}
+        package-manager-cache: false
+        registry-url: ${{ inputs.registry-url }}
+
+    - name: Enable Corepack
+      if: ${{ inputs.use-pnpm == 'true' }}
+      shell: bash
+      run: corepack enable
+
+    - name: Install dependencies
+      if: ${{ inputs.install-dependencies == 'true' && inputs.use-pnpm == 'true' }}
+      shell: bash
+      run: pnpm install --frozen-lockfile
+
+    - name: Update npm
+      if: ${{ inputs.update-npm == 'true' }}
+      shell: bash
+      run: |
+        npm install -g "npm@^11.5.1"
+        npm --version
+
+    - name: Verify runtime prerequisites
+      shell: bash
+      run: |
+        mkdir -p tmp/runtime-checks
+        node ./scripts/verify-runtime-prereqs.mjs \
+          --label "${{ inputs.label }}" \
+          --commands "${{ inputs.required-commands }}" \
+          --files "${{ inputs.required-files }}" \
+          --min-npm-version "11.5.1" \
+          --output "tmp/runtime-checks/${{ inputs.label }}.json"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,29 +32,14 @@ jobs:
             exit 1
           fi
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      - name: Setup publish readiness runtime
+        uses: ./.github/actions/setup-publish-runtime
         with:
-          run_install: false
-
-      - uses: actions/setup-node@v5
-        with:
-          node-version: 22
-          cache: "pnpm"
-          registry-url: "https://registry.npmjs.org"
-
-      - run: corepack enable
-
-      - run: pnpm --version
-
-      - run: pnpm install --frozen-lockfile
-
-      - name: Update npm
-        shell: bash
-        run: |
-          # npm Trusted Publishing (OIDC) requires npm >= 11.5.1.
-          npm install -g "npm@^11.5.1"
-          npm --version
+          use-pnpm: "true"
+          install-dependencies: "true"
+          update-npm: "true"
+          required-commands: "node,npm,pnpm"
+          label: "verify-publish-readiness"
 
       - name: Verify publish readiness
         id: plan
@@ -64,7 +49,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: publish-readiness
-          path: tmp/publish-readiness
+          path: |
+            tmp/publish-readiness
+            tmp/runtime-checks
 
   build_publish_artifacts:
     needs: verify_publish_readiness
@@ -73,19 +60,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      - name: Setup artifact build runtime
+        uses: ./.github/actions/setup-publish-runtime
         with:
-          run_install: false
-
-      - uses: actions/setup-node@v5
-        with:
-          node-version: 22
-          cache: "pnpm"
-
-      - run: corepack enable
-
-      - run: pnpm install --frozen-lockfile
+          use-pnpm: "true"
+          install-dependencies: "true"
+          update-npm: "false"
+          required-commands: "node,npm,pnpm"
+          label: "build-publish-artifacts"
 
       - name: Download publish readiness evidence
         uses: actions/download-artifact@v4
@@ -101,7 +83,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: publish-artifacts
-          path: tmp/publish-artifacts
+          path: |
+            tmp/publish-artifacts
+            tmp/runtime-checks
 
   actual_publish:
     needs: [verify_publish_readiness, build_publish_artifacts]
@@ -112,23 +96,29 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v5
+      - name: Setup actual publish runtime
+        uses: ./.github/actions/setup-publish-runtime
         with:
-          node-version: 22
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Update npm
-        shell: bash
-        run: |
-          # npm Trusted Publishing (OIDC) requires npm >= 11.5.1.
-          npm install -g "npm@^11.5.1"
-          npm --version
+          use-pnpm: "false"
+          install-dependencies: "false"
+          update-npm: "true"
+          required-commands: "node,npm,git,gh"
+          label: "actual-publish"
 
       - name: Download built publish artifacts
         uses: actions/download-artifact@v4
         with:
           name: publish-artifacts
           path: tmp/publish-artifacts
+
+      - name: Verify publish manifest is present
+        run: |
+          node ./scripts/verify-runtime-prereqs.mjs \
+            --label "actual-publish-manifest" \
+            --commands "node,npm,git,gh" \
+            --files "tmp/publish-artifacts/publish-manifest.json" \
+            --min-npm-version "11.5.1" \
+            --output "tmp/runtime-checks/actual-publish-manifest.json"
 
       - name: Configure git identity for tags
         shell: bash
@@ -162,3 +152,10 @@ jobs:
           # Preserve the existing npm token under a separate name so ci-publish.mjs can use it only for explicit retries.
           # Then drop NODE_AUTH_TOKEN from the live environment to keep the primary publish path on OIDC.
           RAWSQL_PUBLISH_FALLBACK_TOKEN="${NODE_AUTH_TOKEN:-}" env -u NODE_AUTH_TOKEN node ./scripts/ci-publish.mjs
+
+      - name: Upload actual publish diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: actual-publish-diagnostics
+          path: tmp/runtime-checks

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "playground:test": "pnpm --filter ztd-playground test",
     "prepare": "husky",
     "verify:publish-readiness": "node scripts/publish-plan.mjs",
+    "verify:runtime-prereqs": "node scripts/verify-runtime-prereqs.mjs",
     "docs:dev": "vitepress dev docs",
     "docs:build": "pnpm docs:api && vitepress build docs",
     "docs:preview": "vitepress preview docs",

--- a/scripts/ci-publish.mjs
+++ b/scripts/ci-publish.mjs
@@ -94,6 +94,21 @@ function tryRun(command, args, options = {}) {
   return { ok: result.status === 0, status: result.status };
 }
 
+function ensureCommandAvailable(command) {
+  const probe = spawnSync(command, ["--version"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    shell: IS_WINDOWS,
+  });
+
+  if (probe.error || probe.status !== 0) {
+    const message = probe.error instanceof Error
+      ? probe.error.message
+      : `${command} --version failed with exit code ${probe.status ?? "unknown"}`;
+    throw new Error(`[publish] Required command is missing or unusable: ${command}. ${message}`);
+  }
+}
+
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, "utf8"));
 }
@@ -629,6 +644,11 @@ async function main() {
   const workspaceRoot = process.cwd();
   const dryRun = process.env.RAWSQL_CI_DRY_RUN === "1";
   const publishAuth = detectPublishAuth();
+
+  // Keep actual publish self-diagnosing even when invoked outside the intended workflow wrapper.
+  for (const command of [NPM, GIT, GH]) {
+    ensureCommandAvailable(command);
+  }
 
   const preservedNodeAuthToken = getPreservedPublishToken();
   const allowTokenFallback = process.env.RAWSQL_PUBLISH_OIDC_FALLBACK_TO_TOKEN === "1";

--- a/scripts/verify-runtime-prereqs.mjs
+++ b/scripts/verify-runtime-prereqs.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+function parseArgs(argv) {
+  const options = {
+    label: "runtime-check",
+    commands: [],
+    files: [],
+    minNpmVersion: null,
+    output: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1] ?? "";
+
+    if (arg === "--label") {
+      options.label = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--commands") {
+      options.commands = next.split(",").map((value) => value.trim()).filter(Boolean);
+      index += 1;
+      continue;
+    }
+    if (arg === "--files") {
+      options.files = next.split(",").map((value) => value.trim()).filter(Boolean);
+      index += 1;
+      continue;
+    }
+    if (arg === "--min-npm-version") {
+      options.minNpmVersion = next || null;
+      index += 1;
+      continue;
+    }
+    if (arg === "--output") {
+      options.output = next || null;
+      index += 1;
+    }
+  }
+
+  return options;
+}
+
+function compareSemver(left, right) {
+  const a = String(left).split(".").map((value) => Number.parseInt(value, 10));
+  const b = String(right).split(".").map((value) => Number.parseInt(value, 10));
+
+  for (let index = 0; index < 3; index += 1) {
+    const av = Number.isFinite(a[index]) ? a[index] : 0;
+    const bv = Number.isFinite(b[index]) ? b[index] : 0;
+    if (av < bv) return -1;
+    if (av > bv) return 1;
+  }
+  return 0;
+}
+
+function runVersion(command) {
+  const result = spawnSync(command, ["--version"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    shell: process.platform === "win32",
+  });
+
+  if (result.error) {
+    return {
+      ok: false,
+      command,
+      version: null,
+      message: result.error.message,
+    };
+  }
+
+  if (result.status !== 0) {
+    return {
+      ok: false,
+      command,
+      version: null,
+      message: `${command} --version failed with exit code ${result.status ?? "unknown"}`,
+    };
+  }
+
+  return {
+    ok: true,
+    command,
+    version: (result.stdout ?? "").trim(),
+    message: null,
+  };
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function main() {
+  const workspaceRoot = process.cwd();
+  const options = parseArgs(process.argv.slice(2));
+  const commandChecks = options.commands.map((command) => runVersion(command));
+  const fileChecks = options.files.map((filePath) => ({
+    path: filePath,
+    exists: fs.existsSync(path.resolve(workspaceRoot, filePath)),
+  }));
+  const failures = [];
+
+  for (const check of commandChecks) {
+    if (!check.ok) {
+      failures.push(`[runtime-check] Missing required command "${check.command}": ${check.message}`);
+    }
+  }
+
+  if (options.minNpmVersion) {
+    const npmCheck = commandChecks.find((check) => check.command === "npm");
+    if (!npmCheck?.ok) {
+      failures.push(`[runtime-check] npm is required to validate minimum version ${options.minNpmVersion}.`);
+    } else if (compareSemver(npmCheck.version, options.minNpmVersion) < 0) {
+      failures.push(
+        `[runtime-check] npm ${npmCheck.version} is below the required minimum ${options.minNpmVersion}.`,
+      );
+    }
+  }
+
+  for (const check of fileChecks) {
+    if (!check.exists) {
+      failures.push(`[runtime-check] Required file is missing: ${check.path}`);
+    }
+  }
+
+  const report = {
+    schemaVersion: 1,
+    kind: "runtime-prereq-check",
+    label: options.label,
+    checkedAt: new Date().toISOString(),
+    commands: commandChecks,
+    files: fileChecks,
+    ok: failures.length === 0,
+    failures,
+  };
+
+  if (options.output) {
+    writeJson(path.resolve(workspaceRoot, options.output), report);
+  }
+
+  for (const check of commandChecks) {
+    if (check.ok) {
+      console.log(`[runtime-check] ${check.command}=${check.version}`);
+    }
+  }
+  for (const check of fileChecks) {
+    console.log(`[runtime-check] file ${check.path}: ${check.exists ? "present" : "missing"}`);
+  }
+
+  if (failures.length > 0) {
+    throw new Error(failures.join("\n"));
+  }
+}
+
+main();


### PR DESCRIPTION
## Objective
Restore publish success probability after run 23110001107 by making each publish workflow job self-contained and by turning runtime prerequisites into reusable checks instead of reviewer memory.

## Why this follow-up exists
PR #583 improved stage separation:
- verify_publish_readiness
- build_publish_artifacts
- actual_publish

That separation worked: the new failure was isolated to actual_publish only. The miss was job runtime self-sufficiency. This PR addresses that missing layer.

## What changed
- add a reusable composite action at `.github/actions/setup-publish-runtime`
- use that action from all three publish jobs instead of hand-copying setup steps
- add `scripts/verify-runtime-prereqs.mjs` for idempotent command/file self-checks with machine-readable JSON output
- keep `actual_publish` manifest-driven and remove any need for pnpm-specific setup there
- add fail-fast command checks inside `scripts/ci-publish.mjs`

## Prevention mechanism
- shared runtime setup removes copy/paste drift between jobs
- actual_publish now uses setup-node without package-manager cache and does not require pnpm on PATH
- every job emits runtime-check JSON evidence
- actual_publish verifies `tmp/publish-artifacts/publish-manifest.json` before publish starts
- `ci-publish.mjs` fails fast if required commands (`npm`, `git`, `gh`) are unavailable

## Verification summary
- `node ./scripts/publish-plan.mjs`
- `node ./scripts/build-publish-artifacts.mjs --plan tmp/manual-publish-plan.json --output-dir tmp/manual-publish-artifacts`
- `RAWSQL_CI_DRY_RUN=1 RAWSQL_PUBLISH_AUTH=token RAWSQL_PUBLISH_MANIFEST=tmp/manual-publish-artifacts/publish-manifest.json node ./scripts/ci-publish.mjs`
- `pnpm --filter @rawsql-ts/sql-grep-core build`
- `node ./scripts/verify-runtime-prereqs.mjs --label local-success-1 --commands "node,npm,git" --output tmp/runtime-checks/local-success-1.json`
- `node ./scripts/verify-runtime-prereqs.mjs --label local-success-2 --commands "node,npm,git" --output tmp/runtime-checks/local-success-2.json`
- expected failure: `node ./scripts/verify-runtime-prereqs.mjs --label expected-failure-missing-file --commands "node" --files "tmp/does-not-exist.json" --output tmp/runtime-checks/expected-failure-missing-file.json`
- expected failure: `node ./scripts/verify-runtime-prereqs.mjs --label local-success-1 --commands "node,npm,git" --min-npm-version "11.5.1" --output tmp/runtime-checks/local-success-1.json`

## CI-only checks to watch
- actual_publish logs should no longer show `Unable to locate executable file: pnpm.`
- actual_publish runtime check should report `node`, `npm`, `git`, and `gh` as present
- actual_publish should verify `publish-manifest.json` before invoking `ci-publish.mjs`
- OIDC Trusted Publishing remains CI-only and must still be validated in GitHub Actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced publish workflow with improved runtime prerequisite validation and comprehensive diagnostic reporting for more reliable deployments.
  * Added environment readiness checks to validate required commands and dependencies before publishing, with detailed diagnostics for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->