### PR TITLE
[codex] remove deprecated layout fields from ztd-config output

### DIFF
--- a/packages/ztd-cli/src/commands/ztdConfigCommand.ts
+++ b/packages/ztd-cli/src/commands/ztdConfigCommand.ts
@@ -71,18 +71,12 @@ function renderZtdLayoutGeneratedFile(config: ZtdProjectConfig): string {
   const ztdRootDir = config.ztdRootDir?.replace(/\\/g, '/') ?? resolveGeneratedDir(config).replace(/\/generated$/, '');
   const ddlDir = config.ddlDir.replace(/\\/g, '/');
 
-  // Keep default sibling directories deterministic for downstream tooling.
-  const enumsDir = path.posix.join(ztdRootDir, 'enums');
-  const domainSpecsDir = path.posix.join(ztdRootDir, 'domain-specs');
-
   return [
     '// GENERATED FILE. DO NOT EDIT.',
     '',
     'export default {',
     `  ztdRootDir: ${JSON.stringify(ztdRootDir)},`,
     `  ddlDir: ${JSON.stringify(ddlDir)},`,
-    `  enumsDir: ${JSON.stringify(enumsDir)},`,
-    `  domainSpecsDir: ${JSON.stringify(domainSpecsDir)},`,
     '};',
     ''
   ].join('\n');

--- a/packages/ztd-cli/tests/cliCommands.test.ts
+++ b/packages/ztd-cli/tests/cliCommands.test.ts
@@ -151,6 +151,7 @@ test(
 
   const outDir = createTempDir('cli-gen-out');
   const outputFile = path.join(outDir, 'ztd-row-map.generated.ts');
+  const layoutFile = path.join(outDir, 'ztd-layout.generated.ts');
   const manifestFile = path.join(outDir, 'ztd-fixture-manifest.generated.ts');
 
   const result = runCli(['ztd-config', '--ddl-dir', ddlDir, '--extensions', '.sql', '--out', outputFile]);
@@ -158,6 +159,14 @@ test(
 
   const content = readNormalizedFile(outputFile);
   expect(content).toMatchSnapshot();
+  const layoutContent = readNormalizedFile(layoutFile);
+  expect(layoutContent).toBe(`// GENERATED FILE. DO NOT EDIT.
+
+export default {
+  ztdRootDir: ".ztd",
+  ddlDir: "db/ddl",
+};
+`);
   const manifestContent = readNormalizedFile(manifestFile);
   expect(manifestContent).toContain("import type { TableDefinitionModel } from 'rawsql-ts';");
   expect(manifestContent).toContain('export const generatedFixtureManifest');


### PR DESCRIPTION
## Summary

Remove the deprecated `enumsDir` and `domainSpecsDir` fields from the `ztd-config` generated layout output and lock the current layout shape in a CLI test.

## Why

Issue #663 called out that the generated layout should only expose currently supported directories. Keeping the legacy sibling paths around made the generated artifact look like older layouts were still valid.

## What changed

- `packages/ztd-cli/src/commands/ztdConfigCommand.ts` now writes only `ztdRootDir` and `ddlDir` in `ztd-layout.generated.ts`
- `packages/ztd-cli/tests/cliCommands.test.ts` now checks the generated layout file to prevent the legacy fields from coming back

## Verification

- `pnpm --filter @rawsql-ts/ztd-cli test -- cliCommands.test.ts -t "ztd-config CLI produces the expected ztd-row-map.generated.ts snapshot"`

Closes #663

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated layout configuration generation to remove unnecessary entries from the generated output file, simplifying the generated configuration structure.

* **Tests**
  * Enhanced test coverage to validate the updated layout configuration output with additional assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->