### PR TITLE
[codex] fix feature scaffold cardinality helpers

### DIFF
--- a/.changeset/silent-badgers-guess.md
+++ b/.changeset/silent-badgers-guess.md
@@ -1,0 +1,5 @@
+---
+"@rawsql-ts/ztd-cli": patch
+---
+
+Fix feature scaffold queryspec generation so CRUD baselines no longer import non-existent `sql-contract` cardinality helpers and instead use locally generated row-count handling.

--- a/packages/ztd-cli/src/commands/feature.ts
+++ b/packages/ztd-cli/src/commands/feature.ts
@@ -1029,7 +1029,6 @@ function renderQuerySpecFile(params: {
     "import { z } from 'zod';",
     '',
     "import type { FeatureQueryExecutor } from '../../_shared/featureQueryExecutor';",
-    "import { queryExactlyOneRow, type QueryParams } from '@rawsql-ts/sql-contract';",
     "import { loadSqlResource } from '../../_shared/loadSqlResource';",
     '',
     `const ${params.queryCamelName}SqlResource = loadSqlResource(__dirname, '${params.queryName}.sql');`,
@@ -1062,19 +1061,23 @@ function renderQuerySpecFile(params: {
     '  return QueryResultSchema.parse(row);',
     '}',
     '',
+    '/** Loads the single row for the write baseline. */',
+    `async function loadSingleRow(executor: FeatureQueryExecutor, sql: string, params: Record<string, unknown>): Promise<${params.queryPascalName}Row> {`,
+    '  const rows = await executor.query<Record<string, unknown>>(sql, params);',
+    '  if (rows.length !== 1) {',
+    `    throw new Error('${params.queryPascalName}QuerySpec expected exactly one row.');`,
+    '  }',
+    '  return parseRow(rows[0]);',
+    '}',
+    '',
     '/** Executes the query boundary flow for this query spec. */',
     `export async function execute${params.queryPascalName}QuerySpec(`,
     `  executor: FeatureQueryExecutor,`,
     `  rawParams: unknown`,
     `): Promise<${params.queryPascalName}QueryResult> {`,
     '  const params = parseQueryParams(rawParams);',
-    `  const row = await queryExactlyOneRow<Record<string, unknown>>(`,
-    '    (sql, params) => executor.query(sql, params as Record<string, unknown>),',
-    `    ${params.queryCamelName}SqlResource,`,
-    '    params as QueryParams,',
-    `    { label: '${params.featureName}/${params.queryName}/queryspec' }`,
-    '  );',
-    '  return mapRowToResult(parseRow(row));',
+    `  const row = await loadSingleRow(executor, ${params.queryCamelName}SqlResource, params);`,
+    '  return mapRowToResult(row);',
     '}',
     ''
   ].join('\n');
@@ -1137,7 +1140,7 @@ function renderReadmeFile(params: {
     '',
     '- `src/features/_shared/featureQueryExecutor.ts`',
     '- `src/features/_shared/loadSqlResource.ts`',
-    '- Cardinality and catalog runtime primitives from `@rawsql-ts/sql-contract`',
+    '- Catalog runtime primitives from `@rawsql-ts/sql-contract`',
     '',
     '## AI-created files',
     '',
@@ -1280,9 +1283,9 @@ function renderReadmeOperationNotes(action: FeatureAction, primaryKeyColumn: str
   if (action === 'get-by-id') {
     return [
       `- The baseline get-by-id query uses \`${primaryKeyColumn}\` as the predicate and selects the scaffolded row shape explicitly.`,
-      '- The baseline uses `queryZeroOrOneRow`, so not found is allowed instead of being treated as an exception.',
+      '- The baseline allows not found instead of treating it as an exception.',
       '- Generated request and response contracts follow the DDL-derived column types for this feature; the scaffold does not assume that every ID is a 32-bit integer.',
-      '- If the feature later needs a strict existence guarantee, this scaffold can be tightened to `queryExactlyOneRow` as a follow-up decision.'
+      '- If the feature later needs a strict existence guarantee, this scaffold can be tightened to a strict one-row contract as a follow-up decision.'
     ];
   }
   if (action === 'list') {
@@ -1316,7 +1319,7 @@ function renderReadmeOperationNotes(action: FeatureAction, primaryKeyColumn: str
 function renderReadmeFollowUpNotes(action: FeatureAction): string[] {
   if (action === 'get-by-id') {
     return [
-      '- Switch to `queryExactlyOneRow` later only if the feature decides that missing rows must fail instead of returning a nullable result.'
+      '- Switch to a strict one-row contract later only if the feature decides that missing rows must fail instead of returning a nullable result.'
     ];
   }
   if (action === 'list') {
@@ -1551,7 +1554,6 @@ function renderGetByIdQuerySpecFile(params: {
     "import { z } from 'zod';",
     '',
     "import type { FeatureQueryExecutor } from '../../_shared/featureQueryExecutor';",
-    "import { queryZeroOrOneRow, type QueryParams } from '@rawsql-ts/sql-contract';",
     "import { loadSqlResource } from '../../_shared/loadSqlResource';",
     '',
     `const ${params.queryCamelName}SqlResource = loadSqlResource(__dirname, '${params.queryName}.sql');`,
@@ -1587,19 +1589,26 @@ function renderGetByIdQuerySpecFile(params: {
     `  return QueryResultSchema.parse(row);`,
     '}',
     '',
+    '/** Loads the optional row for the get-by-id baseline. */',
+    `async function loadOptionalRow(executor: FeatureQueryExecutor, sql: string, params: Record<string, unknown>): Promise<${params.queryPascalName}Row | undefined> {`,
+    '  const rows = await executor.query<Record<string, unknown>>(sql, params);',
+    '  if (rows.length === 0) {',
+    '    return undefined;',
+    '  }',
+    '  if (rows.length > 1) {',
+    `    throw new Error('${params.queryPascalName}QuerySpec expected at most one row.');`,
+    '  }',
+    '  return parseRow(rows[0]);',
+    '}',
+    '',
     '/** Executes the query boundary flow for this query spec. */',
     `export async function execute${params.queryPascalName}QuerySpec(`,
     '  executor: FeatureQueryExecutor,',
     '  rawParams: unknown',
     `): Promise<${params.queryPascalName}QueryResult> {`,
     '  const params = parseQueryParams(rawParams);',
-    `  const row = await queryZeroOrOneRow<Record<string, unknown>>(`,
-    '    (sql, queryParams) => executor.query(sql, queryParams as Record<string, unknown>),',
-    `    ${params.queryCamelName}SqlResource,`,
-    '    params as QueryParams,',
-    `    { label: '${params.featureName}/${params.queryName}/queryspec' }`,
-    '  );',
-    '  return mapRowToResult(row === undefined ? undefined : parseRow(row));',
+    `  const row = await loadOptionalRow(executor, ${params.queryCamelName}SqlResource, params);`,
+    '  return mapRowToResult(row);',
     '}',
     ''
   ].join('\n');

--- a/packages/ztd-cli/tests/cliCommands.test.ts
+++ b/packages/ztd-cli/tests/cliCommands.test.ts
@@ -405,10 +405,13 @@ test(
       "import { z } from 'zod';"
     );
     expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'users-insert', 'insert-users', 'queryspec.ts'))).toContain(
-      "import { queryExactlyOneRow, type QueryParams } from '@rawsql-ts/sql-contract';"
+      "import type { FeatureQueryExecutor } from '../../_shared/featureQueryExecutor';"
+    );
+    expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'users-insert', 'insert-users', 'queryspec.ts'))).not.toContain(
+      'queryExactlyOneRow'
     );
     expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'users-insert', 'insert-users', 'queryspec.ts'))).toContain(
-      "import type { FeatureQueryExecutor } from '../../_shared/featureQueryExecutor';"
+      'loadSingleRow'
     );
     expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'users-insert', 'insert-users', 'queryspec.ts'))).not.toContain(
       'export const insertUsersQueryParamsSchema'
@@ -587,7 +590,8 @@ test(
     expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'users-get-by-id', 'entryspec.ts'))).toContain('id: z.string()');
     expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'users-get-by-id', 'entryspec.ts'))).toContain('function parseRequest');
     expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'users-get-by-id', 'entryspec.ts'))).toContain('function toQueryParams');
-    expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'users-get-by-id', 'get-by-id', 'queryspec.ts'))).toContain('queryZeroOrOneRow');
+    expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'users-get-by-id', 'get-by-id', 'queryspec.ts'))).toContain('loadOptionalRow');
+    expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'users-get-by-id', 'get-by-id', 'queryspec.ts'))).not.toContain('queryZeroOrOneRow');
     expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'users-get-by-id', 'get-by-id', 'queryspec.ts'))).toContain('}).strict();');
     expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'users-get-by-id', 'get-by-id', 'queryspec.ts'))).toContain('const RowSchema = z.object({');
   },

--- a/packages/ztd-cli/tests/featureScaffold.unit.test.ts
+++ b/packages/ztd-cli/tests/featureScaffold.unit.test.ts
@@ -276,7 +276,6 @@ test('runFeatureScaffoldCommand writes the entryspec/queryspec baseline and excl
     'utf8'
   );
   expect(querySpecFile).toContain("import { z } from 'zod';");
-  expect(querySpecFile).toContain("import { queryExactlyOneRow, type QueryParams } from '@rawsql-ts/sql-contract';");
   expect(querySpecFile).toContain("import type { FeatureQueryExecutor } from '../../_shared/featureQueryExecutor';");
   expect(querySpecFile).toContain("const insertUsersSqlResource = loadSqlResource(__dirname, 'insert-users.sql');");
   expect(querySpecFile).toContain('const QueryParamsSchema = z.object({');
@@ -295,8 +294,8 @@ test('runFeatureScaffoldCommand writes the entryspec/queryspec baseline and excl
   expect(querySpecFile).toContain('function mapRowToResult');
   expect(querySpecFile).toContain('/** Executes the query boundary flow for this query spec. */');
   expect(querySpecFile).toContain('export async function executeInsertUsersQuerySpec');
-  expect(querySpecFile).toContain('queryExactlyOneRow<Record<string, unknown>>(');
-  expect(querySpecFile).toContain("(sql, params) => executor.query(sql, params as Record<string, unknown>)");
+  expect(querySpecFile).toContain('loadSingleRow');
+  expect(querySpecFile).toContain('executor.query<Record<string, unknown>>(sql, params)');
   expect(querySpecFile).not.toContain('export interface InsertUsersQueryContract');
   expect(querySpecFile).not.toContain('export const insertUsersQueryContract');
   expect(querySpecFile).not.toContain('export function parseInsertUsersQueryParams');
@@ -340,7 +339,7 @@ test('runFeatureScaffoldCommand writes the entryspec/queryspec baseline and excl
   expect(readmeFile).toContain('DDL-backed default expressions written directly into SQL: `created_at`.');
   expect(readmeFile).toContain('When DDL declares a column default, the scaffold writes that default expression into SQL explicitly');
   expect(readmeFile).toContain('featureQueryExecutor.ts` is the shared runtime contract for DB execution injection');
-  expect(readmeFile).toContain('Cardinality and catalog execution should come from `@rawsql-ts/sql-contract`');
+  expect(readmeFile).toContain('Catalog runtime primitives from `@rawsql-ts/sql-contract`');
   expect(readmeFile).toContain('Keep this baseline as one workflow and one primary query by default');
 });
 
@@ -458,7 +457,8 @@ test('runFeatureScaffoldCommand writes the update baseline with pk predicate and
     'utf8'
   );
   expect(querySpecFile).toContain('export type UpdateUsersQueryParams');
-  expect(querySpecFile).toContain("import { queryExactlyOneRow, type QueryParams } from '@rawsql-ts/sql-contract';");
+  expect(querySpecFile).toContain('loadSingleRow');
+  expect(querySpecFile).not.toContain('queryExactlyOneRow');
 
   const sqlFile = readFileSync(
     path.join(workspace, 'src', 'features', 'users-update', 'update-users', 'update-users.sql'),
@@ -580,14 +580,15 @@ test('runFeatureScaffoldCommand writes the get-by-id baseline with zero-or-one c
     path.join(workspace, 'src', 'features', 'users-get-by-id', 'get-by-id', 'queryspec.ts'),
     'utf8'
   );
-  expect(querySpecFile).toContain("import { queryZeroOrOneRow, type QueryParams } from '@rawsql-ts/sql-contract';");
+  expect(querySpecFile).not.toContain('queryZeroOrOneRow');
   expect(querySpecFile).toContain('}).strict();');
   expect(querySpecFile).toContain('const RowSchema = z.object({');
   expect(querySpecFile).toContain('const QueryResultSchema = RowSchema.nullable();');
   expect(querySpecFile).toContain('function parseQueryParams');
   expect(querySpecFile).toContain('function parseRow');
   expect(querySpecFile).toContain('function mapRowToResult');
-  expect(querySpecFile).toContain('queryZeroOrOneRow<Record<string, unknown>>(');
+  expect(querySpecFile).toContain('loadOptionalRow');
+  expect(querySpecFile).toContain('executor.query<Record<string, unknown>>(sql, params)');
   expect(querySpecFile).toContain('return null;');
 
   const sqlFile = readFileSync(
@@ -602,11 +603,10 @@ test('runFeatureScaffoldCommand writes the get-by-id baseline with zero-or-one c
     path.join(workspace, 'src', 'features', 'users-get-by-id', 'README.md'),
     'utf8'
   );
-  expect(readmeFile).toContain('The baseline uses `queryZeroOrOneRow`');
-  expect(readmeFile).toContain('not found is allowed');
+  expect(readmeFile).toContain('The baseline allows not found instead of treating it as an exception.');
   expect(readmeFile).toContain('does not assume that every ID is a 32-bit integer');
   expect(readmeFile).toContain('rejects unsupported request fields instead of silently ignoring them');
-  expect(readmeFile).toContain('tightened to `queryExactlyOneRow`');
+  expect(readmeFile).toContain('tightened to a strict one-row contract');
 });
 
 test('runFeatureScaffoldCommand writes the list baseline with catalog paging and items response', async () => {


### PR DESCRIPTION
## Issue
The feature scaffold generator was emitting generated `queryspec.ts` code that referenced cardinality helpers not present in the published `@rawsql-ts/sql-contract` API.

## Customer Value
Developers can scaffold CRUD features without getting immediate typecheck failures from generated code. This keeps the first-run experience for `ztd feature scaffold` usable and predictable.

## Outcome
- Write-style CRUD scaffolds now use a local `loadSingleRow` helper instead of a non-existent exported cardinality helper.
- `get-by-id` scaffolds keep the optional-row path via a local `loadOptionalRow` helper.
- The generator README wording now describes the public `sql-contract` dependency without naming missing helpers.
- Tests were updated to lock in the public-API-only output.
- A changeset was added for the `@rawsql-ts/ztd-cli` patch release.

## Acceptance Criteria
- `feature scaffold` should no longer generate imports or helper names that do not exist in the published `@rawsql-ts/sql-contract` package.
- Generated CRUD scaffolds should typecheck immediately after creation.
- The regression should be covered by unit tests.
- The fix should include a prevention path for future releases.

## Verification
- `pnpm exec vitest run packages/ztd-cli/tests/featureScaffold.unit.test.ts`
- `pnpm --filter @rawsql-ts/ztd-cli build`
- Full `packages/ztd-cli` test execution was attempted via the commit hook, but the repository currently has unrelated failing tests and legacy-layout fixtures outside this change.

## Repository Evidence
- [`packages/ztd-cli/src/commands/feature.ts`](./packages/ztd-cli/src/commands/feature.ts)
- [`packages/ztd-cli/tests/featureScaffold.unit.test.ts`](./packages/ztd-cli/tests/featureScaffold.unit.test.ts)
- [`packages/ztd-cli/tests/cliCommands.test.ts`](./packages/ztd-cli/tests/cliCommands.test.ts)
- [`.changeset/silent-badgers-guess.md`](./.changeset/silent-badgers-guess.md)

## Supplementary Evidence
- Local inspection confirmed the generated scaffold paths now use `loadSingleRow` for write scaffolds and `loadOptionalRow` for `get-by-id`.
- The repository-wide CLI test suite still contains unrelated legacy-layout and fixture issues, so those failures are not used as acceptance evidence for this fix.

## Open Questions
- None for this fix.

## Merge Blockers
- None from this change. The remaining failing repository-wide tests are unrelated pre-existing issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed feature scaffolding to generate working CRUD operations that no longer rely on non-existent external cardinality helpers. Generated insert, update, and get-by-id code now includes internal row validation logic, properly enforcing single-row constraints for write operations and optional-row behavior for read operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->