### PR TITLE
feat(cli): add QuerySpec-first scaffold sample

### DIFF
--- a/packages/ztd-cli/src/commands/init.ts
+++ b/packages/ztd-cli/src/commands/init.ts
@@ -116,6 +116,7 @@ type FileKey =
   | 'localSourceGuardScript'
   | 'smokeValidationTest'
   | 'testsSmoke'
+  | 'querySpecExampleTest'
   | 'testkitClient'
   | 'globalSetup'
   | 'vitestConfig'
@@ -297,6 +298,7 @@ const SMOKE_RUNTIME_TEMPLATE = 'src/catalog/runtime/_smoke.runtime.ts';
 const LOCAL_SOURCE_GUARD_TEMPLATE = 'scripts/local-source-guard.mjs';
 const SMOKE_VALIDATION_TEST_TEMPLATE = 'tests/smoke.validation.test.ts';
 const TESTS_SMOKE_TEMPLATE = 'tests/smoke.test.ts';
+const QUERYSPEC_EXAMPLE_TEST_TEMPLATE = 'tests/queryspec.example.test.ts';
 const TESTKIT_CLIENT_TEMPLATE = 'tests/support/testkit-client.ts';
 const TESTKIT_CLIENT_WEBAPI_TEMPLATE = 'tests/support/testkit-client.webapi.ts';
 const GLOBAL_SETUP_TEMPLATE = 'tests/support/global-setup.ts';
@@ -556,6 +558,7 @@ export async function runInitCommand(prompter: Prompter, options?: InitCommandOp
     localSourceGuardScript: path.join(rootDir, 'scripts', 'local-source-guard.mjs'),
     smokeValidationTest: path.join(rootDir, DEFAULT_ZTD_CONFIG.testsDir, 'smoke.validation.test.ts'),
     testsSmoke: path.join(rootDir, DEFAULT_ZTD_CONFIG.testsDir, 'smoke.test.ts'),
+    querySpecExampleTest: path.join(rootDir, DEFAULT_ZTD_CONFIG.testsDir, 'queryspec.example.test.ts'),
     readme: path.join(rootDir, 'README.md'),
     context: path.join(rootDir, 'CONTEXT.md'),
     promptDogfood: scaffoldLayout.promptDogfoodPath ?? path.join(rootDir, 'PROMPT_DOGFOOD.md'),
@@ -1020,6 +1023,19 @@ export async function runInitCommand(prompter: Prompter, options?: InitCommandOp
   );
   if (testsSmokeSummary) {
     summaries.testsSmoke = testsSmokeSummary;
+  }
+
+  const querySpecExampleTestSummary = await writeTemplateFile(
+    rootDir,
+    absolutePaths.querySpecExampleTest,
+    relativePath('querySpecExampleTest'),
+    QUERYSPEC_EXAMPLE_TEST_TEMPLATE,
+    dependencies,
+    prompter,
+    overwritePolicy
+  );
+  if (querySpecExampleTestSummary) {
+    summaries.querySpecExampleTest = querySpecExampleTestSummary;
   }
 
   const testkitSummary = await writeTemplateFile(
@@ -1995,6 +2011,8 @@ function buildNextSteps(
       ? `Review ${sqlClientPath} and ${repositoryTelemetryPath} so the first SQL-backed repository has a seam to plug into`
       : `Review ${sqlClientPath} and ${repositoryTelemetryPath} so the first SQL-backed repository has a seam to plug into`;
   const firstTestStep = `Run tests (${runScriptCommand('test')} or npx vitest run) to pass the generated smoke test before adding SQL-backed coverage`;
+  const sampleTestStep =
+    'Open tests/queryspec.example.test.ts as the QuerySpec-first sample before you write the first repository test';
   const fallbackSteps = [
     `If ${ztdCommand} ztd-config fails, keep editing ${schemaRelativePath} and ${sqlAssetPath} first, then rerun generation after the DDL is ready`,
     `If ${ztdCommand} model-gen fails, keep the SQL file and rerun it after ${ztdCommand} ztd-config succeeds; the ztd probe path does not need DATABASE_URL`,
@@ -2008,6 +2026,7 @@ function buildNextSteps(
       sqlStep,
       ...generationSteps.map((step) => step.replace(ztdCommand, runLocalSourceZtdCommand)),
       wiringStep,
+      sampleTestStep,
       firstTestStep,
       `Run ${runScriptCommand('typecheck')} before you start wiring handwritten repository code`
     ];
@@ -2023,7 +2042,7 @@ function buildNextSteps(
   if (installStrategy.shouldDeferAutoInstall) {
     nextSteps.push(`Run ${installCommand}`);
   }
-  nextSteps.push(...generationSteps, wiringStep, firstTestStep);
+  nextSteps.push(...generationSteps, wiringStep, sampleTestStep, firstTestStep);
   // Avoid repeating the same install hint when the deferred-install path already emitted it explicitly.
   if (installStrategy.workspaceGuard.shouldIgnoreWorkspace && !installStrategy.shouldDeferAutoInstall) {
     fallbackSteps.push('This project is nested under a parent pnpm workspace; use pnpm install --ignore-workspace for manual installs.');
@@ -2116,6 +2135,7 @@ function buildSummaryLines(
     'localSourceGuardScript',
     'smokeValidationTest',
     'testsSmoke',
+    'querySpecExampleTest',
     'sqlClient',
     'sqlClientAdapters',
     'repositoryTelemetryTypes',
@@ -2200,6 +2220,7 @@ function buildInitDryRunPlan(rootDir: string, options: {
     path.join(DEFAULT_ZTD_CONFIG.testsDir, 'smoke.validation.test.ts'),
     path.join(DEFAULT_ZTD_CONFIG.testsDir, 'support', 'testkit-client.ts'),
     path.join(DEFAULT_ZTD_CONFIG.testsDir, 'support', 'global-setup.ts'),
+    path.join(DEFAULT_ZTD_CONFIG.testsDir, 'queryspec.example.test.ts'),
     path.join(DEFAULT_ZTD_CONFIG.testsDir, 'generated', 'ztd-row-map.generated.ts'),
     path.join(DEFAULT_ZTD_CONFIG.testsDir, 'generated', 'ztd-layout.generated.ts'),
     'README.md',

--- a/packages/ztd-cli/templates/README.md
+++ b/packages/ztd-cli/templates/README.md
@@ -16,20 +16,21 @@ Quick boundary table:
 Key folders:
 - ztd/ddl: schema files (source of truth)
 - src: application SQL and repositories
-- tests: ZTD tests and support
+- tests: ZTD tests, smoke checks, and the QuerySpec-first example sample
 
 Next steps:
 1. Update `ztd/ddl/<schema>.sql` if needed.
 2. Add or edit your first SQL asset under `src/sql/`.
 3. Run `npx ztd ztd-config` to regenerate DDL-derived test rows and layout metadata.
 4. Run `npx ztd model-gen --probe-mode ztd <sql-file> --out <spec-file>` to scaffold a QuerySpec from that SQL file.
-5. Review `src/db/sql-client.ts` and `src/infrastructure/telemetry/repositoryTelemetry.ts` so the first SQL-backed repository has a seam to plug into.
+5. Review `src/catalog/specs/_smoke.spec.ts`, `tests/queryspec.example.test.ts`, and `src/db/sql-client.ts` so the first SQL-backed repository has both a minimal gate and a QuerySpec-first sample to copy.
 6. Run tests (`npm run test` or `npx vitest run`) to pass the generated smoke test before adding SQL-backed coverage.
 
 If this fails:
 - If `npx ztd ztd-config` fails, keep editing `ztd/ddl/<schema>.sql` and `src/sql/` first, then rerun generation after the DDL is ready.
 - If `npx ztd model-gen` fails, keep the SQL file and rerun it after `npx ztd ztd-config` succeeds; the `ztd` probe path does not need `DATABASE_URL`.
 - If you do not have `ZTD_TEST_DATABASE_URL` yet, use the generated smoke test as the first DB-free pass and wait to add SQL-backed tests until the connection is ready.
+- If you want a concrete repository-test sample, start from `tests/queryspec.example.test.ts` after the smoke gate is green.
 - Use `ztd model-gen --probe-mode live`, `ztd ddl pull`, or `ztd ddl diff` only for explicit target inspection by passing `--url` or a complete `--db-*` flag set.
 - If you generate migration SQL artifacts, apply them with your deployment tooling instead of `ztd-cli`.
 

--- a/packages/ztd-cli/templates/README.webapi.md
+++ b/packages/ztd-cli/templates/README.webapi.md
@@ -19,7 +19,7 @@ Key folders:
 - `src/presentation/http`: HTTP handlers, request parsing, and response shaping
 - `src/infrastructure/persistence`: repositories, SQL assets, and QuerySpec wiring
 - `src/sql`, `src/catalog`, `ztd/ddl`: ZTD-owned persistence assets
-- `tests`: smoke tests and test support
+- `tests`: smoke tests, support files, and the QuerySpec-first example sample
 
 Prompt dogfooding:
 - See `PROMPT_DOGFOOD.md` when you want to verify that generic WebAPI requests stay out of persistence-specific ZTD guidance unless repository or SQL work is explicitly requested.
@@ -29,13 +29,14 @@ Next steps:
 2. Add or edit your first SQL asset under `src/sql/`, while keeping `src/domain`, `src/application`, and `src/presentation/http` free from direct SQL or DDL concerns.
 3. Run `npx ztd ztd-config` to regenerate DDL-derived test rows and layout metadata.
 4. Run `npx ztd model-gen --probe-mode ztd <sql-file> --out <spec-file>` to scaffold a QuerySpec from that SQL file.
-5. Review `src/infrastructure/db/sql-client.ts` and `src/infrastructure/telemetry/repositoryTelemetry.ts` so the first SQL-backed repository has a seam to plug into.
+5. Review `src/catalog/specs/_smoke.spec.ts`, `tests/queryspec.example.test.ts`, and `src/infrastructure/db/sql-client.ts` so the first SQL-backed repository has both a minimal gate and a QuerySpec-first sample to copy.
 6. Run tests (`npm run test` or `npx vitest run`) to pass the generated smoke test before adding SQL-backed coverage.
 
 If this fails:
 - If `npx ztd ztd-config` fails, keep editing `ztd/ddl/<schema>.sql` and `src/sql/` first, then rerun generation after the DDL is ready.
 - If `npx ztd model-gen` fails, keep the SQL file and rerun it after `npx ztd ztd-config` succeeds; the `ztd` probe path does not need `DATABASE_URL`.
 - If you do not have `ZTD_TEST_DATABASE_URL` yet, use the generated smoke test as the first DB-free pass and wait to add SQL-backed tests until the connection is ready.
+- If you want the repository-test sample that mirrors the first SQL-backed workflow, start from `tests/queryspec.example.test.ts`.
 - Treat `ddl pull` and `ddl diff` as explicit target inspection commands that require `--url` or a complete `--db-*` flag set.
 - If you generate migration SQL artifacts, apply them outside `ztd-cli`.
 

--- a/packages/ztd-cli/templates/src/application/README.md
+++ b/packages/ztd-cli/templates/src/application/README.md
@@ -4,3 +4,4 @@ Use cases and orchestration live here.
 
 - Coordinate domain behavior and repository ports here.
 - Avoid direct ownership of SQL, DDL, and ZTD configuration in this layer.
+- When you need a repository-test example, start from `tests/queryspec.example.test.ts` and keep the application layer free of SQL.

--- a/packages/ztd-cli/templates/src/catalog/AGENTS.md
+++ b/packages/ztd-cli/templates/src/catalog/AGENTS.md
@@ -9,6 +9,7 @@
 - `src/catalog/runtime` MUST implement runtime wiring only.
 - Code in `src/catalog` MUST remain independent from `tests`, `tests/generated`, and `ztd` imports.
 - Each spec MUST be covered by tests for rewrite execution, mapping/validation outcomes, and output shape.
+- The scaffold MUST keep `src/catalog/specs/_smoke.spec.*` minimal and pair it with `tests/queryspec.example.test.ts` as the reusable QuerySpec-first sample.
 
 ## ALLOWED
 - Runtime catalog code MAY add observability hooks where contract behavior is unchanged.

--- a/packages/ztd-cli/templates/src/catalog/runtime/_smoke.runtime.ts
+++ b/packages/ztd-cli/templates/src/catalog/runtime/_smoke.runtime.ts
@@ -3,6 +3,8 @@ import { normalizeTimestamp } from './_coercions.js';
 
 /**
  * Validate runtime output against the catalog smoke invariant.
+ *
+ * The reusable QuerySpec-first sample lives in `tests/queryspec.example.test.ts`.
  */
 export function ensureSmokeOutput(value: unknown): SmokeOutput {
   // Normalize driver-dependent timestamp representations before contract validation.

--- a/packages/ztd-cli/templates/src/catalog/specs/_smoke.spec.arktype.ts
+++ b/packages/ztd-cli/templates/src/catalog/specs/_smoke.spec.arktype.ts
@@ -1,7 +1,9 @@
 import { type } from 'arktype';
 
 /**
- * Validator invariant contract used to prove runtime validation wiring.
+ * Validator invariant contract used to prove the minimal onboarding gate.
+ *
+ * The reusable QuerySpec-first example lives in `tests/queryspec.example.test.ts`.
  *
  * This file is intentionally minimal and domain-agnostic.
  */

--- a/packages/ztd-cli/templates/src/catalog/specs/_smoke.spec.zod.ts
+++ b/packages/ztd-cli/templates/src/catalog/specs/_smoke.spec.zod.ts
@@ -1,7 +1,9 @@
 import { z } from 'zod';
 
 /**
- * Validator invariant contract used to prove runtime validation wiring.
+ * Validator invariant contract used to prove the minimal onboarding gate.
+ *
+ * The reusable QuerySpec-first example lives in `tests/queryspec.example.test.ts`.
  *
  * This file is intentionally minimal and domain-agnostic.
  */

--- a/packages/ztd-cli/templates/src/domain/README.md
+++ b/packages/ztd-cli/templates/src/domain/README.md
@@ -4,3 +4,4 @@ Domain types, invariants, and business rules live here.
 
 - Do not import SQL files, QuerySpecs, or ZTD-generated artifacts into this layer.
 - Prefer ports or plain interfaces for dependencies on application or infrastructure code.
+- If you need a persistence example, follow `tests/queryspec.example.test.ts` instead of adding SQL here.

--- a/packages/ztd-cli/templates/src/infrastructure/README.md
+++ b/packages/ztd-cli/templates/src/infrastructure/README.md
@@ -4,3 +4,4 @@ Infrastructure adapters live here.
 
 - Database, telemetry, and persistence integration belong here.
 - Keep domain and application contracts stable while swapping implementations.
+- Use `tests/queryspec.example.test.ts` as the first repository-oriented sample when you add a persistence seam.

--- a/packages/ztd-cli/templates/src/infrastructure/persistence/README.md
+++ b/packages/ztd-cli/templates/src/infrastructure/persistence/README.md
@@ -6,3 +6,4 @@ This is the primary ZTD-aware layer.
 - Place QuerySpecs in `src/catalog/specs`.
 - Maintain runtime mapping helpers in `src/catalog/runtime`.
 - Keep DDL in `ztd/ddl`.
+- Start the first repository test from `tests/queryspec.example.test.ts` so the SQL, QuerySpec, and test shape stay aligned.

--- a/packages/ztd-cli/templates/src/infrastructure/persistence/repositories/tables/README.md
+++ b/packages/ztd-cli/templates/src/infrastructure/persistence/repositories/tables/README.md
@@ -3,3 +3,4 @@
 Write-focused repositories that execute CRUD SQL from `src/sql`.
 
 Accept an optional telemetry hook from `src/infrastructure/telemetry/repositoryTelemetry.ts` and default it through `resolveRepositoryTelemetry(...)` so applications can replace the sink without editing repository internals.
+- When you add the first table repository test, start from `tests/queryspec.example.test.ts` so the QuerySpec, mapping, and repository seam stay aligned.

--- a/packages/ztd-cli/templates/src/infrastructure/persistence/repositories/views/README.md
+++ b/packages/ztd-cli/templates/src/infrastructure/persistence/repositories/views/README.md
@@ -3,3 +3,4 @@
 Read-only repositories backed by SELECT SQL in `src/sql`.
 
 Accept an optional telemetry hook from `src/infrastructure/telemetry/repositoryTelemetry.ts` and default it through `resolveRepositoryTelemetry(...)` so applications can bridge structured events into their own logging stack.
+- When you add the first view repository test, start from `tests/queryspec.example.test.ts` so the QuerySpec, mapping, and read-model seam stay aligned.

--- a/packages/ztd-cli/templates/src/presentation/http/README.md
+++ b/packages/ztd-cli/templates/src/presentation/http/README.md
@@ -4,3 +4,4 @@ HTTP handlers, controllers, and transport mapping live here.
 
 - Keep framework-specific code here.
 - Delegate use-case orchestration to `src/application`.
+- Keep persistence examples out of this layer and use `tests/queryspec.example.test.ts` when you need a repository-oriented sample.

--- a/packages/ztd-cli/templates/src/repositories/AGENTS.md
+++ b/packages/ztd-cli/templates/src/repositories/AGENTS.md
@@ -21,6 +21,7 @@
 
 # Mandatory Workflow
 - Repository changes MUST run tests covering mapping, rowCount behavior, and error surfaces.
+- When introducing the first repository-backed QuerySpec, start from `tests/queryspec.example.test.ts` so the sample and the repository seam stay aligned.
 
 # Hygiene
 - Error messages MUST include operation identifiers and relevant parameters.

--- a/packages/ztd-cli/templates/src/repositories/tables/README.md
+++ b/packages/ztd-cli/templates/src/repositories/tables/README.md
@@ -3,3 +3,4 @@
 Write-focused repositories that execute CRUD SQL from `src/sql`.
 
 Accept an optional telemetry hook from `src/infrastructure/telemetry/repositoryTelemetry.ts` and default it through `resolveRepositoryTelemetry(...)` so applications can replace the sink without editing repository internals.
+- When you add the first table repository test, start from `tests/queryspec.example.test.ts` so the QuerySpec, mapping, and repository seam stay aligned.

--- a/packages/ztd-cli/templates/src/repositories/views/README.md
+++ b/packages/ztd-cli/templates/src/repositories/views/README.md
@@ -3,3 +3,4 @@
 Read-only repositories backed by SELECT SQL in `src/sql`.
 
 Accept an optional telemetry hook from `src/infrastructure/telemetry/repositoryTelemetry.ts` and default it through `resolveRepositoryTelemetry(...)` so applications can bridge structured events into their own logging stack.
+- When you add the first view repository test, start from `tests/queryspec.example.test.ts` so the QuerySpec, mapping, and read-model seam stay aligned.

--- a/packages/ztd-cli/templates/src/sql/AGENTS.md
+++ b/packages/ztd-cli/templates/src/sql/AGENTS.md
@@ -21,6 +21,7 @@
 
 # Mandatory Workflow
 - SQL asset changes MUST run tests that execute the changed SQL via catalog/repository paths.
+- The first SQL-backed repository should be mirrored in `tests/queryspec.example.test.ts` so SQL, QuerySpec, and tests stay aligned.
 
 # Hygiene
 - Keep SQL filenames stable and unambiguous for CRUD intent.

--- a/packages/ztd-cli/templates/src/sql/README.md
+++ b/packages/ztd-cli/templates/src/sql/README.md
@@ -4,3 +4,4 @@ Store SQL statements by table or domain in subfolders.
 
 - Use named parameters (for example `:id`).
 - Keep SQL in files; repositories should load them.
+- When you turn the first SQL asset into a QuerySpec, mirror the repository-test shape shown in `tests/queryspec.example.test.ts`.

--- a/packages/ztd-cli/templates/tests/AGENTS.md
+++ b/packages/ztd-cli/templates/tests/AGENTS.md
@@ -9,6 +9,7 @@
 - CREATE tests for table repositories MUST expect identifier-only returns unless spec explicitly requires DTO return.
 - Test runner configuration MUST exist and support single-command execution.
 - Initial template state MUST include at least one executable test.
+- Initial template state MUST include one QuerySpec-first example test at `tests/queryspec.example.test.ts` so the repository sample is easy to copy.
 
 ## ALLOWED
 - Tests MAY import runtime modules from `src/`.

--- a/packages/ztd-cli/templates/tests/queryspec.example.test.ts
+++ b/packages/ztd-cli/templates/tests/queryspec.example.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from 'vitest';
+
+import { rowMapping, type QuerySpec } from '@rawsql-ts/sql-contract';
+
+type UserProfileRow = {
+  userId: string;
+  displayName: string;
+};
+
+const listActiveUsersSpec: QuerySpec<[], UserProfileRow> = {
+  id: 'users.list-active',
+  sqlFile: 'src/sql/users/list-active-users.sql',
+  params: {
+    shape: 'positional',
+    example: [] as []
+  },
+  output: {
+    mapping: rowMapping({
+      name: 'UserProfile',
+      key: 'userId',
+      columnMap: {
+        userId: 'user_id',
+        displayName: 'display_name'
+      }
+    }),
+    validate: (value) => {
+      const row = value as { userId: unknown; displayName: unknown };
+      return {
+        userId: String(row.userId),
+        displayName: String(row.displayName)
+      };
+    },
+    example: {
+      userId: 'user-1',
+      displayName: 'Alice'
+    }
+  },
+  notes: 'Use this as the sample when you add the first repository-backed QuerySpec.'
+};
+
+test('queryspec example keeps SQL, rowMapping, and tests aligned', () => {
+  expect(listActiveUsersSpec.id).toBe('users.list-active');
+  expect(listActiveUsersSpec.sqlFile).toBe('src/sql/users/list-active-users.sql');
+  expect(listActiveUsersSpec.output.example.userId).toBe('user-1');
+  expect(listActiveUsersSpec.output.validate?.(listActiveUsersSpec.output.example)).toEqual(
+    listActiveUsersSpec.output.example
+  );
+});

--- a/packages/ztd-cli/templates/tests/smoke.test.ts
+++ b/packages/ztd-cli/templates/tests/smoke.test.ts
@@ -3,7 +3,7 @@ import { expect, test } from 'vitest';
 import { ensureSmokeOutput } from '../src/catalog/runtime/_smoke.runtime.js';
 import { createTestkitClient } from './support/testkit-client.js';
 
-test('smoke: runtime contract wiring is usable before SQL-backed tests exist', () => {
+test('smoke: first sanity check keeps the scaffold runnable', () => {
   const output = ensureSmokeOutput({
     id: 1,
     createdAt: '2025-01-01T00:00:00.000Z',
@@ -14,7 +14,7 @@ test('smoke: runtime contract wiring is usable before SQL-backed tests exist', (
   expect(output.createdAt.toISOString()).toBe('2025-01-01T00:00:00.000Z');
 });
 
-test('smoke: SqlClient seam is either wired or fails with an actionable message', async () => {
+test('smoke: SqlClient seam is the handoff point after the QuerySpec sample', async () => {
   try {
     const client = await createTestkitClient();
     expect(typeof client.query).toBe('function');

--- a/packages/ztd-cli/templates/tests/smoke.validation.test.ts
+++ b/packages/ztd-cli/templates/tests/smoke.validation.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest';
 
 import { ensureSmokeOutput } from '../src/catalog/runtime/_smoke.runtime.js';
 
+// Keep this file as the smallest DB-free validation gate; the reusable QuerySpec sample lives in queryspec.example.test.ts.
 test('validator invariant smoke passes for valid runtime output', () => {
   const output = ensureSmokeOutput({
     id: 1,

--- a/packages/ztd-cli/tests/__snapshots__/init.command.test.ts.snap
+++ b/packages/ztd-cli/tests/__snapshots__/init.command.test.ts.snap
@@ -17,6 +17,7 @@ Created:
  - src/catalog/runtime/_smoke.runtime.ts
  - tests/smoke.validation.test.ts
  - tests/smoke.test.ts
+ - tests/queryspec.example.test.ts
  - src/db/sql-client.ts
  - src/db/sql-client-adapters.ts
  - src/infrastructure/telemetry/types.ts
@@ -42,7 +43,8 @@ Next steps:
  3. Run npx ztd ztd-config to regenerate DDL-derived test rows and layout metadata
  4. Run npx ztd model-gen --probe-mode ztd <sql-file> --out <spec-file> to scaffold a QuerySpec from that SQL file
  5. Review src/db/sql-client.ts and src/infrastructure/telemetry/repositoryTelemetry.ts so the first SQL-backed repository has a seam to plug into
- 6. Run tests (npm run test or npx vitest run) to pass the generated smoke test before adding SQL-backed coverage
+ 6. Open tests/queryspec.example.test.ts as the QuerySpec-first sample before you write the first repository test
+ 7. Run tests (npm run test or npx vitest run) to pass the generated smoke test before adding SQL-backed coverage
 
 If this fails:
  - If npx ztd ztd-config fails, keep editing ztd/ddl/public.sql and src/sql/ first, then rerun generation after the DDL is ready
@@ -67,6 +69,7 @@ Created:
  - src/catalog/runtime/_smoke.runtime.ts
  - tests/smoke.validation.test.ts
  - tests/smoke.test.ts
+ - tests/queryspec.example.test.ts
  - src/db/sql-client.ts
  - src/db/sql-client-adapters.ts
  - src/infrastructure/telemetry/types.ts
@@ -92,7 +95,8 @@ Next steps:
  3. Run npx ztd ztd-config to regenerate DDL-derived test rows and layout metadata
  4. Run npx ztd model-gen --probe-mode ztd <sql-file> --out <spec-file> to scaffold a QuerySpec from that SQL file
  5. Review src/db/sql-client.ts and src/infrastructure/telemetry/repositoryTelemetry.ts so the first SQL-backed repository has a seam to plug into
- 6. Run tests (npm run test or npx vitest run) to pass the generated smoke test before adding SQL-backed coverage
+ 6. Open tests/queryspec.example.test.ts as the QuerySpec-first sample before you write the first repository test
+ 7. Run tests (npm run test or npx vitest run) to pass the generated smoke test before adding SQL-backed coverage
 
 If this fails:
  - If npx ztd ztd-config fails, keep editing ztd/ddl/public.sql and src/sql/ first, then rerun generation after the DDL is ready
@@ -117,6 +121,7 @@ Created:
  - src/catalog/runtime/_smoke.runtime.ts
  - tests/smoke.validation.test.ts
  - tests/smoke.test.ts
+ - tests/queryspec.example.test.ts
  - src/db/sql-client.ts
  - src/db/sql-client-adapters.ts
  - src/infrastructure/telemetry/types.ts
@@ -142,7 +147,8 @@ Next steps:
  3. Run npx ztd ztd-config to regenerate DDL-derived test rows and layout metadata
  4. Run npx ztd model-gen --probe-mode ztd <sql-file> --out <spec-file> to scaffold a QuerySpec from that SQL file
  5. Review src/db/sql-client.ts and src/infrastructure/telemetry/repositoryTelemetry.ts so the first SQL-backed repository has a seam to plug into
- 6. Run tests (npm run test or npx vitest run) to pass the generated smoke test before adding SQL-backed coverage
+ 6. Open tests/queryspec.example.test.ts as the QuerySpec-first sample before you write the first repository test
+ 7. Run tests (npm run test or npx vitest run) to pass the generated smoke test before adding SQL-backed coverage
 
 If this fails:
  - If npx ztd ztd-config fails, keep editing ztd/ddl/public.sql and src/sql/ first, then rerun generation after the DDL is ready

--- a/packages/ztd-cli/tests/init.command.test.ts
+++ b/packages/ztd-cli/tests/init.command.test.ts
@@ -112,7 +112,8 @@ const requiredInvariantFiles = [
   'src/catalog/specs/_smoke.spec.ts',
   'src/catalog/runtime/_coercions.ts',
   'src/catalog/runtime/_smoke.runtime.ts',
-  'tests/smoke.validation.test.ts'
+  'tests/smoke.validation.test.ts',
+  'tests/queryspec.example.test.ts'
 ];
 
 class TestPrompter implements Prompter {
@@ -175,6 +176,7 @@ test('init wizard bootstraps an empty scaffold', async () => {
   expect(existsSync(path.join(workspace, 'tests', 'smoke.test.ts'))).toBe(true);
   expect(existsSync(path.join(workspace, 'tests', 'support', 'global-setup.ts'))).toBe(true);
   expect(existsSync(testkitClientPath)).toBe(true);
+  expect(existsSync(path.join(workspace, 'tests', 'queryspec.example.test.ts'))).toBe(true);
   expect(existsSync(path.join(workspace, 'vitest.config.ts'))).toBe(true);
   expect(existsSync(path.join(workspace, 'package.json'))).toBe(true);
   expect(existsSync(path.join(workspace, 'ztd.config.json'))).toBe(true);
@@ -246,10 +248,13 @@ test('init wizard bootstraps an empty scaffold', async () => {
     'normalizes valid timestamp strings',
   );
   expect(readNormalizedFile(path.join(workspace, 'tests', 'smoke.test.ts'))).toContain(
-    'runtime contract wiring is usable before SQL-backed tests exist',
+    'first sanity check keeps the scaffold runnable',
   );
   expect(readNormalizedFile(path.join(workspace, 'tests', 'smoke.test.ts'))).toContain(
-    'SqlClient seam is either wired or fails with an actionable message',
+    'SqlClient seam is the handoff point after the QuerySpec sample',
+  );
+  expect(readNormalizedFile(path.join(workspace, 'tests', 'queryspec.example.test.ts'))).toContain(
+    'queryspec example keeps SQL, rowMapping, and tests aligned',
   );
   expect(readNormalizedFile(path.join(workspace, 'tests', 'support', 'global-setup.ts'))).toContain(
     'ZTD_TEST_DATABASE_URL'
@@ -279,6 +284,7 @@ test('init wizard bootstraps a scaffold with demo DDL', async () => {
   expect(existsSync(path.join(workspace, 'tests', 'generated', 'ztd-layout.generated.ts'))).toBe(false);
   expect(existsSync(path.join(workspace, 'tests', 'smoke.test.ts'))).toBe(true);
   expect(existsSync(path.join(workspace, 'tests', 'smoke.validation.test.ts'))).toBe(true);
+  expect(existsSync(path.join(workspace, 'tests', 'queryspec.example.test.ts'))).toBe(true);
 
   const config = JSON.parse(readNormalizedFile(path.join(workspace, 'ztd.config.json'))) as {
     ddl: { defaultSchema: string; searchPath: string[] };
@@ -317,12 +323,14 @@ test('init webapi scaffold localizes ZTD guidance to persistence-oriented paths'
     true
   );
   expect(existsSync(path.join(workspace, 'src', 'infrastructure', 'db', 'sql-client.ts'))).toBe(true);
+  expect(existsSync(path.join(workspace, 'tests', 'queryspec.example.test.ts'))).toBe(true);
   expect(readNormalizedFile(path.join(workspace, 'tests', 'support', 'testkit-client.ts'))).toContain(
     "../../src/infrastructure/db/sql-client"
   );
   expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('src/domain');
   expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('npx ztd ztd-config');
   expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('npx ztd model-gen --probe-mode ztd <sql-file> --out <spec-file>');
+  expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('tests/queryspec.example.test.ts');
   expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('If this fails:');
   expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('does not read it automatically');
   expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('explicit target inspection');
@@ -1047,6 +1055,7 @@ test('init local-source mode links direct rawsql-ts dependencies from the monore
   expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('pnpm install --ignore-workspace');
   expect(result.summary).toContain('Run pnpm ztd ztd-config');
   expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('pnpm ztd ztd-config');
+  expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('tests/queryspec.example.test.ts');
   expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('If this fails:');
   expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain(
     'The scaffold keeps `@rawsql-ts/sql-contract` as a normal package import even in local-source developer mode.'


### PR DESCRIPTION
Resolves #598.

Adds a reusable QuerySpec-first scaffold sample at tests/queryspec.example.test.ts and updates init scaffolding / README guidance so QuerySpec and tests read as the main path, while keeping the #602 generated smoke gate intact.

Verification:
- pnpm --filter @rawsql-ts/ztd-cli test -- init.command.test.ts
- pnpm verify:published-package-mode
- pnpm verify:customer-consumers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a QuerySpec-first example test file generated during project initialization to serve as a reusable onboarding sample.

* **Documentation**
  * Updated READMEs and guidance across all architecture layers to reference the new example test as the starting point for repository and persistence patterns.
  * Clarified test descriptions to better reflect the project's onboarding workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->