### PR TITLE
fix(ztd-cli): clarify published join-direction surface

### DIFF
--- a/.changeset/rare-bears-drum.md
+++ b/.changeset/rare-bears-drum.md
@@ -1,0 +1,7 @@
+---
+"@rawsql-ts/ztd-cli": patch
+---
+
+Republish `@rawsql-ts/ztd-cli` so the published CLI surface for `ztd query lint --rules join-direction` stays aligned with the current Further Reading docs.
+
+Clarify the public help and guide text so users can confirm that their installed CLI exposes `--rules` before trying the join-direction examples.

--- a/docs/guide/join-direction-lint-spec.md
+++ b/docs/guide/join-direction-lint-spec.md
@@ -8,6 +8,11 @@ title: JOIN Direction Lint Specification
 
 The goal is not to prove that one query is semantically wrong. The goal is to reduce review noise, AI-generated drift, and cognitive load by making join paths easier to read and compare.
 
+Before you try the examples on a published CLI, run `npx ztd query lint --help` first and confirm that the help output includes `--rules <list>`.
+
+- If `--rules` is present, the published package surface is new enough for the examples in this guide.
+- If `--rules` is missing or `unknown option '--rules'` appears, you are on an older published `@rawsql-ts/ztd-cli` release and should upgrade before using this guide as-written.
+
 ## Purpose
 
 This lint looks for inner-join patterns where the query walks **from a parent table down to a child table** even though DDL already defines a clear FK path in the opposite direction.

--- a/docs/guide/published-package-verification.md
+++ b/docs/guide/published-package-verification.md
@@ -29,6 +29,7 @@ This is not a perfect substitute for a real registry publish. It is a local veri
 - This check does **not** fully emulate npm registry resolution for every unpublished transitive dependency.
 - A real post-publish smoke check is still required.
 - Do not use this to claim that every package combination is already registry-valid.
+- When Further Reading docs mention `query lint --rules join-direction`, a real post-publish smoke check should also confirm that `npx ztd query lint --help` exposes `--rules <list>` on the published package.
 
 ## Canonical command
 

--- a/packages/ztd-cli/src/commands/query.ts
+++ b/packages/ztd-cli/src/commands/query.ts
@@ -203,6 +203,7 @@ Notes:
       'after',
       `
 Notes:
+  - If your installed CLI does not list --rules in this help output, upgrade to a newer published ztd-cli release before trying join-direction examples from Further Reading.
   - Use --rules join-direction to enable the FK-aware JOIN direction readability check.
   - Suppress a specific query with "-- ztd-lint-disable join-direction" when the reverse path is intentional.
   - The rule is opt-in in v1 and currently focuses on top-level inner joins with explicit FK evidence.

--- a/packages/ztd-cli/tests/cliCommands.test.ts
+++ b/packages/ztd-cli/tests/cliCommands.test.ts
@@ -1103,6 +1103,15 @@ test('ddl diff help explains review-first output and companion artifacts', () =>
   expect(result.stdout).toContain('SQL/.txt/.json artifacts');
 });
 
+test('query lint help exposes the published join-direction command surface', () => {
+  const result = runCli(['query', 'lint', '--help']);
+
+  assertCliSuccess(result, 'query lint help');
+  expect(result.stdout).toContain('--rules <list>');
+  expect(result.stdout).toContain('join-direction');
+  expect(result.stdout).toContain('upgrade to a newer published ztd-cli release');
+});
+
 test('ddl risk help explains post-hoc evaluation for hand-edited migration SQL', () => {
   const result = runCli(['ddl', 'risk', '--help']);
 

--- a/packages/ztd-cli/tests/furtherReading.docs.test.ts
+++ b/packages/ztd-cli/tests/furtherReading.docs.test.ts
@@ -144,6 +144,9 @@ test('Further Reading docs stay aligned with the current standalone and CLI beha
       docPath: 'docs/guide/join-direction-lint-spec.md',
       phrases: [
         '`ztd query lint --rules join-direction`',
+        '`npx ztd query lint --help`',
+        '`--rules <list>`',
+        '`unknown option \'--rules\'`',
         '`parent -> child` is not a universal anti-pattern.',
         'v1 uses **FK-only** relation evidence.',
         '`LEFT JOIN` can be a clean parent-first pattern when the query intentionally preserves the parent row set.',


### PR DESCRIPTION
## Summary

This PR addresses issue #651 by closing the gap between the documented `query lint --rules join-direction` surface and what published-package consumers can reliably discover and use.

The source tree already had the `--rules` implementation and packed published-package verification, but users can still hit an older published `@rawsql-ts/ztd-cli` and see:

```text
error: unknown option '--rules'
```

This PR does two things:

- adds a patch changeset so `@rawsql-ts/ztd-cli` is republished and the current command surface is guaranteed to ship again
- adds explicit self-diagnosis guidance so users can confirm `npx ztd query lint --help` exposes `--rules <list>` before following the Further Reading examples

## What changed

- added a patch changeset for `@rawsql-ts/ztd-cli`
- updated `query lint --help` to explain that missing `--rules` means the installed published CLI is too old for the join-direction examples
- updated `JOIN Direction Lint Specification` with a published-package self-check
- updated `Published-Package Verification Before Release` so real post-publish smoke checks explicitly confirm the `--rules` surface on the published package
- added regression coverage for:
  - `query lint --help` exposing `--rules <list>`
  - the new upgrade/self-diagnosis wording
  - Further Reading docs staying aligned with that guidance

## Why

Issue #651 is not primarily a missing source implementation problem. The command surface is already present in source and already covered on the packed tarball path.

The mismatch is that a user can still encounter an older published package while reading current docs. That creates two needs:

- the next release must definitely republish `@rawsql-ts/ztd-cli`
- docs and help must let users distinguish “my published CLI is old” from “the docs are wrong”

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter @rawsql-ts/ztd-cli test -- cliCommands.test.ts furtherReading.docs.test.ts`
- `pnpm --filter @rawsql-ts/ztd-cli build`
- `pnpm verify:published-package-mode`

## Notes

- The packed published-package path is already green on this branch.
- This PR improves the user-facing path while also forcing a fresh `@rawsql-ts/ztd-cli` publish via changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated CLI help text for `ztd query lint` to clarify the `--rules` option requirement for join-direction examples.
  * Added prerequisite section to guide directing users to verify `--rules` support before proceeding with examples.

* **Tests**
  * Added tests to verify CLI help output and documentation alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->