### PR TITLE
testkit-postgres: prove multi-db client workflow

### DIFF
--- a/packages/testkit-postgres/tests/client.test.ts
+++ b/packages/testkit-postgres/tests/client.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { TableDefinitionModel } from 'rawsql-ts';
-import { createPostgresTestkitClient, type QueryExecutor } from '../src';
+import { createPostgresTestkitClient, type PostgresTestkitClient, type QueryExecutor } from '../src';
 
 const usersTableDefinition: TableDefinitionModel = {
   name: 'users',
@@ -11,6 +11,18 @@ const usersTableDefinition: TableDefinitionModel = {
 };
 
 const resultExecutor: QueryExecutor = async (_sql, _params) => [{ id: 1, email: 'alice@example.com' }];
+
+async function runCrossDbWorkflow<RowA extends Record<string, unknown>, RowB extends Record<string, unknown>>(
+  clients: {
+    dbA: PostgresTestkitClient<RowA>;
+    dbB: PostgresTestkitClient<RowB>;
+  }
+) {
+  const aResult = await clients.dbA.query<{ id: number; email: string }>('select id, email from users where id = $1', [1]);
+  const bResult = await clients.dbB.query<{ id: number; email: string }>('select id, email from users where id = $1', [2]);
+
+  return { aResult, bResult };
+}
 
 describe('Postgres testkit client', () => {
   it('accepts generated fixture manifests without scanning ddl.directories', async () => {
@@ -84,6 +96,53 @@ describe('Postgres testkit client', () => {
     await client.close();
     await client.close();
     expect(disposeCount).toBe(1);
+  });
+
+  it('allows two database clients to participate in the same workflow without sharing lifecycle state', async () => {
+    const dbAExecutions: Array<{ sql: string; params: readonly unknown[] }> = [];
+    const dbBExecutions: Array<{ sql: string; params: readonly unknown[] }> = [];
+    let dbACloseCount = 0;
+    let dbBCloseCount = 0;
+
+    const dbA = createPostgresTestkitClient({
+      queryExecutor: async (sql, params) => {
+        dbAExecutions.push({ sql, params });
+        return [{ id: 1, email: 'db-a@example.com' }];
+      },
+      tableDefinitions: [usersTableDefinition],
+      tableRows: [{ tableName: 'users', rows: [{ id: 1, email: 'db-a@example.com' }] }],
+      disposeExecutor: () => {
+        dbACloseCount += 1;
+      },
+    });
+
+    const dbB = createPostgresTestkitClient({
+      queryExecutor: async (sql, params) => {
+        dbBExecutions.push({ sql, params });
+        return [{ id: 2, email: 'db-b@example.com' }];
+      },
+      tableDefinitions: [usersTableDefinition],
+      tableRows: [{ tableName: 'users', rows: [{ id: 2, email: 'db-b@example.com' }] }],
+      disposeExecutor: () => {
+        dbBCloseCount += 1;
+      },
+    });
+
+    const workflowResult = await runCrossDbWorkflow({ dbA, dbB });
+
+    expect(workflowResult.aResult.rows).toEqual([{ id: 1, email: 'db-a@example.com' }]);
+    expect(workflowResult.bResult.rows).toEqual([{ id: 2, email: 'db-b@example.com' }]);
+    expect(dbAExecutions).toHaveLength(1);
+    expect(dbAExecutions[0]?.params).toEqual([1]);
+    expect(dbAExecutions[0]?.sql).toContain('db-a@example.com');
+    expect(dbBExecutions).toHaveLength(1);
+    expect(dbBExecutions[0]?.params).toEqual([2]);
+    expect(dbBExecutions[0]?.sql).toContain('db-b@example.com');
+
+    await dbA.close();
+    await dbB.close();
+    expect(dbACloseCount).toBe(1);
+    expect(dbBCloseCount).toBe(1);
   });
 });
 

--- a/packages/ztd-cli/README.md
+++ b/packages/ztd-cli/README.md
@@ -137,6 +137,26 @@ Run `npx ztd describe command <name>` for per-command flags and options.
 
 - [ztd-cli Telemetry Philosophy](../../docs/guide/ztd-cli-telemetry-philosophy.md) - opt-in telemetry guidance
 
+#### Multiple DB Clients in One Workflow
+
+`ztd-config` can already produce separate artifacts for multiple DB contexts. At runtime, treat each context as its own `SqlClient` and keep the clients side by side when a single workflow needs to talk to more than one database.
+
+```ts
+type AppClients = {
+  dbA: SqlClient;
+  dbB: SqlClient;
+};
+
+async function runWorkflow(clients: AppClients) {
+  const users = await createUsersRepository(clients.dbA).listActiveUsers();
+  const invoices = await createBillingRepository(clients.dbB).listOpenInvoices();
+
+  return { users, invoices };
+}
+```
+
+This is the minimum runtime step needed for multi-DB workflows. It is not saga orchestration itself; it is the client-binding pattern that makes a saga-style design possible later. See the proof test in [packages/testkit-postgres/tests/client.test.ts](../testkit-postgres/tests/client.test.ts).
+
 ### Developer Guides
 
 - [Migration Lifecycle Dogfooding](../../docs/dogfooding/ztd-migration-lifecycle.md) - separate-AI prompts for DDL, SQL, DTO, and migration repair

--- a/packages/ztd-cli/templates/src/db/sql-client.ts
+++ b/packages/ztd-cli/templates/src/db/sql-client.ts
@@ -13,7 +13,8 @@ export type SqlQueryRows<T> = Promise<T[]>;
  * - Tests: replace the implementation with a mock, a fixture helper, or an adapter that follows this contract.
  *
  * Connection strategy note:
- * - Prefer a shared client per worker process for better performance.
+ * - Prefer one live client per DB context or worker process for better performance.
+ * - Multiple clients can coexist in the same workflow as long as each one owns its own lifecycle.
  * - Do not share a live client across parallel workers without proper synchronization.
  */
 export type SqlClient = {

--- a/packages/ztd-cli/templates/src/infrastructure/db/sql-client.ts
+++ b/packages/ztd-cli/templates/src/infrastructure/db/sql-client.ts
@@ -13,7 +13,8 @@ export type SqlQueryRows<T> = Promise<T[]>;
  * - Tests: replace the implementation with a mock, a fixture helper, or an adapter that follows this contract.
  *
  * Connection strategy note:
- * - Prefer a shared client per worker process for better performance.
+ * - Prefer one live client per DB context or worker process for better performance.
+ * - Multiple clients can coexist in the same workflow as long as each one owns its own lifecycle.
  * - Do not share a live client across parallel workers without proper synchronization.
  */
 export type SqlClient = {

--- a/packages/ztd-cli/templates/tests/support/postgres-testkit.ts
+++ b/packages/ztd-cli/templates/tests/support/postgres-testkit.ts
@@ -76,6 +76,8 @@ export function loadStarterPostgresDefaults(rootDir: string = process.cwd()): St
 /**
  * Create a reusable starter Postgres testkit client for DB-backed smoke tests.
  *
+ * Call this helper once per DB context so a workflow can hold multiple clients at the same time.
+ *
  * The helper keeps the setup defaults in one place, but leaves table definitions
  * and rows next to the individual test so the sample stays readable.
  */


### PR DESCRIPTION
What was solved
- Verified that multiple `SqlClient` instances can coexist in one workflow and added a proof test that exercises `dbA` and `dbB` independently.
- Kept the runtime binding pattern explicit: each DB context owns its own client and lifecycle.
- Added a short customer-facing README note so the multi-DB workflow is discoverable from `packages/ztd-cli/README.md`.

Customer benefit
- A `ztd-cli` project can now be read as more than a single-DB scaffold: one workflow can bind separate generated artifacts, repositories, and executors to different databases.
- This gives users a concrete path toward multi-persistence-boundary designs without claiming saga orchestration support.

Evidence
- Proof test: `packages/testkit-postgres/tests/client.test.ts`
- README note: `packages/ztd-cli/README.md`
- The proof test shows two clients can be created in the same test, each can run against its own fixture set, and each closes independently.
- The README explains the minimum runtime pattern and points readers to the proof test.

Non-goals
- Saga orchestration is not implemented.
- Distributed transaction support is not implemented.
- Cross-database consistency guarantees are not provided.

Closes #657


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled support for running multiple independent database clients simultaneously within a single workflow, with each client managing its own separate lifecycle and state.

* **Documentation**
  * Updated connection strategy guidance to reflect best practices for multi-database scenarios.
  * Added developer guide with examples for handling multiple database clients in runtime workflows.

* **Tests**
  * Added test coverage validating proper isolation and lifecycle management across multiple concurrent database clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->