### PR TITLE
fix: republish adapter install graph for standalone tutorial

### DIFF
--- a/.changeset/bright-cups-happen.md
+++ b/.changeset/bright-cups-happen.md
@@ -1,0 +1,6 @@
+---
+"@rawsql-ts/adapter-node-pg": patch
+"@rawsql-ts/testkit-postgres": patch
+---
+
+Fix the published dependency graph for the PostgreSQL adapter tutorial path so standalone consumers can install `@rawsql-ts/adapter-node-pg` without a `workspace:` protocol leak.


### PR DESCRIPTION
## Summary
- Add a changeset so the adapter install graph fix is released again.
- Keep the standalone tutorial install path covered by publish-time verification.

## Verification
- Reproduced the standalone failure in C:\\Users\\mssgm\\CodexApp\\ztd-quickstart-dg with 
pm install -D @rawsql-ts/adapter-node-pg.
- Confirmed the published manifests for @rawsql-ts/adapter-node-pg and @rawsql-ts/testkit-postgres still contained workspace:^.
- Added a patch changeset for @rawsql-ts/adapter-node-pg and @rawsql-ts/testkit-postgres.
- Ran 
ode scripts/verify-published-package-mode.mjs successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue preventing standalone installation of the PostgreSQL adapter package.

* **Chores**
  * Updated dependency configuration for the PostgreSQL adapter and testkit packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->