### PR TITLE
docs(ztd-cli): add Docker helper guidance

### DIFF
--- a/.changeset/tiny-dodos-hear.md
+++ b/.changeset/tiny-dodos-hear.md
@@ -1,0 +1,5 @@
+---
+"@rawsql-ts/ztd-cli": patch
+---
+
+Add a small PostgreSQL 18 Docker helper to the Getting Started with AI guidance so users can bootstrap a local ZTD test database more easily.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,33 @@ Procedure: `DDL -> SQL -> generate -> wire -> test`.
 
 For a step-by-step example, see the SQL-first tutorial above.
 
+## Getting Started with AI
+
+If you are using an AI coding agent, start with a short prompt that sets only the minimum project shape and domain language. You do **not** need to explain package-manager setup in that prompt.
+
+Optional Docker helper:
+
+If you want a local PostgreSQL 18 instance for ZTD tests, use a tiny compose file like this:
+
+```yaml
+services:
+  postgres:
+    image: postgres:18
+    environment:
+      POSTGRES_USER: ztd
+      POSTGRES_PASSWORD: ztd
+      POSTGRES_DB: ztd
+    ports:
+      - "5432:5432"
+    volumes:
+      - ztd-postgres-data:/var/lib/postgresql/data
+
+volumes:
+  ztd-postgres-data:
+```
+
+Then run `docker compose up -d` and point `ZTD_TEST_DATABASE_URL` at that database for the fixture-backed rewrite path.
+
 ## CLI Tool Routing Happy Paths
 
 - SQL pipeline / debug → `ztd query plan <sql-file>`

--- a/packages/ztd-cli/README.md
+++ b/packages/ztd-cli/README.md
@@ -52,6 +52,8 @@ npm install -D @rawsql-ts/ztd-cli
 
 If you are using an AI coding agent, start with a short prompt that sets only the minimum project shape and domain language. You do **not** need to explain package-manager setup in that prompt — the agent handles `npm install` or `pnpm install` automatically.
 
+Treat each query as one unit: 1 SQL file / 1 QuerySpec / 1 repository entrypoint / 1 DTO.
+
 Example prompt:
 
 ```text
@@ -59,12 +61,35 @@ I want to build a WebAPI application with @rawsql-ts/ztd-cli.
 Use Docker and Postgres.
 Start from the webapi scaffold.
 Model three tables: sales, sale_lines, and products.
-Keep domain, application, presentation, and persistence concerns separated.
-Prepare the initial DDL, scaffold the ZTD project, and explain what was created.
-Do not apply migrations automatically.
+  Keep domain, application, presentation, and persistence concerns separated.
+  Prepare the initial DDL, scaffold the ZTD project, and explain what was created.
+  Do not apply migrations automatically.
+  ```
+
+Optional Docker helper:
+
+If you want a local PostgreSQL 18 instance for ZTD tests, use a tiny compose file like this:
+
+```yaml
+services:
+  postgres:
+    image: postgres:18
+    environment:
+      POSTGRES_USER: ztd
+      POSTGRES_PASSWORD: ztd
+      POSTGRES_DB: ztd
+    ports:
+      - "5432:5432"
+    volumes:
+      - ztd-postgres-data:/var/lib/postgresql/data
+
+volumes:
+  ztd-postgres-data:
 ```
 
-What a prompt at this level should usually guarantee:
+Then run `docker compose up -d` and point `ZTD_TEST_DATABASE_URL` at that database for the fixture-backed rewrite path.
+
+  What a prompt at this level should usually guarantee:
 
 * a `webapi`-shaped project layout
 * starter DDL under `ztd/ddl/`

--- a/packages/ztd-cli/templates/README.md
+++ b/packages/ztd-cli/templates/README.md
@@ -40,6 +40,8 @@ Keep handwritten SQL assets in `src/sql/` as the single human-owned source locat
 
 Use this scaffold as a query-unit project.
 
+Treat each query as one unit: 1 SQL file / 1 QuerySpec / 1 repository entrypoint / 1 DTO.
+
 When asking an AI assistant to extend it, a natural request like the following usually works well:
 
 ```text
@@ -59,6 +61,29 @@ A few points matter when using AI with this scaffold:
 * For repository code, use `QuerySpec + CatalogExecutor`.
 * For tests, use fixture-backed ZTD rewrite through `tableFixture()` and the testkit client.
 * Start from the provided examples instead of inventing a different structure first.
+
+Optional Docker helper:
+
+If you want a local PostgreSQL 18 instance for ZTD tests, use a tiny compose file like this:
+
+```yaml
+services:
+  postgres:
+    image: postgres:18
+    environment:
+      POSTGRES_USER: ztd
+      POSTGRES_PASSWORD: ztd
+      POSTGRES_DB: ztd
+    ports:
+      - "5432:5432"
+    volumes:
+      - ztd-postgres-data:/var/lib/postgresql/data
+
+volumes:
+  ztd-postgres-data:
+```
+
+Then run `docker compose up -d` and point `ZTD_TEST_DATABASE_URL` at that database for the fixture-backed rewrite path.
 
 Good example files to start from:
 

--- a/packages/ztd-cli/templates/README.webapi.md
+++ b/packages/ztd-cli/templates/README.webapi.md
@@ -46,6 +46,8 @@ Keep SQL and QuerySpec work inside the persistence side of the project.
 
 Use this scaffold as a layered WebAPI project with query-unit persistence.
 
+Treat each query as one unit: 1 SQL file / 1 QuerySpec / 1 repository entrypoint / 1 DTO.
+
 When asking an AI assistant to extend it, a natural request like the following usually works well:
 
 ```text
@@ -69,6 +71,29 @@ A few points matter when using AI with this scaffold:
 * Keep persistence-specific code under `src/infrastructure/persistence/`.
 * Keep `src/domain`, `src/application`, and `src/presentation/http` free from direct SQL or DDL concerns.
 * Start from the provided examples instead of creating a new structure first.
+
+Optional Docker helper:
+
+If you want a local PostgreSQL 18 instance for ZTD tests, use a tiny compose file like this:
+
+```yaml
+services:
+  postgres:
+    image: postgres:18
+    environment:
+      POSTGRES_USER: ztd
+      POSTGRES_PASSWORD: ztd
+      POSTGRES_DB: ztd
+    ports:
+      - "5432:5432"
+    volumes:
+      - ztd-postgres-data:/var/lib/postgresql/data
+
+volumes:
+  ztd-postgres-data:
+```
+
+Then run `docker compose up -d` and point `ZTD_TEST_DATABASE_URL` at that database for the fixture-backed rewrite path.
 
 Good example files to start from:
 

--- a/packages/ztd-cli/tests/directoryFinding.docs.test.ts
+++ b/packages/ztd-cli/tests/directoryFinding.docs.test.ts
@@ -11,10 +11,11 @@ function readNormalizedFile(relativePath: string): string {
 
 test('readmes promote the query-unit rule without tables/views taxonomy', () => {
   const rootReadme = readNormalizedFile('README.md');
+  const packageReadme = readNormalizedFile('packages/ztd-cli/README.md');
   const scaffoldReadme = readNormalizedFile('packages/ztd-cli/templates/README.md');
   const webapiReadme = readNormalizedFile('packages/ztd-cli/templates/README.webapi.md');
 
-  for (const doc of [rootReadme, scaffoldReadme, webapiReadme]) {
+  for (const doc of [rootReadme, packageReadme, scaffoldReadme, webapiReadme]) {
     expect(doc).toContain('1 SQL file / 1 QuerySpec / 1 repository entrypoint / 1 DTO');
     expect(doc).toContain('src/sql');
     expect(doc).not.toContain('tables/views');
@@ -22,8 +23,20 @@ test('readmes promote the query-unit rule without tables/views taxonomy', () => 
   }
 
   expect(rootReadme).toContain('Keep handwritten SQL assets in `src/sql/` as the single human-owned source location for query logic.');
+  expect(packageReadme).toContain('Optional Docker helper:');
+  expect(packageReadme).toContain('postgres:18');
+  expect(packageReadme).toContain('docker compose up -d');
+  expect(packageReadme).toContain('ZTD_TEST_DATABASE_URL');
   expect(scaffoldReadme).toContain('Keep handwritten SQL assets in `src/sql/` as the single human-owned source location for query logic.');
+  expect(scaffoldReadme).toContain('Optional Docker helper:');
+  expect(scaffoldReadme).toContain('postgres:18');
+  expect(scaffoldReadme).toContain('docker compose up -d');
+  expect(scaffoldReadme).toContain('ZTD_TEST_DATABASE_URL');
   expect(webapiReadme).toContain('Keep handwritten SQL assets in `src/sql/` as the single human-owned source location for query logic.');
+  expect(webapiReadme).toContain('Optional Docker helper:');
+  expect(webapiReadme).toContain('postgres:18');
+  expect(webapiReadme).toContain('docker compose up -d');
+  expect(webapiReadme).toContain('ZTD_TEST_DATABASE_URL');
   expect(scaffoldReadme).toContain('Think in query units:');
   expect(webapiReadme).toContain('Think in query units:');
   expect(scaffoldReadme).toContain('1 SQL file');


### PR DESCRIPTION
## Summary
- Add an optional PostgreSQL 18 Docker helper to the Getting Started with AI guidance in the repo and ztd-cli READMEs.
- Align the scaffold docs test with the new guidance.
- Add a patch changeset for @rawsql-ts/ztd-cli.

## Verification
- pnpm --filter @rawsql-ts/ztd-cli test -- tests/directoryFinding.docs.test.ts
- pnpm --filter @rawsql-ts/ztd-cli build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Getting Started with AI" section with minimal prompt guidance for AI coding agents.
  * Introduced optional Docker Compose setup for local PostgreSQL 18 database with configuration instructions.
  * Documented query-as-unit constraint (1:1 mapping between SQL file, QuerySpec, repository entrypoint, and DTO).

* **Chores**
  * Patch release prepared for ztd-cli package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->