### PR TITLE
[codex] add JSON support to query sssql refresh

### DIFF
--- a/packages/ztd-cli/src/commands/query.ts
+++ b/packages/ztd-cli/src/commands/query.ts
@@ -82,6 +82,7 @@ interface QuerySssqlScaffoldOptions {
 interface QuerySssqlRefreshOptions {
   format?: string;
   out?: string;
+  json?: string;
 }
 
 interface QueryMatchObservedOptions {
@@ -278,6 +279,7 @@ Notes:
     .command('refresh <sqlFile>')
     .description('Refresh existing SSSQL optional filter scaffolds without changing predicate meaning')
     .option('--format <format>', 'Output format (text|json)', 'text')
+    .option('--json <payload>', 'Pass command options as a JSON object')
     .option('--out <path>', 'Write output to file')
     .action((sqlFile: string, options: QuerySssqlRefreshOptions) => {
       runQuerySssqlRefreshCommand(sqlFile, options);
@@ -539,14 +541,17 @@ function runQuerySssqlScaffoldCommand(sqlFile: string, options: QuerySssqlScaffo
 }
 
 function runQuerySssqlRefreshCommand(sqlFile: string, options: QuerySssqlRefreshOptions): void {
+  const resolved = options.json
+    ? { ...options, ...parseJsonPayload<Record<string, unknown>>(options.json, '--json') }
+    : options;
   const sql = readFileSync(sqlFile, 'utf8');
   const parsed = SelectQueryParser.parse(sql);
   const existingBranches = collectSupportedOptionalConditionBranches(parsed);
   const filters = Object.fromEntries(existingBranches.map((branch) => [branch.parameterName, null]));
   const result = new SSSQLFilterBuilder().refresh(parsed, filters);
   const formatted = new SqlFormatter().format(result).formattedSql;
-  const outputFile = normalizeStringOption(options.out);
-  const format = normalizeFormat(normalizeStringOption(options.format) ?? getAgentOutputFormat());
+  const outputFile = normalizeStringOption(resolved.out);
+  const format = normalizeFormat(normalizeStringOption(resolved.format) ?? getAgentOutputFormat());
 
   if (outputFile) {
     writeFileSync(outputFile, `${formatted}\n`, 'utf8');

--- a/packages/ztd-cli/tests/cliCommands.test.ts
+++ b/packages/ztd-cli/tests/cliCommands.test.ts
@@ -777,6 +777,56 @@ test(
 );
 
 test(
+  'query sssql refresh accepts a JSON payload for machine-readable automation',
+  () => {
+    const workspace = createSqlWorkspace('query-sssql-refresh-json', path.join('src', 'sql', 'users.sql'));
+    writeFileSync(
+      workspace.sqlFile,
+      `
+        SELECT u.id, u.status
+        FROM users u
+        WHERE (:status IS NULL OR u.status = :status)
+      `,
+      'utf8'
+    );
+
+    const outFile = path.join(workspace.rootDir, 'users.refreshed.sql');
+    const result = runCli(
+      [
+        'query',
+        'sssql',
+        'refresh',
+        workspace.sqlFile,
+        '--format',
+        'json',
+        '--json',
+        JSON.stringify({
+          out: outFile
+        })
+      ],
+      {},
+      workspace.rootDir
+    );
+
+    assertCliSuccess(result, 'query sssql refresh json');
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed).toMatchObject({
+      command: 'query sssql refresh',
+      ok: true,
+      data: {
+        file: workspace.sqlFile,
+        output_file: outFile,
+        written: true
+      }
+    });
+
+    const contents = readFileSync(outFile, 'utf8').replace(/\r\n/g, '\n').trim().toLowerCase();
+    expect(contents).toContain('(:status is null or "u"."status" = :status)');
+  },
+  60000,
+);
+
+test(
   'query match-observed ranks the likely source asset for observed SELECT SQL',
   () => {
     const workspace = createSqlWorkspace('query-match-observed', path.join('src', 'sql', 'users', 'list.sql'));


### PR DESCRIPTION
## What changed
- Added `--json` support to `ztd query sssql refresh` so it matches the scaffold command's machine-readable option style.
- Added a CLI test that covers JSON payload parsing and JSON envelope output for refresh.

## Why
- Issue #632 already had the core SSSQL scaffold/refresh flow in place, but refresh lacked the same automation-friendly `--json` entrypoint as scaffold.
- This makes the refresh command easier to script and keeps the public CLI surface more consistent.

## Impact
- Users can now drive `ztd query sssql refresh` through JSON payloads in the same way as `scaffold`.
- Existing refresh behavior is unchanged when `--json` is not used.

## Checks
- `pnpm test -- packages/core/tests/transformers/SSSQLFilterBuilder.test.ts`
- `pnpm --filter @rawsql-ts/ztd-cli exec vitest run --config vitest.config.ts tests/cliCommands.test.ts -t "query sssql"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* The `query sssql refresh` command now accepts a `--json` option with a JSON payload for specifying output destination and format.

## Tests
* Added test coverage for JSON payload handling in the `query sssql refresh` command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->