### PR TITLE
fix: align npm primary path for external onboarding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
 
-    - name: Run customer consumer guard
+    - name: Run npm primary-path consumer guard
       run: pnpm verify:customer-consumers
 
   benchmark:

--- a/docs/guide/published-package-verification.md
+++ b/docs/guide/published-package-verification.md
@@ -5,16 +5,21 @@ Use this guide when you need to validate the published-package happy path **befo
 This is not a perfect substitute for a real registry publish. It is a local verification layer that answers two practical questions:
 
 1. Did `pnpm pack` rewrite workspace protocol dependencies to concrete semver ranges?
-2. Does the packed `@rawsql-ts/ztd-cli` tarball still reach a green standalone smoke run?
+2. Does the packed `@rawsql-ts/ztd-cli` tarball still reach a green npm-first standalone smoke run?
 
 ## What this check proves
 
 - Release builds complete for the packages needed by the published-package path.
 - Packed tarballs do not leak `workspace:*`, `workspace:^`, or similar references.
-- A standalone app can install the packed `@rawsql-ts/ztd-cli` tarball and complete:
-  - `ztd init --yes`
-  - `ztd ztd-config`
-  - `pnpm test`
+- Phase A proves the packaging / npm primary path gate:
+  - the tarball installs with `npm install`
+  - `npx ztd init --yes` completes
+  - the generated completion message stays on the npm primary path
+  - follow-up `npm install` still works
+- Phase B proves the stronger consumer smoke:
+  - `npx ztd ztd-config`
+  - `npm run test`
+  - TypeScript compile checks for both default and Node16 settings
 
 ## What this check does not prove
 
@@ -35,16 +40,18 @@ The script will:
 1. Run `pnpm build:publish`
 2. Pack the publishable packages into `tmp/published-package-check/tarballs`
 3. Inspect each packed `package.json` for leaked `workspace:` references
-4. Create a standalone app under `tmp/published-package-check/standalone-app`
-5. Install the packed `@rawsql-ts/ztd-cli` tarball there
-6. Run `ztd init --yes`, `ztd ztd-config`, and `pnpm test`
+4. Create a standalone app under `tmp/published-package-check/packages/npm-primary-path`
+5. Run Phase A: `npm install`, `npx ztd init --yes`, completion-message assertions, and follow-up `npm install`
+6. Run Phase B: `npx ztd ztd-config`, `npm run test`, and TypeScript compile checks
 7. Write a machine-readable summary to `tmp/published-package-check/summary.json`
 
 ## How to interpret failures
 
 - Pack inspection fails because a tarball still contains `workspace:` references.
   - Treat this as a packaging/release bug.
-- The standalone app fails during `pnpm add` or later install steps because an unpublished transitive dependency still expects the public registry.
+- Phase A fails before `ztd-config`.
+  - Treat this as a packaging or npm-primary-path regression.
+- Phase B fails after the npm-first setup completed.
   - Treat this as a published-package-mode release gap.
   - The local-source developer path may still be healthy.
 - The standalone smoke app passes, but local-source dogfooding fails.

--- a/packages/ztd-cli/src/commands/init.ts
+++ b/packages/ztd-cli/src/commands/init.ts
@@ -1125,7 +1125,7 @@ export async function runInitCommand(prompter: Prompter, options?: InitCommandOp
     summaries.package = packageSummary;
   }
 
-  await ensureTemplateDependenciesInstalled(rootDir, absolutePaths, summaries, dependencies);
+  await ensureTemplateDependenciesInstalled(rootDir, absolutePaths, summaries, dependencies, scaffoldProfile);
 
   const nextSteps = buildNextSteps(
     normalizeRelative(rootDir, absolutePaths.schema),
@@ -1340,7 +1340,11 @@ export function buildPackageManagerArgs(
     : ['add', '-D', ...packages];
 }
 
-function detectPackageManager(rootDir: string): PackageManager {
+function defaultPackageManagerForScaffold(scaffoldProfile?: InitScaffoldProfile): PackageManager {
+  return scaffoldProfile?.dependencyProfile === 'local-source' ? 'pnpm' : 'npm';
+}
+
+function detectPackageManager(rootDir: string, fallbackPackageManager: PackageManager = 'npm'): PackageManager {
   // Prefer lockfiles to avoid guessing when multiple package managers are installed.
   if (existsSync(path.join(rootDir, 'pnpm-lock.yaml'))) {
     return 'pnpm';
@@ -1352,8 +1356,8 @@ function detectPackageManager(rootDir: string): PackageManager {
     return 'npm';
   }
 
-  // Fall back to pnpm because rawsql-ts itself standardizes on pnpm.
-  return 'pnpm';
+  // Default external standalone consumers to npm unless the scaffold explicitly targets local-source dogfooding.
+  return fallbackPackageManager;
 }
 
 function extractPackageName(specifier: string): string | null {
@@ -1462,17 +1466,18 @@ async function ensureTemplateDependenciesInstalled(
   rootDir: string,
   absolutePaths: Record<FileKey, string>,
   summaries: Partial<Record<FileKey, FileSummary>>,
-  dependencies: ZtdConfigWriterDependencies
+  dependencies: ZtdConfigWriterDependencies,
+  scaffoldProfile: InitScaffoldProfile
 ): Promise<void> {
+  const packageManager = detectPackageManager(rootDir, defaultPackageManagerForScaffold(scaffoldProfile));
   const packageJsonPath = path.join(rootDir, 'package.json');
   if (!dependencies.fileExists(packageJsonPath)) {
     dependencies.log(
-      'Skipping dependency installation because package.json is missing. Next: run pnpm init (or npm init), install dependencies, then run npx ztd ztd-config.'
+      `Skipping dependency installation because package.json is missing. Next: run ${packageManager} init, install dependencies, then run npx ztd ztd-config.`
     );
     return;
   }
 
-  const packageManager = detectPackageManager(rootDir);
   const installStrategy = resolveInitInstallStrategy(rootDir, packageManager);
   if (installStrategy.workspaceGuard.shouldIgnoreWorkspace) {
     dependencies.log(
@@ -1961,7 +1966,7 @@ function buildNextSteps(
   scaffoldProfile: InitScaffoldProfile,
   appShape: InitAppShape
 ): string[] {
-  const packageManager = detectPackageManager(rootDir);
+  const packageManager = detectPackageManager(rootDir, defaultPackageManagerForScaffold(scaffoldProfile));
   const installStrategy = resolveInitInstallStrategy(rootDir, packageManager);
   const installCommand = installStrategy.installCommand;
   const runScriptCommand = (script: 'typecheck' | 'test'): string =>
@@ -2004,7 +2009,7 @@ function buildNextSteps(
   }
   nextSteps.push('Wire repositories to src/infrastructure/telemetry/repositoryTelemetry.ts when you add SQL-backed repository classes');
   nextSteps.push('Provide a SqlClient implementation (adapter or mock)');
-  nextSteps.push('Run tests (pnpm test or npx vitest run)');
+  nextSteps.push(`Run tests (${runScriptCommand('test')} or npx vitest run)`);
   // Avoid repeating the same install hint when the deferred-install path already emitted it explicitly.
   if (installStrategy.workspaceGuard.shouldIgnoreWorkspace && !installStrategy.shouldDeferAutoInstall) {
     nextSteps.push('This project is nested under a parent pnpm workspace; use pnpm install --ignore-workspace for manual installs.');

--- a/packages/ztd-cli/src/utils/optionalDependencies.ts
+++ b/packages/ztd-cli/src/utils/optionalDependencies.ts
@@ -30,6 +30,10 @@ async function loadOptionalModule<T>(
   return moduleLoader;
 }
 
+export function buildConsumerInstallHint(...packages: string[]): string {
+  return `npm install --save-dev ${packages.join(' ')}`;
+}
+
 export type TestkitCoreModule = typeof import('@rawsql-ts/testkit-core');
 
 export interface PgTestkitClientLike {
@@ -163,7 +167,7 @@ export async function ensureTestkitCoreModule(): Promise<TestkitCoreModule> {
     '@rawsql-ts/testkit-core',
     () => import('@rawsql-ts/testkit-core'),
     'This command requires @rawsql-ts/testkit-core so fixtures and schema metadata are available.',
-    'pnpm add -D @rawsql-ts/testkit-core'
+    buildConsumerInstallHint('@rawsql-ts/testkit-core')
   );
 }
 
@@ -172,7 +176,7 @@ export async function ensureAdapterNodePgModule(): Promise<AdapterNodePgModule> 
     '@rawsql-ts/adapter-node-pg',
     loadAdapterNodePgModule,
     'A database adapter (for example @rawsql-ts/adapter-node-pg) is required to execute the rewritten SQL.',
-    'pnpm add -D @rawsql-ts/adapter-node-pg'
+    buildConsumerInstallHint('@rawsql-ts/adapter-node-pg')
   );
 }
 
@@ -181,7 +185,7 @@ export async function ensurePgModule(): Promise<PgModule> {
     'pg',
     () => import('pg'),
     'The SQL lint command needs a PostgreSQL driver such as pg.',
-    'pnpm add -D pg'
+    buildConsumerInstallHint('pg')
   );
 }
 
@@ -190,7 +194,7 @@ export async function ensurePostgresContainerModule(): Promise<PostgresContainer
     '@testcontainers/postgresql',
     () => import('@testcontainers/postgresql'),
     'ztd lint wants to spin up a disposable Postgres container via @testcontainers/postgresql.',
-    'pnpm add -D @testcontainers/postgresql'
+    buildConsumerInstallHint('@testcontainers/postgresql')
   );
 }
 

--- a/packages/ztd-cli/templates/README.md
+++ b/packages/ztd-cli/templates/README.md
@@ -20,11 +20,11 @@ Key folders:
 
 Next steps:
 1. Update `ztd/ddl/<schema>.sql` if needed.
-2. Run `pnpm exec ztd ztd-config` (or `npx ztd ztd-config` if you prefer npm-style invocation).
-3. Run `pnpm exec ztd model-gen --probe-mode ztd <sql-file> --out <spec-file>` when you want a QuerySpec scaffold from the local DDL snapshot.
+2. Run `npx ztd ztd-config`.
+3. Run `npx ztd model-gen --probe-mode ztd <sql-file> --out <spec-file>` when you want a QuerySpec scaffold from the local DDL snapshot.
 4. Wire repositories to `src/infrastructure/telemetry/repositoryTelemetry.ts` so application code can replace the default telemetry hook.
 5. Provide a SqlClient implementation.
-6. Run tests (`pnpm test` or `npx vitest run`).
+6. Run tests (`npm run test` or `npx vitest run`).
 7. Use `ZTD_TEST_DATABASE_URL` for ZTD-owned test and verification workflows.
 8. Use `ztd model-gen --probe-mode live`, `ztd ddl pull`, or `ztd ddl diff` only for explicit target inspection by passing `--url` or a complete `--db-*` flag set.
 9. If you generate migration SQL artifacts, apply them with your deployment tooling instead of `ztd-cli`.
@@ -38,9 +38,9 @@ If you later switch this scaffold into a layered WebAPI shape, add a prompt-dogf
 Examples:
 
 ```bash
-pnpm exec ztd query uses table public.sale_items --exclude-generated
-pnpm exec ztd query uses table public.sale_lines --exclude-generated
-pnpm exec ztd query uses column public.products.title --exclude-generated
-pnpm exec ztd query uses column public.sale_items.quantity --exclude-generated
-pnpm exec ztd query uses table public.sale_lines --view detail --exclude-generated
+npx ztd query uses table public.sale_items --exclude-generated
+npx ztd query uses table public.sale_lines --exclude-generated
+npx ztd query uses column public.products.title --exclude-generated
+npx ztd query uses column public.sale_items.quantity --exclude-generated
+npx ztd query uses table public.sale_lines --view detail --exclude-generated
 ```

--- a/packages/ztd-cli/templates/README.webapi.md
+++ b/packages/ztd-cli/templates/README.webapi.md
@@ -26,12 +26,12 @@ Prompt dogfooding:
 
 Next steps:
 1. Update `ztd/ddl/<schema>.sql` if needed.
-2. Run `pnpm exec ztd ztd-config` (or `npx ztd ztd-config` if you prefer npm-style invocation).
+2. Run `npx ztd ztd-config`.
 3. Keep `src/domain`, `src/application`, and `src/presentation/http` free from direct SQL or DDL concerns.
-4. Use `pnpm exec ztd model-gen --probe-mode ztd <sql-file> --out <spec-file>` when you want a QuerySpec scaffold from the local DDL snapshot.
+4. Use `npx ztd model-gen --probe-mode ztd <sql-file> --out <spec-file>` when you want a QuerySpec scaffold from the local DDL snapshot.
 5. Wire repositories to `src/infrastructure/telemetry/repositoryTelemetry.ts` only when you add SQL-backed repository classes.
 6. Provide a SqlClient implementation in `src/infrastructure/db`.
-7. Run tests (`pnpm test` or `npx vitest run`) with `ZTD_TEST_DATABASE_URL` when SQL-backed verification needs a managed test database.
+7. Run tests (`npm run test` or `npx vitest run`) with `ZTD_TEST_DATABASE_URL` when SQL-backed verification needs a managed test database.
 8. Treat `ddl pull` and `ddl diff` as explicit target inspection commands that require `--url` or a complete `--db-*` flag set.
 9. If you generate migration SQL artifacts, apply them outside `ztd-cli`.
 

--- a/packages/ztd-cli/tests/__snapshots__/init.command.test.ts.snap
+++ b/packages/ztd-cli/tests/__snapshots__/init.command.test.ts.snap
@@ -38,11 +38,10 @@ Validation configuration:
 
 Next steps:
  1. If the schema file is empty, edit ztd/ddl/public.sql
- 2. Run pnpm exec ztd ztd-config
+ 2. Run npx ztd ztd-config
  3. Wire repositories to src/infrastructure/telemetry/repositoryTelemetry.ts when you add SQL-backed repository classes
  4. Provide a SqlClient implementation (adapter or mock)
- 5. Run tests (pnpm test or npx vitest run)
- 6. This project is nested under a parent pnpm workspace; use pnpm install --ignore-workspace for manual installs."
+ 5. Run tests (npm run test or npx vitest run)"
 `;
 
 exports[`init wizard bootstraps an empty scaffold 1`] = `
@@ -83,11 +82,10 @@ Validation configuration:
 
 Next steps:
  1. If the schema file is empty, edit ztd/ddl/public.sql
- 2. Run pnpm exec ztd ztd-config
+ 2. Run npx ztd ztd-config
  3. Wire repositories to src/infrastructure/telemetry/repositoryTelemetry.ts when you add SQL-backed repository classes
  4. Provide a SqlClient implementation (adapter or mock)
- 5. Run tests (pnpm test or npx vitest run)
- 6. This project is nested under a parent pnpm workspace; use pnpm install --ignore-workspace for manual installs."
+ 5. Run tests (npm run test or npx vitest run)"
 `;
 
 exports[`init wizard pulls schema if pg_dump is available 1`] = `
@@ -128,9 +126,8 @@ Validation configuration:
 
 Next steps:
  1. Review the dumped DDL in ztd/ddl/public.sql
- 2. Run pnpm exec ztd ztd-config
+ 2. Run npx ztd ztd-config
  3. Wire repositories to src/infrastructure/telemetry/repositoryTelemetry.ts when you add SQL-backed repository classes
  4. Provide a SqlClient implementation (adapter or mock)
- 5. Run tests (pnpm test or npx vitest run)
- 6. This project is nested under a parent pnpm workspace; use pnpm install --ignore-workspace for manual installs."
+ 5. Run tests (npm run test or npx vitest run)"
 `;

--- a/packages/ztd-cli/tests/init.command.test.ts
+++ b/packages/ztd-cli/tests/init.command.test.ts
@@ -321,13 +321,13 @@ test('init webapi scaffold localizes ZTD guidance to persistence-oriented paths'
     "../../src/infrastructure/db/sql-client"
   );
   expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('src/domain');
-  expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('pnpm exec ztd ztd-config');
+  expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('npx ztd ztd-config');
   expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('does not read it automatically');
   expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('explicit target inspection');
   expect(readNormalizedFile(path.join(workspace, 'src', 'domain', 'README.md'))).not.toContain('ztd');
   expect(result.summary).toContain('src/domain/README.md');
   expect(result.summary).toContain('src/infrastructure/persistence/repositories/views/README.md');
-  expect(result.summary).toContain('Run pnpm exec ztd ztd-config');
+  expect(result.summary).toContain('Run npx ztd ztd-config');
 });
 
 test('init can opt into AI guidance files when explicitly requested', async () => {
@@ -664,7 +664,7 @@ test('webapi telemetry dogfood scenario keeps repository guidance inside infrast
   expect(existsSync(path.join(workspace, 'CONTEXT.md'))).toBe(false);
 });
 
-test('registry webapi scaffold exposes ztd via pnpm exec for dogfooding', async () => {
+test('registry webapi scaffold exposes ztd via npm exec for external onboarding', async () => {
   const workspace = createTempDir('cli-init-webapi-ztd-registry');
   const prompter = new TestPrompter([]);
 
@@ -677,10 +677,10 @@ test('registry webapi scaffold exposes ztd via pnpm exec for dogfooding', async 
     appShape: 'webapi'
   });
 
-  const installResult = installScaffoldDependencies(workspace);
+  const installResult = runNpmCommand(workspace, ['install']);
   expect(installResult.status).toBe(0);
 
-  const commandResult = runPnpmCommand(workspace, ['exec', 'ztd', 'ztd-config']);
+  const commandResult = runNpmCommand(workspace, ['exec', '--', 'ztd', 'ztd-config']);
 
   expect(commandResult.status).toBe(0);
   expect(commandResult.stdout).toContain('Generated 3 ZTD test rows');
@@ -741,7 +741,7 @@ test('init runs install when package.json is created from scratch', async () => 
 
   expect(installs.length).toBe(1);
   expect(installs[0].kind).toBe('install');
-  expect(installs[0].packageManager).toBe('pnpm');
+  expect(installs[0].packageManager).toBe('npm');
   expect(installs[0].packages).toEqual([]);
 });
 
@@ -767,7 +767,7 @@ test('init runs install when package.json is updated', async () => {
 
   expect(installs.length).toBe(1);
   expect(installs[0].kind).toBe('install');
-  expect(installs[0].packageManager).toBe('pnpm');
+  expect(installs[0].packageManager).toBe('npm');
   expect(installs[0].packages).toEqual([]);
 
   const packageJson = JSON.parse(readNormalizedFile(path.join(workspace, 'package.json'))) as {

--- a/packages/ztd-cli/tests/optionalDependencies.unit.test.ts
+++ b/packages/ztd-cli/tests/optionalDependencies.unit.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { expect, test } from 'vitest';
 
-import { findNearestPackageRoot, findWorkspaceRoot } from '../src/utils/optionalDependencies';
+import { buildConsumerInstallHint, findNearestPackageRoot, findWorkspaceRoot } from '../src/utils/optionalDependencies';
 
 const repoRoot = path.resolve(__dirname, '..', '..', '..');
 const tmpRoot = path.join(repoRoot, 'tmp');
@@ -29,4 +29,11 @@ test('findWorkspaceRoot still detects the rawsql-ts monorepo root when present',
   const nestedDir = path.join(repoRoot, 'packages', 'ztd-cli', 'src', 'utils');
 
   expect(findWorkspaceRoot(nestedDir)).toBe(repoRoot);
+});
+
+test('buildConsumerInstallHint uses npm as the external standalone primary path', () => {
+  expect(buildConsumerInstallHint('@rawsql-ts/testkit-core')).toBe('npm install --save-dev @rawsql-ts/testkit-core');
+  expect(buildConsumerInstallHint('pg', '@testcontainers/postgresql')).toBe(
+    'npm install --save-dev pg @testcontainers/postgresql'
+  );
 });

--- a/scripts/verify-published-package-mode.mjs
+++ b/scripts/verify-published-package-mode.mjs
@@ -214,6 +214,18 @@ function writeNode16Tsconfig(directory) {
   });
 }
 
+function assertIncludes(haystack, needle, label) {
+  if (!haystack.includes(needle)) {
+    throw new Error(`[${label}] Expected output to include: ${needle}`);
+  }
+}
+
+function assertExcludes(haystack, needle, label) {
+  if (haystack.includes(needle)) {
+    throw new Error(`[${label}] Unexpected output included: ${needle}`);
+  }
+}
+
 function packPublishedPackages() {
   const workspacePackages = Array.from(getWorkspacePackages(workspaceRoot).values())
     .filter(isPublishTarget)
@@ -277,8 +289,8 @@ function verifyPackedTarballInstall(packages) {
   return appDir;
 }
 
-function verifyNpmConsumerSmoke(packages) {
-  const appDir = path.join(packageRoot, "npm-consumer-smoke");
+function verifyNpmPrimaryPath(packages) {
+  const appDir = path.join(packageRoot, "npm-primary-path");
   ensureCleanDir(appDir);
   const tarballDependencies = createTarballDependencyMap(packages);
 
@@ -290,15 +302,33 @@ function verifyNpmConsumerSmoke(packages) {
   });
 
   runIn(appDir, NPM, ["install"]);
-  runIn(appDir, NPM, ["exec", "--", "ztd", "init", "--yes", "--workflow", "demo", "--validator", "zod"]);
+  const initResult = runIn(appDir, NPM, ["exec", "--", "ztd", "init", "--yes", "--workflow", "demo", "--validator", "zod"]);
+
+  assertIncludes(initResult.stdout, "Run npx ztd ztd-config", "phase-a npm-primary-path");
+  assertIncludes(initResult.stdout, "Run tests (npm run test or npx vitest run)", "phase-a npm-primary-path");
+  assertExcludes(initResult.stdout, "pnpm exec ztd", "phase-a npm-primary-path");
+  assertExcludes(initResult.stdout, "pnpm test", "phase-a npm-primary-path");
+
+  const readme = fs.readFileSync(path.join(appDir, "README.md"), "utf8");
+  assertIncludes(readme, "Run `npx ztd ztd-config`.", "phase-a scaffold-readme");
+  assertIncludes(readme, "Run tests (`npm run test` or `npx vitest run`).", "phase-a scaffold-readme");
+  assertExcludes(readme, "pnpm exec ztd ztd-config", "phase-a scaffold-readme");
+
   restoreTarballDependencies(appDir, tarballDependencies);
   runIn(appDir, NPM, ["install"]);
+
+  return { appDir };
+}
+
+function verifyNpmConsumerSmoke(phaseAResult) {
+  const { appDir } = phaseAResult;
+
   runIn(appDir, NPM, ["exec", "--", "ztd", "ztd-config"]);
 
   setPackageTypeModule(appDir);
   writeNode16Tsconfig(appDir);
 
-  runIn(appDir, PNPM, ["test"]);
+  runIn(appDir, NPM, ["test"]);
   runIn(appDir, NPM, ["exec", "--", "tsc", "--noEmit", "-p", "tsconfig.json"]);
   runIn(appDir, NPM, ["exec", "--", "tsc", "-p", "tsconfig.node16.json"]);
 
@@ -361,7 +391,8 @@ function main() {
 
   const packedPackages = packPublishedPackages();
   const packedInstallApp = verifyPackedTarballInstall(packedPackages);
-  const npmSmokeApp = verifyNpmConsumerSmoke(packedPackages);
+  const npmPrimaryPathApp = verifyNpmPrimaryPath(packedPackages);
+  const npmSmokeApp = verifyNpmConsumerSmoke(npmPrimaryPathApp);
   const overwriteSafetyApp = verifyOverwriteSafety(packedPackages);
 
   writeJson(path.join(outputRoot, "summary.json"), {
@@ -369,6 +400,7 @@ function main() {
     node: process.version,
     platform: os.platform(),
     packedInstallApp,
+    npmPrimaryPathApp: npmPrimaryPathApp.appDir,
     npmSmokeApp,
     overwriteSafetyApp,
     packages: packedPackages.map((pkg) => ({


### PR DESCRIPTION
## Summary
- default registry consumer scaffolds to npm-first onboarding while keeping local-source dogfooding on pnpm
- split published-package verification into npm primary-path assertions and stronger consumer smoke checks
- align init snapshots, scaffold README guidance, optional dependency hints, and docs with the npm external path

## Testing
- pnpm --filter @rawsql-ts/ztd-cli test -- init.command.test.ts optionalDependencies.unit.test.ts
- pnpm verify:published-package-mode

Closes #595

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced package manager selection during scaffold initialization for improved workflow compatibility.

* **Documentation**
  * Updated verification process to use npm-first, two-phase approach (Phase A: npm install and initialization; Phase B: build and test steps).
  * Updated template README and command guides to use npm/npx instead of pnpm for consistency.

* **Refactor**
  * Improved package manager detection and selection logic for better default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->