### PR TITLE
docs: add SQL-first end-to-end tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ npm install rawsql-ts
 
 See the [Core Package Documentation](./packages/core/README.md) for usage examples and API reference. For reusable AST-based impact analysis, see [@rawsql-ts/sql-grep-core](./packages/sql-grep-core). For repo-level SQL lifecycle workflows, inspection commands, and ZTD project guidance, see [@rawsql-ts/ztd-cli](./packages/ztd-cli/README.md). Deterministic dogfooding spec: [docs/dogfooding/DOGFOODING.md](./docs/dogfooding/DOGFOODING.md).
 
+## Tutorials
+
+- [SQL-first End-to-End Tutorial](./docs/guide/sql-first-end-to-end-tutorial.md) - Walk from DDL to `ztd-config`, `model-gen`, repository wiring, and the first passing smoke test in one focused path.
+
 ## CLI Tool Routing Happy Paths
 
 - SQL pipeline / debug → `ztd query plan <sql-file>`

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -28,6 +28,7 @@ export default defineConfig({
       '/guide/': [
         { text: 'Overview', link: '/guide/overview' },
         { text: 'Getting Started', link: '/guide/getting-started' },
+        { text: 'SQL-first End-to-End Tutorial', link: '/guide/sql-first-end-to-end-tutorial' },
         {
           text: 'Execution',
           items: [

--- a/docs/guide/feature-index.md
+++ b/docs/guide/feature-index.md
@@ -54,6 +54,7 @@ An at-a-glance index of easy-to-miss but important capabilities across the rawsq
 | Guide | Path | When to read |
 |-------|------|-------------|
 | Happy Path Quickstart | [ztd-cli README](https://github.com/mk3008/rawsql-ts/blob/main/packages/ztd-cli/README.md#happy-path-quickstart) | First-time setup |
+| SQL-first End-to-End Tutorial | [guide/sql-first-end-to-end-tutorial](./sql-first-end-to-end-tutorial.md) | Walk from DDL to the first passing test with one table and one SQL asset |
 | After DDL Changes | [ztd-cli README](https://github.com/mk3008/rawsql-ts/blob/main/packages/ztd-cli/README.md#after-ddlschema-changes) | Schema evolution workflow |
 | Mapping vs Validation pipeline | [recipes/mapping-vs-validation](../recipes/mapping-vs-validation.md) | Avoid coerce/validator conflicts |
 | Postgres Pitfalls | [guide/postgres-pitfalls](./postgres-pitfalls.md) | Postgres-specific quirks |

--- a/docs/guide/sql-first-end-to-end-tutorial.md
+++ b/docs/guide/sql-first-end-to-end-tutorial.md
@@ -1,0 +1,127 @@
+---
+title: SQL-first End-to-End Tutorial
+outline: deep
+---
+
+# SQL-first End-to-End Tutorial
+
+This tutorial shows the shortest path from DDL to the first passing test.
+
+It walks the sequence `DDL -> SQL -> ztd-config -> model-gen -> repository wiring -> first test` with one table, one SQL asset, one repository seam, and one smoke test.
+
+It uses one table, one SQL asset, one repository seam, and one smoke test. The sequence stays aligned with the first-success path established by `ztd init`, `ztd-config`, `model-gen`, and `npm run test`.
+
+## What you will build
+
+- `ztd/ddl/public.sql`
+- `src/sql/users/list_active_users.sql`
+- `src/catalog/specs/users/list_active_users.spec.ts`
+- `src/repositories/users/list-active-users.ts`
+- `tests/smoke.test.ts`
+
+## 1. Scaffold the project
+
+Start from a new project, install the CLI, and scaffold the default layout:
+
+```bash
+npm init -y
+npm install -D @rawsql-ts/ztd-cli vitest typescript
+npx ztd init --yes --workflow empty --validator zod
+```
+
+After `ztd init`, keep the generated `README.md`, `tests/`, `src/sql/`, and `src/repositories/` folders in place. This tutorial assumes the default scaffold so the repository seam stays simple and visible.
+
+## 2. Add one table
+
+Put the source of truth in `ztd/ddl/public.sql`:
+
+```sql
+create table public.users (
+  id integer primary key,
+  email text not null,
+  active boolean not null
+);
+```
+
+Keep the DDL intentionally small. The goal is to prove the lifecycle, not to design a complete schema.
+
+## 3. Add one SQL asset
+
+Create `src/sql/users/list_active_users.sql`:
+
+```sql
+select
+  id,
+  email
+from public.users
+where active = :active
+order by id
+```
+
+This keeps the handwritten SQL on the source-asset side of the boundary while the repository stays focused on orchestration.
+
+## 4. Regenerate the DDL-backed contract
+
+Run:
+
+```bash
+npx ztd ztd-config
+```
+
+This refreshes the generated `TestRowMap` and layout metadata from the DDL snapshot. If this step fails, fix the schema first before moving on.
+
+## 5. Generate the QuerySpec scaffold
+
+Run:
+
+```bash
+npx ztd model-gen src/sql/users/list_active_users.sql --probe-mode ztd --out src/catalog/specs/users/list_active_users.spec.ts
+```
+
+The generated file should stay under `src/catalog/specs/`. Review the resulting row mapping, nullability, and example values before treating it as ready.
+
+## 6. Wire the repository seam
+
+Create a small repository wrapper in `src/repositories/users/list-active-users.ts`.
+
+Keep the wrapper responsible for:
+
+- importing the generated QuerySpec scaffold
+- calling the SQL client or adapter boundary
+- hiding the SQL asset path from the rest of the app
+
+Keep the wrapper intentionally thin. The repository should not own DDL or query-shape generation; it should only connect the generated spec to the runtime seam.
+
+## 7. Keep the first test green
+
+Update or create the first smoke test in `tests/smoke.test.ts`.
+
+Use the test to prove that the repository seam is importable and that the scaffold still reaches a passing first test before any deeper integration work is added.
+
+Example:
+
+```ts
+import { expect, test } from 'vitest';
+import { listActiveUsers } from '../src/repositories/users/list-active-users';
+
+test('first smoke test', () => {
+  expect(listActiveUsers).toBeTypeOf('function');
+});
+```
+
+Run the first test with:
+
+```bash
+npm run test
+```
+
+This is the first test, not the full integration suite. It proves the consumer path can reach visible value before you add DB-backed coverage.
+
+## What to do next
+
+- Expand the repository seam only after the first smoke test is green.
+- Add stronger SQL-backed coverage when the lifecycle needs it.
+- Re-run `npx ztd ztd-config` whenever the DDL changes.
+- Re-run `npx ztd model-gen` whenever the SQL asset changes.
+
+The tutorial is intentionally small so the first successful loop stays easy to understand and easy to repeat.

--- a/packages/ztd-cli/README.md
+++ b/packages/ztd-cli/README.md
@@ -128,6 +128,8 @@ For pre-release work inside this monorepo, use the repository-root verification 
 
 A complete copy-paste sequence to reach a green test run. Choose the **demo** workflow during `ztd init` to get a working example immediately.
 
+If you want a shorter DDL-to-first-test walkthrough, see [SQL-first End-to-End Tutorial](../../docs/guide/sql-first-end-to-end-tutorial.md).
+
 ### Prerequisites
 
 * Node.js 20+

--- a/packages/ztd-cli/tests/sqlFirstTutorial.docs.test.ts
+++ b/packages/ztd-cli/tests/sqlFirstTutorial.docs.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { expect, test } from 'vitest';
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+
+function readNormalizedFile(relativePath: string): string {
+  const filePath = path.join(repoRoot, relativePath);
+  return readFileSync(filePath, 'utf8').replace(/\r\n/g, '\n');
+}
+
+function expectInOrder(haystack: string, needles: string[]): void {
+  let cursor = 0;
+  for (const needle of needles) {
+    const index = haystack.indexOf(needle, cursor);
+    expect(index, `Expected to find "${needle}" after offset ${cursor}`).toBeGreaterThanOrEqual(0);
+    cursor = index + needle.length;
+  }
+}
+
+test('root README links to the SQL-first end-to-end tutorial', () => {
+  const readme = readNormalizedFile('README.md');
+
+  expect(readme).toContain('SQL-first End-to-End Tutorial');
+  expect(readme).toContain('./docs/guide/sql-first-end-to-end-tutorial.md');
+});
+
+test('the tutorial preserves the shortest DDL to first test path', () => {
+  const tutorial = readNormalizedFile('docs/guide/sql-first-end-to-end-tutorial.md');
+
+  expectInOrder(tutorial, [
+    'This tutorial shows the shortest path from DDL to the first passing test.',
+    'It walks the sequence `DDL -> SQL -> ztd-config -> model-gen -> repository wiring -> first test`',
+    'npm init -y',
+    'npm install -D @rawsql-ts/ztd-cli vitest typescript',
+    'npx ztd init --yes --workflow empty --validator zod',
+    'create table public.users',
+    'src/sql/users/list_active_users.sql',
+    'npx ztd ztd-config',
+    'npx ztd model-gen src/sql/users/list_active_users.sql --probe-mode ztd --out src/catalog/specs/users/list_active_users.spec.ts',
+    'src/repositories/users/list-active-users.ts',
+    'tests/smoke.test.ts',
+    'npm run test'
+  ]);
+});
+
+test('guide navigation and feature index surface the tutorial', () => {
+  const sidebar = readNormalizedFile('docs/.vitepress/config.mts');
+  const featureIndex = readNormalizedFile('docs/guide/feature-index.md');
+
+  expect(sidebar).toContain('/guide/sql-first-end-to-end-tutorial');
+  expect(featureIndex).toContain('SQL-first End-to-End Tutorial');
+  expect(featureIndex).toContain('./sql-first-end-to-end-tutorial.md');
+});


### PR DESCRIPTION
Adds the SQL-first end-to-end tutorial and docs navigation for #597.\n\nVerification:\n- pnpm --filter @rawsql-ts/ztd-cli test -- sqlFirstTutorial.docs.test.ts\n- pnpm verify:published-package-mode\n- pnpm verify:customer-consumers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new SQL-first End-to-End Tutorial providing step-by-step workflow guidance from schema definition through first passing test
  * Updated navigation and README with cross-references to the tutorial

* **Tests**
  * Added test suite to validate tutorial integration and documentation consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->