### PR TITLE
fix(ci): add repository metadata for npm provenance

### DIFF
--- a/.changeset/hot-suns-vanish.md
+++ b/.changeset/hot-suns-vanish.md
@@ -1,0 +1,6 @@
+---
+'@rawsql-ts/ddl-docs-cli': patch
+'@rawsql-ts/ddl-docs-vitepress': patch
+---
+
+Add repository metadata to the ddl-docs packages so npm Trusted Publishing provenance validation can verify the package source during release.

--- a/packages/ddl-docs-cli/package.json
+++ b/packages/ddl-docs-cli/package.json
@@ -21,6 +21,11 @@
   ],
   "author": "msugiura",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mk3008/rawsql-ts",
+    "directory": "packages/ddl-docs-cli"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/ddl-docs-vitepress/package.json
+++ b/packages/ddl-docs-vitepress/package.json
@@ -24,6 +24,11 @@
   ],
   "author": "msugiura",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mk3008/rawsql-ts",
+    "directory": "packages/ddl-docs-vitepress"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary\n- Add repository metadata to the ddl-docs packages so npm Trusted Publishing provenance validation can verify the source repository.\n- This fixes the release failure where npm rejected the tarball because repository.url was missing.\n\n## Verification\n- npm pack --json in packages/ddl-docs-cli\n- npm pack --json in packages/ddl-docs-vitepress\n- Verified both tarballs now contain repository.url=https://github.com/mk3008/rawsql-ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata with repository information for `ddl-docs-cli` and `ddl-docs-vitepress` packages.
  * Prepared patch version releases for both packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->