### PR TITLE
Add ztd-cli guard for uncovered SQL assets

### DIFF
--- a/.changeset/fuzzy-whales-persist.md
+++ b/.changeset/fuzzy-whales-persist.md
@@ -2,4 +2,4 @@
 "@rawsql-ts/ztd-cli": patch
 ---
 
-Keep the generated QuerySpec sample aligned with the published consumer smoke path so the scaffolded repository example validates raw rows correctly.
+Keep the generated QuerySpec sample aligned with the published consumer smoke path and add a contract guard for uncovered SQL assets so the scaffolded repository example validates raw rows correctly.

--- a/packages/ztd-cli/src/commands/checkContract.ts
+++ b/packages/ztd-cli/src/commands/checkContract.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { Command } from 'commander';
 import { BinarySelectQuery, ColumnReference, DeleteQuery, MultiQuerySplitter, SimpleSelectQuery, SqlParser, UpdateQuery } from 'rawsql-ts';
@@ -19,11 +19,12 @@ export interface ContractViolation {
     | 'duplicate-spec-id'
     | 'unresolved-sql-file'
     | 'params-shape-mismatch'
-    | 'mapping-invalid-entry'
-    | 'mapping-duplicate-entry'
-    | 'safety-select-star'
-    | 'safety-missing-where'
-    | 'sql-parse-error';
+  | 'mapping-invalid-entry'
+  | 'mapping-duplicate-entry'
+  | 'uncovered-sql-file'
+  | 'safety-select-star'
+  | 'safety-missing-where'
+  | 'sql-parse-error';
   severity: ViolationSeverity;
   specId: string;
   filePath: string;
@@ -167,6 +168,31 @@ export function runCheckContract(options: { strict: boolean; rootDir?: string; s
     loadSqlCatalogSpecsFromFile(filePath, (message) => new CheckContractRuntimeError(message))
   );
   const violations: ContractViolation[] = [];
+  const sqlDir = path.resolve(root, 'src', 'sql');
+  const sqlFiles = existsSync(sqlDir) ? walkSqlFiles(sqlDir) : [];
+
+  const coveredSqlFiles = new Set<string>();
+  for (const loaded of loadedSpecs) {
+    if (typeof loaded.spec.sqlFile !== 'string' || loaded.spec.sqlFile.trim().length === 0) {
+      continue;
+    }
+    coveredSqlFiles.add(path.resolve(path.dirname(loaded.filePath), loaded.spec.sqlFile));
+  }
+
+  const uncoveredSeverity: ViolationSeverity = options.strict ? 'error' : 'warning';
+  for (const sqlFile of sqlFiles) {
+    if (coveredSqlFiles.has(sqlFile)) {
+      continue;
+    }
+    violations.push({
+      rule: 'uncovered-sql-file',
+      severity: uncoveredSeverity,
+      specId: path.relative(root, sqlFile).replace(/\\/g, '/'),
+      filePath: sqlFile,
+      message:
+        'SQL asset is not covered by any QuerySpec. Start from tests/queryspec.example.test.ts or run ztd model-gen to scaffold the first spec.'
+    });
+  }
 
   const duplicateMap = new Map<string, LoadedSqlCatalogSpec[]>();
   for (const loaded of loadedSpecs) {
@@ -407,6 +433,30 @@ function validateMapping(
     }
     seenColumns.set(normalized, key);
   }
+}
+
+function walkSqlFiles(rootDir: string): string[] {
+  const files: string[] = [];
+  const stack = [rootDir];
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    const entries = readdirSync(current, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
+    for (const entry of entries) {
+      const absolute = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(absolute);
+        continue;
+      }
+      if (!entry.isFile()) {
+        continue;
+      }
+      if (path.extname(entry.name).toLowerCase() !== '.sql') {
+        continue;
+      }
+      files.push(absolute);
+    }
+  }
+  return files.sort((a, b) => a.localeCompare(b));
 }
 
 /** Format check results into human text or deterministic JSON text. */

--- a/packages/ztd-cli/tests/checkContract.cli.test.ts
+++ b/packages/ztd-cli/tests/checkContract.cli.test.ts
@@ -92,6 +92,23 @@ test('CLI: check contract prints violations and sets exitCode=1', async () => {
   expect(parsed.violations.some((v: { rule: string }) => v.rule === 'params-shape-mismatch')).toBe(true);
 });
 
+test('CLI: check contract flags uncovered SQL assets in strict mode', async () => {
+  const workspace = createWorkspace('check-contract-cli-uncovered-sql');
+  writeFileSync(path.join(workspace, 'src', 'sql', 'orphan.sql'), 'select 1', 'utf8');
+
+  process.env.ZTD_PROJECT_ROOT = workspace;
+  const capture = { stdout: [] as string[], stderr: [] as string[] };
+  const program = createProgram(capture);
+  const outPath = path.join(workspace, 'artifacts', 'contract-check.json');
+
+  await program.parseAsync(['check', 'contract', '--format', 'json', '--strict', '--out', outPath], { from: 'user' });
+
+  expect(process.exitCode).toBe(1);
+  const parsed = JSON.parse(readFileSync(outPath, 'utf8'));
+  expect(parsed.ok).toBe(false);
+  expect(parsed.violations.some((v: { rule: string }) => v.rule === 'uncovered-sql-file')).toBe(true);
+});
+
 test('CLI: check contract sets exitCode=2 for runtime/config errors', async () => {
   const workspace = mkdtempSync(path.join(os.tmpdir(), 'check-contract-cli-error-'));
   process.env.ZTD_PROJECT_ROOT = workspace;

--- a/packages/ztd-cli/tests/checkContract.unit.test.ts
+++ b/packages/ztd-cli/tests/checkContract.unit.test.ts
@@ -50,6 +50,22 @@ describe('runCheckContract', () => {
     expect(result.violations.some((v) => v.rule === 'mapping-invalid-entry')).toBe(true);
   });
 
+  test('warns when SQL assets are not covered by any QuerySpec', () => {
+    const root = createWorkspace();
+    writeFileSync(path.join(root, 'src', 'sql', 'orphan.sql'), 'SELECT 1', 'utf8');
+
+    const result = runCheckContract({ strict: false, rootDir: root });
+    expect(result.ok).toBe(true);
+    expect(result.violations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          rule: 'uncovered-sql-file',
+          severity: 'warning'
+        })
+      ])
+    );
+  });
+
   test('safety checks are warnings by default and errors with strict', () => {
     const root = createWorkspace();
     writeFileSync(path.join(root, 'src', 'sql', 'unsafe.sql'), 'SELECT * FROM users; UPDATE users SET name = $1;', 'utf8');


### PR DESCRIPTION
## Summary\n- Add a ztd-cli contract guard that warns when SQL assets under src/sql are not covered by any QuerySpec.\n- Add unit and CLI coverage for the new guard.\n- Update the changeset entry to reflect the new prevention layer.\n\n## Verification\n- pnpm --filter @rawsql-ts/ztd-cli test -- tests/checkContract.unit.test.ts tests/checkContract.cli.test.ts\n- pnpm --filter @rawsql-ts/ztd-cli build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced SQL asset validation that automatically detects unreferenced SQL files in your repository, ensuring complete coverage and proper cataloging of all SQL definitions against your QuerySpec specifications. The validation operates in two modes: strict mode that reports errors and standard mode that reports warnings, providing flexibility in how you enforce SQL asset management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->