### PR TITLE
docs: add issue framing and fallback guardrails

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -26,7 +26,7 @@
 ## Plan-Time Requirements
 - Plans MUST make the underlying objective explicit even when the source issue or review comment already proposes a solution.
 - If the source frames a tactic such as a specific import style, fallback, or refactor shape, the plan MUST still check whether that tactic is the real goal or only one possible means.
-- If the objective, decision driver, or success condition remains materially unclear, the recognition gap SHOULD be resolved during planning before implementation starts.
+- If the objective, decision driver, or success condition remains materially unclear, the recognition gap MUST be resolved during planning before implementation starts.
 - Plans MUST state the `Source issue` and `Why it matters`.
 - Acceptance items MUST be explicit.
 - Verification methods MUST be explicit for each acceptance item.

--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -24,10 +24,29 @@
 - Reporting guidance makes `Verification basis`, `Guarantee limits`, `Outstanding gaps`, and `What the human should decide next` visible to reviewers and requesters.
 
 ## Plan-Time Requirements
+- Plans MUST make the underlying objective explicit even when the source issue or review comment already proposes a solution.
+- If the source frames a tactic such as a specific import style, fallback, or refactor shape, the plan MUST still check whether that tactic is the real goal or only one possible means.
+- If the objective, decision driver, or success condition remains materially unclear, the recognition gap SHOULD be resolved during planning before implementation starts.
 - Plans MUST state the `Source issue` and `Why it matters`.
 - Acceptance items MUST be explicit.
 - Verification methods MUST be explicit for each acceptance item.
 - Downstream `Decision points` SHOULD be explicit when the result will require a human choice.
+
+## Implementation Decision Rules
+- Fallback behavior MUST be treated as a last resort rather than a default convenience.
+- Before adding a fallback, prefer one of these outcomes when justified by the evidence:
+  1. fix the underlying problem directly
+  2. reject the unsupported state explicitly
+  3. fail fast with a clear error
+- Silent degradation SHOULD NOT be used when it would hide a configuration problem, weaken guarantees, or make quality harder to judge.
+- If a fallback is still the best option, the trigger condition and guarantee limits MUST be explicit in code, tests, and reporting.
+- Scope expansion is ALLOWED when it is strongly aligned and still verifiable, but it MUST be an explicit decision rather than an automatic habit.
+- When a likely follow-up is not needed for the current acceptance items, prefer leaving it out of scope and naming it as follow-up work.
+
+## Question Timing
+- Clarifying questions SHOULD be asked during planning when the objective, scope, or decision criteria are materially ambiguous.
+- Implementation SHOULD resolve local design and coding details autonomously when repository evidence is sufficient.
+- Interrupt implementation with a user question only when the remaining ambiguity is consequential enough that proceeding risks the wrong outcome, unsafe edits, or misleading verification.
 
 ## Reporting Format
 - Reports MUST state the `Source request` or `Source issue` and `Why it matters` before item-level status.

--- a/.codex/agents/planning.md
+++ b/.codex/agents/planning.md
@@ -31,6 +31,8 @@ Use this subagent to shape a rawsql-ts developer task into a plan that can be ex
 - Define completion in terms of attainment, not only file creation or code modification.
 - Prefer one acceptance item per completion judgment.
 - Do not merge unrelated concerns into one acceptance item.
+- When the source issue suggests a solution, explicitly separate `objective` from `proposed tactic` before locking the plan.
+- If the likely goal and the proposed tactic could plausibly diverge, make that uncertainty visible and resolve it during planning instead of carrying it silently into implementation.
 - Verification methods must be concrete enough to show how each item will be checked.
 - Record the active task ledger in `tmp/PLAN.md` unless narrower guidance overrides that location.
 - Update `tmp/PLAN.md` when assumptions, blockers, acceptance items, or dogfooding findings materially change.
@@ -44,6 +46,8 @@ Use this subagent to shape a rawsql-ts developer task into a plan that can be ex
 - For QuerySpec work used for product behavior, treat the QuerySpec and its ZTD-backed test as one completion unit.
 - Do not plan a product-behavior QuerySpec as complete if the ZTD-backed test cannot also be completed.
 - If dogfooding or real-task validation is part of the task, state it explicitly in the plan.
+- If fallback behavior appears to be an option, note why direct repair, fail-fast, or explicit rejection is not sufficient before recommending the fallback.
+- If a question is needed, ask it while planning whenever possible; do not defer an objective-level ambiguity into the implementation phase unless there is a strong reason.
 
 ## Do Not
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,8 @@ Deeper `AGENTS.md` files take precedence when they add stricter or narrower rule
 
 ## Plan and Reporting Minimums
 
+- When an issue, PR comment, or request includes a proposed solution, planning must still make the underlying objective explicit and check whether the proposed solution is only one tactic rather than the actual goal.
+- If there is meaningful uncertainty about the true objective, decision driver, or success condition, resolve that recognition gap during planning before implementation begins.
 - Plans must state the source issue or request, acceptance items, verification methods, and explicit out-of-scope items when scope is limited.
 - Multi-step tasks must keep a working ledger in `tmp/PLAN.md` unless a deeper `AGENTS.md` says otherwise.
 - `tmp/PLAN.md` should be updated when the plan changes, when a blocker is discovered, and when a verification or dogfooding result materially changes the current understanding.
@@ -95,6 +97,20 @@ Deeper `AGENTS.md` files take precedence when they add stricter or narrower rule
 - Final user-facing progress and completion reports should use explicit sections rather than long narrative-only blocks when multiple concerns are being reported.
 - When reporting task status, show the current status label near the top and again at the end when the report is long enough that scrolling could hide it.
 - When reporting multiple concerns, separate at least `status`, `current situation`, and `remaining issues or decisions` so the reader can scan quickly.
+
+## Implementation Decision Rules
+
+- Treat fallback behavior as a last resort, not as a default convenience.
+- Before adding a fallback, first consider whether the problem should instead be fixed directly, rejected as unsupported, or made fail-fast with a clear error.
+- Prefer an explicit error over a silent degradation when silent recovery would hide a configuration problem, weaken guarantees, or make quality harder to judge.
+- If a fallback is still the best option, make the trigger condition and guarantee limits explicit in code, tests, and reporting.
+- Scope decisions should be intentional: do not broaden a task automatically, but do not reject closely aligned follow-up work automatically either; decide based on fit, risk, and verification cost.
+
+## Collaboration and Escalation
+
+- Ask clarification questions during planning when objective, scope, or decision criteria remain materially ambiguous.
+- During implementation, prefer autonomous resolution of local design and coding details whenever the repository evidence is sufficient.
+- Interrupt implementation with a user question only when the remaining ambiguity is consequential enough that proceeding would risk the wrong outcome, unsafe edits, or misleading verification.
 
 ## Review Minimums
 


### PR DESCRIPTION
## Summary
- add repository-level guidance to separate the real objective from a proposed tactic during planning
- add durable fallback guardrails that prefer direct repair or fail-fast over silent degradation
- clarify when to ask the user during planning versus resolving implementation details autonomously

## Why
Recent work showed a few recurring failure modes that are better handled as durable workflow policy:
- treating a proposed solution as if it were the actual objective
- reaching for fallback behavior too early
- deferring objective-level ambiguity into implementation instead of resolving it during planning

## What changed
- `AGENTS.md`
  - added planning rules for checking the true objective when the source already suggests a solution
  - added implementation decision rules for fallback discipline and scoped follow-up choices
  - added collaboration rules for when to ask the user versus resolve implementation details autonomously
- `.agent/AGENTS.md`
  - mirrored the same durable policy in the visible policy mirror
- `.codex/agents/planning.md`
  - made the planning workflow explicitly separate objective from tactic and justify fallback recommendations

## Verification
- inspected the updated guidance files to confirm the new rules are present and aligned across the canonical policy, the visible mirror, and planning guidance

## Out of scope
- mechanizing these rules in scripts or CI
- changing implementation behavior outside the guidance documents

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated development and planning guidelines: added Implementation Decision Rules (make fallbacks last-resort, require documented fallback triggers/limits, constrain scope expansion), strengthened Plan-Time Requirements (explicitly restate objectives, validate tactic vs. goal, close recognition gaps before work begins), and clarified Question Timing/Collaboration rules (ask clarifying questions during planning; limit interruptions during implementation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->