### PR TITLE
fix: make publish tarball contracts relocatable

### DIFF
--- a/scripts/build-publish-artifacts.mjs
+++ b/scripts/build-publish-artifacts.mjs
@@ -12,6 +12,7 @@ import {
   getReadinessContractDir,
   getReadinessPlanPath,
   loadValidatedPublishPlanContract,
+  toRelocatableTarballLocator,
   run,
   writeJson,
 } from "./publish-workspace-utils.mjs";
@@ -109,7 +110,7 @@ function main() {
       const tarballPath = findPackedTarball(packDir);
       report.packedArtifacts.push({
         ...candidate,
-        tarballPath,
+        tarballPath: toRelocatableTarballLocator(outputDir, tarballPath),
       });
     }
   } catch (error) {

--- a/scripts/ci-publish.mjs
+++ b/scripts/ci-publish.mjs
@@ -131,7 +131,7 @@ function loadPublishManifest(workspaceRoot) {
     version: pkg.version,
     dir: pkg.dir,
     changelogPath: pkg.changelogPath,
-    publishSource: pkg.tarballPath,
+    publishSource: pkg.resolvedTarballPath ?? pkg.tarballPath,
     publishCwd: workspaceRoot,
   }));
 }

--- a/scripts/publish-workspace-utils.mjs
+++ b/scripts/publish-workspace-utils.mjs
@@ -163,6 +163,17 @@ function requireStringArray(value, contractName, description) {
   }
 }
 
+function toPortableRelativePath(filePath) {
+  return filePath.split(path.sep).join("/");
+}
+
+function ensurePathInsideRoot(rootDir, candidatePath, contractName, description) {
+  const relative = path.relative(rootDir, candidatePath);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw publishContractError(contractName, `${description} must stay within contract root ${rootDir}.`);
+  }
+}
+
 function validateSchemaVersion(payload, contractName) {
   if (payload.schemaVersion !== PUBLISH_CONTRACT_SCHEMA_VERSION) {
     throw publishContractError(
@@ -232,6 +243,29 @@ export function resolveContractFileFromArtifactRoot(artifactRoot, fileName, cont
   return matches[0];
 }
 
+export function resolveTarballPathFromContractDir(contractDir, locator, contractName, description) {
+  requireString(locator, contractName, description);
+  if (path.isAbsolute(locator)) {
+    throw publishContractError(contractName, `${description} must be relative to the contract root, received absolute path ${locator}.`);
+  }
+
+  const resolvedPath = path.resolve(contractDir, locator);
+  ensurePathInsideRoot(contractDir, resolvedPath, contractName, description);
+
+  if (!fs.existsSync(resolvedPath)) {
+    throw publishContractError(contractName, `${description} resolved to a missing tarball: ${resolvedPath}.`);
+  }
+
+  return resolvedPath;
+}
+
+export function toRelocatableTarballLocator(contractDir, tarballPath, contractName = "publish-artifacts") {
+  const resolvedContractDir = path.resolve(contractDir);
+  const resolvedTarballPath = path.resolve(tarballPath);
+  ensurePathInsideRoot(resolvedContractDir, resolvedTarballPath, contractName, "tarballPath");
+  return toPortableRelativePath(path.relative(resolvedContractDir, resolvedTarballPath));
+}
+
 export function loadValidatedPublishPlanContract(planPath) {
   if (!fs.existsSync(planPath)) {
     throw publishContractError("publish-readiness", `expected publish plan file at ${planPath}.`);
@@ -261,6 +295,7 @@ export function loadValidatedPublishManifestContract(manifestPath) {
     throw publishContractError("publish-artifacts", `expected publish manifest file at ${manifestPath}.`);
   }
 
+  const contractDir = path.dirname(path.resolve(manifestPath));
   const manifest = readContractJson(manifestPath, "publish-artifacts", "publish manifest payload");
   requireObject(manifest, "publish-artifacts", "publish manifest payload");
   validateSchemaVersion(manifest, "publish-artifacts");
@@ -270,6 +305,12 @@ export function loadValidatedPublishManifestContract(manifestPath) {
   requireArray(manifest.packages, "publish-artifacts", "packages");
   for (let index = 0; index < manifest.packages.length; index += 1) {
     validateManifestPackageEntry(manifest.packages[index], "publish-artifacts", index);
+    manifest.packages[index].resolvedTarballPath = resolveTarballPathFromContractDir(
+      contractDir,
+      manifest.packages[index].tarballPath,
+      "publish-artifacts",
+      `packages[${index}].tarballPath`,
+    );
   }
   return manifest;
 }
@@ -279,6 +320,7 @@ export function loadValidatedBuildReportContract(reportPath) {
     throw publishContractError("publish-artifacts", `expected build report file at ${reportPath}.`);
   }
 
+  const contractDir = path.dirname(path.resolve(reportPath));
   const report = readContractJson(reportPath, "publish-artifacts", "build report payload");
   requireObject(report, "publish-artifacts", "build report payload");
   validateSchemaVersion(report, "publish-artifacts");
@@ -293,6 +335,12 @@ export function loadValidatedBuildReportContract(reportPath) {
   }
   for (let index = 0; index < report.packedArtifacts.length; index += 1) {
     validateManifestPackageEntry(report.packedArtifacts[index], "publish-artifacts", index);
+    report.packedArtifacts[index].resolvedTarballPath = resolveTarballPathFromContractDir(
+      contractDir,
+      report.packedArtifacts[index].tarballPath,
+      "publish-artifacts",
+      `packedArtifacts[${index}].tarballPath`,
+    );
   }
   return report;
 }


### PR DESCRIPTION
## Summary
- store relocatable tarball paths in publish-manifest.json instead of job-specific absolute paths
- resolve and verify tarball files relative to the downloaded artifacts contract root
- fail fast with artifact contract violations for missing, absolute, or escaping tarball locators

## Testing
- node ./scripts/publish-plan.mjs --output-dir tmp/relocatable-test/source-readiness
- node ./scripts/build-publish-artifacts.mjs --plan ./tmp/relocatable-test/source-readiness/publish-plan.json --output-dir ./tmp/relocatable-test/source-artifacts
- node ./scripts/verify-publish-contract.mjs --contract artifacts --artifact-root tmp/relocatable-test/downloads/artifacts --label relocatable-artifacts --output tmp/relocatable-test/artifacts-verify.json --github-output tmp/relocatable-test/artifacts-verify.out
- RAWSQL_CI_DRY_RUN=1 RAWSQL_PUBLISH_AUTH=token RAWSQL_PUBLISH_MANIFEST=tmp/relocatable-test/downloads/artifacts/nested/publish-manifest.json NODE_AUTH_TOKEN=dummy-token node ./scripts/ci-publish.mjs
- node ./scripts/verify-publish-contract.mjs --contract artifacts --artifact-root tmp/relocatable-test/bad-missing --label bad-missing --output tmp/relocatable-test/bad-missing-report.json
- node ./scripts/verify-publish-contract.mjs --contract artifacts --artifact-root tmp/relocatable-test/bad-absolute --label bad-absolute --output tmp/relocatable-test/bad-absolute-report.json
- node ./scripts/verify-publish-contract.mjs --contract artifacts --artifact-root tmp/relocatable-test/bad-outside --label bad-outside --output tmp/relocatable-test/bad-outside-report.json
- RAWSQL_CI_DRY_RUN=1 RAWSQL_PUBLISH_AUTH=token RAWSQL_PUBLISH_MANIFEST=tmp/relocatable-test/bad-missing/nested/publish-manifest.json NODE_AUTH_TOKEN=dummy-token node ./scripts/ci-publish.mjs
- RAWSQL_CI_DRY_RUN=1 RAWSQL_PUBLISH_AUTH=token RAWSQL_PUBLISH_MANIFEST=tmp/relocatable-test/bad-absolute/nested/publish-manifest.json NODE_AUTH_TOKEN=dummy-token node ./scripts/ci-publish.mjs
