### PR TITLE
feat(ztd-cli): add finding registry validation

### DIFF
--- a/.changeset/green-kids-try.md
+++ b/.changeset/green-kids-try.md
@@ -1,0 +1,5 @@
+---
+"@rawsql-ts/ztd-cli": patch
+---
+
+Add `ztd findings validate` so machine-readable finding registries can be checked deterministically in CI or locally.

--- a/docs/guide/finding-registry.md
+++ b/docs/guide/finding-registry.md
@@ -48,6 +48,8 @@ Recommended status progression:
 The example registry at [finding-registry.example.json](./finding-registry.example.json) contains representative findings from the ztd-cli dogfooding work.
 It is intentionally small and should be treated as a starting point, not as a complete audit log.
 
+Validate the example registry with `npx ztd findings validate docs/guide/finding-registry.example.json` when you want a deterministic CI check.
+
 ## How to use it
 
 When you add a new finding:

--- a/packages/ztd-cli/README.md
+++ b/packages/ztd-cli/README.md
@@ -276,6 +276,8 @@ Reference docs:
 * [ztd-cli Agent Interface](../../docs/guide/ztd-cli-agent-interface.md)
 * [ztd-cli Describe Schema](../../docs/guide/ztd-cli-describe-schema.md)
 
+Validate a machine-readable finding registry with `npx ztd findings validate docs/guide/finding-registry.example.json`.
+
 ### Global JSON mode
 
 ```bash

--- a/packages/ztd-cli/src/commands/findings.ts
+++ b/packages/ztd-cli/src/commands/findings.ts
@@ -1,0 +1,126 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { Command } from 'commander';
+import { getAgentOutputFormat, parseJsonPayload } from '../utils/agentCli';
+import { validateFindingRegistry, type FindingRegistryIssue } from '../utils/findingRegistry';
+
+export type FindingRegistryValidationFormat = 'human' | 'json';
+
+export interface FindingRegistryValidationResult {
+  ok: boolean;
+  registryPath: string;
+  entriesChecked: number;
+  issues: FindingRegistryIssue[];
+}
+
+interface FindingsCommandOptions {
+  format?: string;
+  out?: string;
+  json?: string;
+}
+
+/** Runtime/configuration error for finding registry validation (maps to exit code 2). */
+export class FindingRegistryValidationRuntimeError extends Error {
+  readonly exitCode = 2;
+}
+
+/** Register finding-registry validation commands on the CLI root. */
+export function registerFindingRegistryCommand(program: Command): void {
+  const findings = program.command('findings').description('Validate machine-readable finding registry files');
+
+  findings
+    .command('validate <registryFile>')
+    .description('Validate a machine-readable finding registry JSON file')
+    .option('--format <format>', 'Output format (human|json)')
+    .option('--out <path>', 'Write output to file')
+    .option('--json <payload>', 'Pass command options as a JSON object')
+    .action(async (registryFile: string, options: FindingsCommandOptions) => {
+      try {
+        const merged = options.json ? { ...options, ...parseJsonPayload<Record<string, unknown>>(options.json, '--json') } : options;
+        const format = resolveValidationFormat(merged.format);
+        const result = runValidateFindingRegistry(registryFile);
+        const text = formatFindingRegistryValidationResult(result, format);
+        const outPath = normalizeStringOption(merged.out);
+        if (outPath) {
+          mkdirSync(path.dirname(path.resolve(process.cwd(), outPath)), { recursive: true });
+          writeFileSync(path.resolve(process.cwd(), outPath), text, 'utf8');
+        } else {
+          const writer = result.ok ? console.log : console.error;
+          writer(text);
+        }
+        process.exitCode = result.ok ? 0 : 1;
+      } catch (error) {
+        process.exitCode = error instanceof FindingRegistryValidationRuntimeError ? 2 : 1;
+        console.error(error instanceof Error ? error.message : String(error));
+      }
+    });
+}
+
+export function runValidateFindingRegistry(registryFile: string, rootDir = process.cwd()): FindingRegistryValidationResult {
+  const absolute = path.resolve(rootDir, registryFile);
+  if (!existsSync(absolute)) {
+    throw new FindingRegistryValidationRuntimeError(`Finding registry not found: ${absolute}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(absolute, 'utf8'));
+  } catch (error) {
+    throw new FindingRegistryValidationRuntimeError(
+      `Failed to parse finding registry JSON at ${absolute}: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+
+  const issues = validateFindingRegistry(parsed);
+  return {
+    ok: issues.length === 0,
+    registryPath: absolute,
+    entriesChecked: Array.isArray(parsed) ? parsed.length : 0,
+    issues
+  };
+}
+
+export function formatFindingRegistryValidationResult(
+  result: FindingRegistryValidationResult,
+  format: FindingRegistryValidationFormat
+): string {
+  if (format === 'json') {
+    return `${JSON.stringify(result, null, 2)}\n`;
+  }
+
+  const lines = result.ok
+    ? [`Finding registry is valid: ${result.entriesChecked} entries checked.`]
+    : [
+        `Finding registry has ${result.issues.length} issue(s) across ${result.entriesChecked} entries.`,
+        ...result.issues.map((issue) => formatIssue(issue))
+      ];
+  return `${lines.join('\n')}\n`;
+}
+
+function formatIssue(issue: FindingRegistryIssue): string {
+  const location = issue.index >= 0 ? `entry ${issue.index}` : 'registry';
+  return `- ${location} / ${issue.field}: ${issue.message}`;
+}
+
+function resolveValidationFormat(value: unknown): FindingRegistryValidationFormat {
+  const explicit = normalizeStringOption(value);
+  if (explicit) {
+    const normalized = explicit.trim().toLowerCase();
+    if (normalized === 'human' || normalized === 'json') {
+      return normalized;
+    }
+    throw new FindingRegistryValidationRuntimeError(`Unsupported format: ${explicit}`);
+  }
+
+  return getAgentOutputFormat() === 'json' ? 'json' : 'human';
+}
+
+function normalizeStringOption(value: unknown): string | undefined {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+  if (typeof value !== 'string') {
+    throw new FindingRegistryValidationRuntimeError(`Expected a string option but received ${typeof value}.`);
+  }
+  return value;
+}

--- a/packages/ztd-cli/src/index.ts
+++ b/packages/ztd-cli/src/index.ts
@@ -5,6 +5,7 @@ import { registerAgentsCommand } from './commands/agents';
 import { CheckContractRuntimeError, registerCheckContractCommand } from './commands/checkContract';
 import { registerDescribeCommand } from './commands/describe';
 import { registerDdlCommands } from './commands/ddl';
+import { registerFindingRegistryCommand } from './commands/findings';
 import { registerInitCommand } from './commands/init';
 import { registerLintCommand } from './commands/lint';
 import { registerModelGenCommand } from './commands/modelGen';
@@ -89,6 +90,7 @@ export function buildProgram(): Command {
   registerPerfCommands(program);
   registerQueryCommands(program);
   registerCheckContractCommand(program);
+  registerFindingRegistryCommand(program);
   registerTestEvidenceCommand(program);
   registerZtdConfigCommand(program);
   registerDdlCommands(program);
@@ -101,6 +103,7 @@ Getting started:
   $ ztd init --yes --force     Allow non-interactive overwrite of scaffold-owned files
   $ ztd agents install         Materialize visible AGENTS.md files on demand
   $ ztd ztd-config             Generate TestRowMap types from DDL
+  $ ztd findings validate docs/guide/finding-registry.example.json
   $ ztd lint <path>            Lint SQL files against the schema
   $ ztd perf init             Scaffold the opt-in perf sandbox
   $ ztd perf run --query src/sql/report.sql --dry-run

--- a/packages/ztd-cli/tests/findings.cli.test.ts
+++ b/packages/ztd-cli/tests/findings.cli.test.ts
@@ -1,0 +1,104 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { Command } from 'commander';
+import { afterEach, expect, test } from 'vitest';
+import { registerFindingRegistryCommand } from '../src/commands/findings';
+
+const originalExitCode = process.exitCode;
+
+afterEach(() => {
+  process.exitCode = originalExitCode;
+});
+
+function createWorkspace(prefix: string): string {
+  return mkdtempSync(path.join(os.tmpdir(), `${prefix}-`));
+}
+
+function createProgram(capture: { stdout: string[]; stderr: string[] }): Command {
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({
+    writeOut: (str) => capture.stdout.push(str),
+    writeErr: (str) => capture.stderr.push(str)
+  });
+  registerFindingRegistryCommand(program);
+  return program;
+}
+
+test('CLI: findings validate writes json output and sets exitCode=0 on success', async () => {
+  const workspace = createWorkspace('findings-cli-pass');
+  const registryPath = path.join(workspace, 'finding-registry.json');
+  const outPath = path.join(workspace, 'artifacts', 'findings.json');
+  mkdirSync(path.dirname(outPath), { recursive: true });
+  writeFileSync(
+    registryPath,
+    JSON.stringify([
+      {
+        id: 'F-001',
+        title: 'example',
+        symptom: 'example symptom',
+        source: ['Report'],
+        failure_surface: 'internal',
+        category: ['docs'],
+        severity: 'warning',
+        detectability: 'local',
+        recurrence_risk: 'low',
+        desired_prevention_layer: ['docs_policy'],
+        candidate_action: 'add guidance',
+        verification_evidence: 'docs test',
+        status: 'planned'
+      }
+    ]),
+    'utf8'
+  );
+
+  const capture = { stdout: [] as string[], stderr: [] as string[] };
+  const program = createProgram(capture);
+  await program.parseAsync(['findings', 'validate', registryPath, '--format', 'json', '--out', outPath], { from: 'user' });
+
+  expect(process.exitCode).toBe(0);
+  const parsed = JSON.parse(readFileSync(outPath, 'utf8'));
+  expect(parsed).toMatchObject({ ok: true, entriesChecked: 1, issues: [] });
+  expect(capture.stdout.join('')).toBe('');
+  expect(capture.stderr.join('')).toBe('');
+});
+
+test('CLI: findings validate sets exitCode=1 for invalid registry entries', async () => {
+  const workspace = createWorkspace('findings-cli-invalid');
+  const registryPath = path.join(workspace, 'finding-registry.json');
+  const outPath = path.join(workspace, 'artifacts', 'findings.json');
+  mkdirSync(path.dirname(outPath), { recursive: true });
+  writeFileSync(
+    registryPath,
+    JSON.stringify([
+      {
+        id: '',
+        title: 'broken',
+        symptom: 'missing fields',
+        source: ['Report'],
+        failure_surface: 'internal',
+        category: ['docs'],
+        severity: 'warning',
+        detectability: 'local',
+        recurrence_risk: 'low',
+        desired_prevention_layer: ['docs_policy'],
+        candidate_action: 'fix it',
+        verification_evidence: 'none',
+        status: 'done'
+      }
+    ]),
+    'utf8'
+  );
+
+  const capture = { stdout: [] as string[], stderr: [] as string[] };
+  const program = createProgram(capture);
+  await program.parseAsync(['findings', 'validate', registryPath, '--format', 'json', '--out', outPath], { from: 'user' });
+
+  expect(process.exitCode).toBe(1);
+  const parsed = JSON.parse(readFileSync(outPath, 'utf8'));
+  expect(parsed.ok).toBe(false);
+  expect(parsed.issues.some((issue: { field: string }) => issue.field === 'id')).toBe(true);
+  expect(capture.stdout.join('')).toBe('');
+  expect(capture.stderr.join('')).toBe('');
+});

--- a/packages/ztd-cli/tests/findings.unit.test.ts
+++ b/packages/ztd-cli/tests/findings.unit.test.ts
@@ -1,0 +1,88 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, test } from 'vitest';
+import { formatFindingRegistryValidationResult, runValidateFindingRegistry } from '../src/commands/findings';
+
+function createWorkspace(): string {
+  return mkdtempSync(path.join(os.tmpdir(), 'ztd-findings-'));
+}
+
+describe('runValidateFindingRegistry', () => {
+  test('accepts the example registry', () => {
+    const root = createWorkspace();
+    const registryPath = path.join(root, 'finding-registry.example.json');
+    writeFileSync(
+      registryPath,
+      JSON.stringify([
+        {
+          id: 'F-001',
+          title: 'example',
+          symptom: 'example symptom',
+          source: ['Report'],
+          failure_surface: 'internal',
+          category: ['docs'],
+          severity: 'warning',
+          detectability: 'local',
+          recurrence_risk: 'low',
+          desired_prevention_layer: ['docs_policy'],
+          candidate_action: 'add guidance',
+          verification_evidence: 'docs test',
+          status: 'planned'
+        }
+      ]),
+      'utf8'
+    );
+
+    const result = runValidateFindingRegistry(registryPath, root);
+    expect(result.ok).toBe(true);
+    expect(result.entriesChecked).toBe(1);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  test('flags malformed registry entries', () => {
+    const root = createWorkspace();
+    const registryPath = path.join(root, 'finding-registry.bad.json');
+    writeFileSync(
+      registryPath,
+      JSON.stringify([
+        {
+          id: '',
+          title: 'broken',
+          symptom: 'missing fields',
+          source: ['Report'],
+          failure_surface: 'internal',
+          category: ['docs'],
+          severity: 'warning',
+          detectability: 'local',
+          recurrence_risk: 'low',
+          desired_prevention_layer: ['docs_policy'],
+          candidate_action: 'fix it',
+          verification_evidence: 'none',
+          status: 'done'
+        }
+      ]),
+      'utf8'
+    );
+
+    const result = runValidateFindingRegistry(registryPath, root);
+    expect(result.ok).toBe(false);
+    expect(result.issues.some((issue) => issue.field === 'id')).toBe(true);
+    expect(result.issues.some((issue) => issue.field === 'status')).toBe(true);
+  });
+
+  test('formats a human summary', () => {
+    const text = formatFindingRegistryValidationResult(
+      {
+        ok: false,
+        registryPath: '/tmp/findings.json',
+        entriesChecked: 1,
+        issues: [{ index: 0, field: 'status', message: 'status must be one of: planned, implemented, evidence_collected, verified.' }]
+      },
+      'human'
+    );
+
+    expect(text).toContain('Finding registry has 1 issue');
+    expect(text).toContain('entry 0 / status');
+  });
+});


### PR DESCRIPTION
## Summary
- Add ztd findings validate <registryFile> to validate machine-readable finding registries deterministically.
- Document the command in the ztd-cli README and finding registry guide.
- Add a patch changeset for @rawsql-ts/ztd-cli.

## Verification
- pnpm --filter @rawsql-ts/ztd-cli test -- tests/findings.unit.test.ts tests/findings.cli.test.ts tests/directoryFinding.docs.test.ts
- pnpm --filter @rawsql-ts/ztd-cli build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `ztd findings validate` command to deterministically validate machine-readable finding registries for CI and local use
  * Supports `--format` option for JSON or human-readable output
  * Supports `--out` option to write validation results to a file

* **Documentation**
  * Updated guides with examples of running the validation command

* **Tests**
  * Added test coverage for the new findings validation command

<!-- end of auto-generated comment: release notes by coderabbit.ai -->