### PR TITLE
Improve observed SQL matching and docs

### DIFF
--- a/docs/guide/observed-sql-investigation.md
+++ b/docs/guide/observed-sql-investigation.md
@@ -17,6 +17,7 @@ Use this workflow when you need to answer questions like:
 - Which query shape should I inspect before I change application code?
 
 It is a ranking tool, not a proof engine.
+The matcher is best-effort: it continues past parse failures and file-read failures, and it reports how many files were read, skipped, and scored.
 
 ## How to run it
 
@@ -40,11 +41,13 @@ The initial matcher focuses on SELECT-shaped SQL and compares structural areas:
 
 - projection
 - FROM / JOIN graph
-- predicate family
+- predicate structure and predicate families
 - ORDER BY
 - LIMIT / OFFSET presence
 
 It ignores whitespace, comments, and alias drift where possible.
+Boolean branch order is normalized, so `AND` / `OR` reordering alone should not dominate the result.
+Function calls include their argument shape, so similar names with different inputs stay distinguishable.
 
 ## Reading the result
 
@@ -54,8 +57,10 @@ Look for:
 - the score for each candidate
 - the main reasons it matched
 - the major differences that remain
+- the files-read / files-skipped counts and any warnings
 
 The top score tells you which asset to inspect first. It does not prove semantic equivalence.
+When warnings are present, treat the ranking as a filtered search result rather than a clean proof.
 
 ## Typical investigation flow
 

--- a/docs/guide/observed-sql-matching.md
+++ b/docs/guide/observed-sql-matching.md
@@ -22,6 +22,7 @@ Use `ztd query match-observed` when you need to answer questions like:
 - Which query shape should I inspect first before I change application code?
 
 It is a ranking tool, not a proof engine.
+The matcher is best-effort: it continues past parse failures and file-read failures, and it reports how many files were read, skipped, and scored.
 
 ## What it compares
 
@@ -29,11 +30,13 @@ The initial matcher focuses on SELECT-shaped SQL and compares these structural a
 
 - projection
 - FROM / JOIN graph
-- predicate family
+- predicate structure and predicate families
 - ORDER BY
 - LIMIT / OFFSET presence
 
 It ignores cosmetic differences such as whitespace, comments, and alias drift where possible.
+It also normalizes boolean branch order, so `AND` / `OR` reordering alone should not lower a candidate as much as a real structural change.
+Function calls are compared with their argument shape, so `lower(email)` and `lower(status)` no longer collapse into the same bucket.
 
 ## Good inputs
 
@@ -57,8 +60,10 @@ Look for:
 - the score for each candidate
 - why the candidate matched
 - what was different
+- how many files were read versus skipped
 
 High scores mean the structural shape is close, but they do not prove semantic equivalence.
+If the report shows skipped files or warnings, read them first before trusting the ranking order.
 
 ## Relationship to telemetry
 

--- a/packages/sql-grep-core/src/observed/match.ts
+++ b/packages/sql-grep-core/src/observed/match.ts
@@ -112,6 +112,7 @@ export function discoverObservedSqlAssetFiles(rootDir: string): string[] {
 export function buildObservedSqlMatchReport(params: ObservedSqlMatchReportParams): ObservedSqlMatchReport {
   const rootDir = path.resolve(params.rootDir ?? process.cwd());
   const topResults = params.topResults ?? DEFAULT_TOP_RESULTS;
+  const readFile = params.readFileSync ?? readFileSync;
   const warnings: ObservedSqlMatchWarning[] = [];
 
   const observedSummaries = collectQuerySummaries(params.observedSql, 'observed SQL', warnings);
@@ -128,11 +129,38 @@ export function buildObservedSqlMatchReport(params: ObservedSqlMatchReportParams
 
   const candidateFiles = discoverObservedSqlAssetFiles(rootDir);
   const candidates: CandidateSummary[] = [];
+  let filesRead = 0;
+  let filesSkipped = 0;
   let queriesSkipped = 0;
 
   for (const sqlFile of candidateFiles) {
-    const sqlText = readFileSync(sqlFile, 'utf8');
-    const queries = splitQueries(sqlText).getNonEmpty();
+    let sqlText: string;
+    try {
+      sqlText = readFile(sqlFile, 'utf8');
+      filesRead += 1;
+    } catch (error) {
+      filesSkipped += 1;
+      warnings.push({
+        code: 'file-read-failed',
+        sql_file: normalizePath(path.relative(rootDir, sqlFile)),
+        message: error instanceof Error ? error.message : String(error)
+      });
+      continue;
+    }
+
+    let queries: Array<{ sql: string }>;
+    try {
+      queries = splitQueries(sqlText).getNonEmpty();
+    } catch (error) {
+      filesSkipped += 1;
+      warnings.push({
+        code: 'file-scan-failed',
+        sql_file: normalizePath(path.relative(rootDir, sqlFile)),
+        message: error instanceof Error ? error.message : String(error)
+      });
+      continue;
+    }
+
     for (const [queryIndex, query] of queries.entries()) {
       const summaries = collectQuerySummaries(query.sql, normalizePath(path.relative(rootDir, sqlFile)), warnings);
       if (summaries.length === 0) {
@@ -188,6 +216,8 @@ export function buildObservedSqlMatchReport(params: ObservedSqlMatchReportParams
     observedQueries: observedSummaries.length,
     summary: {
       filesScanned: candidateFiles.length,
+      filesRead,
+      filesSkipped,
       sqlFilesScanned: candidateFiles.length,
       queriesScored: candidates.length,
       queriesSkipped,
@@ -211,6 +241,8 @@ export function formatObservedSqlMatchReport(report: ObservedSqlMatchReport, for
     `root: ${report.rootDir}`,
     `observed statements: ${report.observedQueries}`,
     `files scanned: ${report.summary.filesScanned}`,
+    `files read: ${report.summary.filesRead}`,
+    `files skipped: ${report.summary.filesSkipped}`,
     `queries scored: ${report.summary.queriesScored}`,
     `queries skipped: ${report.summary.queriesSkipped}`,
     `candidates returned: ${report.summary.candidates}`
@@ -518,22 +550,19 @@ function normalizeValueSignature(value: ValueComponent, aliasMap: Map<string, st
     return `raw:${normalizeIdentifier(candidate.value)}`;
   }
   if (candidate instanceof FunctionCall) {
-    const name = normalizeFunctionName(candidate);
-    const args: string[] = [];
-    if (candidate.argument) {
-      args.push(normalizeValueSignature(candidate.argument, aliasMap));
-    }
-    if (candidate.filterCondition) {
-      args.push(`filter:${normalizeValueSignature(candidate.filterCondition, aliasMap)}`);
-    }
-    return `fn:${name}(${args.join('|')})`;
+    return normalizeFunctionSignature(candidate, aliasMap);
   }
   if (candidate instanceof BinaryExpression) {
     const operator = normalizeIdentifier(candidate.operator.value);
+
+    if (operator === 'and' || operator === 'or') {
+      return normalizeBooleanSignature(candidate, aliasMap, operator);
+    }
+
     const left = normalizeValueSignature(candidate.left, aliasMap);
     const right = normalizeValueSignature(candidate.right, aliasMap);
 
-    if (operator === 'and' || operator === 'or' || operator === '=' || operator === 'is') {
+    if (operator === '=' || operator === 'is') {
       const ordered = [left, right].sort();
       return `${operator}(${ordered.join('|')})`;
     }
@@ -565,7 +594,7 @@ function normalizePredicateSignature(value: ValueComponent, aliasMap: Map<string
       return `${operator}(${normalizePredicateOperand(candidate.left, aliasMap)}|${normalizePredicateOperand(candidate.right, aliasMap)})`;
     }
     if (operator === 'and' || operator === 'or') {
-      return `${operator}(${normalizePredicateSignature(candidate.left, aliasMap)}|${normalizePredicateSignature(candidate.right, aliasMap)})`;
+      return normalizeBooleanSignature(candidate, aliasMap, operator);
     }
   }
 
@@ -596,7 +625,7 @@ function normalizePredicateOperand(value: ValueComponent, aliasMap: Map<string, 
   }
 
   if (candidate instanceof FunctionCall) {
-    return `fn:${normalizeFunctionName(candidate)}`;
+    return normalizeFunctionSignature(candidate, aliasMap);
   }
 
   if (candidate instanceof TupleExpression) {
@@ -614,6 +643,41 @@ function normalizeFunctionName(value: FunctionCall): string {
   const name = value.name instanceof RawString ? value.name.value : value.name.name;
   const namespaces = value.namespaces?.map((namespace) => normalizeIdentifier(namespace.name)) ?? [];
   return [...namespaces, normalizeIdentifier(name)].join('.');
+}
+
+function normalizeFunctionSignature(value: FunctionCall, aliasMap: Map<string, string>): string {
+  const name = normalizeFunctionName(value);
+  const args: string[] = [];
+
+  if (value.argument) {
+    args.push(normalizeValueSignature(value.argument, aliasMap));
+  }
+
+  if (value.filterCondition) {
+    args.push(`filter:${normalizeValueSignature(value.filterCondition, aliasMap)}`);
+  }
+
+  return `fn:${name}(${args.join('|')})`;
+}
+
+function normalizeBooleanSignature(
+  value: BinaryExpression,
+  aliasMap: Map<string, string>,
+  operator: 'and' | 'or'
+): string {
+  const operands = flattenBooleanOperands(value, operator).map((operand) => normalizeValueSignature(operand, aliasMap));
+  return `${operator}(${operands.sort().join('|')})`;
+}
+
+function flattenBooleanOperands(value: ValueComponent, operator: 'and' | 'or'): ValueComponent[] {
+  const candidate = unwrap(value);
+  if (candidate instanceof BinaryExpression && normalizeIdentifier(candidate.operator.value) === operator) {
+    return [
+      ...flattenBooleanOperands(candidate.left, operator),
+      ...flattenBooleanOperands(candidate.right, operator)
+    ];
+  }
+  return [candidate];
 }
 
 function normalizeColumnReference(value: ColumnReference, aliasMap: Map<string, string>): string {

--- a/packages/sql-grep-core/src/observed/types.ts
+++ b/packages/sql-grep-core/src/observed/types.ts
@@ -4,6 +4,7 @@ export interface ObservedSqlMatchReportParams {
   observedSql: string;
   rootDir?: string;
   topResults?: number;
+  readFileSync?: (filePath: string, encoding: BufferEncoding) => string;
 }
 
 export interface ObservedSqlMatchWarning {
@@ -50,6 +51,8 @@ export interface ObservedSqlMatchReport {
   observedQueries: number;
   summary: {
     filesScanned: number;
+    filesRead: number;
+    filesSkipped: number;
     sqlFilesScanned: number;
     queriesScored: number;
     queriesSkipped: number;

--- a/packages/sql-grep-core/tests/observedSqlMatch.test.ts
+++ b/packages/sql-grep-core/tests/observedSqlMatch.test.ts
@@ -101,6 +101,98 @@ describe('observed SQL matching', () => {
     expect(text).toContain('differences:');
   });
 
+  it('keeps boolean branch order stable and distinguishes function calls with different arguments', () => {
+    const workspace = createTempDir('observed-sql-match-structure');
+    const observedSql = `
+      SELECT lower(u.email)
+      FROM public.users u
+      WHERE u.status = :status AND (u.deleted_at IS NULL OR u.active = true)
+    `;
+
+    writeSqlFile(
+      path.join(workspace, 'src', 'sql', 'users', 'structure.sql'),
+      `
+        SELECT lower(u.email)
+        FROM public.users u
+        WHERE (u.active = true OR u.deleted_at IS NULL) AND u.status = :status
+      `
+    );
+
+    writeSqlFile(
+      path.join(workspace, 'src', 'sql', 'users', 'function-match.sql'),
+      `
+        SELECT lower(u.email)
+        FROM public.users u
+        WHERE lower(u.email) = :email
+      `
+    );
+
+    writeSqlFile(
+      path.join(workspace, 'src', 'sql', 'users', 'function-collision.sql'),
+      `
+        SELECT lower(u.status)
+        FROM public.users u
+        WHERE lower(u.status) = :status
+      `
+    );
+
+    const report = buildObservedSqlMatchReport({
+      rootDir: workspace,
+      observedSql
+    });
+
+    expect(report.matches[0]?.sql_file).toBe('src/sql/users/structure.sql');
+    expect(report.matches[0]?.score).toBeGreaterThan(report.matches[1]?.score ?? 0);
+    const scoresByFile = Object.fromEntries(report.matches.map((match) => [match.sql_file, match.score]));
+    expect(scoresByFile['src/sql/users/function-match.sql']).toBeGreaterThan(
+      scoresByFile['src/sql/users/function-collision.sql'] ?? 0
+    );
+  });
+
+  it('continues ranking when a candidate file cannot be read', () => {
+    const workspace = createTempDir('observed-sql-match-partial-failure');
+    const readableSqlFile = path.join(workspace, 'src', 'sql', 'users', 'good.sql');
+    const unreadableSqlFile = path.join(workspace, 'src', 'sql', 'users', 'broken.sql');
+
+    writeSqlFile(
+      readableSqlFile,
+      `
+        SELECT u.user_id
+        FROM public.users u
+        WHERE u.active = true
+      `
+    );
+    writeSqlFile(
+      unreadableSqlFile,
+      `
+        SELECT u.user_id
+        FROM public.users u
+        WHERE u.active = true
+      `
+    );
+
+    const report = buildObservedSqlMatchReport({
+      rootDir: workspace,
+      observedSql: `
+        SELECT u.user_id
+        FROM public.users u
+        WHERE u.active = true
+      `,
+      readFileSync: (filePath) => {
+        if (filePath.endsWith('broken.sql')) {
+          throw new Error('simulated read failure');
+        }
+        return readFileSync(filePath, 'utf8');
+      }
+    });
+
+    expect(report.matches[0]?.sql_file).toBe('src/sql/users/good.sql');
+    expect(report.summary.filesRead).toBeGreaterThan(0);
+    expect(report.summary.filesSkipped).toBe(1);
+    expect(report.warnings.some((warning) => warning.code === 'file-read-failed')).toBe(true);
+    expect(formatObservedSqlMatchReport(report, 'text')).toContain('files skipped: 1');
+  });
+
   it('keeps formatter output stable when no candidate matches are found', () => {
     const workspace = createTempDir('observed-sql-match-empty');
     const report = buildObservedSqlMatchReport({

--- a/packages/ztd-cli/README.md
+++ b/packages/ztd-cli/README.md
@@ -194,7 +194,7 @@ Run `npx ztd describe command <name>` for per-command flags and options.
 ### Advanced User Guides
 
 - [ztd-cli Telemetry Philosophy](../../docs/guide/ztd-cli-telemetry-philosophy.md) - opt-in telemetry guidance
-- [Observed SQL Matching](../../docs/guide/observed-sql-matching.md) - why reverse lookup exists and where it fits
+- [Observed SQL Matching](../../docs/guide/observed-sql-matching.md) - reverse lookup for missing `queryId`, with best-effort ranking and skip/warning reporting
 
 #### Multiple DB Clients in One Workflow
 

--- a/packages/ztd-cli/tests/furtherReading.docs.test.ts
+++ b/packages/ztd-cli/tests/furtherReading.docs.test.ts
@@ -56,9 +56,9 @@ test('Further Reading docs stay aligned with the current standalone and CLI beha
         'The starter setup derives `ZTD_TEST_DATABASE_URL` from `.env`',
         'If port `5432` is already in use, update `ZTD_DB_PORT` in `.env` before you rerun the compose path, for example:',
         'Copy-Item .env.example .env',
-        'npx ztd query uses column users.email --specs-dir src/features/users/persistence --any-schema --view detail',
+        'npx ztd query uses column users.email --specs-dir src/features/users-insert --any-schema --view detail',
         'Passing the feature folder as `--specs-dir` is a normal way to narrow the project-wide scan, not a workaround for feature-local layouts.',
-        'npx ztd model-gen --probe-mode ztd src/features/users/persistence/users.sql --out src/features/users/persistence/users.spec.ts',
+        'npx ztd model-gen --probe-mode ztd src/features/users-insert/insert-users/insert-users.sql --out src/features/users-insert/insert-users/queryspec.ts',
         'model-gen` now treats the SQL file location as the primary contract source',
         'Read the review summary first:',
         '- the risks section lists destructive and operational apply-plan risks separately',
@@ -171,7 +171,7 @@ test('Further Reading docs stay aligned with the current standalone and CLI beha
         '.codex/config.toml',
         '',
         'customer bootstrap targets separately from internal `.ztd` guidance',
-        'Read the nearest AGENTS files, inspect src/features/smoke, and plan the next users feature.'
+        'Read the nearest AGENTS.md files first. Then read `.codex/agents/*` if present.'
       ]
     },
     {


### PR DESCRIPTION
Issue
- Fixes #683.

Customer Value
- Observed SQL ranking becomes more stable for logically equivalent boolean shapes.
- Function calls are distinguished by their arguments, so lookups like `lower(email)` and `lower(status)` are less likely to collide.
- Large corpus scans continue past broken SQL assets and now tell you how many files were read and skipped, which makes reverse lookup safer in messy repos.
- The advanced guides now describe the actual matcher behavior, so users can interpret the ranking and warnings correctly.

Outcome
- Improved observed SQL token normalization and ranking behavior in `@rawsql-ts/sql-grep-core`.
- Added failure-tolerant scanning with warning and summary reporting.
- Updated the observed SQL guides and the public `ztd-cli` README to match the current CLI surface.
- Fixed the docs consistency test that was still asserting the older `users/persistence` paths.

Acceptance Criteria
- Boolean branch order is normalized for observed SQL comparisons.
- Function-call matching uses argument shape, not just the function name.
- File-read and parse failures are reported as warnings, while scanning continues.
- Summary output exposes read/skipped counts.
- `Observed SQL Matching` docs reflect the current behavior and CLI paths.

Verification
- `pnpm --filter @rawsql-ts/sql-grep-core test -- tests/observedSqlMatch.test.ts`
- `pnpm --filter @rawsql-ts/sql-grep-core build`
- `pnpm --filter @rawsql-ts/ztd-cli test -- tests/furtherReading.docs.test.ts`
- `git diff --check`

Repository Evidence
- `packages/sql-grep-core/src/observed/match.ts`
- `packages/sql-grep-core/src/observed/types.ts`
- `packages/sql-grep-core/tests/observedSqlMatch.test.ts`
- `docs/guide/observed-sql-matching.md`
- `docs/guide/observed-sql-investigation.md`
- `packages/ztd-cli/README.md`
- `packages/ztd-cli/tests/furtherReading.docs.test.ts`

Supplementary Evidence
- Local command output showed the targeted `sql-grep-core` test suite and the `ztd-cli` docs consistency test passing after the fixes.

Open Questions
- None.

Merge Blockers
- None known.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified `ztd query match-observed` behavior, including best-effort matching and file read/skip count reporting with warnings

* **New Features**
  * Match reports now include counts of files read and skipped
  * Enhanced error reporting with warnings for unreadable files during matching

* **Bug Fixes**
  * Improved matching accuracy and robustness with better boolean predicate normalization and function signature handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->