### PR TITLE
Stabilize deep boundary scaffold imports in ztd-cli

### DIFF
--- a/.changeset/smart-gifts-pull.md
+++ b/.changeset/smart-gifts-pull.md
@@ -1,0 +1,7 @@
+---
+"@rawsql-ts/ztd-cli": patch
+---
+
+Stabilize scaffolded shared imports in deep recursive boundary layouts without rewriting every generated import style.
+
+Generated query-boundary files now use stable shared specifiers for `src/features/_shared/*` and `tests/support/*`, while nearby boundary-local imports stay relative. Starter scaffolds also add the matching package imports, TypeScript paths, and Vitest aliases so deeper boundary splits are less likely to break when code moves into lower child boundaries.

--- a/packages/ztd-cli/README.md
+++ b/packages/ztd-cli/README.md
@@ -132,6 +132,7 @@ As boundary depth grows, avoid making every import depth-sensitive by default.
 - Stabilize only shared references that are likely to break when work is split horizontally and moved into a deeper child boundary, such as `src/features/_shared/*` or `tests/support/*`.
 - One workable tactic is package `imports` or an equivalent alias that works in both TypeScript and runtime resolution, but that is a means, not the architectural goal.
 - Minimum rule: imports that cross boundaries should make the target boundary explicit and go through its `boundary.ts` entrypoint.
+- Pragmatic exception: designated shared infrastructure such as `src/features/_shared/*` and `tests/support/*` may use stabilized root-level aliases or package-style imports because they are shared support seams, not another boundary's private internals.
 - Do not treat this issue as a reason to rewrite every scaffolded import to one style.
 
 ## Troubleshooting

--- a/packages/ztd-cli/README.md
+++ b/packages/ztd-cli/README.md
@@ -125,11 +125,14 @@ After the cases are filled, run `npx vitest run src/features/<feature-name>/quer
 
 ## Import Paths
 
-As boundary depth grows, avoid making deep relative imports part of the architecture contract.
+As boundary depth grows, avoid making every import depth-sensitive by default.
 
-- Preferred direction: use a root-based import convention such as package `imports` (`#src/*`) or an equivalent alias that works in both TypeScript and runtime resolution.
+- The goal is boundary-change safety, not a blanket root-alias migration.
+- Keep local, nearby references relative when they move with the same boundary.
+- Stabilize only shared references that are likely to break when work is split horizontally and moved into a deeper child boundary, such as `src/features/_shared/*` or `tests/support/*`.
+- One workable tactic is package `imports` or an equivalent alias that works in both TypeScript and runtime resolution, but that is a means, not the architectural goal.
 - Minimum rule: imports that cross boundaries should make the target boundary explicit and go through its `boundary.ts` entrypoint.
-- If a project has not adopted a root alias yet, treat the alias migration as recommended follow-up before boundary nesting becomes deep.
+- Do not treat this issue as a reason to rewrite every scaffolded import to one style.
 
 ## Troubleshooting
 

--- a/packages/ztd-cli/src/commands/feature.ts
+++ b/packages/ztd-cli/src/commands/feature.ts
@@ -18,6 +18,8 @@ import { registerFeatureTestsScaffoldCommand } from './featureTests';
 const FEATURE_ACTIONS = ['insert', 'update', 'delete', 'get-by-id', 'list'] as const;
 type FeatureAction = (typeof FEATURE_ACTIONS)[number];
 const DEFAULT_PAGE_SIZE = 50;
+const FEATURE_SHARED_EXECUTOR_IMPORT_PATH = '#features/_shared/featureQueryExecutor.js';
+const FEATURE_SHARED_LOAD_SQL_RESOURCE_IMPORT_PATH = '#features/_shared/loadSqlResource.js';
 const FIXED_LAYOUT_DESCRIPTION = [
   'src/features/<feature-name>/',
   '  boundary.ts',
@@ -1105,8 +1107,8 @@ function renderQuerySpecFile(params: {
     "import { dirname } from 'node:path';",
     "import { fileURLToPath } from 'node:url';",
     '',
-    "import type { FeatureQueryExecutor } from '../../../_shared/featureQueryExecutor.js';",
-    "import { loadSqlResource } from '../../../_shared/loadSqlResource.js';",
+    `import type { FeatureQueryExecutor } from '${FEATURE_SHARED_EXECUTOR_IMPORT_PATH}';`,
+    `import { loadSqlResource } from '${FEATURE_SHARED_LOAD_SQL_RESOURCE_IMPORT_PATH}';`,
     '',
     'const __dirname = dirname(fileURLToPath(import.meta.url));',
     `const ${params.queryCamelName}SqlResource = loadSqlResource(__dirname, '${params.queryName}.sql');`,
@@ -1644,8 +1646,8 @@ function renderGetByIdQuerySpecFile(params: {
     "import { dirname } from 'node:path';",
     "import { fileURLToPath } from 'node:url';",
     '',
-    "import type { FeatureQueryExecutor } from '../../../_shared/featureQueryExecutor.js';",
-    "import { loadSqlResource } from '../../../_shared/loadSqlResource.js';",
+    `import type { FeatureQueryExecutor } from '${FEATURE_SHARED_EXECUTOR_IMPORT_PATH}';`,
+    `import { loadSqlResource } from '${FEATURE_SHARED_LOAD_SQL_RESOURCE_IMPORT_PATH}';`,
     '',
     'const __dirname = dirname(fileURLToPath(import.meta.url));',
     `const ${params.queryCamelName}SqlResource = loadSqlResource(__dirname, '${params.queryName}.sql');`,
@@ -1733,9 +1735,9 @@ function renderListQuerySpecFile(params: {
     "import { dirname } from 'node:path';",
     "import { fileURLToPath } from 'node:url';",
     '',
-    "import type { FeatureQueryExecutor } from '../../../_shared/featureQueryExecutor.js';",
+    `import type { FeatureQueryExecutor } from '${FEATURE_SHARED_EXECUTOR_IMPORT_PATH}';`,
     "import { createCatalogExecutor, type QuerySpec } from '@rawsql-ts/sql-contract';",
-    "import { loadSqlResource } from '../../../_shared/loadSqlResource.js';",
+    `import { loadSqlResource } from '${FEATURE_SHARED_LOAD_SQL_RESOURCE_IMPORT_PATH}';`,
     '',
     `const DEFAULT_PAGE_SIZE = ${DEFAULT_PAGE_SIZE};`,
     'const __dirname = dirname(fileURLToPath(import.meta.url));',

--- a/packages/ztd-cli/src/commands/feature.ts
+++ b/packages/ztd-cli/src/commands/feature.ts
@@ -12,6 +12,7 @@ import {
 import { emitDiagnostic, isJsonOutput, writeCommandEnvelope } from '../utils/agentCli';
 import { ensureDirectory } from '../utils/fs';
 import { collectSqlFiles, type SqlSource } from '../utils/collectSqlFiles';
+import { inspectImportAliasSupport } from '../utils/importAliasSupport';
 import { loadZtdProjectConfig, resolveGeneratedDir } from '../utils/ztdProjectConfig';
 import { registerFeatureTestsScaffoldCommand } from './featureTests';
 
@@ -20,6 +21,8 @@ type FeatureAction = (typeof FEATURE_ACTIONS)[number];
 const DEFAULT_PAGE_SIZE = 50;
 const FEATURE_SHARED_EXECUTOR_IMPORT_PATH = '#features/_shared/featureQueryExecutor.js';
 const FEATURE_SHARED_LOAD_SQL_RESOURCE_IMPORT_PATH = '#features/_shared/loadSqlResource.js';
+const FEATURE_SHARED_EXECUTOR_RELATIVE_IMPORT_PATH = '../../../_shared/featureQueryExecutor.js';
+const FEATURE_SHARED_LOAD_SQL_RESOURCE_RELATIVE_IMPORT_PATH = '../../../_shared/loadSqlResource.js';
 const FIXED_LAYOUT_DESCRIPTION = [
   'src/features/<feature-name>/',
   '  boundary.ts',
@@ -159,6 +162,7 @@ export async function runFeatureScaffoldCommand(options: FeatureCommandOptions):
   const primaryKeyColumn = resolvePrimaryKeyColumn(input.table);
   const paths = buildFeatureScaffoldPaths(rootDir, featureName, queryName);
   const contents = renderFeatureScaffoldFiles({
+    rootDir,
     featureName,
     queryName,
     action,
@@ -500,6 +504,7 @@ function buildFeatureScaffoldPaths(rootDir: string, featureName: string, queryNa
 }
 
 function renderFeatureScaffoldFiles(params: {
+  rootDir: string;
   featureName: string;
   queryName: string;
   action: FeatureAction;
@@ -514,6 +519,17 @@ function renderFeatureScaffoldFiles(params: {
   featureQueryExecutorFile: string;
   loadSqlResourceFile: string;
 } {
+  const importAliasSupport = inspectImportAliasSupport(params.rootDir, {
+    packageImportKey: '#features/*.js',
+    tsconfigPathKey: '#features/*',
+    vitestAliasPrefix: '#features'
+  });
+  if (importAliasSupport === 'partial') {
+    throw new Error(
+      'Feature scaffold found partial #features alias configuration. Configure package.json#imports, tsconfig.json compilerOptions.paths, and vitest.config.ts resolve.alias together, or remove the partial alias setup.'
+    );
+  }
+  const useStableSharedImports = importAliasSupport === 'supported';
   const pascalName = toPascalCase(params.featureName);
   const entryCamelName = toCamelCase(params.featureName);
   const queryPascalName = toPascalCase(params.queryName);
@@ -557,7 +573,8 @@ function renderFeatureScaffoldFiles(params: {
     queryPascalName,
     queryCamelName,
     requestFields,
-    responseFields
+    responseFields,
+    useStableSharedImports
   });
   const readmeFile = renderReadmeFile({
     action: params.action,
@@ -1075,6 +1092,7 @@ function renderQuerySpecFile(params: {
   queryCamelName: string;
   requestFields: RenderField[];
   responseFields: RenderField[];
+  useStableSharedImports: boolean;
 }): string {
   if (params.action === 'get-by-id') {
     return renderGetByIdQuerySpecFile(params);
@@ -1107,8 +1125,8 @@ function renderQuerySpecFile(params: {
     "import { dirname } from 'node:path';",
     "import { fileURLToPath } from 'node:url';",
     '',
-    `import type { FeatureQueryExecutor } from '${FEATURE_SHARED_EXECUTOR_IMPORT_PATH}';`,
-    `import { loadSqlResource } from '${FEATURE_SHARED_LOAD_SQL_RESOURCE_IMPORT_PATH}';`,
+    `import type { FeatureQueryExecutor } from '${params.useStableSharedImports ? FEATURE_SHARED_EXECUTOR_IMPORT_PATH : FEATURE_SHARED_EXECUTOR_RELATIVE_IMPORT_PATH}';`,
+    `import { loadSqlResource } from '${params.useStableSharedImports ? FEATURE_SHARED_LOAD_SQL_RESOURCE_IMPORT_PATH : FEATURE_SHARED_LOAD_SQL_RESOURCE_RELATIVE_IMPORT_PATH}';`,
     '',
     'const __dirname = dirname(fileURLToPath(import.meta.url));',
     `const ${params.queryCamelName}SqlResource = loadSqlResource(__dirname, '${params.queryName}.sql');`,
@@ -1627,6 +1645,7 @@ function renderGetByIdQuerySpecFile(params: {
   queryCamelName: string;
   requestFields: RenderField[];
   responseFields: RenderField[];
+  useStableSharedImports: boolean;
 }): string {
   const paramsSchema = renderZodObjectSchema('QueryParamsSchema', params.requestFields, {
     trimStrings: false,
@@ -1646,8 +1665,8 @@ function renderGetByIdQuerySpecFile(params: {
     "import { dirname } from 'node:path';",
     "import { fileURLToPath } from 'node:url';",
     '',
-    `import type { FeatureQueryExecutor } from '${FEATURE_SHARED_EXECUTOR_IMPORT_PATH}';`,
-    `import { loadSqlResource } from '${FEATURE_SHARED_LOAD_SQL_RESOURCE_IMPORT_PATH}';`,
+    `import type { FeatureQueryExecutor } from '${params.useStableSharedImports ? FEATURE_SHARED_EXECUTOR_IMPORT_PATH : FEATURE_SHARED_EXECUTOR_RELATIVE_IMPORT_PATH}';`,
+    `import { loadSqlResource } from '${params.useStableSharedImports ? FEATURE_SHARED_LOAD_SQL_RESOURCE_IMPORT_PATH : FEATURE_SHARED_LOAD_SQL_RESOURCE_RELATIVE_IMPORT_PATH}';`,
     '',
     'const __dirname = dirname(fileURLToPath(import.meta.url));',
     `const ${params.queryCamelName}SqlResource = loadSqlResource(__dirname, '${params.queryName}.sql');`,
@@ -1716,6 +1735,7 @@ function renderListQuerySpecFile(params: {
   queryCamelName: string;
   requestFields: RenderField[];
   responseFields: RenderField[];
+  useStableSharedImports: boolean;
 }): string {
   const paramsSchema = renderZodObjectSchema('QueryParamsSchema', params.requestFields, {
     trimStrings: false,
@@ -1735,9 +1755,9 @@ function renderListQuerySpecFile(params: {
     "import { dirname } from 'node:path';",
     "import { fileURLToPath } from 'node:url';",
     '',
-    `import type { FeatureQueryExecutor } from '${FEATURE_SHARED_EXECUTOR_IMPORT_PATH}';`,
+    `import type { FeatureQueryExecutor } from '${params.useStableSharedImports ? FEATURE_SHARED_EXECUTOR_IMPORT_PATH : FEATURE_SHARED_EXECUTOR_RELATIVE_IMPORT_PATH}';`,
     "import { createCatalogExecutor, type QuerySpec } from '@rawsql-ts/sql-contract';",
-    `import { loadSqlResource } from '${FEATURE_SHARED_LOAD_SQL_RESOURCE_IMPORT_PATH}';`,
+    `import { loadSqlResource } from '${params.useStableSharedImports ? FEATURE_SHARED_LOAD_SQL_RESOURCE_IMPORT_PATH : FEATURE_SHARED_LOAD_SQL_RESOURCE_RELATIVE_IMPORT_PATH}';`,
     '',
     `const DEFAULT_PAGE_SIZE = ${DEFAULT_PAGE_SIZE};`,
     'const __dirname = dirname(fileURLToPath(import.meta.url));',

--- a/packages/ztd-cli/src/commands/featureTests.ts
+++ b/packages/ztd-cli/src/commands/featureTests.ts
@@ -5,6 +5,9 @@ import { Command } from 'commander';
 import { emitDiagnostic, isJsonOutput, writeCommandEnvelope } from '../utils/agentCli';
 import { ensureDirectory } from '../utils/fs';
 
+const TESTS_SUPPORT_HARNESS_IMPORT_PATH = '#tests/support/ztd/harness.js';
+const TESTS_SUPPORT_CASE_TYPES_IMPORT_PATH = '#tests/support/ztd/case-types.js';
+
 type FeatureTestsCommandOptions = {
   feature?: string;
   query?: string;
@@ -287,7 +290,7 @@ function renderFeatureTestScaffoldFiles(params: {
   )}\n`;
 
   const querySpecImportPath = '../boundary.js';
-  const harnessImportPath = '../../../../../../tests/support/ztd/harness.js';
+  const harnessImportPath = TESTS_SUPPORT_HARNESS_IMPORT_PATH;
   const casesImportPath = './cases/basic.case.js';
   const executorName = readExportedFunctionName(params.planDetails.querySpecSourcePath, 'execute', 'QuerySpec');
   const queryTypePrefix = toPascalCase(params.queryName);
@@ -350,7 +353,7 @@ function renderFeatureTestScaffoldFiles(params: {
   ].join('\n');
 
   const queryTypesFile = [
-    `import type { QuerySpecZtdCase } from '../../../../../../tests/support/ztd/case-types.js';`,
+    `import type { QuerySpecZtdCase } from '${TESTS_SUPPORT_CASE_TYPES_IMPORT_PATH}';`,
     '',
     `export type ${queryTypePrefix}BeforeDb = ${beforeDbTypeLiteral};`,
     `export type ${queryTypePrefix}Input = ${queryInputTypeLiteral};`,

--- a/packages/ztd-cli/src/commands/featureTests.ts
+++ b/packages/ztd-cli/src/commands/featureTests.ts
@@ -4,6 +4,7 @@ import { Command } from 'commander';
 
 import { emitDiagnostic, isJsonOutput, writeCommandEnvelope } from '../utils/agentCli';
 import { ensureDirectory } from '../utils/fs';
+import { inspectImportAliasSupport } from '../utils/importAliasSupport';
 
 const TESTS_SUPPORT_HARNESS_IMPORT_PATH = '#tests/support/ztd/harness.js';
 const TESTS_SUPPORT_CASE_TYPES_IMPORT_PATH = '#tests/support/ztd/case-types.js';
@@ -123,6 +124,7 @@ export async function runFeatureTestsScaffoldCommand(options: FeatureTestsComman
   });
 
   const files = renderFeatureTestScaffoldFiles({
+    rootDir,
     featureName,
     queryName: queryLayout.queryName,
     planDetails
@@ -195,6 +197,7 @@ function assertSharedZtdTestSupport(rootDir: string): void {
 }
 
 function renderFeatureTestScaffoldFiles(params: {
+  rootDir: string;
   featureName: string;
   queryName: string;
   planDetails: TestPlanDetails;
@@ -205,6 +208,17 @@ function renderFeatureTestScaffoldFiles(params: {
   basicCaseFile: string;
   queryTypesFile: string;
 } {
+  const importAliasSupport = inspectImportAliasSupport(params.rootDir, {
+    packageImportKey: '#tests/*.js',
+    tsconfigPathKey: '#tests/*',
+    vitestAliasPrefix: '#tests'
+  });
+  if (importAliasSupport === 'partial') {
+    throw new Error(
+      'Feature tests scaffold found partial #tests alias configuration. Configure package.json#imports, tsconfig.json compilerOptions.paths, and vitest.config.ts resolve.alias together, or remove the partial alias setup.'
+    );
+  }
+  const useStableTestSupportImports = importAliasSupport === 'supported';
   const fixtureCandidateTablesLine = params.planDetails.fixtureCandidateTables.length > 0
     ? params.planDetails.fixtureCandidateTables.map((field) => `- ${field}`).join('\n')
     : '- TODO: inspect the scaffolded SQL and DDL for fixture candidate tables.';
@@ -290,7 +304,9 @@ function renderFeatureTestScaffoldFiles(params: {
   )}\n`;
 
   const querySpecImportPath = '../boundary.js';
-  const harnessImportPath = TESTS_SUPPORT_HARNESS_IMPORT_PATH;
+  const harnessImportPath = useStableTestSupportImports
+    ? TESTS_SUPPORT_HARNESS_IMPORT_PATH
+    : '../../../../../../tests/support/ztd/harness.js';
   const casesImportPath = './cases/basic.case.js';
   const executorName = readExportedFunctionName(params.planDetails.querySpecSourcePath, 'execute', 'QuerySpec');
   const queryTypePrefix = toPascalCase(params.queryName);
@@ -353,7 +369,7 @@ function renderFeatureTestScaffoldFiles(params: {
   ].join('\n');
 
   const queryTypesFile = [
-    `import type { QuerySpecZtdCase } from '${TESTS_SUPPORT_CASE_TYPES_IMPORT_PATH}';`,
+    `import type { QuerySpecZtdCase } from '${useStableTestSupportImports ? TESTS_SUPPORT_CASE_TYPES_IMPORT_PATH : '../../../../../../tests/support/ztd/case-types.js'}';`,
     '',
     `export type ${queryTypePrefix}BeforeDb = ${beforeDbTypeLiteral};`,
     `export type ${queryTypePrefix}Input = ${queryInputTypeLiteral};`,

--- a/packages/ztd-cli/src/commands/init.ts
+++ b/packages/ztd-cli/src/commands/init.ts
@@ -2041,6 +2041,28 @@ function ensurePackageJsonFormatting(
     changed = true;
   }
 
+  const importsField = (parsed.imports as Record<string, unknown> | undefined) ?? {};
+  const requiredImports: Record<string, Record<string, string>> = {
+    '#features/*.js': {
+      types: './src/features/*.ts',
+      default: './dist/features/*.js'
+    },
+    '#tests/*.js': {
+      types: './tests/*.ts',
+      default: './tests/*.ts'
+    }
+  };
+  for (const [key, value] of Object.entries(requiredImports)) {
+    if (JSON.stringify(importsField[key]) === JSON.stringify(value)) {
+      continue;
+    }
+    importsField[key] = value;
+    changed = true;
+  }
+  if (Object.keys(importsField).length > 0) {
+    parsed.imports = importsField;
+  }
+
   const scripts = (parsed.scripts as Record<string, string> | undefined) ?? {};
   const requiredScripts: Record<string, string> = {
     test: 'vitest run --passWithNoTests',

--- a/packages/ztd-cli/src/utils/importAliasSupport.ts
+++ b/packages/ztd-cli/src/utils/importAliasSupport.ts
@@ -1,0 +1,73 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+type JsonRecord = Record<string, unknown>;
+
+export type ImportAliasSupportStatus = 'supported' | 'absent' | 'partial';
+
+function readJsonRecordIfExists(filePath: string): JsonRecord | null {
+  if (!existsSync(filePath)) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(readFileSync(filePath, 'utf8')) as JsonRecord;
+  } catch {
+    return null;
+  }
+}
+
+function hasPackageImport(rootDir: string, importKey: string): boolean {
+  const packageJson = readJsonRecordIfExists(path.join(rootDir, 'package.json'));
+  if (!packageJson) {
+    return false;
+  }
+
+  const imports = packageJson.imports;
+  return typeof imports === 'object' && imports !== null && importKey in (imports as JsonRecord);
+}
+
+function hasTsconfigPath(rootDir: string, pathKey: string): boolean {
+  const tsconfig = readJsonRecordIfExists(path.join(rootDir, 'tsconfig.json'));
+  if (!tsconfig) {
+    return false;
+  }
+
+  const compilerOptions = tsconfig.compilerOptions;
+  if (!compilerOptions || typeof compilerOptions !== 'object') {
+    return false;
+  }
+
+  const paths = (compilerOptions as JsonRecord).paths;
+  return typeof paths === 'object' && paths !== null && pathKey in (paths as JsonRecord);
+}
+
+function hasVitestAlias(rootDir: string, aliasPrefix: string): boolean {
+  const configPath = path.join(rootDir, 'vitest.config.ts');
+  if (!existsSync(configPath)) {
+    return false;
+  }
+
+  const contents = readFileSync(configPath, 'utf8');
+  return contents.includes(`'${aliasPrefix}'`) || contents.includes(`"${aliasPrefix}"`);
+}
+
+export function inspectImportAliasSupport(rootDir: string, options: {
+  packageImportKey: string;
+  tsconfigPathKey: string;
+  vitestAliasPrefix: string;
+}): ImportAliasSupportStatus {
+  const checks = [
+    hasPackageImport(rootDir, options.packageImportKey),
+    hasTsconfigPath(rootDir, options.tsconfigPathKey),
+    hasVitestAlias(rootDir, options.vitestAliasPrefix)
+  ];
+
+  if (checks.every(Boolean)) {
+    return 'supported';
+  }
+  if (checks.every((value) => !value)) {
+    return 'absent';
+  }
+  return 'partial';
+}

--- a/packages/ztd-cli/templates/src/features/README.md
+++ b/packages/ztd-cli/templates/src/features/README.md
@@ -34,9 +34,11 @@ When you are on the boundary lane, treat it as query-local: `src/features/<featu
 
 ## Import Paths
 
-Prefer root-based imports once the project grows beyond shallow nesting.
+Prefer stability at recursive boundary seams over one blanket import style.
 
-- Recommended direction: add a project-root import convention such as `#src/*` package imports or an equivalent root alias that works in both TypeScript and runtime resolution.
+- Keep local, nearby references relative when they naturally move with the same boundary.
+- Stabilize only shared references that are likely to break when a boundary is split and moved deeper, such as `src/features/_shared/*` or `tests/support/*`.
+- One workable tactic is package `imports` such as `#features/*` and `#tests/*`, or an equivalent alias that works in both TypeScript and runtime resolution.
 - Minimum rule: do not let deep relative imports become the public boundary contract.
 - When a boundary depends on another boundary, make the dependency obvious by importing its compiled ESM entrypoint with `.js` specifiers, such as `./boundary.js` or `../boundary.js`, rather than walking through internal files.
 

--- a/packages/ztd-cli/templates/src/features/README.md
+++ b/packages/ztd-cli/templates/src/features/README.md
@@ -41,6 +41,7 @@ Prefer stability at recursive boundary seams over one blanket import style.
 - One workable tactic is package `imports` such as `#features/*` and `#tests/*`, or an equivalent alias that works in both TypeScript and runtime resolution.
 - Minimum rule: do not let deep relative imports become the public boundary contract.
 - When a boundary depends on another boundary, make the dependency obvious by importing its compiled ESM entrypoint with `.js` specifiers, such as `./boundary.js` or `../boundary.js`, rather than walking through internal files.
+- Pragmatic exception: designated shared infrastructure such as `src/features/_shared/*` and `tests/support/*` may use stabilized root-level aliases because those files are shared support seams, not another boundary's private implementation.
 
 ## Sample feature
 

--- a/packages/ztd-cli/templates/src/features/smoke/queries/smoke/boundary.ts
+++ b/packages/ztd-cli/templates/src/features/smoke/queries/smoke/boundary.ts
@@ -2,8 +2,8 @@ import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 
-import type { FeatureQueryExecutor } from '../../../_shared/featureQueryExecutor.js';
-import { loadSqlResource } from '../../../_shared/loadSqlResource.js';
+import type { FeatureQueryExecutor } from '#features/_shared/featureQueryExecutor.js';
+import { loadSqlResource } from '#features/_shared/loadSqlResource.js';
 
 const smokeSqlResource = loadSqlResource(dirname(fileURLToPath(import.meta.url)), 'smoke.sql');
 

--- a/packages/ztd-cli/templates/src/features/smoke/queries/smoke/tests/boundary-ztd-types.ts
+++ b/packages/ztd-cli/templates/src/features/smoke/queries/smoke/tests/boundary-ztd-types.ts
@@ -1,4 +1,4 @@
-import type { QuerySpecZtdCase } from '../../../../../../tests/support/ztd/case-types.js';
+import type { QuerySpecZtdCase } from '#tests/support/ztd/case-types.js';
 
 export type SmokeBeforeDb = {
   public: {

--- a/packages/ztd-cli/templates/src/features/smoke/queries/smoke/tests/smoke.boundary.ztd.test.ts
+++ b/packages/ztd-cli/templates/src/features/smoke/queries/smoke/tests/smoke.boundary.ztd.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
 
-import { runQuerySpecZtdCases } from '../../../../../../tests/support/ztd/harness.js';
+import { runQuerySpecZtdCases } from '#tests/support/ztd/harness.js';
 import { executeSmokeQuerySpec } from '../boundary.js';
 import cases from './cases/basic.case.js';
 

--- a/packages/ztd-cli/templates/tsconfig.json
+++ b/packages/ztd-cli/templates/tsconfig.json
@@ -4,6 +4,11 @@
     "lib": ["ES2022"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "baseUrl": ".",
+    "paths": {
+      "#features/*": ["src/features/*"],
+      "#tests/*": ["tests/*"]
+    },
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/packages/ztd-cli/templates/vitest.config.ts
+++ b/packages/ztd-cli/templates/vitest.config.ts
@@ -1,6 +1,13 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '#features': fileURLToPath(new URL('./src/features', import.meta.url)),
+      '#tests': fileURLToPath(new URL('./tests', import.meta.url)),
+    },
+  },
   test: {
     include: ['tests/**/*.test.ts', 'src/features/**/*.test.ts'],
     environment: 'node',

--- a/packages/ztd-cli/tests/cliCommands.test.ts
+++ b/packages/ztd-cli/tests/cliCommands.test.ts
@@ -420,7 +420,7 @@ test(
       "import { z } from 'zod';"
     );
     expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'users-insert', 'queries', 'insert-users', 'boundary.ts'))).toContain(
-      "import type { FeatureQueryExecutor } from '#features/_shared/featureQueryExecutor.js';"
+      "import type { FeatureQueryExecutor } from '../../../_shared/featureQueryExecutor.js';"
     );
     expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'users-insert', 'queries', 'insert-users', 'boundary.ts'))).not.toContain(
       'queryExactlyOneRow'

--- a/packages/ztd-cli/tests/cliCommands.test.ts
+++ b/packages/ztd-cli/tests/cliCommands.test.ts
@@ -420,7 +420,7 @@ test(
       "import { z } from 'zod';"
     );
     expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'users-insert', 'queries', 'insert-users', 'boundary.ts'))).toContain(
-      "import type { FeatureQueryExecutor } from '../../../_shared/featureQueryExecutor.js';"
+      "import type { FeatureQueryExecutor } from '#features/_shared/featureQueryExecutor.js';"
     );
     expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'users-insert', 'queries', 'insert-users', 'boundary.ts'))).not.toContain(
       'queryExactlyOneRow'

--- a/packages/ztd-cli/tests/featureScaffold.unit.test.ts
+++ b/packages/ztd-cli/tests/featureScaffold.unit.test.ts
@@ -22,6 +22,50 @@ function createTempDir(prefix: string): string {
   return mkdtempSync(path.join(tmpRoot, `${prefix}-`));
 }
 
+function seedStableFeatureAliases(workspace: string): void {
+  writeFileSync(
+    path.join(workspace, 'package.json'),
+    `${JSON.stringify({
+      name: 'feature-scaffold-test',
+      private: true,
+      type: 'module',
+      imports: {
+        '#features/*.js': {
+          types: './src/features/*.ts',
+          default: './dist/features/*.js'
+        }
+      }
+    }, null, 2)}\n`,
+    'utf8'
+  );
+  writeFileSync(
+    path.join(workspace, 'tsconfig.json'),
+    `${JSON.stringify({
+      compilerOptions: {
+        baseUrl: '.',
+        paths: {
+          '#features/*': ['src/features/*']
+        }
+      }
+    }, null, 2)}\n`,
+    'utf8'
+  );
+  writeFileSync(
+    path.join(workspace, 'vitest.config.ts'),
+    [
+      "import { defineConfig } from 'vitest/config';",
+      '',
+      'export default defineConfig({',
+      '  resolve: {',
+      "    alias: { '#features': '/virtual/src/features' }",
+      '  }',
+      '});',
+      ''
+    ].join('\n'),
+    'utf8'
+  );
+}
+
 test('deriveFeatureName defaults to resource-action form', () => {
   expect(deriveFeatureName('users', 'insert')).toBe('users-insert');
   expect(deriveFeatureName('users', 'update')).toBe('users-update');
@@ -289,7 +333,7 @@ test('runFeatureScaffoldCommand writes the boundary baseline and excludes genera
     'utf8'
   );
   expect(querySpecFile).toContain("import { z } from 'zod';");
-  expect(querySpecFile).toContain("import type { FeatureQueryExecutor } from '#features/_shared/featureQueryExecutor.js';");
+  expect(querySpecFile).toContain("import type { FeatureQueryExecutor } from '../../../_shared/featureQueryExecutor.js';");
   expect(querySpecFile).toContain("const insertUsersSqlResource = loadSqlResource(__dirname, 'insert-users.sql');");
   expect(querySpecFile).toContain('const QueryParamsSchema = z.object({');
   expect(querySpecFile).toContain("}).strict();");
@@ -361,6 +405,77 @@ test('runFeatureScaffoldCommand writes the boundary baseline and excludes genera
   expect(readmeFile).toContain('featureQueryExecutor.ts` is the shared runtime contract for DB execution injection');
   expect(readmeFile).toContain('Catalog runtime primitives from `@rawsql-ts/sql-contract`');
   expect(readmeFile).toContain('Keep this baseline as one workflow and one primary query by default');
+});
+
+test('runFeatureScaffoldCommand uses stable shared imports when the workspace supports #features', async () => {
+  const workspace = createTempDir('feature-scaffold-stable-imports');
+  const ddlDir = path.join(workspace, 'db', 'ddl');
+  seedStableFeatureAliases(workspace);
+  mkdirSync(ddlDir, { recursive: true });
+  writeFileSync(
+    path.join(ddlDir, 'users.sql'),
+    [
+      'create table public.users (',
+      '  id integer generated always as identity primary key,',
+      '  email text not null,',
+      '  created_at timestamptz not null default now()',
+      ');',
+      ''
+    ].join('\n'),
+    'utf8'
+  );
+
+  await runFeatureScaffoldCommand({
+    table: 'users',
+    action: 'insert',
+    rootDir: workspace
+  });
+
+  const querySpecFile = readFileSync(
+    path.join(workspace, 'src', 'features', 'users-insert', 'queries', 'insert-users', 'boundary.ts'),
+    'utf8'
+  );
+  expect(querySpecFile).toContain("import type { FeatureQueryExecutor } from '#features/_shared/featureQueryExecutor.js';");
+  expect(querySpecFile).toContain("import { loadSqlResource } from '#features/_shared/loadSqlResource.js';");
+});
+
+test('runFeatureScaffoldCommand fails fast when #features alias support is partial', async () => {
+  const workspace = createTempDir('feature-scaffold-partial-import-alias');
+  const ddlDir = path.join(workspace, 'db', 'ddl');
+  mkdirSync(ddlDir, { recursive: true });
+  writeFileSync(
+    path.join(workspace, 'package.json'),
+    `${JSON.stringify({
+      name: 'feature-scaffold-test',
+      private: true,
+      type: 'module',
+      imports: {
+        '#features/*.js': {
+          types: './src/features/*.ts',
+          default: './dist/features/*.js'
+        }
+      }
+    }, null, 2)}\n`,
+    'utf8'
+  );
+  writeFileSync(
+    path.join(ddlDir, 'users.sql'),
+    [
+      'create table public.users (',
+      '  id serial primary key,',
+      '  email text not null',
+      ');'
+    ].join('\n'),
+    'utf8'
+  );
+
+  await expect(
+    runFeatureScaffoldCommand({
+      table: 'users',
+      action: 'insert',
+      rootDir: workspace
+    })
+  ).rejects.toThrow(/partial #features alias configuration/i);
 });
 
 test('runFeatureScaffoldCommand uses default values when every insert column is DB-generated', async () => {

--- a/packages/ztd-cli/tests/featureScaffold.unit.test.ts
+++ b/packages/ztd-cli/tests/featureScaffold.unit.test.ts
@@ -289,7 +289,7 @@ test('runFeatureScaffoldCommand writes the boundary baseline and excludes genera
     'utf8'
   );
   expect(querySpecFile).toContain("import { z } from 'zod';");
-  expect(querySpecFile).toContain("import type { FeatureQueryExecutor } from '../../../_shared/featureQueryExecutor.js';");
+  expect(querySpecFile).toContain("import type { FeatureQueryExecutor } from '#features/_shared/featureQueryExecutor.js';");
   expect(querySpecFile).toContain("const insertUsersSqlResource = loadSqlResource(__dirname, 'insert-users.sql');");
   expect(querySpecFile).toContain('const QueryParamsSchema = z.object({');
   expect(querySpecFile).toContain("}).strict();");

--- a/packages/ztd-cli/tests/featureTestsScaffold.unit.test.ts
+++ b/packages/ztd-cli/tests/featureTestsScaffold.unit.test.ts
@@ -21,6 +21,50 @@ function seedSharedZtdSupport(workspace: string): void {
   writeFileSync(path.join(supportDir, 'case-types.ts'), 'export type QuerySpecZtdCase<A, B, C, D> = { beforeDb: A; input: B; output: C; afterDb?: D };\n', 'utf8');
 }
 
+function seedStableTestAliases(workspace: string): void {
+  writeFileSync(
+    path.join(workspace, 'package.json'),
+    `${JSON.stringify({
+      name: 'feature-tests-scaffold-test',
+      private: true,
+      type: 'module',
+      imports: {
+        '#tests/*.js': {
+          types: './tests/*.ts',
+          default: './tests/*.ts'
+        }
+      }
+    }, null, 2)}\n`,
+    'utf8'
+  );
+  writeFileSync(
+    path.join(workspace, 'tsconfig.json'),
+    `${JSON.stringify({
+      compilerOptions: {
+        baseUrl: '.',
+        paths: {
+          '#tests/*': ['tests/*']
+        }
+      }
+    }, null, 2)}\n`,
+    'utf8'
+  );
+  writeFileSync(
+    path.join(workspace, 'vitest.config.ts'),
+    [
+      "import { defineConfig } from 'vitest/config';",
+      '',
+      'export default defineConfig({',
+      '  resolve: {',
+      "    alias: { '#tests': '/virtual/tests' }",
+      '  }',
+      '});',
+      ''
+    ].join('\n'),
+    'utf8'
+  );
+}
+
 test('runFeatureTestsScaffoldCommand writes query-local ZTD scaffolds from the current feature files', async () => {
   const workspace = createTempDir('feature-tests-scaffold');
   const featureDir = path.join(workspace, 'src', 'features', 'users-insert');
@@ -85,7 +129,7 @@ test('runFeatureTestsScaffoldCommand writes query-local ZTD scaffolds from the c
     'utf8'
   );
   expect(vitestEntrypointFile).toContain("import { expect, test } from 'vitest';");
-  expect(vitestEntrypointFile).toContain("import { runQuerySpecZtdCases } from '#tests/support/ztd/harness.js';");
+  expect(vitestEntrypointFile).toContain("import { runQuerySpecZtdCases } from '../../../../../../tests/support/ztd/harness.js';");
   expect(vitestEntrypointFile).toContain("import { executeBoundaryQuerySpec } from '../boundary.js';");
   expect(vitestEntrypointFile).toContain("import cases from './cases/basic.case.js';");
   expect(vitestEntrypointFile).toContain("import type { InsertUsersQueryBoundaryZtdCase } from './boundary-ztd-types.js';");
@@ -99,7 +143,7 @@ test('runFeatureTestsScaffoldCommand writes query-local ZTD scaffolds from the c
   expect(queryTypesFile).toContain('export type InsertUsersBeforeDb = { public: { users: readonly { email?: unknown }[] } };');
   expect(queryTypesFile).toContain('export type InsertUsersInput = { email: unknown };');
   expect(queryTypesFile).toContain('export type InsertUsersOutput = Record<string, unknown>;');
-  expect(queryTypesFile).toContain("import type { QuerySpecZtdCase } from '#tests/support/ztd/case-types.js';");
+  expect(queryTypesFile).toContain("import type { QuerySpecZtdCase } from '../../../../../../tests/support/ztd/case-types.js';");
   expect(queryTypesFile).not.toContain('InsertUsersBeforeDb = Record<string, unknown>');
 
   const testPlanFile = readFileSync(
@@ -221,6 +265,70 @@ test('runFeatureTestsScaffoldCommand refreshes generated analysis without overwr
   expect(readFileSync(entrypointFile, 'utf8')).toBe("export const entrypointMarker = 'keep-me';\n");
   expect(readFileSync(queryTypesFile, 'utf8')).not.toBe("export const queryTypesMarker = 'refresh-me';\n");
   expect(readFileSync(path.join(generatedDir, 'analysis.json'), 'utf8')).toContain('"schemaVersion": 1');
+});
+
+test('runFeatureTestsScaffoldCommand uses stable shared test imports when the workspace supports #tests', async () => {
+  const workspace = createTempDir('feature-tests-stable-imports');
+  const featureDir = path.join(workspace, 'src', 'features', 'users-insert');
+  const queryDir = path.join(featureDir, 'queries', 'insert-users');
+  mkdirSync(queryDir, { recursive: true });
+  seedSharedZtdSupport(workspace);
+  seedStableTestAliases(workspace);
+
+  writeFileSync(path.join(featureDir, 'boundary.ts'), 'export const RequestSchema = null;\n', 'utf8');
+  writeFileSync(path.join(queryDir, 'boundary.ts'), 'export async function executeInsertUsersBoundary() { return {}; }\n', 'utf8');
+  writeFileSync(path.join(queryDir, 'insert-users.sql'), 'select 1;', 'utf8');
+
+  await runFeatureTestsScaffoldCommand({
+    feature: 'users-insert',
+    rootDir: workspace
+  });
+
+  const vitestEntrypointFile = readFileSync(
+    path.join(featureDir, 'queries', 'insert-users', 'tests', 'insert-users.boundary.ztd.test.ts'),
+    'utf8'
+  );
+  expect(vitestEntrypointFile).toContain("import { runQuerySpecZtdCases } from '#tests/support/ztd/harness.js';");
+
+  const queryTypesFile = readFileSync(
+    path.join(featureDir, 'queries', 'insert-users', 'tests', 'boundary-ztd-types.ts'),
+    'utf8'
+  );
+  expect(queryTypesFile).toContain("import type { QuerySpecZtdCase } from '#tests/support/ztd/case-types.js';");
+});
+
+test('runFeatureTestsScaffoldCommand fails fast when #tests alias support is partial', async () => {
+  const workspace = createTempDir('feature-tests-partial-import-alias');
+  const featureDir = path.join(workspace, 'src', 'features', 'users-insert');
+  const queryDir = path.join(featureDir, 'queries', 'insert-users');
+  mkdirSync(queryDir, { recursive: true });
+  seedSharedZtdSupport(workspace);
+  writeFileSync(
+    path.join(workspace, 'package.json'),
+    `${JSON.stringify({
+      name: 'feature-tests-scaffold-test',
+      private: true,
+      type: 'module',
+      imports: {
+        '#tests/*.js': {
+          types: './tests/*.ts',
+          default: './tests/*.ts'
+        }
+      }
+    }, null, 2)}\n`,
+    'utf8'
+  );
+
+  writeFileSync(path.join(featureDir, 'boundary.ts'), 'export const RequestSchema = null;\n', 'utf8');
+  writeFileSync(path.join(queryDir, 'boundary.ts'), 'export async function executeInsertUsersBoundary() { return {}; }\n', 'utf8');
+  writeFileSync(path.join(queryDir, 'insert-users.sql'), 'select 1;', 'utf8');
+
+  await expect(
+    runFeatureTestsScaffoldCommand({
+      feature: 'users-insert',
+      rootDir: workspace
+    })
+  ).rejects.toThrow(/partial #tests alias configuration/i);
 });
 
 test('runFeatureTestsScaffoldCommand fails fast when starter-owned ZTD support is missing', async () => {

--- a/packages/ztd-cli/tests/featureTestsScaffold.unit.test.ts
+++ b/packages/ztd-cli/tests/featureTestsScaffold.unit.test.ts
@@ -85,7 +85,7 @@ test('runFeatureTestsScaffoldCommand writes query-local ZTD scaffolds from the c
     'utf8'
   );
   expect(vitestEntrypointFile).toContain("import { expect, test } from 'vitest';");
-  expect(vitestEntrypointFile).toContain("import { runQuerySpecZtdCases } from '../../../../../../tests/support/ztd/harness.js';");
+  expect(vitestEntrypointFile).toContain("import { runQuerySpecZtdCases } from '#tests/support/ztd/harness.js';");
   expect(vitestEntrypointFile).toContain("import { executeBoundaryQuerySpec } from '../boundary.js';");
   expect(vitestEntrypointFile).toContain("import cases from './cases/basic.case.js';");
   expect(vitestEntrypointFile).toContain("import type { InsertUsersQueryBoundaryZtdCase } from './boundary-ztd-types.js';");
@@ -99,7 +99,7 @@ test('runFeatureTestsScaffoldCommand writes query-local ZTD scaffolds from the c
   expect(queryTypesFile).toContain('export type InsertUsersBeforeDb = { public: { users: readonly { email?: unknown }[] } };');
   expect(queryTypesFile).toContain('export type InsertUsersInput = { email: unknown };');
   expect(queryTypesFile).toContain('export type InsertUsersOutput = Record<string, unknown>;');
-  expect(queryTypesFile).toContain("import type { QuerySpecZtdCase } from '../../../../../../tests/support/ztd/case-types.js';");
+  expect(queryTypesFile).toContain("import type { QuerySpecZtdCase } from '#tests/support/ztd/case-types.js';");
   expect(queryTypesFile).not.toContain('InsertUsersBeforeDb = Record<string, unknown>');
 
   const testPlanFile = readFileSync(

--- a/packages/ztd-cli/tests/init.command.test.ts
+++ b/packages/ztd-cli/tests/init.command.test.ts
@@ -497,6 +497,10 @@ test('init local-source mode links rawsql-ts dependencies from the monorepo with
   );
   expect(packageJson.type).toBe('module');
   expect(packageJson.imports?.['#features/*.js']?.default).toBe('./dist/features/*.js');
+  expect(packageJson.imports?.['#tests/*.js']).toEqual({
+    types: './tests/*.ts',
+    default: './tests/*.ts'
+  });
 });
 
 test('init starter local-source mode keeps starter rawsql-ts packages on file dependencies', async () => {
@@ -533,6 +537,10 @@ test('init starter local-source mode keeps starter rawsql-ts packages on file de
   );
   expect(packageJson.type).toBe('module');
   expect(packageJson.imports?.['#features/*.js']?.default).toBe('./dist/features/*.js');
+  expect(packageJson.imports?.['#tests/*.js']).toEqual({
+    types: './tests/*.ts',
+    default: './tests/*.ts'
+  });
   expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('pnpm ztd ztd-config');
   expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('pnpm ztd feature scaffold --table users --action insert');
   expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('pnpm ztd feature tests scaffold --feature users-insert');

--- a/packages/ztd-cli/tests/init.command.test.ts
+++ b/packages/ztd-cli/tests/init.command.test.ts
@@ -114,6 +114,8 @@ test('init bootstraps a feature-first scaffold', { timeout: 60_000 }, async () =
   expect(readNormalizedFile(path.join(workspace, 'vitest.config.ts'))).toContain(
     ".ztd/support/setup-env.ts"
   );
+  expect(readNormalizedFile(path.join(workspace, 'vitest.config.ts'))).toContain("'#features'");
+  expect(readNormalizedFile(path.join(workspace, 'vitest.config.ts'))).toContain("'#tests'");
   expect(readNormalizedFile(path.join(workspace, '.ztd', 'support', 'setup-env.ts'))).toContain(
     'ZTD_DB_PORT'
   );
@@ -121,10 +123,19 @@ test('init bootstraps a feature-first scaffold', { timeout: 60_000 }, async () =
   const packageJson = JSON.parse(readNormalizedFile(path.join(workspace, 'package.json'))) as {
     type?: string;
     devDependencies: Record<string, string>;
+    imports?: Record<string, { types: string; default: string }>;
   };
   expect(packageJson.devDependencies).toHaveProperty('dotenv');
   expect(packageJson.devDependencies).toHaveProperty('@rawsql-ts/sql-contract');
   expect(packageJson.devDependencies).toHaveProperty('@rawsql-ts/testkit-core');
+  expect(packageJson.imports?.['#features/*.js']).toEqual({
+    types: './src/features/*.ts',
+    default: './dist/features/*.js'
+  });
+  expect(packageJson.imports?.['#tests/*.js']).toEqual({
+    types: './tests/*.ts',
+    default: './tests/*.ts'
+  });
   expect(result.summary).not.toContain('src/features/smoke/tests/smoke.test.ts');
   expect(result.summary).toContain('src/features/README.md');
   expect(result.summary).toContain('.env.example');
@@ -195,7 +206,7 @@ test('init starter bootstraps compose, starter DDL, and smoke tests without visi
   expect(existsSync(path.join(workspace, 'src', 'features', 'smoke', 'queries', 'smoke', 'smoke.sql'))).toBe(true);
   expect(existsSync(path.join(workspace, 'src', 'features', 'smoke', 'queries', 'smoke', 'tests', 'boundary-ztd-types.ts'))).toBe(true);
   expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'smoke', 'queries', 'smoke', 'tests', 'boundary-ztd-types.ts'))).toContain(
-    "from '../../../../../../tests/support/ztd/case-types.js'"
+    "from '#tests/support/ztd/case-types.js'"
   );
   expect(existsSync(path.join(workspace, 'src', 'features', 'smoke', 'queries', 'smoke', 'tests', 'cases', 'basic.case.ts'))).toBe(true);
   expect(existsSync(path.join(workspace, 'src', 'features', 'smoke', 'queries', 'smoke', 'tests', 'generated', 'TEST_PLAN.md'))).toBe(true);
@@ -220,7 +231,7 @@ test('init starter bootstraps compose, starter DDL, and smoke tests without visi
   expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'smoke', 'tests', 'smoke.validation.test.ts'))).toContain('Validation should reject before the query lane runs.');
   expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'smoke', 'queries', 'smoke', 'tests', 'smoke.boundary.ztd.test.ts'))).toContain('runQuerySpecZtdCases');
   expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'smoke', 'queries', 'smoke', 'tests', 'smoke.boundary.ztd.test.ts'))).toContain(
-    "from '../../../../../../tests/support/ztd/harness.js'"
+    "from '#tests/support/ztd/harness.js'"
   );
   expect(existsSync(path.join(workspace, 'src', 'infrastructure', 'README.md'))).toBe(true);
   expect(existsSync(path.join(workspace, 'src', 'infrastructure', 'telemetry', 'types.ts'))).toBe(true);
@@ -239,6 +250,7 @@ test('init starter bootstraps compose, starter DDL, and smoke tests without visi
   const packageJson = JSON.parse(readNormalizedFile(path.join(workspace, 'package.json'))) as {
     type?: string;
     devDependencies: Record<string, string>;
+    imports?: Record<string, { types: string; default: string }>;
   };
   expect(packageJson.devDependencies).toHaveProperty('dotenv');
   expect(packageJson.devDependencies).toHaveProperty('@rawsql-ts/sql-contract');
@@ -246,6 +258,14 @@ test('init starter bootstraps compose, starter DDL, and smoke tests without visi
   expect(packageJson.devDependencies).toHaveProperty('@rawsql-ts/testkit-postgres');
   expect(packageJson.devDependencies).toHaveProperty('pg');
   expect(packageJson.devDependencies).toHaveProperty('@types/pg');
+  expect(packageJson.imports?.['#features/*.js']).toEqual({
+    types: './src/features/*.ts',
+    default: './dist/features/*.js'
+  });
+  expect(packageJson.imports?.['#tests/*.js']).toEqual({
+    types: './tests/*.ts',
+    default: './tests/*.ts'
+  });
   expect(existsSync(path.join(workspace, '.ztd', 'support', 'testkit-client.ts'))).toBe(false);
   expect(existsSync(path.join(workspace, 'src', 'features', 'smoke', 'queries', 'smoke', 'tests', 'smoke.boundary.ztd.test.ts'))).toBe(true);
   expect(result.summary).toContain('compose.yaml');
@@ -458,6 +478,7 @@ test('init local-source mode links rawsql-ts dependencies from the monorepo with
 
   const packageJson = JSON.parse(readNormalizedFile(path.join(workspace, 'package.json'))) as {
     devDependencies: Record<string, string>;
+    imports?: Record<string, { types: string; default: string }>;
   };
   const localSourceGuardPath = path.join(workspace, 'scripts', 'local-source-guard.mjs');
 
@@ -475,6 +496,7 @@ test('init local-source mode links rawsql-ts dependencies from the monorepo with
     `file:${path.relative(workspace, path.join(repoRoot, 'packages', 'ztd-cli')).replace(/\\/g, '/')}`
   );
   expect(packageJson.type).toBe('module');
+  expect(packageJson.imports?.['#features/*.js']?.default).toBe('./dist/features/*.js');
 });
 
 test('init starter local-source mode keeps starter rawsql-ts packages on file dependencies', async () => {
@@ -494,6 +516,7 @@ test('init starter local-source mode keeps starter rawsql-ts packages on file de
   const packageJson = JSON.parse(readNormalizedFile(path.join(workspace, 'package.json'))) as {
     type?: string;
     devDependencies: Record<string, string>;
+    imports?: Record<string, { types: string; default: string }>;
   };
 
   expect(packageJson.devDependencies['@rawsql-ts/sql-contract']).toBe(
@@ -509,6 +532,7 @@ test('init starter local-source mode keeps starter rawsql-ts packages on file de
     `file:${path.relative(workspace, path.join(repoRoot, 'packages', 'ztd-cli')).replace(/\\/g, '/')}`
   );
   expect(packageJson.type).toBe('module');
+  expect(packageJson.imports?.['#features/*.js']?.default).toBe('./dist/features/*.js');
   expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('pnpm ztd ztd-config');
   expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('pnpm ztd feature scaffold --table users --action insert');
   expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('pnpm ztd feature tests scaffold --feature users-insert');


### PR DESCRIPTION
## Summary
- stabilize only the scaffold-generated shared imports that become fragile when recursive boundaries move deeper
- add starter `package.json#imports`, TypeScript paths, and Vitest aliases for `#features/*` and `#tests/*`
- update docs, smoke templates, and a patch changeset for the new generated starter behavior

## Why
The goal of this change is not a blanket root-import migration. The goal is to make `ztd-cli` scaffolds more resistant to boundary refactors when work is split horizontally and moved into lower child boundaries.

This keeps nearby local imports relative, while giving the deeper shared references a stable coordinate.

## Verification
- `pnpm --filter @rawsql-ts/ztd-cli test -- tests/featureScaffold.unit.test.ts tests/featureTestsScaffold.unit.test.ts tests/init.command.test.ts`
- `pnpm --filter @rawsql-ts/ztd-cli build`
- dogfooding: generated a starter with local-source mode, then ran `pnpm typecheck`
- dogfooding: ran DB-free smoke tests in the generated starter
- dogfooding: ran the DB-backed smoke entrypoint and confirmed it reached runtime DB auth failure rather than import-resolution failure

## Scope notes
- selective change only: deep shared scaffold imports now use stable specifiers
- nearby boundary-local imports remain relative
- handwritten consumer code is out of scope

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced import aliases (#features/*, #tests/*) to stabilize cross-boundary module references.

* **Documentation**
  * Updated import path guidance for safer code reorganization across boundaries.

* **Configuration**
  * Added TypeScript path mappings and Vitest aliases for module resolution.
  * Extended package.json with ESM import field configuration.

* **Tests**
  * Updated test expectations for new import path conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->