### PR TITLE
Fix published query lint command-surface drift for join-direction docs

### DIFF
--- a/.changeset/issue-645-published-query-lint.md
+++ b/.changeset/issue-645-published-query-lint.md
@@ -1,0 +1,5 @@
+---
+'@rawsql-ts/ztd-cli': patch
+---
+
+Add a published-package verification gate that checks `ztd query lint --help` still exposes `--rules` and that `ztd query lint --rules join-direction <sql-file>` runs on the packed CLI path. This keeps the release contract aligned with the Further Reading docs for the join-direction lint command surface.

--- a/docs/guide/published-package-verification.md
+++ b/docs/guide/published-package-verification.md
@@ -18,6 +18,8 @@ This is not a perfect substitute for a real registry publish. It is a local veri
   - follow-up `npm install` still works
 - Phase B proves the first test quality gate:
   - `npx ztd ztd-config`
+  - `npx ztd query lint --help` still exposes `--rules`
+  - `npx ztd query lint --rules join-direction <sql-file>` parses on the packed CLI path
   - `npm run test`
   - the generated scaffold reaches a passing first smoke test on the npm-first consumer path
   - TypeScript compile checks for both default and Node16 settings as follow-up smoke coverage
@@ -43,7 +45,7 @@ The script will:
 3. Inspect each packed `package.json` for leaked `workspace:` references
 4. Create a standalone app under `tmp/published-package-check/packages/npm-primary-path`
 5. Run Phase A: `npm install`, `npx ztd init --yes`, completion-message assertions, and follow-up `npm install`
-6. Run Phase B: `npx ztd ztd-config`, `npm run test`, and TypeScript compile checks
+6. Run Phase B: `npx ztd ztd-config`, `npx ztd query lint --help`, `npx ztd query lint --rules join-direction <sql-file>`, `npm run test`, and TypeScript compile checks
 7. Write a machine-readable summary to `tmp/published-package-check/summary.json`
 
 ## How to interpret failures
@@ -54,6 +56,7 @@ The script will:
   - Treat this as a packaging or npm-primary-path regression.
 - Phase B fails after the npm-first setup completed.
   - Treat this as a first test quality gate regression on the published-package path.
+  - This now includes command-surface regressions where docs mention `query lint --rules join-direction` but the packed CLI no longer accepts `--rules`.
   - The local-source developer path may still be healthy.
 - The standalone smoke app passes, but local-source dogfooding fails.
   - Treat that as a developer-mode problem, not a packaging problem.

--- a/scripts/verify-published-package-mode.mjs
+++ b/scripts/verify-published-package-mode.mjs
@@ -333,6 +333,23 @@ function verifyNpmConsumerSmoke(phaseAResult) {
   // Phase B proves the first generated smoke test can pass on the npm-first consumer path.
   runIn(appDir, NPM, ["exec", "--", "ztd", "ztd-config"]);
 
+  // Keep the published command surface aligned with Further Reading docs by
+  // exercising the opt-in join-direction flag from the packed CLI artifact.
+  fs.mkdirSync(path.join(appDir, "tmp"), { recursive: true });
+  fs.writeFileSync(path.join(appDir, "tmp", "join-direction-smoke.sql"), "select 1;\n", "utf8");
+  const lintHelp = runIn(appDir, NPM, ["exec", "--", "ztd", "query", "lint", "--help"]);
+  assertIncludes(lintHelp.stdout, "--rules <list>", "phase-b query-lint-help-surface");
+  runIn(appDir, NPM, [
+    "exec",
+    "--",
+    "ztd",
+    "query",
+    "lint",
+    "--rules",
+    "join-direction",
+    "tmp/join-direction-smoke.sql",
+  ]);
+
   setPackageTypeModule(appDir);
   writeNode16Tsconfig(appDir);
 


### PR DESCRIPTION
## Summary
- add a published-package verification gate for `ztd query lint --help` exposing `--rules`
- run `ztd query lint --rules join-direction <sql-file>` on the packed CLI path
- document the new Phase B command-surface verification in the published-package guide

## Why
- issue #645 reported a mismatch between the join-direction Further Reading docs and the published package command surface
- the latest published `@rawsql-ts/ztd-cli@0.22.2` did not reproduce the reported `unknown option '--rules'` failure in a fresh consumer check
- adding this release gate prevents future docs/package drift from shipping unnoticed

## Verification
- `npm install @rawsql-ts/ztd-cli@0.22.2`
- `npx ztd query lint --help`
- `npx ztd query lint --rules join-direction sample.sql`
- `pnpm install --frozen-lockfile`
- `pnpm verify:published-package-mode`

Closes #645


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated published package verification guide with enhanced validation steps.

* **Tests**
  * Added verification tests to ensure CLI surface integrity during releases.

* **Chores**
  * Added release verification entry for package quality assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->