### PR TITLE
fix(ztd-cli): reject empty legacy ddl blocks

### DIFF
--- a/.changeset/few-forks-prepare.md
+++ b/.changeset/few-forks-prepare.md
@@ -1,0 +1,7 @@
+---
+"@rawsql-ts/ztd-cli": minor
+---
+
+Simplify `ztd.config.json` by removing the legacy `ddl.defaultSchema` and `ddl.searchPath` mirror.
+
+`ztd-cli` now reads and writes schema resolution settings only from the top-level `defaultSchema` and `searchPath` fields. Projects that still keep those values under `ddl` must move them to the top level.

--- a/benchmarks/sql-unit-test/ztd.config.json
+++ b/benchmarks/sql-unit-test/ztd.config.json
@@ -2,10 +2,8 @@
   "dialect": "postgres",
   "ddlDir": "ztd/ddl",
   "testsDir": "tests",
-  "ddl": {
-    "defaultSchema": "public",
-    "searchPath": [
-      "public"
-    ]
-  }
+  "defaultSchema": "public",
+  "searchPath": [
+    "public"
+  ]
 }

--- a/docs/guide/postgres-pitfalls.md
+++ b/docs/guide/postgres-pitfalls.md
@@ -70,12 +70,12 @@ PostgreSQL sorts `NULL` values last in ascending order and first in descending o
 
 ## 7. Schema search path affects table resolution
 
-PostgreSQL uses `search_path` to resolve unqualified table names. ZTD's `ztd.config.json` has `ddl.searchPath` to match this behavior.
+PostgreSQL uses `search_path` to resolve unqualified table names. ZTD's `ztd.config.json` has `searchPath` to match this behavior.
 
 **Symptom:** `ztd-config` generates types for the wrong schema or misses tables.
 
 **Mitigation:**
-- Set `ddl.defaultSchema` and `ddl.searchPath` in `ztd.config.json` to match your database's `search_path`.
+- Set `defaultSchema` and `searchPath` in `ztd.config.json` to match your database's `search_path`.
 - Use `ztd ztd-config --default-schema <name> --search-path <list>` to override.
 
 ## Further reading

--- a/docs/guide/spec-change-scenarios.md
+++ b/docs/guide/spec-change-scenarios.md
@@ -56,7 +56,7 @@ Condensed scenarios covering common specification and schema changes, what steps
 
 ## 7. Change the default schema or search path
 
-**What changed:** `ddl.defaultSchema` or `ddl.searchPath` updated in `ztd.config.json`.
+**What changed:** `defaultSchema` or `searchPath` updated in `ztd.config.json`.
 
 **Steps:** `ztd ztd-config --default-schema <name> --search-path <list>` → regenerate types → SQL files may need schema-qualified names → re-run tests.
 

--- a/packages/ztd-cli/README.md
+++ b/packages/ztd-cli/README.md
@@ -92,7 +92,7 @@ Keep handwritten SQL, spec, and tests inside src/features/<feature>.
 Do not apply migrations automatically.
 ```
 
-Quickstart already places `npx ztd agents init` immediately after starter scaffold creation.
+Quickstart treats `npx ztd agents init` as an optional follow-up after starter scaffold creation.
 If you skipped that step and still want the opt-in Codex bootstrap for the project, run it before asking Codex to inspect `src/features/smoke`.
 If you want `PROMPT_DOGFOOD.md` for debugging or prompt review, pass `--with-dogfooding` to `npx ztd init --starter`.
 
@@ -114,7 +114,7 @@ Read the nearest AGENTS files, inspect src/features/smoke, and plan the next use
 ## Core features
 
 - `ztd init --starter` creates a feature-first starter scaffold with `smoke`, starter DDL, and local Postgres wiring.
-- `ztd agents init` adds the opt-in Codex bootstrap on demand: visible `AGENTS.md`, `.codex/agents`, `.agents/skills`, and `.codex/config.toml`.
+- `ztd agents init` adds the optional Codex bootstrap on demand: visible `AGENTS.md`, `.codex/agents`, `.agents/skills`, and `.codex/config.toml`.
 - `ztd ztd-config --watch` keeps generated `TestRowMap` types and runtime fixture metadata aligned with DDL as files change.
 - `ztd lint` checks SQL against a temporary Postgres before you ship it.
 - `ztd model-gen` and `ztd query uses` keep QuerySpec scaffolding and impacted-file discovery close to the feature-first slice.
@@ -128,7 +128,7 @@ Read the nearest AGENTS files, inspect src/features/smoke, and plan the next use
 | Command | Purpose |
 |---|---|
 | `ztd init --starter` | Scaffold the recommended first-run project. |
-| `ztd agents init` | Add the opt-in Codex bootstrap after starter setup. |
+| `ztd agents init` | Add the optional Codex bootstrap on demand. |
 | `ztd ztd-config` | Regenerate `TestRowMap`, runtime fixture metadata, and layout metadata from DDL; add `--watch` for live updates. |
 | `ztd lint` | Lint SQL files against a temporary Postgres. |
 | `ztd model-gen` | Generate QuerySpec scaffolding from SQL assets. |
@@ -141,6 +141,23 @@ Read the nearest AGENTS files, inspect src/features/smoke, and plan the next use
 
 After DDL or schema changes, rerun `ztd ztd-config`, `ztd lint`, and `npx vitest run`. Use `ztd ddl diff` or `ztd ddl pull` when you need a migration plan. The generated runtime manifest is the preferred input for `@rawsql-ts/testkit-postgres`; raw DDL directories remain a fallback for legacy layouts.
 Run `npx ztd describe command <name>` for per-command flags and options.
+
+## ztd.config.json
+
+`ztd.config.json` now keeps schema resolution at the top level:
+
+```json
+{
+  "dialect": "postgres",
+  "ddlDir": "ztd/ddl",
+  "testsDir": "tests",
+  "defaultSchema": "public",
+  "searchPath": ["public"],
+  "ddlLint": "strict"
+}
+```
+
+`ddl.defaultSchema` and `ddl.searchPath` are no longer read. If an older project still keeps schema settings under `ddl`, move them to the top-level `defaultSchema` and `searchPath` fields.
 
 ## Glossary
 

--- a/packages/ztd-cli/src/commands/init.ts
+++ b/packages/ztd-cli/src/commands/init.ts
@@ -355,7 +355,6 @@ const GLOBAL_SETUP_TEMPLATE = 'tests/support/global-setup.ts';
 const SETUP_ENV_TEMPLATE = 'tests/support/setup-env.ts';
 const VITEST_CONFIG_TEMPLATE = 'vitest.config.ts';
 const TSCONFIG_TEMPLATE = 'tsconfig.json';
-const GITIGNORE_TEMPLATE = 'gitignore.template';
 const SQL_CLIENT_TEMPLATE = 'src/db/sql-client.ts';
 const SQL_CLIENT_ADAPTERS_TEMPLATE = 'src/db/sql-client-adapters.ts';
 const INFRASTRUCTURE_README_TEMPLATE = 'src/infrastructure/README.md';
@@ -651,7 +650,7 @@ export async function runInitCommand(prompter: Prompter, options?: InitCommandOp
     );
   }
 
-  const schemaName = normalizeSchemaName(DEFAULT_ZTD_CONFIG.ddl.defaultSchema);
+  const schemaName = normalizeSchemaName(DEFAULT_ZTD_CONFIG.defaultSchema);
   const schemaFileName = `${sanitizeSchemaFileName(schemaName)}.sql`;
   const appShape: InitAppShape = options?.appShape ?? 'default';
   const postgresImage = options?.postgresImage?.trim() || DEFAULT_POSTGRES_IMAGE;
@@ -784,11 +783,7 @@ export async function runInitCommand(prompter: Prompter, options?: InitCommandOp
       writeZtdProjectConfig(rootDir, {
         ztdRootDir: '.',
         defaultSchema: schemaName,
-        searchPath: [schemaName],
-        ddl: {
-          defaultSchema: schemaName,
-          searchPath: [schemaName]
-        }
+        searchPath: [schemaName]
       });
     }
   );
@@ -1226,8 +1221,8 @@ export async function runInitCommand(prompter: Prompter, options?: InitCommandOp
   const editorconfigSummary = copyTemplateFileIfMissing(
     rootDir,
     relativePath('editorconfig'),
-    dependencies,
-    '.editorconfig'
+    '.editorconfig',
+    dependencies
   );
   if (editorconfigSummary) {
     summaries.editorconfig = editorconfigSummary;
@@ -1236,8 +1231,8 @@ export async function runInitCommand(prompter: Prompter, options?: InitCommandOp
   const prettierSummary = copyTemplateFileIfMissing(
     rootDir,
     relativePath('prettier'),
-    dependencies,
-    '.prettierrc'
+    '.prettierrc',
+    dependencies
   );
   if (prettierSummary) {
     summaries.prettier = prettierSummary;
@@ -1246,8 +1241,9 @@ export async function runInitCommand(prompter: Prompter, options?: InitCommandOp
   const gitignoreSummary = copyTemplateFileIfMissing(
     rootDir,
     relativePath('gitignore'),
-    dependencies,
-    GITIGNORE_TEMPLATE
+    // npm pack can omit dotfile templates from the published bundle, so keep a non-dotfile fallback.
+    ['.gitignore', 'gitignore.template'],
+    dependencies
   );
   if (gitignoreSummary) {
     summaries.gitignore = gitignoreSummary;
@@ -1260,8 +1256,8 @@ export async function runInitCommand(prompter: Prompter, options?: InitCommandOp
   const prettierignoreSummary = copyTemplateFileIfMissing(
     rootDir,
     relativePath('prettierignore'),
-    dependencies,
-    '.prettierignore'
+    '.prettierignore',
+    dependencies
   );
   if (prettierignoreSummary) {
     summaries.prettierignore = prettierignoreSummary;
@@ -1760,15 +1756,28 @@ async function ensureTemplateDependenciesInstalled(
   return null;
 }
 
+function resolveTemplatePath(templateNames: string[]): string | null {
+  for (const templateName of templateNames) {
+    const templatePath = path.join(TEMPLATE_DIRECTORY, templateName);
+    if (existsSync(templatePath)) {
+      return templatePath;
+    }
+  }
+
+  return null;
+}
+
 function copyTemplateFileIfMissing(
   rootDir: string,
   relative: string,
-  dependencies: ZtdConfigWriterDependencies,
-  templateName: string = relative
+  templateName: string | string[],
+  dependencies: ZtdConfigWriterDependencies
 ): FileSummary | null {
-  const templatePath = path.join(TEMPLATE_DIRECTORY, templateName);
+  const templatePath = resolveTemplatePath(
+    Array.isArray(templateName) ? templateName : [templateName]
+  );
   // Skip copying when the CLI package does not include the requested template.
-  if (!existsSync(templatePath)) {
+  if (!templatePath) {
     return null;
   }
 
@@ -2139,7 +2148,7 @@ function normalizeCliPath(filePath: string): string {
 export function normalizeSchemaName(value: string): string {
   const trimmed = value.trim();
   if (!trimmed) {
-    return DEFAULT_ZTD_CONFIG.ddl.defaultSchema;
+    return DEFAULT_ZTD_CONFIG.defaultSchema;
   }
   return trimmed.replace(/^"|"$/g, '').toLowerCase();
 }
@@ -2523,7 +2532,7 @@ export function buildInitDryRunPlan(rootDir: string, options: {
   validator: ValidatorBackend;
   localSourceRoot?: string;
 }): InitDryRunPlan {
-  const schemaName = normalizeSchemaName(DEFAULT_ZTD_CONFIG.ddl.defaultSchema);
+  const schemaName = normalizeSchemaName(DEFAULT_ZTD_CONFIG.defaultSchema);
   const schemaFileName = `${sanitizeSchemaFileName(schemaName)}.sql`;
   const scaffoldLayout = resolveInitScaffoldLayout(rootDir, options.appShape);
   const starter = options.starter === true;

--- a/packages/ztd-cli/src/commands/lint.ts
+++ b/packages/ztd-cli/src/commands/lint.ts
@@ -237,8 +237,8 @@ async function runLintCommand(pattern: string): Promise<void> {
     const result = await runSqlLint({
       sqlFiles,
       ddlDirectories: [ddlRoot],
-      defaultSchema: config.ddl.defaultSchema,
-      searchPath: config.ddl.searchPath,
+      defaultSchema: config.defaultSchema,
+      searchPath: config.searchPath,
       ddlLint: config.ddlLint,
       client
     });

--- a/packages/ztd-cli/src/commands/modelGen.ts
+++ b/packages/ztd-cli/src/commands/modelGen.ts
@@ -591,8 +591,8 @@ export function resolveModelGenZtdProbeOptions(
   }
   return {
     ddlDirectories: [absoluteDir],
-    defaultSchema: config.ddl.defaultSchema,
-    searchPath: config.ddl.searchPath
+    defaultSchema: config.defaultSchema,
+    searchPath: config.searchPath
   };
 }
 

--- a/packages/ztd-cli/src/commands/perf.ts
+++ b/packages/ztd-cli/src/commands/perf.ts
@@ -327,7 +327,7 @@ function buildPerfSeedDryRunPlan(rootDir: string): { seed: number; tables: Recor
 
   const tables = Object.fromEntries(
     Object.entries(seedConfig.tables).map(([tableName, tableConfig]) => {
-      const definition = definitions.find((candidate) => candidate.name === tableName || candidate.name === `${config.ddl.defaultSchema}.${tableName}`);
+      const definition = definitions.find((candidate) => candidate.name === tableName || candidate.name === `${config.defaultSchema}.${tableName}`);
       if (!definition) {
         throw new Error(`No table definition found for perf seed table: ${tableName}`);
       }

--- a/packages/ztd-cli/src/commands/ztdConfigCommand.ts
+++ b/packages/ztd-cli/src/commands/ztdConfigCommand.ts
@@ -101,7 +101,7 @@ export function registerZtdConfigCommand(program: Command): void {
     .option('--ddl-dir <directory>', 'DDL directory to scan (repeatable)', collectDirectories, [])
     .option('--extensions <list>', 'Comma-separated extensions to include', parseExtensions, DEFAULT_EXTENSIONS)
     .option('--out <file>', 'Destination TypeScript file for generated config')
-    .option('--default-schema <schema>', 'Override ddl.defaultSchema stored in ztd.config.json')
+    .option('--default-schema <schema>', 'Override defaultSchema stored in ztd.config.json')
     .option('--search-path <list>', 'Comma-separated schema search path entries', parseCsvList)
     .option('--watch', 'Watch DDL files and regenerate when schema changes', false)
     .option('--quiet', 'Suppress next-step hints after generation', false)
@@ -127,16 +127,17 @@ export function registerZtdConfigCommand(program: Command): void {
         const layoutOut = path.join(path.dirname(output), 'ztd-layout.generated.ts');
         const manifestOut = path.join(path.dirname(output), 'ztd-fixture-manifest.generated.ts');
 
-        const ddlOverrides: ZtdProjectConfig['ddl'] = { ...projectConfig.ddl };
+        let nextDefaultSchema = projectConfig.defaultSchema;
+        let nextSearchPath = projectConfig.searchPath;
         let shouldUpdateConfig = false;
 
         if (merged.defaultSchema) {
-          ddlOverrides.defaultSchema = validateResourceIdentifier(merged.defaultSchema, '--default-schema');
+          nextDefaultSchema = validateResourceIdentifier(merged.defaultSchema, '--default-schema');
           shouldUpdateConfig = true;
         }
 
         if (merged.searchPath && merged.searchPath.length > 0) {
-          ddlOverrides.searchPath = merged.searchPath.map((entry) => validateResourceIdentifier(entry, '--search-path'));
+          nextSearchPath = merged.searchPath.map((entry) => validateResourceIdentifier(entry, '--search-path'));
           shouldUpdateConfig = true;
         }
 
@@ -147,12 +148,16 @@ export function registerZtdConfigCommand(program: Command): void {
           directories,
           extensions,
           out: validatedOutput,
-          defaultSchema: ddlOverrides.defaultSchema,
-          searchPath: ddlOverrides.searchPath,
+          defaultSchema: nextDefaultSchema,
+          searchPath: nextSearchPath,
           ddlLint: projectConfig.ddlLint,
           dryRun: merged.dryRun
         };
-        const layoutConfig: ZtdProjectConfig = { ...projectConfig, ddl: ddlOverrides };
+        const layoutConfig: ZtdProjectConfig = {
+          ...projectConfig,
+          defaultSchema: nextDefaultSchema,
+          searchPath: nextSearchPath
+        };
 
         emitDecisionEvent('command.options.resolved', {
           dryRun: merged.dryRun,
@@ -166,7 +171,8 @@ export function registerZtdConfigCommand(program: Command): void {
           merged,
           projectConfig,
           shouldUpdateConfig,
-          ddlOverrides,
+          nextDefaultSchema,
+          nextSearchPath,
           validatedOutput,
           validatedLayoutOut,
           validatedManifestOut,
@@ -182,11 +188,14 @@ export function registerZtdConfigCommand(program: Command): void {
         await withSpan('persist-project-config', async () => {
           configUpdated = writeZtdProjectConfig(
             process.cwd(),
-            { ddl: commandState.ddlOverrides },
+            {
+              defaultSchema: commandState.nextDefaultSchema,
+              searchPath: commandState.nextSearchPath
+            },
             commandState.projectConfig
           );
           if (configUpdated) {
-            emitDiagnostic({ code: 'ztd-config.config-updated', message: 'ztd.config.json ddl schema settings updated.' });
+            emitDiagnostic({ code: 'ztd-config.config-updated', message: 'ztd.config.json schema settings updated.' });
             emitDecisionEvent('config.updated');
           }
         });
@@ -315,9 +324,9 @@ async function watchZtdConfig(
   await new Promise<void>((resolve) => {
     const stop = async (): Promise<void> => {
       console.log('[watch] Shutting down ztd-config watcher...');
-      watcher.off('add', scheduleReload);
-      watcher.off('change', scheduleReload);
-      watcher.off('unlink', scheduleReload);
+      watcher.off('add', scheduleReloadIfDdl);
+      watcher.off('change', scheduleReloadIfDdl);
+      watcher.off('unlink', scheduleReloadIfDdl);
       if (debounceTimer) {
         clearTimeout(debounceTimer);
         debounceTimer = null;

--- a/packages/ztd-cli/src/perf/sandbox.ts
+++ b/packages/ztd-cli/src/perf/sandbox.ts
@@ -249,7 +249,7 @@ export async function seedPerfSandbox(rootDir: string): Promise<PerfSeedResult> 
     await client.connect();
 
     for (const [tableName, tableSeed] of Object.entries(seedConfig.tables)) {
-      const definition = resolveTableDefinition(definitions, tableName, config.ddl.defaultSchema);
+      const definition = resolveTableDefinition(definitions, tableName, config.defaultSchema);
       if (!definition) {
         throw new Error(`No table definition found for perf seed table: ${tableName}`);
       }

--- a/packages/ztd-cli/src/utils/ztdProjectConfig.ts
+++ b/packages/ztd-cli/src/utils/ztdProjectConfig.ts
@@ -18,10 +18,6 @@ export interface ZtdProjectConfig {
   testsDir: string;
   defaultSchema: string;
   searchPath: string[];
-  ddl: {
-    defaultSchema: string;
-    searchPath: string[];
-  };
   /** Controls DDL integrity validation during config generation and tests. */
   ddlLint: DdlLintMode;
   /** @deprecated Legacy field. ztd-cli no longer uses config-based DB connections implicitly. */
@@ -29,11 +25,6 @@ export interface ZtdProjectConfig {
 }
 
 const CONFIG_NAME = 'ztd.config.json';
-
-const DEFAULT_DDL_PROPERTIES = {
-  defaultSchema: 'public',
-  searchPath: ['public']
-};
 
 let hasWarnedLegacyConnectionConfig = false;
 
@@ -43,7 +34,6 @@ export const DEFAULT_ZTD_CONFIG: ZtdProjectConfig = {
   testsDir: 'tests',
   defaultSchema: 'public',
   searchPath: ['public'],
-  ddl: { ...DEFAULT_DDL_PROPERTIES },
   ddlLint: 'strict'
 };
 
@@ -70,17 +60,21 @@ export function loadZtdProjectConfig(rootDir: string = process.cwd()): ZtdProjec
   try {
     // Merge on top of defaults so partial configs remain valid.
     const raw = JSON.parse(readFileSync(filePath, 'utf8'));
-    const rawDdl = typeof raw.ddl === 'object' && raw.ddl !== null ? raw.ddl : undefined;
+    const legacySchemaConfig = detectLegacySchemaConfig(raw);
+    if (legacySchemaConfig) {
+      throw new Error(
+        `${filePath} uses removed legacy ddl.defaultSchema / ddl.searchPath settings. Move them to top-level defaultSchema and searchPath.`
+      );
+    }
     const rawConnection = typeof raw.connection === 'object' && raw.connection !== null ? raw.connection : undefined;
     const rawLintMode = typeof raw.ddlLint === 'string' ? raw.ddlLint.trim().toLowerCase() : undefined;
     const resolvedDefaultSchema = resolveSchemaName(
       typeof raw.defaultSchema === 'string' ? raw.defaultSchema : undefined,
-      typeof rawDdl?.defaultSchema === 'string' ? rawDdl.defaultSchema : undefined,
       DEFAULT_ZTD_CONFIG.defaultSchema
     );
     const resolvedSearchPath = resolveSearchPath(
       raw.searchPath,
-      rawDdl?.searchPath,
+      undefined,
       resolvedDefaultSchema
     );
     const normalizedConnection = normalizeConnectionConfig(rawConnection);
@@ -96,10 +90,6 @@ export function loadZtdProjectConfig(rootDir: string = process.cwd()): ZtdProjec
         typeof raw.testsDir === 'string' && raw.testsDir.length ? raw.testsDir : DEFAULT_ZTD_CONFIG.testsDir,
       defaultSchema: resolvedDefaultSchema,
       searchPath: resolvedSearchPath,
-      ddl: {
-        defaultSchema: resolvedDefaultSchema,
-        searchPath: resolvedSearchPath
-      },
       ddlLint: isDdlLintMode(rawLintMode) ? rawLintMode : DEFAULT_ZTD_CONFIG.ddlLint,
       connection: normalizedConnection
     };
@@ -141,6 +131,15 @@ function normalizeSchemaList(value: unknown): string[] {
   }
 
   return value.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0);
+}
+
+function detectLegacySchemaConfig(raw: unknown): boolean {
+  if (typeof raw !== 'object' || raw === null) {
+    return false;
+  }
+
+  const rawRecord = raw as Record<string, unknown>;
+  return Object.prototype.hasOwnProperty.call(rawRecord, 'ddl') && typeof rawRecord.ddl === 'object' && rawRecord.ddl !== null;
 }
 
 /**
@@ -256,26 +255,16 @@ function mergeProjectConfig(
   const defaultSchema =
     typeof overrides.defaultSchema === 'string' && overrides.defaultSchema.length > 0
       ? overrides.defaultSchema
-      : typeof overrides.ddl?.defaultSchema === 'string' && overrides.ddl.defaultSchema.length > 0
-        ? overrides.ddl.defaultSchema
-        : baseConfig.defaultSchema;
+      : baseConfig.defaultSchema;
   const searchPath =
     normalizeSchemaList(overrides.searchPath).length > 0
       ? normalizeSchemaList(overrides.searchPath)
-      : normalizeSchemaList(overrides.ddl?.searchPath).length > 0
-        ? normalizeSchemaList(overrides.ddl?.searchPath)
-        : baseConfig.searchPath;
+      : baseConfig.searchPath;
   return {
     ...baseConfig,
     ...overrides,
     defaultSchema,
-    searchPath,
-    ddl: {
-      ...baseConfig.ddl,
-      ...(overrides.ddl ?? {}),
-      defaultSchema,
-      searchPath
-    }
+    searchPath
   };
 }
 

--- a/packages/ztd-cli/templates/README.md
+++ b/packages/ztd-cli/templates/README.md
@@ -33,7 +33,7 @@ npx vitest run
 The generated runtime manifest is the preferred input for `@rawsql-ts/testkit-postgres`; raw DDL directories remain a fallback for legacy layouts. The generated contract itself is schema metadata only (`tableDefinitions`), so test rows stay explicit.
 The removable starter smoke test shows the DB-backed path through `createStarterPostgresTestkitClient`, so the starter can fail fast when setup is incomplete.
 If you add a second DB-backed feature, reuse `tests/support/postgres-testkit.ts` for the pool, config defaults, and cleanup, then keep each feature's fixtures next to the test that needs them.
-The starter keeps `ztdRootDir`, `ddlDir`, `defaultSchema`, and `searchPath` in `ztd.config.json`, with the same values mirrored under `ddl` for compatibility. The helper reads the project defaults from one place instead of repeating them in every DB-backed test.
+The starter keeps `ztdRootDir`, `ddlDir`, `defaultSchema`, and `searchPath` in `ztd.config.json`. The helper reads the project defaults from one place instead of repeating them in every DB-backed test.
 
 src/catalog may still exist as internal support, but it is not the user-facing standard location.
 

--- a/packages/ztd-cli/templates/tests/support/postgres-testkit.ts
+++ b/packages/ztd-cli/templates/tests/support/postgres-testkit.ts
@@ -9,10 +9,6 @@ interface StarterProjectConfigFile {
   ddlDir?: string;
   defaultSchema?: string;
   searchPath?: string[];
-  ddl?: {
-    defaultSchema?: string;
-    searchPath?: string[];
-  };
 }
 
 export interface StarterPostgresDefaults {
@@ -56,15 +52,11 @@ function loadStarterProjectConfig(rootDir: string = process.cwd()): StarterProje
 export function loadStarterPostgresDefaults(rootDir: string = process.cwd()): StarterPostgresDefaults {
   const projectConfig = loadStarterProjectConfig(rootDir);
   const resolvedProjectRootDir = path.resolve(rootDir, projectConfig.ztdRootDir ?? '.');
-  const resolvedDdl = typeof projectConfig.ddl === 'object' && projectConfig.ddl !== null ? projectConfig.ddl : undefined;
-  // Prefer top-level config defaults first, then fall back to the legacy ddl block.
   const defaultSchema =
     typeof projectConfig.defaultSchema === 'string' && projectConfig.defaultSchema.length > 0
       ? projectConfig.defaultSchema
-      : typeof resolvedDdl?.defaultSchema === 'string' && resolvedDdl.defaultSchema.length > 0
-        ? resolvedDdl.defaultSchema
-        : 'public';
-  const searchPath = normalizeSearchPath(projectConfig.searchPath ?? resolvedDdl?.searchPath);
+      : 'public';
+  const searchPath = normalizeSearchPath(projectConfig.searchPath);
 
   return {
     projectRootDir: resolvedProjectRootDir,

--- a/packages/ztd-cli/tests/cliCommands.test.ts
+++ b/packages/ztd-cli/tests/cliCommands.test.ts
@@ -488,10 +488,8 @@ test(
         dialect: 'postgres',
         ddlDir: 'ztd/ddl',
         testsDir: 'tests',
-        ddl: {
-          defaultSchema: 'public',
-          searchPath: ['public']
-        },
+        defaultSchema: 'public',
+        searchPath: ['public'],
         ddlLint: 'strict'
       }, null, 2),
       'utf8'
@@ -797,7 +795,8 @@ test('perf db reset dry-run lists DDL files without touching Docker', () => {
       dialect: 'postgres',
       ddlDir: 'ztd/ddl',
       testsDir: 'tests',
-      ddl: { defaultSchema: 'public', searchPath: ['public'] },
+      defaultSchema: 'public',
+      searchPath: ['public'],
       ddlLint: 'strict'
     }, null, 2),
     'utf8'
@@ -829,7 +828,8 @@ test('perf db reset dry-run fails fast when the configured DDL directory is miss
       dialect: 'postgres',
       ddlDir: 'ztd/ddl',
       testsDir: 'tests',
-      ddl: { defaultSchema: 'public', searchPath: ['public'] },
+      defaultSchema: 'public',
+      searchPath: ['public'],
       ddlLint: 'strict'
     }, null, 2),
     'utf8'
@@ -850,7 +850,8 @@ test('perf seed output redacts connection credentials in global json mode', () =
       dialect: 'postgres',
       ddlDir: 'ztd/ddl',
       testsDir: 'tests',
-      ddl: { defaultSchema: 'public', searchPath: ['public'] },
+      defaultSchema: 'public',
+      searchPath: ['public'],
       ddlLint: 'strict'
     }, null, 2),
     'utf8'
@@ -883,7 +884,8 @@ test('perf db reset refuses implicit DATABASE_URL without explicit ZTD test opt-
       dialect: 'postgres',
       ddlDir: 'ztd/ddl',
       testsDir: 'tests',
-      ddl: { defaultSchema: 'public', searchPath: ['public'] },
+      defaultSchema: 'public',
+      searchPath: ['public'],
       ddlLint: 'strict'
     }, null, 2),
     'utf8'
@@ -911,7 +913,8 @@ test('perf seed dry-run rejects unknown tables from perf seed config', () => {
       dialect: 'postgres',
       ddlDir: 'ztd/ddl',
       testsDir: 'tests',
-      ddl: { defaultSchema: 'public', searchPath: ['public'] },
+      defaultSchema: 'public',
+      searchPath: ['public'],
       ddlLint: 'strict'
     }, null, 2),
     'utf8'
@@ -941,7 +944,8 @@ test('perf seed dry-run reports deterministic row counts from perf seed config',
       dialect: 'postgres',
       ddlDir: 'ztd/ddl',
       testsDir: 'tests',
-      ddl: { defaultSchema: 'public', searchPath: ['public'] },
+      defaultSchema: 'public',
+      searchPath: ['public'],
       ddlLint: 'strict'
     }, null, 2),
     'utf8'
@@ -1576,7 +1580,9 @@ pullTest('pull CLI dry-run validates dump without writing files', async () => {
       dryRun: true,
       files: [expect.objectContaining({ schema: 'public' })]
     });
-    expect(existsSync(path.join(outDir, 'public.sql'))).toBe(false);
+    for (const file of parsed.data.files as Array<{ path: string }>) {
+      expect(existsSync(file.path)).toBe(false);
+    }
   } finally {
     await resetPublicSchema(client);
     await client.end();
@@ -1666,10 +1672,8 @@ pullTest('model-gen emits a spec scaffold from ZTD DDL metadata without physical
         dialect: 'postgres',
         ddlDir: 'ztd/ddl',
         testsDir: 'tests',
-        ddl: {
-          defaultSchema: 'public',
-          searchPath: ['public']
-        },
+        defaultSchema: 'public',
+        searchPath: ['public'],
         ddlLint: 'strict'
       }, null, 2),
       'utf8'
@@ -1738,10 +1742,8 @@ pullTest('model-gen ztd resolves unqualified table names through defaultSchema/s
         dialect: 'postgres',
         ddlDir: 'ztd/ddl',
         testsDir: 'tests',
-        ddl: {
-          defaultSchema: 'public',
-          searchPath: ['public']
-        },
+        defaultSchema: 'public',
+        searchPath: ['public'],
         ddlLint: 'strict'
       }, null, 2),
       'utf8'
@@ -1810,10 +1812,8 @@ pullTest('model-gen ztd honors searchPath precedence for unqualified table names
         dialect: 'postgres',
         ddlDir: 'ztd/ddl',
         testsDir: 'tests',
-        ddl: {
-          defaultSchema: 'app',
-          searchPath: ['app', 'public']
-        },
+        defaultSchema: 'app',
+        searchPath: ['app', 'public'],
         ddlLint: 'strict'
       }, null, 2),
       'utf8'

--- a/packages/ztd-cli/tests/modelGen.unit.test.ts
+++ b/packages/ztd-cli/tests/modelGen.unit.test.ts
@@ -260,10 +260,8 @@ test('resolveModelGenZtdProbeOptions preserves defaultSchema and searchPath from
       dialect: 'postgres',
       ddlDir: 'schema',
       testsDir: 'tests',
-      ddl: {
-        defaultSchema: 'app',
-        searchPath: ['app', 'public']
-      },
+      defaultSchema: 'app',
+      searchPath: ['app', 'public'],
       ddlLint: 'strict'
     }),
     'utf8'

--- a/packages/ztd-cli/tests/perfBenchmark.unit.test.ts
+++ b/packages/ztd-cli/tests/perfBenchmark.unit.test.ts
@@ -1299,7 +1299,8 @@ test('runPerfBenchmark dry-run reports ddl inventory and pipeline-first tuning g
     dialect: 'postgres',
     ddlDir: 'ztd/ddl',
     testsDir: 'tests',
-    ddl: { defaultSchema: 'public', searchPath: ['public'] },
+    defaultSchema: 'public',
+    searchPath: ['public'],
     ddlLint: 'strict'
   }, null, 2), 'utf8');
   writeFileSync(ddlFile, [

--- a/packages/ztd-cli/tests/perfSandbox.unit.test.ts
+++ b/packages/ztd-cli/tests/perfSandbox.unit.test.ts
@@ -127,7 +127,8 @@ test('inspectPerfDdlInventory counts CREATE INDEX statements so perf reset can r
     dialect: 'postgres',
     ddlDir: 'ztd/ddl',
     testsDir: 'tests',
-    ddl: { defaultSchema: 'public', searchPath: ['public'] },
+    defaultSchema: 'public',
+    searchPath: ['public'],
     ddlLint: 'strict'
   }, null, 2), 'utf8');
   writeFileSync(path.join(ddlDir, 'public.sql'), [
@@ -151,7 +152,8 @@ test('inspectPerfDdlInventory fails fast when the configured DDL directory does 
     dialect: 'postgres',
     ddlDir: 'ztd/ddl',
     testsDir: 'tests',
-    ddl: { defaultSchema: 'public', searchPath: ['public'] },
+    defaultSchema: 'public',
+    searchPath: ['public'],
     ddlLint: 'strict'
   }, null, 2), 'utf8');
 

--- a/packages/ztd-cli/tests/postgresTestkitHelper.unit.test.ts
+++ b/packages/ztd-cli/tests/postgresTestkitHelper.unit.test.ts
@@ -27,11 +27,7 @@ test('loadStarterPostgresDefaults reads top-level starter defaults and falls bac
       {
         ztdRootDir: '.',
         defaultSchema: 'app',
-        searchPath: ['app'],
-        ddl: {
-          defaultSchema: 'legacy',
-          searchPath: ['legacy']
-        }
+        searchPath: ['app']
       },
       null,
       2

--- a/packages/ztd-cli/tests/queryLint.unit.test.ts
+++ b/packages/ztd-cli/tests/queryLint.unit.test.ts
@@ -47,10 +47,8 @@ function createJoinDirectionWorkspace(prefix: string): {
     path.join(rootDir, 'ztd.config.json'),
     JSON.stringify({
       ddlDir: 'ztd/ddl',
-      ddl: {
-        defaultSchema: 'public',
-        searchPath: ['public']
-      }
+      defaultSchema: 'public',
+      searchPath: ['public']
     }, null, 2),
     'utf8'
   );

--- a/packages/ztd-cli/tests/ztdConfigCommand.telemetry.unit.test.ts
+++ b/packages/ztd-cli/tests/ztdConfigCommand.telemetry.unit.test.ts
@@ -119,7 +119,8 @@ test('ztd-config does not emit a config.updated decision when the effective conf
         dialect: 'postgres',
         ddlDir: 'ztd/ddl',
         testsDir: 'tests',
-        ddl: { defaultSchema: 'public', searchPath: ['public'] },
+        defaultSchema: 'public',
+        searchPath: ['public'],
         ddlLint: 'strict'
       },
       null,

--- a/packages/ztd-cli/tests/ztdProjectConfig.unit.test.ts
+++ b/packages/ztd-cli/tests/ztdProjectConfig.unit.test.ts
@@ -30,7 +30,6 @@ test('writeZtdProjectConfig skips rewriting when the effective config is unchang
         testsDir: 'tests',
         defaultSchema: 'public',
         searchPath: ['public'],
-        ddl: { defaultSchema: 'public', searchPath: ['public'] },
         ddlLint: 'strict'
       },
       null,
@@ -66,7 +65,6 @@ test('loadZtdProjectConfig warns when legacy connection config is present', asyn
         testsDir: 'tests',
         defaultSchema: 'public',
         searchPath: ['public'],
-        ddl: { defaultSchema: 'public', searchPath: ['public'] },
         ddlLint: 'strict',
         connection: {
           host: 'legacy-db',
@@ -110,7 +108,6 @@ test('loadZtdProjectConfig does not warn when legacy connection config is absent
         testsDir: 'tests',
         defaultSchema: 'public',
         searchPath: ['public'],
-        ddl: { defaultSchema: 'public', searchPath: ['public'] },
         ddlLint: 'strict'
       },
       null,
@@ -128,4 +125,54 @@ test('loadZtdProjectConfig does not warn when legacy connection config is absent
   expect(config.defaultSchema).toBe('public');
   expect(config.searchPath).toEqual(['public']);
   expect(emitWarning).not.toHaveBeenCalled();
+});
+
+test('loadZtdProjectConfig rejects removed ddl schema settings', async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), 'ztd-config-no-ddl-fallback-'));
+  tempDirs.push(rootDir);
+
+  writeFileSync(
+    path.join(rootDir, 'ztd.config.json'),
+    JSON.stringify(
+      {
+        dialect: 'postgres',
+        ddlDir: 'ztd/ddl',
+        testsDir: 'tests',
+        ddl: { defaultSchema: 'legacy', searchPath: ['legacy', 'public'] },
+        ddlLint: 'strict'
+      },
+      null,
+      2
+    ),
+    'utf8'
+  );
+
+  const { loadZtdProjectConfig } = await loadConfigModule();
+
+  expect(() => loadZtdProjectConfig(rootDir)).toThrow(/removed legacy ddl\.defaultSchema \/ ddl\.searchPath settings/);
+});
+
+test('loadZtdProjectConfig rejects an empty legacy ddl block', async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), 'ztd-config-empty-ddl-'));
+  tempDirs.push(rootDir);
+
+  writeFileSync(
+    path.join(rootDir, 'ztd.config.json'),
+    JSON.stringify(
+      {
+        dialect: 'postgres',
+        ddlDir: 'ztd/ddl',
+        testsDir: 'tests',
+        ddl: {},
+        ddlLint: 'strict'
+      },
+      null,
+      2
+    ),
+    'utf8'
+  );
+
+  const { loadZtdProjectConfig } = await loadConfigModule();
+
+  expect(() => loadZtdProjectConfig(rootDir)).toThrow(/removed legacy ddl\.defaultSchema \/ ddl\.searchPath settings/);
 });


### PR DESCRIPTION
This PR is a clean replacement for #689 after the original branch accumulated unrelated/conflicting changes. It keeps only the fix for rejecting empty legacy `ddl` blocks in `ztd.config.json`.

Original review comment addressed:
- detect legacy `ddl` schema by presence, not by populated values
- reject empty legacy `ddl` blocks as well

Validation:
- attempted `pnpm --filter @rawsql-ts/ztd-cli test -- tests/ztdProjectConfig.unit.test.ts` in a clean worktree, but dependencies were not installed there, so test execution could not complete in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Schema configuration structure has changed: `defaultSchema` and `searchPath` are now top-level fields in `ztd.config.json`. Legacy nested `ddl.defaultSchema` and `ddl.searchPath` settings are no longer supported. Migration to the new structure is required.

* **Documentation**
  * Updated guides and README to reflect the new schema configuration structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->