### PR TITLE
[codex] drop npm self-update from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,9 +45,10 @@ jobs:
       - name: Setup publish readiness runtime
         uses: ./.github/actions/setup-publish-runtime
         with:
+          node-version: "24"
           use-pnpm: "true"
           install-dependencies: "true"
-          update-npm: "true"
+          update-npm: "false"
           required-commands: "node,npm,pnpm"
           warn-min-npm-version: "11.5.1"
           label: "verify-publish-readiness"
@@ -79,6 +80,7 @@ jobs:
       - name: Setup artifact build runtime
         uses: ./.github/actions/setup-publish-runtime
         with:
+          node-version: "24"
           use-pnpm: "true"
           install-dependencies: "true"
           update-npm: "false"
@@ -134,9 +136,10 @@ jobs:
       - name: Setup actual publish runtime
         uses: ./.github/actions/setup-publish-runtime
         with:
+          node-version: "24"
           use-pnpm: "false"
           install-dependencies: "false"
-          update-npm: "true"
+          update-npm: "false"
           required-commands: "node,npm,git,gh"
           min-npm-version: "11.5.1"
           label: "actual-publish"


### PR DESCRIPTION
What changed
- Stopped self-updating npm inside the publish runtime helper.
- Pinned publish workflow jobs to Node 24 so the required npm version is available without `npm install -g`.

Why
- The manual publish workflow was failing in `verify_publish_readiness` because `npm install -g "npm@^11.5.1"` crashed on the runner with `Cannot find module 'promise-retry'`.

Validation
- Reviewed GitHub Actions run 23899778356 and confirmed the failure point.
- Verified the local diff and committed it as `ci: drop npm self-update from publish workflow`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated publishing workflow configuration to use Node.js 24 for build and deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->