### PR TITLE
feat(query-uses): make VSA spec discovery project-wide

### DIFF
--- a/.changeset/khaki-timers-smile.md
+++ b/.changeset/khaki-timers-smile.md
@@ -1,0 +1,6 @@
+---
+'@rawsql-ts/sql-grep-core': patch
+'@rawsql-ts/ztd-cli': patch
+---
+
+Improve `query uses` for feature-local VSA projects by discovering QuerySpec files from the project tree, preferring spec-relative SQL resolution, and clarifying the VSA-first impact-analysis contract in docs and CLI help.

--- a/docs/dogfooding/ztd-migration-lifecycle.md
+++ b/docs/dogfooding/ztd-migration-lifecycle.md
@@ -17,7 +17,7 @@ These prompts are intended to be copied into a separate AI instance, so the tuto
 
 ## Preferred CLI by scenario
 
-- DDL repair: `npx ztd query uses column users.email --sql-root src/features/users/persistence --specs-dir src/features/users/persistence --any-schema --view detail`
+- DDL repair: `npx ztd query uses column users.email --specs-dir src/features/users/persistence --any-schema --view detail`
 - SQL repair: `npx ztd model-gen --probe-mode ztd --sql-root src/features/users/persistence src/features/users/persistence/users.sql --out src/features/users/persistence/users.spec.ts`
 - DTO repair: `npx vitest run`
 - migration artifact creation: `npx ztd ztd-config`, optionally `npx ztd ddl pull --url <target-db-url>` to inspect the target, then `npx ztd ddl diff --url <target-db-url> --out tmp/users.diff.sql` to generate review output plus SQL; if you hand-edit the migration afterward, run `npx ztd ddl risk --file tmp/users.diff.sql` to re-evaluate the final SQL with the same structured risk contract
@@ -30,7 +30,7 @@ These prompts are intended to be copied into a separate AI instance, so the tuto
 ```text
 I changed the DDL for users.
 Read the nearest AGENTS.md files first.
-Run `npx ztd query uses column users.email --sql-root src/features/users/persistence --specs-dir src/features/users/persistence --any-schema --view detail` to find the affected SQL files before you edit anything.
+Run `npx ztd query uses column users.email --specs-dir src/features/users/persistence --any-schema --view detail` to find the affected SQL files before you edit anything. The feature folder is one narrowed spec set inside the normal project-wide discovery flow.
 Fix the tests and feature code that now fail.
 Do not apply migrations automatically.
 ```

--- a/docs/guide/query-uses-impact-checks.md
+++ b/docs/guide/query-uses-impact-checks.md
@@ -14,6 +14,8 @@ This page covers the `table` and `column` impact checks with examples based on a
 
 Implementation note: the CLI command is provided by `@rawsql-ts/ztd-cli`, while the reusable analysis engine now lives in `@rawsql-ts/sql-grep-core`.
 
+The active scan set is **project-wide by default**. `query uses` discovers QuerySpec entries under the current project root and follows each spec's `sqlFile`. Use `--specs-dir` only when you want to narrow the scan to one slice or sub-tree.
+
 ## Quick start
 
 The default view is `impact`, which is the fastest first pass for "used or not, and by which queries?".
@@ -40,7 +42,7 @@ npx ztd query uses column public.sale_items.quantity --exclude-generated
 npx ztd query uses table public.sale_lines --view detail --exclude-generated
 ```
 
-`--exclude-generated` only excludes specs under `src/catalog/specs/generated`. The flag is optional, and the default scan set is unchanged.
+`--exclude-generated` only excludes QuerySpec files under `generated` directories. The flag is optional, and the default scan set is unchanged.
 
 ## When to use which command
 
@@ -225,12 +227,18 @@ Expected pattern:
 
 ### `unresolved sql files` is not zero
 
-Check that your `spec.sqlFile` values still point at the project SQL root. `query uses` resolves `spec.sqlFile` against `src/sql` first and then falls back to the legacy spec-relative behavior for backward compatibility.
+Check that your `spec.sqlFile` values still resolve from the spec itself first. `query uses` prefers feature-local spec-relative paths, then tries project-relative paths, and only uses `--sql-root` as an explicit shared-root fallback.
 
 If needed, be explicit:
 
 ```bash
 npx ztd query uses table public.users --sql-root src/sql
+```
+
+For feature-local layouts, keep the spec and SQL together and let the default resolver work without `--sql-root`:
+
+```bash
+npx ztd query uses column users.email --specs-dir src/features/users/persistence --any-schema --view detail
 ```
 
 ### Matches look noisy
@@ -251,5 +259,6 @@ npx ztd query uses table public.sale_items --view detail --exclude-generated
 
 1. Start with the default `impact` view.
 2. Add `--exclude-generated` for rename or type-change checks.
-3. Use `--view detail` only when you need line-level evidence.
-4. Treat `unresolved sql files` as a signal that the scan setup needs attention before you trust the result.
+3. Use `--specs-dir` only when you need to narrow a project-wide search to one feature.
+4. Use `--view detail` only when you need line-level evidence.
+5. Treat `unresolved sql files` as a signal that the scan setup needs attention before you trust the result.

--- a/docs/guide/query-uses-overview.md
+++ b/docs/guide/query-uses-overview.md
@@ -10,24 +10,28 @@ The command-line UX is provided by `@rawsql-ts/ztd-cli`, and the reusable analys
 
 ## Prerequisites
 
-`ztd query uses` scans **SQL catalog spec files** — the JSON or TypeScript specs that `ztd init` generates under `src/catalog/specs/`. Each spec references a SQL file via its `sqlFile` field, and the command parses those SQL files for analysis.
+`ztd query uses` scans the active **QuerySpec set** for the project. By default it discovers JSON or TypeScript specs recursively under the current project root, then follows each spec's `sqlFile` field and parses the referenced SQL for analysis.
 
-**Minimum project structure:**
+**Common project shapes:**
 
 ```text
 project-root/
 ├── src/
-│   ├── catalog/
-│   │   └── specs/           ← spec files live here (default)
-│   │       └── users.spec.json
-│   └── sql/                 ← SQL files live here (default)
-│       └── users/
-│           └── list.sql
+│   └── features/
+│       ├── users/
+│       │   └── persistence/
+│       │       ├── users.spec.ts
+│       │       └── users.sql
+│       └── orders/
+│           └── persistence/
+│               ├── orders.spec.ts
+│               └── orders.sql
 ```
 
 - **Spec files are required.** Plain `.sql` files without a spec are not scanned. If you have not run `ztd init` yet, start there.
-- **Subdirectories are scanned recursively.** All specs under the specs directory (including nested folders) are discovered automatically.
-- **Default paths are convention-based.** Specs default to `src/catalog/specs`, SQL root defaults to `src/sql`. Both can be overridden with `--specs-dir` and `--sql-root`.
+- **Project-wide discovery is the default.** QuerySpec files are discovered recursively under the project root unless you narrow the scan with `--specs-dir`.
+- **Feature-local specs are first-class.** The preferred contract is a spec that keeps `sqlFile` relative to the spec itself, for example `./users.sql`.
+- **Shared SQL roots still work.** If your project intentionally keeps SQL in one shared tree, you can still use `--sql-root` as a fallback resolver.
 - **No database connection is needed.** The analysis is purely static. It parses SQL text, not a live schema.
 
 ## Why not grep?
@@ -90,6 +94,8 @@ npx ztd query uses table public.sale_lines --exclude-generated --format json
 Use `--out <path>` to write the result to a file instead of stdout, which is useful for piping into downstream tools or archiving evidence.
 
 If you need the same AST-based impact analysis in your own tooling, import `@rawsql-ts/sql-grep-core` directly and call the report builder without the rest of the CLI.
+
+The command does **not** scan every `.sql` file in the repository blindly. It scans the SQL files referenced by the active QuerySpec set, so unregistered SQL stays outside the impact report until it has a spec.
 
 ## When to use it
 

--- a/docs/guide/sql-first-end-to-end-tutorial.md
+++ b/docs/guide/sql-first-end-to-end-tutorial.md
@@ -22,7 +22,7 @@ README gives the first-run copy-paste path. This tutorial gives the scenario-lev
 
 | Scenario | Primary CLI | Why |
 | --- | --- | --- |
-| DDL repair | `npx ztd query uses column users.email --sql-root src/features/users/persistence --specs-dir src/features/users/persistence --any-schema --view detail` | Find the impacted feature-local SQL files before editing them |
+| DDL repair | `npx ztd query uses column users.email --specs-dir src/features/users/persistence --any-schema --view detail` | Find the impacted feature-local SQL files before editing them |
 | SQL repair | `npx ztd model-gen --probe-mode ztd --sql-root src/features/users/persistence src/features/users/persistence/users.sql --out src/features/users/persistence/users.spec.ts` | Regenerate the spec from the feature-local SQL asset |
 | DTO repair | `npx vitest run` after the DTO change | Verify the feature-local runtime and tests after the shape change |
 | migration | `npx ztd ztd-config`, optionally `npx ztd ddl pull --url <target-db-url>` to inspect the target, then `npx ztd ddl diff --url <target-db-url> --out tmp/users.diff.sql` to prepare review output plus apply SQL | Prepare a manually applied migration without asking ztd-cli to deploy it |
@@ -123,7 +123,7 @@ Use the same `users` project for each scenario:
 
 Each scenario should end with `vitest` passing again.
 
-For DDL repair, run `npx ztd query uses column users.email --sql-root src/features/users/persistence --specs-dir src/features/users/persistence --any-schema --view detail` first so the impacted SQL files come from the CLI, not from guesswork.
+For DDL repair, run `npx ztd query uses column users.email --specs-dir src/features/users/persistence --any-schema --view detail` first so the impacted SQL files come from the CLI, not from guesswork. Passing the feature folder as `--specs-dir` is a normal way to narrow the project-wide scan, not a workaround for feature-local layouts.
 
 For SQL repair, keep the SQL assets under the feature folder, keep the query on the starter DDL's `users` table, and pass that folder explicitly as `--sql-root` when you ask `model-gen` to refresh the spec.
 

--- a/packages/sql-grep-core/src/query/report.ts
+++ b/packages/sql-grep-core/src/query/report.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import {
+  discoverProjectSqlCatalogSpecFiles,
   loadSqlCatalogSpecsFromFile,
   walkSqlCatalogSpecFiles,
 } from '../utils/sqlCatalogDiscovery';
@@ -53,13 +54,15 @@ function runSpan<T>(withSpanSync: QueryUsageSpanRunner | undefined, name: string
 }
 
 /**
- * Build a deterministic impact or detail investigation report from catalog specs.
+ * Build a deterministic impact or detail investigation report from discovered QuerySpec entries.
  */
 export function buildQueryUsageReport(params: BuildQueryUsageReportParams): QueryUsageReport {
   const rootDir = path.resolve(params.rootDir ?? process.cwd());
-  const specsDir = params.specsDir ? path.resolve(rootDir, params.specsDir) : path.resolve(rootDir, 'src', 'catalog', 'specs');
-  const sqlRoot = params.sqlRoot ? path.resolve(rootDir, params.sqlRoot) : path.resolve(rootDir, 'src', 'sql');
-  const normalizedSqlRoot = normalizePath(path.relative(rootDir, sqlRoot) || '.');
+  const specsDir = params.specsDir ? path.resolve(rootDir, params.specsDir) : rootDir;
+  const sqlRoot = params.sqlRoot ? path.resolve(rootDir, params.sqlRoot) : null;
+  const legacySqlRoot = path.resolve(rootDir, 'src', 'sql');
+  const normalizedSqlRoot = sqlRoot ? normalizePath(path.relative(rootDir, sqlRoot) || '.') : null;
+  const normalizedLegacySqlRoot = normalizePath(path.relative(rootDir, legacySqlRoot) || '.');
   const view = params.view ?? 'impact';
   const parsedTarget = parseQueryTarget({
     kind: params.kind,
@@ -72,7 +75,15 @@ export function buildQueryUsageReport(params: BuildQueryUsageReportParams): Quer
     const warnings: QueryUsageReport['warnings'] = [];
     const discovery = runSpan(params.withSpanSync, QUERY_USES_REPORT_SPANS.specDiscovery, () => {
       const specFiles = existsSync(specsDir)
-        ? walkSqlCatalogSpecFiles(specsDir, { excludeGenerated: params.excludeGenerated })
+        ? params.specsDir
+          ? walkSqlCatalogSpecFiles(specsDir, {
+            excludeGenerated: params.excludeGenerated,
+            excludeTestFiles: true,
+          })
+          : discoverProjectSqlCatalogSpecFiles(rootDir, {
+            excludeGenerated: params.excludeGenerated,
+            excludeTestFiles: true,
+          })
         : [];
       const loadedSpecs = specFiles.flatMap((filePath) => {
         try {
@@ -100,10 +111,16 @@ export function buildQueryUsageReport(params: BuildQueryUsageReportParams): Quer
     let fallbackMatches = 0;
 
     if (discovery.loadedSpecs.length === 0) {
+      const activeScope = params.specsDir
+        ? normalizePath(path.relative(rootDir, specsDir) || '.')
+        : '.';
       warnings.push({
         code: 'no-catalog-specs-found',
-        message: `No catalog specs found under ${normalizePath(path.relative(rootDir, specsDir) || '.')}.
-Hint: run "ztd init" or pass "--specs-dir".`,
+        message: params.specsDir
+          ? `No QuerySpec entries found under ${activeScope}.
+Hint: pass a narrower --specs-dir only when you need to limit the active spec set.`
+          : `No QuerySpec entries were discovered under ${activeScope}.
+Hint: run "ztd init" or place feature-local specs under your project tree. Use --specs-dir only when you need to narrow the scan.`,
       });
     }
 
@@ -129,23 +146,33 @@ Hint: run "ztd init" or pass "--specs-dir".`,
       }
 
       const resolvedSqlFile = resolveCatalogSqlFile({
+        rootDir,
         sqlRoot,
+        legacySqlRoot,
         specFilePath: loaded.filePath,
         sqlFile,
       });
       if (!resolvedSqlFile) {
         unresolvedSqlFiles += 1;
-        const projectRootCandidate = normalizePath(path.relative(rootDir, path.resolve(sqlRoot, sqlFile)));
         const specRelativeCandidate = normalizePath(path.relative(rootDir, path.resolve(path.dirname(loaded.filePath), sqlFile)));
+        const projectRelativeCandidate = normalizePath(path.relative(rootDir, path.resolve(rootDir, sqlFile)));
+        const sqlRootCandidate = sqlRoot
+          ? normalizePath(path.relative(rootDir, path.resolve(sqlRoot, sqlFile)))
+          : null;
+        const legacySqlRootCandidate = normalizePath(path.relative(rootDir, path.resolve(legacySqlRoot, sqlFile)));
         warnings.push({
           catalog_id: catalogId,
-          sql_file: projectRootCandidate,
+          sql_file: specRelativeCandidate,
           code: 'unresolved-sql-file',
           message: [
             `SQL file does not exist: ${sqlFile}`,
-            `Tried project SQL root (${normalizedSqlRoot}): ${projectRootCandidate}`,
-            `Tried spec-relative fallback: ${specRelativeCandidate}`,
-            `Hint: keep existing sqlFile values unchanged and re-run with --sql-root ${normalizedSqlRoot} if your project stores SQL under a shared root.`,
+            `Tried spec-relative path: ${specRelativeCandidate}`,
+            `Tried project-relative path: ${projectRelativeCandidate}`,
+            ...(sqlRootCandidate && normalizedSqlRoot
+              ? [`Tried --sql-root (${normalizedSqlRoot}): ${sqlRootCandidate}`]
+              : []),
+            `Tried legacy shared root (${normalizedLegacySqlRoot}): ${legacySqlRootCandidate}`,
+            `Hint: prefer feature-local spec-relative sqlFile values. Use --sql-root only when your specs intentionally point into a shared SQL root.`,
           ].join('\n'),
         });
         continue;
@@ -417,20 +444,36 @@ function normalizePath(input: string): string {
 }
 
 function resolveCatalogSqlFile(params: {
-  sqlRoot: string;
+  rootDir: string;
+  sqlRoot: string | null;
+  legacySqlRoot: string;
   specFilePath: string;
   sqlFile: string;
 }): string | null {
-  // Prefer the project-level SQL root because existing QuerySpec sqlFile values are root-relative by convention.
-  const projectRootCandidate = path.resolve(params.sqlRoot, params.sqlFile);
-  if (existsSync(projectRootCandidate)) {
-    return projectRootCandidate;
-  }
-
-  // Preserve backward compatibility for specs that stored sqlFile relative to the spec file itself.
+  // Prefer spec-local ownership so feature-first projects do not need one shared SQL root.
   const specRelativeCandidate = path.resolve(path.dirname(params.specFilePath), params.sqlFile);
   if (existsSync(specRelativeCandidate)) {
     return specRelativeCandidate;
+  }
+
+  // Allow project-relative sqlFile values for repos that keep specs and SQL in separate trees.
+  const projectRelativeCandidate = path.resolve(params.rootDir, params.sqlFile);
+  if (existsSync(projectRelativeCandidate)) {
+    return projectRelativeCandidate;
+  }
+
+  // Preserve the older shared-root escape hatch when callers opt into --sql-root explicitly.
+  if (params.sqlRoot) {
+    const sharedRootCandidate = path.resolve(params.sqlRoot, params.sqlFile);
+    if (existsSync(sharedRootCandidate)) {
+      return sharedRootCandidate;
+    }
+  }
+
+  // Keep older src/sql-based projects working while spec-relative layouts become the preferred contract.
+  const legacySharedRootCandidate = path.resolve(params.legacySqlRoot, params.sqlFile);
+  if (existsSync(legacySharedRootCandidate)) {
+    return legacySharedRootCandidate;
   }
 
   return null;

--- a/packages/sql-grep-core/src/utils/sqlCatalogDiscovery.ts
+++ b/packages/sql-grep-core/src/utils/sqlCatalogDiscovery.ts
@@ -1,6 +1,22 @@
 import { readFileSync, readdirSync } from 'node:fs';
 import path from 'node:path';
 
+const DEFAULT_DISCOVERY_IGNORED_DIRS = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  'build',
+  'coverage',
+  'tmp',
+  'test',
+  'tests',
+  '__tests__',
+  '.turbo',
+  '.next',
+  '.nuxt',
+  'out',
+]);
+
 /**
  * Minimal SQL catalog spec shape shared across command-layer discovery flows.
  */
@@ -38,8 +54,27 @@ export function walkSqlCatalogSpecFiles(
   rootDir: string,
   options?: { excludeTestFiles?: boolean; excludeGenerated?: boolean }
 ): string[] {
+  return collectSqlCatalogSpecFiles(rootDir, rootDir, options);
+}
+
+/**
+ * Discover QuerySpec-like files from the project root without assuming one fixed specs directory.
+ */
+export function discoverProjectSqlCatalogSpecFiles(
+  projectRoot: string,
+  options?: { excludeTestFiles?: boolean; excludeGenerated?: boolean }
+): string[] {
+  return collectSqlCatalogSpecFiles(projectRoot, projectRoot, options, true);
+}
+
+function collectSqlCatalogSpecFiles(
+  walkRoot: string,
+  generatedScopeRoot: string,
+  options?: { excludeTestFiles?: boolean; excludeGenerated?: boolean },
+  useProjectWideIgnores = false
+): string[] {
   const files: string[] = [];
-  const stack = [rootDir];
+  const stack = [walkRoot];
   while (stack.length > 0) {
     const current = stack.pop()!;
     const entries = readdirSync(current, { withFileTypes: true })
@@ -47,6 +82,9 @@ export function walkSqlCatalogSpecFiles(
     for (const entry of entries) {
       const absolute = path.join(current, entry.name);
       if (entry.isDirectory()) {
+        if (useProjectWideIgnores && shouldIgnoreDiscoveryDirectory(entry.name)) {
+          continue;
+        }
         stack.push(absolute);
         continue;
       }
@@ -68,7 +106,7 @@ export function walkSqlCatalogSpecFiles(
       if (options?.excludeTestFiles && lowered.includes('.test.')) {
         continue;
       }
-      if (options?.excludeGenerated && isGeneratedSpecPath(absolute, rootDir)) {
+      if (options?.excludeGenerated && isGeneratedSpecPath(absolute, generatedScopeRoot)) {
         continue;
       }
       files.push(absolute);
@@ -86,9 +124,14 @@ export function loadSqlCatalogSpecsFromFile(
 ): LoadedSqlCatalogSpec[] {
   const ext = path.extname(filePath).toLowerCase();
   if (ext === '.json') {
+    const source = readFileSync(filePath, 'utf8');
+    if (!looksLikeSpecFile(filePath) && !source.includes('"sqlFile"') && !source.includes('sqlFile')) {
+      return [];
+    }
+
     let parsed: unknown;
     try {
-      parsed = JSON.parse(readFileSync(filePath, 'utf8'));
+      parsed = JSON.parse(source);
     } catch (error) {
       throw createError(
         `Failed to parse spec file ${filePath}: ${error instanceof Error ? error.message : String(error)}`
@@ -96,20 +139,26 @@ export function loadSqlCatalogSpecsFromFile(
     }
 
     if (Array.isArray(parsed)) {
-      return parsed.map((spec) => ({ spec: spec as SqlCatalogSpecLike, filePath }));
+      return parsed
+        .filter(isSpecLikeRecord)
+        .map((spec) => ({ spec: spec as SqlCatalogSpecLike, filePath }));
     }
     if (isPlainObject(parsed) && Array.isArray((parsed as Record<string, unknown>).specs)) {
       const specs = (parsed as { specs: unknown[] }).specs;
-      return specs.map((spec) => ({ spec: spec as SqlCatalogSpecLike, filePath }));
+      return specs
+        .filter(isSpecLikeRecord)
+        .map((spec) => ({ spec: spec as SqlCatalogSpecLike, filePath }));
     }
-    if (isPlainObject(parsed)) {
+    if (isSpecLikeRecord(parsed)) {
       return [{ spec: parsed as SqlCatalogSpecLike, filePath }];
     }
-
-    throw createError(`Unsupported spec format in ${filePath}`);
+    return [];
   }
 
   const source = readFileSync(filePath, 'utf8');
+  if (!looksLikeSpecFile(filePath) && !source.includes('sqlFile')) {
+    return [];
+  }
   const blocks = extractTsJsSpecBlocks(source);
   return blocks.map((block) => {
     const id = block.match(/id\s*:\s*['"`]([^'"`]+)['"`]/)?.[1];
@@ -204,8 +253,27 @@ export function isPlainObject(value: unknown): value is Record<string, unknown> 
 }
 
 function isGeneratedSpecPath(filePath: string, specsDir: string): boolean {
-  const generatedDir = path.resolve(specsDir, 'generated');
+  const normalizedScopeRoot = path.resolve(specsDir);
   const normalizedFilePath = path.resolve(filePath);
-  const relativePath = path.relative(generatedDir, normalizedFilePath);
-  return relativePath.length > 0 && !relativePath.startsWith('..') && !path.isAbsolute(relativePath);
+  const relativePath = path.relative(normalizedScopeRoot, normalizedFilePath);
+  if (relativePath.length === 0 || relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    return false;
+  }
+
+  return relativePath
+    .split(path.sep)
+    .some((segment) => segment.trim().toLowerCase() === 'generated');
+}
+
+function shouldIgnoreDiscoveryDirectory(dirName: string): boolean {
+  return DEFAULT_DISCOVERY_IGNORED_DIRS.has(dirName.toLowerCase());
+}
+
+function isSpecLikeRecord(value: unknown): value is Record<string, unknown> {
+  return isPlainObject(value) && typeof value.sqlFile === 'string' && value.sqlFile.trim().length > 0;
+}
+
+function looksLikeSpecFile(filePath: string): boolean {
+  const normalized = path.basename(filePath).toLowerCase();
+  return normalized.includes('.spec.') || normalized.includes('.generated.');
 }

--- a/packages/ztd-cli/src/commands/query.ts
+++ b/packages/ztd-cli/src/commands/query.ts
@@ -74,7 +74,7 @@ export const QUERY_USES_COMMAND_SPANS = {
  * Register strict-first impact investigation commands on the CLI root.
  */
 export function registerQueryCommands(program: Command): void {
-  const query = program.command('query').description('Impact investigation for SQL catalog assets');
+  const query = program.command('query').description('Impact investigation for project QuerySpec-backed SQL assets');
   query.addHelpText(
     'after',
     `
@@ -95,7 +95,10 @@ Notes:
   - Strict mode is the default. Relaxed modes are explicit opt-in only.
   - Impact is the default view. Use --view detail for edit-ready locations/snippets.
   - Impact representatives may omit select snippets; use --view detail for edit-ready SELECT occurrences.
-  - Use --exclude-generated to skip specs under src/catalog/specs/generated when those files are review-only noise.
+  - Project-wide discovery is the default. query uses scans QuerySpec entries discovered under the current project root.
+  - Use --specs-dir only to narrow the active spec set to one slice or sub-tree.
+  - Use --sql-root only when specs intentionally point into a shared SQL root instead of staying feature-local.
+  - Use --exclude-generated to skip QuerySpec files under generated directories when those files are review-only noise.
   - Static column analysis is inherently uncertain and labels ambiguity via confidence/notes.
   - exprHints: best-effort only. Absence of exprHints does not imply the feature is not present.
   - statement_fingerprint is stable across formatting/comment changes under the current normalization contract.
@@ -112,9 +115,9 @@ Notes:
     .description('Find statements that use a table target')
     .option('--format <format>', 'Output format (text|json)', 'text')
     .option('--view <view>', 'Investigation view (impact|detail)', 'impact')
-    .option('--specs-dir <path>', 'Override SQL catalog specs directory (default: src/catalog/specs)')
-    .option('--sql-root <path>', 'Resolve sqlFile paths relative to the project SQL root first (default: src/sql)')
-    .option('--exclude-generated', 'Exclude specs under src/catalog/specs/generated from scan targets')
+    .option('--specs-dir <path>', 'Limit discovery to one QuerySpec subtree instead of scanning the whole project')
+    .option('--sql-root <path>', 'Optional fallback root for shared sqlFile layouts when specs are not feature-local')
+    .option('--exclude-generated', 'Exclude QuerySpec files under generated directories from scan targets')
     .option('--out <path>', 'Write output to file')
     .option('--summary-only', 'Emit summary counts without per-match details')
     .option('--limit <count>', 'Limit returned matches and warnings in the output')
@@ -130,9 +133,9 @@ Notes:
     .description('Find statements that use a column target')
     .option('--format <format>', 'Output format (text|json)', 'text')
     .option('--view <view>', 'Investigation view (impact|detail)', 'impact')
-    .option('--specs-dir <path>', 'Override SQL catalog specs directory (default: src/catalog/specs)')
-    .option('--sql-root <path>', 'Resolve sqlFile paths relative to the project SQL root first (default: src/sql)')
-    .option('--exclude-generated', 'Exclude specs under src/catalog/specs/generated from scan targets')
+    .option('--specs-dir <path>', 'Limit discovery to one QuerySpec subtree instead of scanning the whole project')
+    .option('--sql-root <path>', 'Optional fallback root for shared sqlFile layouts when specs are not feature-local')
+    .option('--exclude-generated', 'Exclude QuerySpec files under generated directories from scan targets')
     .option('--out <path>', 'Write output to file')
     .option('--summary-only', 'Emit summary counts without per-match details')
     .option('--limit <count>', 'Limit returned matches and warnings in the output')
@@ -145,6 +148,8 @@ Notes:
 Notes:
   - Impact is the default view. Use --view detail if you need edit-ready locations/snippets.
   - Impact representatives may omit select snippets; use --view detail for edit-ready SELECT occurrences.
+  - Project-wide discovery is the default. Use --specs-dir only when you want to narrow the active spec set.
+  - Feature-local spec-relative sqlFile values are the preferred contract. Use --sql-root only for shared-root fallback.
   - exprHints: best-effort only. Absence of exprHints does not imply the feature is not present.
 `
     )

--- a/packages/ztd-cli/src/utils/sqlCatalogDiscovery.ts
+++ b/packages/ztd-cli/src/utils/sqlCatalogDiscovery.ts
@@ -1,6 +1,22 @@
 import { readFileSync, readdirSync } from 'node:fs';
 import path from 'node:path';
 
+const DEFAULT_DISCOVERY_IGNORED_DIRS = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  'build',
+  'coverage',
+  'tmp',
+  'test',
+  'tests',
+  '__tests__',
+  '.turbo',
+  '.next',
+  '.nuxt',
+  'out',
+]);
+
 /**
  * Minimal SQL catalog spec shape shared across command-layer discovery flows.
  */
@@ -38,8 +54,27 @@ export function walkSqlCatalogSpecFiles(
   rootDir: string,
   options?: { excludeTestFiles?: boolean; excludeGenerated?: boolean }
 ): string[] {
+  return collectSqlCatalogSpecFiles(rootDir, rootDir, options);
+}
+
+/**
+ * Discover QuerySpec-like files from the project root without assuming one fixed specs directory.
+ */
+export function discoverProjectSqlCatalogSpecFiles(
+  projectRoot: string,
+  options?: { excludeTestFiles?: boolean; excludeGenerated?: boolean }
+): string[] {
+  return collectSqlCatalogSpecFiles(projectRoot, projectRoot, options, true);
+}
+
+function collectSqlCatalogSpecFiles(
+  walkRoot: string,
+  generatedScopeRoot: string,
+  options?: { excludeTestFiles?: boolean; excludeGenerated?: boolean },
+  useProjectWideIgnores = false
+): string[] {
   const files: string[] = [];
-  const stack = [rootDir];
+  const stack = [walkRoot];
   while (stack.length > 0) {
     const current = stack.pop()!;
     const entries = readdirSync(current, { withFileTypes: true })
@@ -47,6 +82,9 @@ export function walkSqlCatalogSpecFiles(
     for (const entry of entries) {
       const absolute = path.join(current, entry.name);
       if (entry.isDirectory()) {
+        if (useProjectWideIgnores && shouldIgnoreDiscoveryDirectory(entry.name)) {
+          continue;
+        }
         stack.push(absolute);
         continue;
       }
@@ -68,7 +106,7 @@ export function walkSqlCatalogSpecFiles(
       if (options?.excludeTestFiles && lowered.includes('.test.')) {
         continue;
       }
-      if (options?.excludeGenerated && isGeneratedSpecPath(absolute, rootDir)) {
+      if (options?.excludeGenerated && isGeneratedSpecPath(absolute, generatedScopeRoot)) {
         continue;
       }
       files.push(absolute);
@@ -86,9 +124,14 @@ export function loadSqlCatalogSpecsFromFile(
 ): LoadedSqlCatalogSpec[] {
   const ext = path.extname(filePath).toLowerCase();
   if (ext === '.json') {
+    const source = readFileSync(filePath, 'utf8');
+    if (!looksLikeSpecFile(filePath) && !source.includes('"sqlFile"') && !source.includes('sqlFile')) {
+      return [];
+    }
+
     let parsed: unknown;
     try {
-      parsed = JSON.parse(readFileSync(filePath, 'utf8'));
+      parsed = JSON.parse(source);
     } catch (error) {
       throw createError(
         `Failed to parse spec file ${filePath}: ${error instanceof Error ? error.message : String(error)}`
@@ -96,20 +139,26 @@ export function loadSqlCatalogSpecsFromFile(
     }
 
     if (Array.isArray(parsed)) {
-      return parsed.map((spec) => ({ spec: spec as SqlCatalogSpecLike, filePath }));
+      return parsed
+        .filter(isSpecLikeRecord)
+        .map((spec) => ({ spec: spec as SqlCatalogSpecLike, filePath }));
     }
     if (isPlainObject(parsed) && Array.isArray((parsed as Record<string, unknown>).specs)) {
       const specs = (parsed as { specs: unknown[] }).specs;
-      return specs.map((spec) => ({ spec: spec as SqlCatalogSpecLike, filePath }));
+      return specs
+        .filter(isSpecLikeRecord)
+        .map((spec) => ({ spec: spec as SqlCatalogSpecLike, filePath }));
     }
-    if (isPlainObject(parsed)) {
+    if (isSpecLikeRecord(parsed)) {
       return [{ spec: parsed as SqlCatalogSpecLike, filePath }];
     }
-
-    throw createError(`Unsupported spec format in ${filePath}`);
+    return [];
   }
 
   const source = readFileSync(filePath, 'utf8');
+  if (!looksLikeSpecFile(filePath) && !source.includes('sqlFile')) {
+    return [];
+  }
   const blocks = extractTsJsSpecBlocks(source);
   return blocks.map((block) => {
     const id = block.match(/id\s*:\s*['"`]([^'"`]+)['"`]/)?.[1];
@@ -206,10 +255,23 @@ export function isPlainObject(value: unknown): value is Record<string, unknown> 
 function isGeneratedSpecPath(filePath: string, specsDir: string): boolean {
   const normalizedFilePath = path.resolve(filePath);
   const relativePath = path.relative(path.resolve(specsDir), normalizedFilePath);
-  if (relativePath === '') {
+  if (relativePath === '' || relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
     return false;
   }
 
   const segments = relativePath.split(path.sep);
-  return segments.includes('generated') || path.basename(normalizedFilePath).includes('.generated.');
+  return segments.some((segment) => segment.trim().toLowerCase() === 'generated');
+}
+
+function shouldIgnoreDiscoveryDirectory(dirName: string): boolean {
+  return DEFAULT_DISCOVERY_IGNORED_DIRS.has(dirName.toLowerCase());
+}
+
+function isSpecLikeRecord(value: unknown): value is Record<string, unknown> {
+  return isPlainObject(value) && typeof value.sqlFile === 'string' && value.sqlFile.trim().length > 0;
+}
+
+function looksLikeSpecFile(filePath: string): boolean {
+  const normalized = path.basename(filePath).toLowerCase();
+  return normalized.includes('.spec.') || normalized.includes('.generated.');
 }

--- a/packages/ztd-cli/templates/src/features/smoke/persistence/smoke.spec.ts
+++ b/packages/ztd-cli/templates/src/features/smoke/persistence/smoke.spec.ts
@@ -1,6 +1,6 @@
 export const smokeSpec = {
   id: 'features.smoke.persistence.smoke',
-  sqlFile: 'src/features/smoke/persistence/smoke.sql',
+  sqlFile: './smoke.sql',
   params: {
     shape: 'named',
     example: {

--- a/packages/ztd-cli/tests/furtherReading.docs.test.ts
+++ b/packages/ztd-cli/tests/furtherReading.docs.test.ts
@@ -45,6 +45,8 @@ test('Further Reading docs stay aligned with the current standalone and CLI beha
         'If port `5432` is already in use, stop the conflicting process or run Postgres on another port and update `ZTD_TEST_DATABASE_URL`, for example:',
         'docker run -d --rm --name ztd-starter-pg',
         '-p 5433:5432',
+        'npx ztd query uses column users.email --specs-dir src/features/users/persistence --any-schema --view detail',
+        'Passing the feature folder as `--specs-dir` is a normal way to narrow the project-wide scan, not a workaround for feature-local layouts.',
         'npx ztd model-gen --probe-mode ztd --sql-root src/features/users/persistence src/features/users/persistence/users.sql --out src/features/users/persistence/users.spec.ts',
         'Read the review summary first:',
         '- the risks section lists destructive and operational apply-plan risks separately',
@@ -62,8 +64,18 @@ test('Further Reading docs stay aligned with the current standalone and CLI beha
         'npx ztd ddl risk --file tmp/users.diff.sql',
         '`ZTD_TEST_DATABASE_URL` is the only implicit database owned by ztd-cli.',
         'Use `--url` or a full `--db-*` flag set for any other inspection target.',
+        'The feature folder is one narrowed spec set inside the normal project-wide discovery flow.',
         'inspect the structured risks second',
         'Do not apply migrations automatically.'
+      ]
+    },
+    {
+      docPath: 'docs/guide/query-uses-impact-checks.md',
+      phrases: [
+        'The active scan set is **project-wide by default**.',
+        'Use `--specs-dir` only when you want to narrow the scan to one slice or sub-tree.',
+        'prefers feature-local spec-relative paths, then tries project-relative paths',
+        'npx ztd query uses column users.email --specs-dir src/features/users/persistence --any-schema --view detail'
       ]
     },
     {

--- a/packages/ztd-cli/tests/queryUses.unit.test.ts
+++ b/packages/ztd-cli/tests/queryUses.unit.test.ts
@@ -117,6 +117,71 @@ test('impact view aggregates table usage by statement', () => {
   expect(formatQueryUsageReport(report, 'text')).toContain('Affected queries:');
 });
 
+test('project-wide discovery finds feature-local specs across multiple slices without sql-root flags', () => {
+  const root = createWorkspace('query-uses-vsa-project-wide');
+  mkdirSync(path.join(root, 'src', 'features', 'users', 'persistence'), { recursive: true });
+  mkdirSync(path.join(root, 'src', 'features', 'orders', 'persistence'), { recursive: true });
+  writeFileSync(
+    path.join(root, 'src', 'features', 'users', 'persistence', 'users.spec.ts'),
+    [
+      'export const usersSpec = {',
+      "  id: 'features.users.persistence.users',",
+      "  sqlFile: './users.sql',",
+      "  params: { shape: 'named', example: { id: 1 } }",
+      '};'
+    ].join('\n'),
+    'utf8'
+  );
+  writeFileSync(
+    path.join(root, 'src', 'features', 'orders', 'persistence', 'orders.spec.ts'),
+    [
+      'export const ordersSpec = {',
+      "  id: 'features.orders.persistence.orders',",
+      "  sqlFile: './orders.sql',",
+      "  params: { shape: 'named', example: { id: 1 } }",
+      '};'
+    ].join('\n'),
+    'utf8'
+  );
+  writeFileSync(
+    path.join(root, 'src', 'features', 'users', 'persistence', 'users.sql'),
+    'SELECT u.email FROM public.users u;',
+    'utf8'
+  );
+  writeFileSync(
+    path.join(root, 'src', 'features', 'orders', 'persistence', 'orders.sql'),
+    'SELECT o.id FROM public.orders o JOIN public.users u ON u.id = o.user_id;',
+    'utf8'
+  );
+
+  const report = buildQueryUsageReport({
+    kind: 'table',
+    rawTarget: 'public.users',
+    rootDir: root,
+  });
+
+  expect(report.summary).toMatchObject({
+    catalogsScanned: 2,
+    statementsScanned: 2,
+    matches: 2,
+    unresolvedSqlFiles: 0,
+  });
+  expect(report.matches).toEqual([
+    expect.objectContaining({
+      kind: 'impact',
+      catalog_id: 'features.orders.persistence.orders',
+      sql_file: 'src/features/orders/persistence/orders.sql',
+      usageKindCounts: { join: 1 },
+    }),
+    expect.objectContaining({
+      kind: 'impact',
+      catalog_id: 'features.users.persistence.users',
+      sql_file: 'src/features/users/persistence/users.sql',
+      usageKindCounts: { from: 1 },
+    }),
+  ]);
+});
+
 test('impact view resolves sql-root-relative sqlFile values before the legacy spec-relative fallback', () => {
   const root = createWorkspace('query-uses-sql-root-relative');
   mkdirSync(path.join(root, 'src', 'sql', 'sales'), { recursive: true });
@@ -663,12 +728,14 @@ test('detail view emits parse warnings, fallback rows, and no-catalog guidance d
       catalog_id: 'catalog.b',
       code: 'unresolved-sql-file',
       message: expect.stringContaining('SQL file does not exist: ../../sql/missing.sql'),
-      sql_file: 'sql/missing.sql'
+      sql_file: 'src/sql/missing.sql'
     }
   ]);
-  expect(tableReport.warnings[1]?.message).toContain('Tried project SQL root (src/sql): sql/missing.sql');
-  expect(tableReport.warnings[1]?.message).toContain('Tried spec-relative fallback: src/sql/missing.sql');
-  expect(tableReport.warnings[1]?.message).toContain('re-run with --sql-root src/sql');
+  expect(tableReport.warnings[1]?.message).toContain('Tried spec-relative path: src/sql/missing.sql');
+  expect(tableReport.warnings[1]?.message).toContain(
+    'Tried project-relative path: ../../sql/missing.sql'
+  );
+  expect(tableReport.warnings[1]?.message).toContain('prefer feature-local spec-relative sqlFile values');
   expect(formatQueryUsageReport(tableReport, 'text')).toContain('Fallback-derived matches:');
 
   const emptyRoot = createWorkspace('query-uses-empty');
@@ -681,10 +748,10 @@ test('detail view emits parse warnings, fallback rows, and no-catalog guidance d
   expect(emptyReport.warnings).toEqual([
     {
       code: 'no-catalog-specs-found',
-      message: expect.stringContaining('Hint: run "ztd init" or pass "--specs-dir".')
+      message: expect.stringContaining('No QuerySpec entries were discovered under .')
     }
   ]);
-  expect(formatQueryUsageReport(emptyReport, 'text')).toContain('No catalog specs found under');
+  expect(formatQueryUsageReport(emptyReport, 'text')).toContain('No QuerySpec entries were discovered under .');
 });
 
 test('table impact finds tables referenced from EXISTS subqueries through their FROM nodes', () => {

--- a/packages/ztd-cli/tests/sqlCatalogDiscovery.unit.test.ts
+++ b/packages/ztd-cli/tests/sqlCatalogDiscovery.unit.test.ts
@@ -5,6 +5,7 @@ import { expect, test } from 'vitest';
 import { runCheckContract } from '../src/commands/checkContract';
 import { runTestEvidenceSpecification } from '../src/commands/testEvidence';
 import {
+  discoverProjectSqlCatalogSpecFiles,
   loadSqlCatalogSpecsFromFile,
   walkSqlCatalogSpecFiles
 } from '../src/utils/sqlCatalogDiscovery';
@@ -67,6 +68,35 @@ test('sql catalog discovery finds feature-local specs under src/features', () =>
     'smoke.spec.ts'
   ]);
   expect(checkFiles.map((filePath) => path.basename(filePath))).toEqual(['smoke.spec.ts']);
+});
+
+test('project-wide spec discovery finds feature-local QuerySpecs without a fixed catalog root', () => {
+  const root = createWorkspace('sql-catalog-project-wide');
+  mkdirSync(path.join(root, 'src', 'features', 'users', 'persistence'), { recursive: true });
+  mkdirSync(path.join(root, 'src', 'features', 'orders', 'persistence'), { recursive: true });
+  mkdirSync(path.join(root, 'tests', 'fixtures'), { recursive: true });
+  writeFileSync(
+    path.join(root, 'src', 'features', 'users', 'persistence', 'users.spec.ts'),
+    "export const usersSpec = { id: 'features.users.persistence.users', sqlFile: './users.sql', params: { shape: 'named', example: { id: 1 } } };",
+    'utf8'
+  );
+  writeFileSync(
+    path.join(root, 'src', 'features', 'orders', 'persistence', 'orders.spec.ts'),
+    "export const ordersSpec = { id: 'features.orders.persistence.orders', sqlFile: './orders.sql', params: { shape: 'named', example: { id: 1 } } };",
+    'utf8'
+  );
+  writeFileSync(
+    path.join(root, 'tests', 'fixtures', 'fake.spec.ts'),
+    "export const fake = { id: 'tests.fake', sqlFile: './fake.sql', params: { shape: 'named' } };",
+    'utf8'
+  );
+
+  const discovered = discoverProjectSqlCatalogSpecFiles(root, { excludeTestFiles: true });
+
+  expect(discovered.map((filePath) => path.relative(root, filePath).replace(/\\/g, '/'))).toEqual([
+    'src/features/orders/persistence/orders.spec.ts',
+    'src/features/users/persistence/users.spec.ts'
+  ]);
 });
 
 test('sql catalog discovery preserves spec ids, ordering, sqlFile, and minimal extracted fields', () => {

--- a/packages/ztd-cli/tests/sqlFirstTutorial.docs.test.ts
+++ b/packages/ztd-cli/tests/sqlFirstTutorial.docs.test.ts
@@ -31,7 +31,7 @@ test('the tutorial preserves the shortest DDL to first test path', () => {
   expectInOrder(tutorial, [
     'This tutorial shows the shortest path from `ztd init --starter` to a small `users` feature that can be changed, broken, and repaired with AI help.',
     'The tutorial uses one starter project, one `smoke` feature, and one `users` feature.',
-    'DDL repair | `npx ztd query uses column users.email --sql-root src/features/users/persistence --specs-dir src/features/users/persistence --any-schema --view detail`',
+    'DDL repair | `npx ztd query uses column users.email --specs-dir src/features/users/persistence --any-schema --view detail`',
     'SQL repair | `npx ztd model-gen --probe-mode ztd --sql-root src/features/users/persistence src/features/users/persistence/users.sql --out src/features/users/persistence/users.spec.ts`',
     'DTO repair | `npx vitest run` after the DTO change',
     'migration | `npx ztd ztd-config`, optionally `npx ztd ddl pull --url <target-db-url>` to inspect the target, then `npx ztd ddl diff --url <target-db-url> --out tmp/users.diff.sql` to prepare review output plus apply SQL',
@@ -49,7 +49,8 @@ test('the tutorial preserves the shortest DDL to first test path', () => {
     'src/features/users/application',
     'src/features/users/persistence',
     'src/features/users/tests',
-    'npx ztd query uses column users.email --sql-root src/features/users/persistence --specs-dir src/features/users/persistence --any-schema --view detail',
+    'npx ztd query uses column users.email --specs-dir src/features/users/persistence --any-schema --view detail',
+    'Passing the feature folder as `--specs-dir` is a normal way to narrow the project-wide scan, not a workaround for feature-local layouts.',
     'For SQL repair, keep the SQL assets under the feature folder, keep the query on the starter DDL\'s `users` table, and pass that folder explicitly as `--sql-root` when you ask `model-gen` to refresh the spec.',
     'npx ztd ztd-config',
     'npx ztd ddl diff'


### PR DESCRIPTION
## Summary
- switch `query uses` from a single-root SQL discovery model to project-wide QuerySpec discovery
- make VSA-style feature-local `*.spec.* -> ./foo.sql` layouts first-class for impact checks
- keep `--sql-root` as a compatibility helper instead of the primary discovery model

## What changed
- discover QuerySpec files from the project root by default when `--specs-dir` is not provided
- resolve `sqlFile` in VSA-first order: spec-relative, project-relative, explicit `--sql-root`, then legacy shared `src/sql`
- update `query uses` help and docs to describe active spec-set scanning instead of catalog-root-only scanning
- update the starter smoke spec to use spec-relative `./smoke.sql`
- add tests for multi-slice project-wide discovery and the revised warning/help/docs contract
- add a changeset for `@rawsql-ts/sql-grep-core` and `@rawsql-ts/ztd-cli`

## Why
The previous `sqlRoot`-centric model fit layered layouts better than VSA. In feature-first projects generated by `ztd init`, SQL and specs stay local to each slice, so impact analysis should work from the project root without assuming a single shared SQL directory.

## Verification
- `pnpm --filter @rawsql-ts/ztd-cli test -- sqlCatalogDiscovery.unit.test.ts queryUses.unit.test.ts sqlFirstTutorial.docs.test.ts furtherReading.docs.test.ts`
- `pnpm --filter @rawsql-ts/ztd-cli build`
- `pnpm --filter @rawsql-ts/ztd-cli test -- cliCommands.test.ts`
- `pnpm --filter @rawsql-ts/ztd-cli test -- init.command.test.ts --testNamePattern "init local-source mode links rawsql-ts dependencies from the monorepo without exposing local-source shims to consumer code"`

## Notes
- a full pre-commit workspace test run hit a timeout in the existing `init local-source` test, but that test passes when run directly and the query-uses-specific suites above pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * `query uses` command now discovers QuerySpec files project-wide by default instead of from a fixed catalog directory.
  * Improved SQL file resolution: prioritizes feature-local spec-relative paths, then project-relative paths, with `--sql-root` as an optional fallback for shared SQL layouts.

* **Documentation**
  * Updated CLI help text and guides to clarify the new discovery behavior and resolution preference order.
  * Clarified that `--specs-dir` narrows discovery to a sub-tree, not a required workaround for feature-local layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->