### PR TITLE
[codex] refine ztd-cli onboarding and guides

### DIFF
--- a/docs/guide/multiple-db-clients-in-one-workflow.md
+++ b/docs/guide/multiple-db-clients-in-one-workflow.md
@@ -1,0 +1,21 @@
+# Multiple DB Clients in One Workflow
+
+`ztd-config` can produce separate artifacts for multiple DB contexts. At runtime, treat each context as its own `SqlClient` and keep the clients side by side when a single workflow needs to talk to more than one database.
+
+```ts
+type AppClients = {
+  dbA: SqlClient;
+  dbB: SqlClient;
+};
+
+async function runWorkflow(clients: AppClients) {
+  const users = await createUsersRepository(clients.dbA).listActiveUsers();
+  const invoices = await createBillingRepository(clients.dbB).listOpenInvoices();
+
+  return { users, invoices };
+}
+```
+
+This is the minimum runtime step needed for multi-DB workflows. It is not saga orchestration itself; it is the client-binding pattern that makes a saga-style design possible later.
+
+See the proof test in [packages/testkit-postgres/tests/client.test.ts](../../packages/testkit-postgres/tests/client.test.ts).

--- a/docs/guide/ztd-config-top-level-settings.md
+++ b/docs/guide/ztd-config-top-level-settings.md
@@ -1,0 +1,19 @@
+# ztd.config.json Top-Level Settings
+
+`ztd.config.json` keeps schema resolution at the top level:
+
+```json
+{
+  "dialect": "postgres",
+  "ztdRootDir": ".ztd",
+  "ddlDir": "db/ddl",
+  "testsDir": ".ztd/tests",
+  "defaultSchema": "public",
+  "searchPath": ["public"],
+  "ddlLint": "strict"
+}
+```
+
+`ddl.defaultSchema` and `ddl.searchPath` are no longer read.
+
+Use this reference when you want to confirm where the generated config keeps schema resolution and which fields are still honored by `ztd-cli`.

--- a/packages/ztd-cli/README.md
+++ b/packages/ztd-cli/README.md
@@ -3,23 +3,21 @@
 ![npm version](https://img.shields.io/npm/v/@rawsql-ts/ztd-cli)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 
-## What
+`ztd-cli` is a SQL-first CLI for feature-first application development.
 
-`ztd-cli` is a SQL-first CLI for feature-first application development. It treats handwritten SQL (DDL and named-parameter DML) as the source of truth and scaffolds feature-local layouts.
+## Highlights
 
-When SQL changes introduce inconsistencies, the toolchain surfaces them as type errors and test failures before they ship.
-
-The focus is SQL maintainability: keep schema, queries, specs, and tests close to each feature, and let the toolchain show you what broke when the SQL changed.
-
-## Why
-
-- DDL stays the source of truth for the shape you test.
-- You can keep the app and deployment databases out of the inner loop while still testing against a real engine.
-- Migration artifacts are generated for review, but they are not applied automatically.
+- DDL is the source of truth, and `pg_dump` output can be used to bootstrap it.
+- SQL lives as files, co-located with each feature.
+- Development starts from SQL changes, then moves through tests and repair loops.
+- ZTD-format SQL tests are the standard, and SQL tuning has a dedicated path.
+- Migration artifacts are generated for review, not applied automatically.
+- No extra DSL is required.
+- VSA-style feature-local SQL layouts are supported.
 
 ## Quickstart
 
-### macOS / Linux / Git Bash
+Run these in order.
 
 ```bash
 npm install -D @rawsql-ts/ztd-cli vitest typescript
@@ -28,12 +26,12 @@ npx ztd init --starter
 npx ztd agents init
 cp .env.example .env
 # edit ZTD_DB_PORT=5433 if needed
-docker compose up -d
 npx ztd ztd-config
+docker compose up -d
 npx vitest run
 ```
 
-### PowerShell
+PowerShell:
 
 ```powershell
 npm install -D @rawsql-ts/ztd-cli vitest typescript
@@ -42,143 +40,81 @@ npx ztd init --starter
 npx ztd agents init
 Copy-Item .env.example .env
 # edit ZTD_DB_PORT=5433 if needed
-docker compose up -d
 npx ztd ztd-config
+docker compose up -d
 npx vitest run
 ```
 
-The starter scaffold includes `@rawsql-ts/testkit-core`, so `npx ztd ztd-config` works in a fresh standalone project and writes the generated runtime manifest to `.ztd/generated/ztd-fixture-manifest.generated.ts`.
-That manifest carries `tableDefinitions` schema metadata only; test rows stay explicit fixtures outside the generated contract.
-The removable starter smoke path also shows `@rawsql-ts/testkit-postgres` and `createPostgresTestkitClient` for the DB-backed test that catches setup problems early.
-If you want the fixture-resolution details, read the `@rawsql-ts/testkit-postgres` package README after the starter smoke path.
+## Troubleshooting
 
-If you add a no-op repository telemetry seam under `src/infrastructure/telemetry/`, use `queryId` as the stable lookup key, and keep `repositoryName`, `methodName`, `paramsShape`, and `transformations` as safe execution metadata only.
-That seam does not emit SQL text or bind values by default, so you can decide explicitly when to connect console, pino, or OpenTelemetry sinks.
+### Port Already In Use
 
-Make sure Docker Desktop or another Docker daemon is already running before you start the compose path, because `docker compose up -d` only launches the stack.
-The generated Vitest setup derives `ZTD_TEST_DATABASE_URL` from `.env`, so the test runtime sees the same port setting as the compose file.
+If port `5432` is already in use, change `ZTD_DB_PORT` in `.env` and then verify recovery with:
 
-> `ztd-cli` prepares the workflow, but it does not execute SQL by itself. Pair it with a database adapter and a DBMS-specific testkit such as `@rawsql-ts/adapter-node-pg` + `@rawsql-ts/testkit-postgres` for Postgres.
+```bash
+docker compose up -d
+npx vitest run
+```
 
-If `5432` is busy, use another local port and update `ZTD_DB_PORT` in `.env`.
+## Create the Users Insert Feature
 
-* macOS / Linux / Git Bash:
+Use this after Quickstart.
 
-  ```bash
-  cp .env.example .env
-  # edit ZTD_DB_PORT=5433 if needed
-  docker compose up -d
-  npx vitest run
-  ```
+The DDL is in `db/ddl/public.sql`.
 
-* PowerShell:
+Run this first:
 
-  ```powershell
-  Copy-Item .env.example .env
-  # edit ZTD_DB_PORT=5433 if needed
-  docker compose up -d
-  npx vitest run
-  ```
+```bash
+npx ztd feature scaffold --table users --action insert
+```
 
+Scaffold the `users-insert` feature with co-located SQL, specs, and tests.
 
-## Getting Started with AI
-
-Use this prompt after Quickstart.
-Choose ztd init or ztd init --starter based on whether I want the removable starter sample.
+Then ask AI to add the follow-up tests in `src/features/users-insert/tests`. ZTD here means SQL-only tests without migrations or mocks, run against the real database engine.
 
 ```text
-Add a users insert feature to this feature-first project.
-Read the nearest AGENTS.md files first. Then read `.codex/agents/*` if present.
-Start with `npx ztd feature scaffold --table users --action insert`.
-Keep `entryspec.ts`, the query-local `queryspec.ts`, and the query-local SQL resource inside `src/features/users-insert`.
-Use `zod` schemas at the feature boundary and DB boundary, then add tests as the AI follow-up.
-Add the two tests in src/features/users-insert/tests as the follow-up step.
+Write ZTD-format tests for the users insert feature.
+Keep them in src/features/users-insert/tests.
+Cover:
+- required-field validation failures
+- successful insert returning an id
 Do not apply migrations automatically.
 ```
 
-Quickstart treats `npx ztd agents init` as an optional follow-up after starter scaffold creation.
-If you skipped that step and still want the opt-in Codex bootstrap for the project, run it before asking Codex to inspect `src/features/smoke`.
-If you want `PROMPT_DOGFOOD.md` for debugging or prompt review, pass `--with-dogfooding` to `npx ztd init --starter`.
+Finish by running:
 
-`ztd agents init` adds:
-
-- visible `AGENTS.md` guidance
-- `.codex/config.toml`
-- `.codex/agents/`
-
-Existing user-owned guidance files are preserved; use `npx ztd agents status` if you need to review customer bootstrap targets separately from internal `.ztd` guidance, including managed, customized, or unmanaged-conflict files.
-
-A good first request after setup is:
-
-```text
-Add a users insert feature to this feature-first project.
-Read the nearest AGENTS.md files first. Then read `.codex/agents/*` if present.
-Start with `npx ztd feature scaffold --table users --action insert`.
-Keep `entryspec.ts`, the query-local `queryspec.ts`, and the query-local SQL resource inside `src/features/users-insert`.
-Use `zod` schemas at the feature boundary and DB boundary, then add tests as the AI follow-up.
-Add the two tests in src/features/users-insert/tests as the follow-up step.
-Do not apply migrations automatically.
+```bash
+npx vitest run
 ```
 
-## Core features
-
-- `ztd init --starter` creates a feature-first starter scaffold with `smoke`, starter DDL, and local Postgres wiring.
-- `ztd feature scaffold --table <table> --action <insert|update|delete|get-by-id|list>` creates a fixed CRUD/SELECT boundary scaffold with `entryspec.ts`, a co-located query directory (`queryspec.ts` + SQL resource), `zod` DTO schemas at both boundaries, a shared executor runtime contract, the empty feature `tests/` directory, and SQL-resource helper files on first run. `get-by-id` uses a zero-or-one baseline, and `list` keeps default paging and primary-key ordering inside `queryspec.ts` while leaving the two test files to AI follow-up.
-- `ztd agents init` adds the optional Codex bootstrap on demand: visible `AGENTS.md`, `.codex/agents`, and `.codex/config.toml`.
-- `ztd ztd-config --watch` keeps generated `TestRowMap` types and runtime fixture metadata aligned with DDL as files change.
-- `ztd lint` checks SQL against a temporary Postgres before you ship it.
-- `ztd model-gen` and `ztd query uses` keep QuerySpec scaffolding and impacted-file discovery close to the feature-first slice.
-- `ztd query sssql scaffold` and `ztd query sssql refresh` move optional filters into SQL-first authoring and keep runtime pruning explicit. Runtime no longer injects new filter predicates.
-- `ztd query match-observed` ranks likely source SQL assets for an observed SELECT statement when `queryId` is missing. See the investigation guide for the full flow.
-- `ztd perf init` / `ztd perf run` support tuning without forcing SQL rewrites first.
-- `--dry-run` / `--output json` make the workflow reviewable and machine-readable.
+If you want a deeper walkthrough, keep that in the linked guides instead of expanding this README.
 
 ## Commands
 
 | Command | Purpose |
 |---|---|
-| `ztd init --starter` | Scaffold the recommended first-run project. |
-| `ztd feature scaffold --table <table> --action <insert/update/delete/get-by-id/list>` | Scaffold the fixed CRUD/SELECT boundary files (`entryspec.ts`, query-local `queryspec.ts` + SQL, `zod` DTO schemas, shared executor runtime contract), the empty `tests/` directory, and SQL-resource helper files on first run, while using `@rawsql-ts/sql-contract` for cardinality and catalog execution and leaving the two test files to AI follow-up. |
-| `ztd agents init` | Add the optional Codex bootstrap on demand. |
-| `ztd ztd-config` | Regenerate `TestRowMap`, runtime fixture metadata, and layout metadata from DDL; add `--watch` for live updates. |
-| `ztd lint` | Lint SQL files against a temporary Postgres. |
+| `ztd init --starter` | Scaffold the starter project with smoke, DDL, compose, and local Postgres wiring. |
+| `ztd feature scaffold --table <table> --action <insert/update/delete/get-by-id/list>` | Scaffold a feature-local CRUD/SELECT slice with SQL, entrypoint, QuerySpec, tests, and DTO schemas. |
+| `ztd agents init` | Add the optional Codex bootstrap files. |
+| `ztd ztd-config` | Regenerate `TestRowMap` and runtime fixture metadata from DDL without Docker. |
+| `ztd lint` | Lint SQL against a temporary Postgres. |
 | `ztd model-gen` | Generate QuerySpec scaffolding from SQL assets. |
 | `ztd query uses` | Find impacted SQL before changing a table or column. |
 | `ztd query match-observed` | Rank likely source SQL assets from observed SELECT text. |
 | `ztd query sssql scaffold` / `ztd query sssql refresh` | Author and refresh SQL-first optional filter branches. |
-| `ztd ddl pull` / `ztd ddl diff` | Inspect an explicit target and prepare migration SQL. |
-| `ztd perf *` | Run the tuning loop (`init`, `db reset`, `run`) for index or pipeline investigation. |
-| `ztd describe` | Inspect commands in machine-readable form, including `--output json`. |
-
-After DDL or schema changes, rerun `ztd ztd-config`, `ztd lint`, and `npx vitest run`. Use `ztd ddl diff` or `ztd ddl pull` when you need a migration plan. The generated runtime manifest under `.ztd/generated/` is the preferred input for `@rawsql-ts/testkit-postgres`.
-Run `npx ztd describe command <name>` for per-command flags and options.
-
-## ztd.config.json
-
-`ztd.config.json` now keeps schema resolution at the top level:
-
-```json
-{
-  "dialect": "postgres",
-  "ztdRootDir": ".ztd",
-  "ddlDir": "db/ddl",
-  "testsDir": ".ztd/tests",
-  "defaultSchema": "public",
-  "searchPath": ["public"],
-  "ddlLint": "strict"
-}
-```
-
-`ddl.defaultSchema` and `ddl.searchPath` are no longer read. If an older project still keeps schema settings under `ddl`, move them to the top-level `defaultSchema` and `searchPath` fields.
+| `ztd ddl pull` / `ztd ddl diff` | Inspect a target and prepare migration SQL. |
+| `ztd perf init` / `ztd perf run` | Run the tuning loop for index or pipeline investigation. |
+| `ztd describe` | Inspect commands in machine-readable form. |
 
 ## Glossary
 
 | Term | Meaning |
 |---|---|
-| ZTD | Zero Table Dependency - test against a real database engine without creating or mutating application tables. |
+| ZTD | [Zero Table Dependency](../../docs/guide/ztd-theory.md) - test against a real database engine without creating or mutating application tables. |
 | DDL | SQL schema files that act as the source of truth for type generation. |
 | TestRowMap | Generated TypeScript types that describe row shape from local DDL. |
 | QuerySpec | Contract object that ties a SQL asset file to parameter and output types. |
+| SSSQL | [SQL-first optional-filter authoring style](../../docs/guide/sssql-overview.md) that keeps the query truthful and lets the runtime prune only what it must. |
 
 ## Further Reading
 
@@ -186,43 +122,28 @@ Run `npx ztd describe command <name>` for per-command flags and options.
 
 - [SQL-first End-to-End Tutorial](../../docs/guide/sql-first-end-to-end-tutorial.md) - starter flow, repair loops, and scenario-specific CLI guidance
 - [SQL Tool Happy Paths](../../docs/guide/sql-tool-happy-paths.md) - choose between query plan, perf, query uses, and telemetry
+- [Dynamic Filter Routing](../../docs/guide/dynamic-filter-routing.md) - decide between DynamicQueryBuilder filters and SSSQL branches
+- [ztd.config.json Top-Level Settings](../../docs/guide/ztd-config-top-level-settings.md) - where schema resolution lives and how to read the generated config
 - [Perf Tuning Decision Guide](../../docs/guide/perf-tuning-decision-guide.md) - index tuning vs pipeline tuning
 - [JOIN Direction Lint Specification](../../docs/guide/join-direction-lint-spec.md) - readable FK-aware JOIN guidance
 - [Repository Telemetry Setup](../../docs/guide/repository-telemetry-setup.md) - how to edit the scaffold, emit logs, and investigate with `queryId`
 - [Observed SQL Investigation](../../docs/guide/observed-sql-investigation.md) - how to use `ztd query match-observed` when `queryId` is missing
+- [ztd-cli Agent Interface](../../docs/guide/ztd-cli-agent-interface.md) - machine-readable command surface
 
 ### Advanced User Guides
 
-- [ztd-cli Telemetry Philosophy](../../docs/guide/ztd-cli-telemetry-philosophy.md) - opt-in telemetry guidance
+- [Published-Package Verification Before Release](../../docs/guide/published-package-verification.md) - pack and smoke-test the published-package path
+- [What Is SSSQL?](../../docs/guide/sssql-overview.md) - the shortest intro to truthful optional-filter SQL
+- [SSSQL for Humans](../../docs/guide/sssql-for-humans.md) - why SSSQL exists and where it fits in the toolchain
+- [ztd-cli Telemetry Philosophy](../../docs/guide/ztd-cli-telemetry-philosophy.md) - when to enable telemetry and why it stays opt-in
+- [ztd-cli Telemetry Policy](../../docs/guide/ztd-cli-telemetry-policy.md) - which event fields are allowed and how redaction works
+- [ztd-cli Telemetry Export Modes](../../docs/guide/ztd-cli-telemetry-export-modes.md) - how to send telemetry to console, debug, file, or OTLP
 - [Observed SQL Matching](../../docs/guide/observed-sql-matching.md) - reverse lookup for missing `queryId`, with best-effort ranking and skip/warning reporting
-
-#### Multiple DB Clients in One Workflow
-
-`ztd-config` can already produce separate artifacts for multiple DB contexts. At runtime, treat each context as its own `SqlClient` and keep the clients side by side when a single workflow needs to talk to more than one database.
-
-```ts
-type AppClients = {
-  dbA: SqlClient;
-  dbB: SqlClient;
-};
-
-async function runWorkflow(clients: AppClients) {
-  const users = await createUsersRepository(clients.dbA).listActiveUsers();
-  const invoices = await createBillingRepository(clients.dbB).listOpenInvoices();
-
-  return { users, invoices };
-}
-```
-
-This is the minimum runtime step needed for multi-DB workflows. It is not saga orchestration itself; it is the client-binding pattern that makes a saga-style design possible later. See the proof test in [packages/testkit-postgres/tests/client.test.ts](../testkit-postgres/tests/client.test.ts).
+- [Multiple DB Clients in One Workflow](../../docs/guide/multiple-db-clients-in-one-workflow.md) - separate DB contexts, one workflow, and side-by-side `SqlClient` bindings
 
 ### Developer Guides
 
-- [Migration Lifecycle Dogfooding](../../docs/dogfooding/ztd-migration-lifecycle.md) - separate-AI prompts for DDL, SQL, DTO, and migration repair
-- [Perf Scale Tuning Dogfooding](../../docs/dogfooding/perf-scale-tuning.md) - separate-AI tuning dogfood
-- [Published-Package Verification Before Release](../../docs/guide/published-package-verification.md) - pack and smoke-test the published-package path
 - [Local-Source Dogfooding](../../docs/guide/ztd-local-source-dogfooding.md) - unpublished local checkout workflow
-- [ztd-cli Agent Interface](../../docs/guide/ztd-cli-agent-interface.md) - machine-readable command surface
 - [Codex Bootstrap Verification](../../docs/dogfooding/ztd-codex-bootstrap-verification.md) - reviewer-checkable fresh-project verification for `ztd agents init`
 - [ztd-cli spawn EPERM Investigation](../../docs/dogfooding/ztd-cli-spawn-eperm-investigation.md) - reviewer-checkable root-cause investigation for the local Vitest startup blocker
 - [ztd Onboarding Dogfooding](../../docs/dogfooding/ztd-onboarding-dogfooding.md) - reviewer-checkable README Quickstart and tutorial verification for the customer-facing onboarding path


### PR DESCRIPTION
## What changed
- Reworked the `packages/ztd-cli` README to prioritize a shorter Quickstart and a clearer first-run flow.
- Added a troubleshooting branch for common port conflicts.
- Simplified the AI setup path for the `users` insert feature and made the follow-up tests more explicit.
- Moved detailed background material into separate guide pages and linked them from the README.

## Why
The README was doing too much at the top and made the first successful run harder to reach. This update puts the fast path first and moves deeper explanations to secondary docs.

## User impact
New users should be able to copy the Quickstart, run it immediately, and get to the first successful ZTD workflow with less reading.

## Verification
- Documentation-only change
- Reviewed the staged diff before commit
- Pushed branch `codex/readme-fast-start`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added guide on configuring and using multiple database clients within a single workflow
  * Added guide explaining ztd-config top-level settings for schema resolution and migration
  * Enhanced ztd-cli README with improved organization, new troubleshooting section, and step-by-step feature development guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->