### PR TITLE
fix: reclassify publish runtime npm guard

### DIFF
--- a/.github/actions/setup-publish-runtime/action.yml
+++ b/.github/actions/setup-publish-runtime/action.yml
@@ -30,6 +30,14 @@ inputs:
     description: "Comma-separated relative file paths validated by verify-runtime-prereqs.mjs"
     required: false
     default: ""
+  min-npm-version:
+    description: "Blocking npm minimum version. Leave empty when a job does not depend on a specific npm floor."
+    required: false
+    default: ""
+  warn-min-npm-version:
+    description: "Warning-only npm minimum version used for advisory checks."
+    required: false
+    default: ""
   label:
     description: "Human-readable label for runtime diagnostics"
     required: false
@@ -85,5 +93,6 @@ runs:
           --label "${{ inputs.label }}" \
           --commands "${{ inputs.required-commands }}" \
           --files "${{ inputs.required-files }}" \
-          --min-npm-version "11.5.1" \
+          ${{ inputs.min-npm-version != '' && format('--min-npm-version "{0}"', inputs.min-npm-version) || '' }} \
+          ${{ inputs.warn-min-npm-version != '' && format('--warn-min-npm-version "{0}"', inputs.warn-min-npm-version) || '' }} \
           --output "tmp/runtime-checks/${{ inputs.label }}.json"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,7 @@ jobs:
           install-dependencies: "true"
           update-npm: "true"
           required-commands: "node,npm,pnpm"
+          warn-min-npm-version: "11.5.1"
           label: "verify-publish-readiness"
 
       - name: Verify publish readiness
@@ -67,6 +68,7 @@ jobs:
           install-dependencies: "true"
           update-npm: "false"
           required-commands: "node,npm,pnpm"
+          warn-min-npm-version: "11.5.1"
           label: "build-publish-artifacts"
 
       - name: Download publish readiness evidence
@@ -103,6 +105,7 @@ jobs:
           install-dependencies: "false"
           update-npm: "true"
           required-commands: "node,npm,git,gh"
+          min-npm-version: "11.5.1"
           label: "actual-publish"
 
       - name: Download built publish artifacts
@@ -117,7 +120,6 @@ jobs:
             --label "actual-publish-manifest" \
             --commands "node,npm,git,gh" \
             --files "tmp/publish-artifacts/publish-manifest.json" \
-            --min-npm-version "11.5.1" \
             --output "tmp/runtime-checks/actual-publish-manifest.json"
 
       - name: Configure git identity for tags

--- a/scripts/verify-runtime-prereqs.mjs
+++ b/scripts/verify-runtime-prereqs.mjs
@@ -9,6 +9,7 @@ function parseArgs(argv) {
     commands: [],
     files: [],
     minNpmVersion: null,
+    warnMinNpmVersion: null,
     output: null,
   };
 
@@ -33,6 +34,11 @@ function parseArgs(argv) {
     }
     if (arg === "--min-npm-version") {
       options.minNpmVersion = next || null;
+      index += 1;
+      continue;
+    }
+    if (arg === "--warn-min-npm-version") {
+      options.warnMinNpmVersion = next || null;
       index += 1;
       continue;
     }
@@ -105,6 +111,7 @@ function main() {
     exists: fs.existsSync(path.resolve(workspaceRoot, filePath)),
   }));
   const failures = [];
+  const warnings = [];
 
   for (const check of commandChecks) {
     if (!check.ok) {
@@ -123,6 +130,17 @@ function main() {
     }
   }
 
+  if (options.warnMinNpmVersion) {
+    const npmCheck = commandChecks.find((check) => check.command === "npm");
+    if (!npmCheck?.ok) {
+      warnings.push(`[runtime-check] npm is unavailable, so recommended minimum ${options.warnMinNpmVersion} could not be checked.`);
+    } else if (compareSemver(npmCheck.version, options.warnMinNpmVersion) < 0) {
+      warnings.push(
+        `[runtime-check] npm ${npmCheck.version} is below the recommended minimum ${options.warnMinNpmVersion}.`,
+      );
+    }
+  }
+
   for (const check of fileChecks) {
     if (!check.exists) {
       failures.push(`[runtime-check] Required file is missing: ${check.path}`);
@@ -137,6 +155,7 @@ function main() {
     commands: commandChecks,
     files: fileChecks,
     ok: failures.length === 0,
+    warnings,
     failures,
   };
 
@@ -151,6 +170,9 @@ function main() {
   }
   for (const check of fileChecks) {
     console.log(`[runtime-check] file ${check.path}: ${check.exists ? "present" : "missing"}`);
+  }
+  for (const warning of warnings) {
+    console.warn(warning);
   }
 
   if (failures.length > 0) {


### PR DESCRIPTION
## Summary
- reclassify the npm minimum-version runtime check so readiness and artifact jobs warn instead of fail
- keep the npm floor blocking only in actual publish after npm is updated in that job
- preserve the existing publish stage split and machine-readable runtime reports

## Testing
- node ./scripts/verify-runtime-prereqs.mjs --label warn-npm-floor --commands "node,npm,git" --warn-min-npm-version "11.5.1" --output tmp/runtime-checks/warn-npm-floor.json
- node ./scripts/publish-plan.mjs
- pnpm --filter @rawsql-ts/sql-grep-core build
- node ./scripts/build-publish-artifacts.mjs --plan tmp/manual-publish-plan.json --output-dir tmp/manual-publish-artifacts
- RAWSQL_CI_DRY_RUN=1 RAWSQL_PUBLISH_AUTH=token RAWSQL_PUBLISH_MANIFEST=tmp/manual-publish-artifacts/publish-manifest.json NODE_AUTH_TOKEN=dummy-token node ./scripts/ci-publish.mjs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced npm version validation throughout the publish workflow. New configurable checks for minimum npm versions now warn and enforce requirements during the build and publish process, improving deployment reliability and ensuring publishing environments meet specified prerequisites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->