### PR TITLE
docs(policy): add intent and procedure guidance

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -1,11 +1,20 @@
 # Visible Policy Mirror
 
 - This file mirrors the repository policy interpretation in `./AGENTS.md` for agent-visible guidance.
+- This file mirrors the repository intent and procedure guidance in `./AGENTS.md` for agent-visible guidance.
 - `MUST` and `REQUIRED` define completion criteria.
 - `ALLOWED` means permitted but not required.
 - `PROHIBITED` means disallowed unless a narrower rule explicitly allows it.
 - User requests can add context, but they do not relax a `MUST` or `REQUIRED` rule by default.
 - When both files apply, the repository root policy remains canonical and deeper files may only narrow scope without weakening completion criteria.
+
+## INTENT
+- Source assets stay human-owned so the repository keeps a clear edit surface.
+- Downstream artifacts exist to match the source assets, not to replace their intent.
+
+## procedure
+- Follow `DDL -> SQL -> generate -> wire -> test` when moving from source assets to downstream artifacts.
+- Keep generated files and tests aligned with the source asset they were derived from.
 
 ## Repository Completion Example
 - Repository implementation is only complete when the required verification and tests that the policy calls for are included in the same change.

--- a/.changeset/three-bears-applaud.md
+++ b/.changeset/three-bears-applaud.md
@@ -1,0 +1,5 @@
+---
+"@rawsql-ts/ztd-cli": patch
+---
+
+Clarify repository intent and procedure so source assets and downstream artifacts are read as causality, not just rules.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,16 @@
 - Plan mode SHOULD stay read-only and produce the smallest defensible plan before execution.
 - Specialist names SHOULD remain internal unless orchestration debugging is requested.
 
+# INTENT
+- Source assets stay human-owned so the repository keeps a clear edit surface.
+- Downstream artifacts exist to match the source assets, not to replace their intent.
+- These rules explain why the repository is arranged the way it is, not only what is forbidden.
+
+# procedure
+- Follow `DDL -> SQL -> generate -> wire -> test` when moving from source assets to downstream artifacts.
+- Keep generated files and tests aligned with the source asset they were derived from.
+- Use the shortest path that preserves that causality.
+
 # Policy
 ## Interpretation
 - `MUST` and `REQUIRED` define completion criteria.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ See the [Core Package Documentation](./packages/core/README.md) for usage exampl
 
 - [SQL-first End-to-End Tutorial](./docs/guide/sql-first-end-to-end-tutorial.md) - Walk from DDL to `ztd-config`, `model-gen`, repository wiring, and the first passing smoke test in one focused path.
 
+## Intent and Procedure
+
+Use this repo by treating DDL and SQL as source assets, and generated specs, repositories, and tests as downstream artifacts that must stay in sync.
+
+Procedure: `DDL -> SQL -> generate -> wire -> test`.
+
+For a step-by-step example, see the SQL-first tutorial above.
+
 ## CLI Tool Routing Happy Paths
 
 - SQL pipeline / debug → `ztd query plan <sql-file>`

--- a/packages/ztd-cli/tests/intentProcedure.docs.test.ts
+++ b/packages/ztd-cli/tests/intentProcedure.docs.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { expect, test } from 'vitest';
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+
+function readNormalizedFile(relativePath: string): string {
+  const filePath = path.join(repoRoot, relativePath);
+  return readFileSync(filePath, 'utf8').replace(/\r\n/g, '\n');
+}
+
+function expectInOrder(haystack: string, needles: string[]): void {
+  let cursor = 0;
+  for (const needle of needles) {
+    const index = haystack.indexOf(needle, cursor);
+    expect(index, `Expected to find "${needle}" after offset ${cursor}`).toBeGreaterThanOrEqual(0);
+    cursor = index + needle.length;
+  }
+}
+
+test('root policy and mirror describe intent and procedure as causality', () => {
+  const rootAgents = readNormalizedFile('AGENTS.md');
+  const mirrorAgents = readNormalizedFile('.agent/AGENTS.md');
+
+  expect(rootAgents).toContain('# INTENT');
+  expect(rootAgents).toContain('Source assets stay human-owned so the repository keeps a clear edit surface.');
+  expect(rootAgents).toContain('# procedure');
+  expect(rootAgents).toContain('Follow `DDL -> SQL -> generate -> wire -> test` when moving from source assets to downstream artifacts.');
+
+  expect(mirrorAgents).toContain('## INTENT');
+  expect(mirrorAgents).toContain('## procedure');
+  expect(mirrorAgents).toContain('Downstream artifacts exist to match the source assets, not to replace their intent.');
+});
+
+test('README exposes the high-level intent and procedure entry point', () => {
+  const readme = readNormalizedFile('README.md');
+
+  expectInOrder(readme, [
+    '## Tutorials',
+    'SQL-first End-to-End Tutorial',
+    '## Intent and Procedure',
+    'Use this repo by treating DDL and SQL as source assets, and generated specs, repositories, and tests as downstream artifacts that must stay in sync.',
+    'Procedure: `DDL -> SQL -> generate -> wire -> test`.',
+    'For a step-by-step example, see the SQL-first tutorial above.',
+  ]);
+});


### PR DESCRIPTION
## Summary\n- Add INTENT and procedure guidance to root AGENTS.md and the visible mirror.\n- Add a README entry that explains source assets vs downstream artifacts.\n- Add a lightweight docs regression test and changeset.\n\n## Verification\n- pnpm --filter @rawsql-ts/ztd-cli test -- intentProcedure.docs.test.ts sqlFirstTutorial.docs.test.ts\n- pnpm lint\n- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced repository guidance with new Intent and Procedure sections clarifying how source assets flow through the generation workflow and align with downstream artifacts.
  * Added procedural workflow documentation (DDL → SQL → generate → wire → test).

* **Tests**
  * Added tests to verify documentation consistency and completeness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->