### PR TITLE
test(ci): verify publish candidates before manual publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -193,7 +193,7 @@ jobs:
           path: |
             tmp/runtime-checks
             tmp/published-package-check
-            ../tmp/published-package-check-standalone
+            tmp/published-package-check-standalone
 
   actual_publish:
     needs: [verify_publish_readiness, build_publish_artifacts, verify_publish_artifacts]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,15 @@ name: Publish (manual)
 
 on:
   workflow_dispatch:
+    inputs:
+      verification_mode:
+        description: "release=real publish path, proof=hosted artifact verification without actual publish"
+        required: false
+        default: "release"
+        type: choice
+        options:
+          - release
+          - proof
 
 concurrency:
   group: publish-npm
@@ -33,6 +42,7 @@ jobs:
           fetch-depth: 0
 
       - name: Fail unless running from main
+        if: ${{ inputs.verification_mode != 'proof' }}
         shell: bash
         run: |
           # npm Trusted Publishing (OIDC) is typically configured against the workflow file on the default branch.
@@ -56,7 +66,18 @@ jobs:
 
       - name: Verify publish readiness
         id: plan
-        run: node ./scripts/publish-plan.mjs --github-output "$GITHUB_OUTPUT" --output-dir "${READINESS_CONTRACT_DIR}"
+        shell: bash
+        run: |
+          if [ "${{ inputs.verification_mode }}" = "proof" ]; then
+            node ./scripts/create-publish-proof-plan.mjs --output-dir "${READINESS_CONTRACT_DIR}"
+            {
+              echo "should_publish=true"
+              echo "publish_plan_path=${READINESS_CONTRACT_DIR}/publish-plan.json"
+              echo "publish_candidate_count=$(node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('${READINESS_CONTRACT_DIR}/publish-plan.json','utf8'));process.stdout.write(String(p.publishCandidates.length))")"
+            } >> "$GITHUB_OUTPUT"
+          else
+            node ./scripts/publish-plan.mjs --github-output "$GITHUB_OUTPUT" --output-dir "${READINESS_CONTRACT_DIR}"
+          fi
 
       - name: Upload publish readiness contract
         uses: actions/upload-artifact@v4
@@ -175,7 +196,7 @@ jobs:
 
   actual_publish:
     needs: [verify_publish_readiness, build_publish_artifacts, verify_publish_artifacts]
-    if: ${{ needs.verify_publish_readiness.outputs.should_publish == 'true' }}
+    if: ${{ needs.verify_publish_readiness.outputs.should_publish == 'true' && inputs.verification_mode != 'proof' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ env:
   ARTIFACTS_DIAGNOSTICS_ARTIFACT_NAME: publish-artifacts-diagnostics
   ARTIFACTS_CONTRACT_DIR: tmp/publish-contracts/artifacts
   ARTIFACTS_DOWNLOAD_ROOT: tmp/downloaded-contracts/artifacts
+  ARTIFACT_VERIFY_DIAGNOSTICS_ARTIFACT_NAME: publish-artifact-verify-diagnostics
 
 jobs:
   verify_publish_readiness:
@@ -124,8 +125,56 @@ jobs:
           name: ${{ env.ARTIFACTS_DIAGNOSTICS_ARTIFACT_NAME }}
           path: tmp/runtime-checks
 
-  actual_publish:
+  verify_publish_artifacts:
     needs: [verify_publish_readiness, build_publish_artifacts]
+    if: ${{ needs.verify_publish_readiness.outputs.should_publish == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup artifact verification runtime
+        uses: ./.github/actions/setup-publish-runtime
+        with:
+          node-version: "24"
+          use-pnpm: "true"
+          install-dependencies: "true"
+          update-npm: "false"
+          required-commands: "node,npm,pnpm"
+          warn-min-npm-version: "11.5.1"
+          label: "verify-publish-artifacts"
+
+      - name: Download built publish artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.ARTIFACTS_CONTRACT_ARTIFACT_NAME }}
+          path: ${{ env.ARTIFACTS_DOWNLOAD_ROOT }}
+
+      - name: Verify downloaded publish artifact contract
+        id: artifacts_contract
+        run: |
+          node ./scripts/verify-publish-contract.mjs \
+            --contract "artifacts" \
+            --artifact-root "${ARTIFACTS_DOWNLOAD_ROOT}" \
+            --label "verify-publish-artifacts-contract" \
+            --output "tmp/runtime-checks/verify-publish-artifacts-contract.json" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Run publish artifact verification
+        run: |
+          node ./scripts/verify-published-package-mode.mjs \
+            --publish-manifest "${{ steps.artifacts_contract.outputs.publish_manifest_path }}"
+
+      - name: Upload publish artifact verification diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ARTIFACT_VERIFY_DIAGNOSTICS_ARTIFACT_NAME }}
+          path: |
+            tmp/runtime-checks
+            tmp/published-package-check
+
+  actual_publish:
+    needs: [verify_publish_readiness, build_publish_artifacts, verify_publish_artifacts]
     if: ${{ needs.verify_publish_readiness.outputs.should_publish == 'true' }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -193,6 +193,7 @@ jobs:
           path: |
             tmp/runtime-checks
             tmp/published-package-check
+            ../tmp/published-package-check-standalone
 
   actual_publish:
     needs: [verify_publish_readiness, build_publish_artifacts, verify_publish_artifacts]

--- a/packages/ztd-cli/tests/publishWorkflow.unit.test.ts
+++ b/packages/ztd-cli/tests/publishWorkflow.unit.test.ts
@@ -14,3 +14,9 @@ test('publish workflow verifies built artifacts before actual publish', () => {
 test('actual_publish depends on publish artifact verification', () => {
   expect(publishWorkflow).toContain('needs: [verify_publish_readiness, build_publish_artifacts, verify_publish_artifacts]');
 });
+
+test('proof mode skips the main-branch requirement and actual publish', () => {
+  expect(publishWorkflow).toContain("if: ${{ inputs.verification_mode != 'proof' }}");
+  expect(publishWorkflow).toContain("if: ${{ needs.verify_publish_readiness.outputs.should_publish == 'true' && inputs.verification_mode != 'proof' }}");
+  expect(publishWorkflow).toContain('create-publish-proof-plan.mjs');
+});

--- a/packages/ztd-cli/tests/publishWorkflow.unit.test.ts
+++ b/packages/ztd-cli/tests/publishWorkflow.unit.test.ts
@@ -1,0 +1,16 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { expect, test } from 'vitest';
+
+const publishWorkflowPath = path.resolve(__dirname, '../../../.github/workflows/publish.yml');
+const publishWorkflow = fs.readFileSync(publishWorkflowPath, 'utf8');
+
+test('publish workflow verifies built artifacts before actual publish', () => {
+  expect(publishWorkflow).toContain('verify_publish_artifacts:');
+  expect(publishWorkflow).toContain('Run publish artifact verification');
+  expect(publishWorkflow).toContain('--publish-manifest "${{ steps.artifacts_contract.outputs.publish_manifest_path }}"');
+});
+
+test('actual_publish depends on publish artifact verification', () => {
+  expect(publishWorkflow).toContain('needs: [verify_publish_readiness, build_publish_artifacts, verify_publish_artifacts]');
+});

--- a/packages/ztd-cli/tests/releaseReadiness.unit.test.ts
+++ b/packages/ztd-cli/tests/releaseReadiness.unit.test.ts
@@ -28,6 +28,34 @@ test('release-readiness matches scaffold, publish workflow, and release-note pat
   ]);
 });
 
+test('release-readiness treats onboarding docs and package READMEs as release-affecting', () => {
+  const classification = classifyReleaseReadiness([
+    'packages/ztd-cli/README.md',
+    'docs/guide/published-package-verification.md',
+    'docs/guide/getting-started.md',
+  ]);
+
+  expect(classification.releaseAffecting).toBe(true);
+  expect(classification.matchedKinds).toEqual([
+    'package-publish-shape',
+    'scaffold-layout',
+  ]);
+  expect(classification.matchedFiles).toEqual([
+    {
+      filePath: 'packages/ztd-cli/README.md',
+      kinds: ['scaffold-layout', 'package-publish-shape'],
+    },
+    {
+      filePath: 'docs/guide/published-package-verification.md',
+      kinds: ['scaffold-layout'],
+    },
+    {
+      filePath: 'docs/guide/getting-started.md',
+      kinds: ['scaffold-layout'],
+    },
+  ]);
+});
+
 test('release-readiness matches package manifest changes as publish-shape changes', () => {
   const classification = classifyReleaseReadiness([
     'packages/ztd-cli/package.json',
@@ -62,10 +90,20 @@ test('release-readiness matches nested package manifests as publish-shape change
   ]);
 });
 
+test('release-readiness treats publish helper changes as release-affecting', () => {
+  const classification = classifyReleaseReadiness([
+    'scripts/build-publish-artifacts.mjs',
+    'scripts/verify-published-package-mode.mjs',
+  ]);
+
+  expect(classification.releaseAffecting).toBe(true);
+  expect(classification.matchedKinds).toEqual(['publish-workflow']);
+});
+
 test('release-readiness ignores ordinary package tests and docs outside the checklist', () => {
   const classification = classifyReleaseReadiness([
     'packages/ztd-cli/tests/queryLint.unit.test.ts',
-    'docs/guide/ztd-cli-quality-gates.md',
+    'docs/guide/overview.md',
   ]);
 
   expect(classification.releaseAffecting).toBe(false);

--- a/packages/ztd-cli/tests/releaseReadiness.unit.test.ts
+++ b/packages/ztd-cli/tests/releaseReadiness.unit.test.ts
@@ -93,6 +93,7 @@ test('release-readiness matches nested package manifests as publish-shape change
 test('release-readiness treats publish helper changes as release-affecting', () => {
   const classification = classifyReleaseReadiness([
     'scripts/build-publish-artifacts.mjs',
+    'scripts/create-publish-proof-plan.mjs',
     'scripts/verify-published-package-mode.mjs',
   ]);
 

--- a/scripts/create-publish-proof-plan.mjs
+++ b/scripts/create-publish-proof-plan.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+import path from "node:path";
+import {
+  collectWorkspaceDependencyNames,
+  ensureDir,
+  getWorkspacePackages,
+  topoSortWorkspaceDependencies,
+  writeJson,
+} from "./publish-workspace-utils.mjs";
+
+function parseArgs(argv) {
+  const options = {
+    outputDir: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--output-dir") {
+      options.outputDir = argv[index + 1] ?? null;
+      index += 1;
+    }
+  }
+
+  return options;
+}
+
+function isPublishCandidate(workspaceRoot, pkg) {
+  return (
+    !pkg.private
+    && pkg.dir.startsWith(path.join(workspaceRoot, "packages"))
+    && !pkg.dir.includes(`${path.sep}templates${path.sep}`)
+  );
+}
+
+function main() {
+  const workspaceRoot = process.cwd();
+  const options = parseArgs(process.argv.slice(2));
+  if (!options.outputDir) {
+    throw new Error("[publish-proof-plan] --output-dir is required.");
+  }
+
+  const outputDir = path.isAbsolute(options.outputDir)
+    ? options.outputDir
+    : path.resolve(workspaceRoot, options.outputDir);
+  ensureDir(outputDir);
+
+  const workspacePackages = getWorkspacePackages(workspaceRoot);
+  const workspaceNames = new Set(workspacePackages.keys());
+  const publishCandidates = Array.from(workspacePackages.values())
+    .filter((pkg) => isPublishCandidate(workspaceRoot, pkg))
+    .sort((left, right) => left.name.localeCompare(right.name))
+    .map((pkg) => ({
+      name: pkg.name,
+      version: pkg.version,
+      dir: pkg.dir,
+      changelogPath: pkg.changelogPath,
+      workspaceDependencies: collectWorkspaceDependencyNames(pkg, workspaceNames),
+    }));
+
+  const buildOrder = topoSortWorkspaceDependencies(
+    workspacePackages,
+    publishCandidates.map((pkg) => pkg.name),
+  ).map((packageName) => {
+    const pkg = workspacePackages.get(packageName);
+    return {
+      name: packageName,
+      dir: pkg.dir,
+      isPublishCandidate: publishCandidates.some((candidate) => candidate.name === packageName),
+      hasBuildScript: typeof pkg.scripts.build === "string",
+    };
+  });
+
+  const reportPath = path.join(outputDir, "publish-plan.json");
+  writeJson(reportPath, {
+    schemaVersion: 1,
+    kind: "publish-readiness-plan",
+    checkedAt: new Date().toISOString(),
+    node: process.version,
+    platform: process.platform,
+    npmRegistry: "https://registry.npmjs.org",
+    shouldPublish: publishCandidates.length > 0,
+    blockers: [],
+    notices: [
+      {
+        classification: "quality-issue",
+        code: "proof-mode-plan",
+        message: "Proof mode plan for hosted publish-candidate artifact verification.",
+      },
+    ],
+    pendingChangesets: [],
+    publishCandidates,
+    buildOrder,
+  });
+
+  console.log(`[publish-proof-plan] wrote ${reportPath}`);
+  console.log(`[publish-proof-plan] publish candidates: ${publishCandidates.length}`);
+}
+
+main();

--- a/scripts/release-readiness.js
+++ b/scripts/release-readiness.js
@@ -28,7 +28,7 @@ const RELEASE_READINESS_PATTERNS = [
     patterns: [
       /^\.github\/actions\/setup-publish-runtime\//u,
       /^\.github\/workflows\/(?:publish|release-pr|release-readiness)\.yml$/u,
-      /^scripts\/(?:build-publish-artifacts|ci-publish|publish-plan|publish-workspace-utils|release-readiness|verify-publish-contract|verify-published-package-mode|verify-runtime-prereqs|version-packages-and-lockfile)\.(?:mjs|js)$/u,
+      /^scripts\/(?:build-publish-artifacts|ci-publish|create-publish-proof-plan|publish-plan|publish-workspace-utils|release-readiness|verify-publish-contract|verify-published-package-mode|verify-runtime-prereqs|version-packages-and-lockfile)\.(?:mjs|js)$/u,
     ],
   },
   {

--- a/scripts/release-readiness.js
+++ b/scripts/release-readiness.js
@@ -7,16 +7,18 @@ const RELEASE_READINESS_PATTERNS = [
     patterns: [
       /^package\.json$/u,
       /^pnpm-lock\.yaml$/u,
+      /^packages\/ztd-cli\/README\.md$/u,
       /^packages\/ztd-cli\/package\.json$/u,
       /^packages\/ztd-cli\/src\/commands\/(?:feature|init)\.ts$/u,
       /^packages\/ztd-cli\/templates\//u,
-      /^docs\/guide\/(?:generated-project-verification|sql-first-end-to-end-tutorial|ztd-local-source-dogfooding)\.md$/u,
+      /^docs\/guide\/(?:generated-project-verification|getting-started|published-package-verification|sql-first-end-to-end-tutorial|ztd-cli-quality-gates|ztd-local-source-dogfooding)\.md$/u,
     ],
   },
   {
     kind: 'package-publish-shape',
     patterns: [
       /^packages\/(?:[^/]+\/)+package\.json$/u,
+      /^packages\/(?:[^/]+\/)+README\.md$/u,
       /^packages\/(?:[^/]+\/)+CHANGELOG\.md$/u,
       /^scripts\/sync-rawsql-dist\.js$/u,
     ],

--- a/scripts/verify-published-package-mode.mjs
+++ b/scripts/verify-published-package-mode.mjs
@@ -9,6 +9,7 @@ import {
   PNPM,
   ensureCleanDir,
   getWorkspacePackages,
+  loadValidatedPublishManifestContract,
   runWithOutput,
   writeJson,
 } from "./publish-workspace-utils.mjs";
@@ -18,6 +19,22 @@ const tarCommand = "tar";
 const outputRoot = path.join(workspaceRoot, "tmp", "published-package-check");
 const tarballRoot = path.join(outputRoot, "tarballs");
 const packageRoot = path.join(outputRoot, "packages");
+
+function parseArgs(argv) {
+  const options = {
+    publishManifestPath: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--publish-manifest") {
+      options.publishManifestPath = argv[index + 1] ?? null;
+      index += 1;
+    }
+  }
+
+  return options;
+}
 
 function sanitizePackageName(packageName) {
   return packageName.replace(/[^a-zA-Z0-9._-]+/g, "_");
@@ -264,6 +281,29 @@ function packPublishedPackages() {
   }
 
   return packed;
+}
+
+function loadPackedPackagesFromManifest(manifestPath) {
+  const resolvedManifestPath = path.isAbsolute(manifestPath)
+    ? manifestPath
+    : path.resolve(workspaceRoot, manifestPath);
+  const manifestContract = loadValidatedPublishManifestContract(resolvedManifestPath);
+
+  return manifestContract.packages.map((pkg) => {
+    const manifest = readPackedManifest(pkg.resolvedTarballPath);
+    const entries = listTarEntries(pkg.resolvedTarballPath);
+
+    assertTarballHasDist(entries, pkg.name);
+    assertNoWorkspaceProtocols(manifest, pkg.name);
+    assertManifestEntrypoints(manifest, entries, pkg.name);
+
+    return {
+      dir: pkg.dir,
+      manifest,
+      name: pkg.name,
+      tarballPath: pkg.resolvedTarballPath,
+    };
+  });
 }
 
 function verifyPackedTarballInstall(packages) {
@@ -613,13 +653,17 @@ function verifyOverwriteSafety(packages) {
 }
 
 function main() {
+  const options = parseArgs(process.argv.slice(2));
   ensureCleanDir(outputRoot);
   ensureCleanDir(tarballRoot);
   ensureCleanDir(packageRoot);
 
-  run(PNPM, ["build:publish"]);
-
-  const packedPackages = packPublishedPackages();
+  const packedPackages = options.publishManifestPath
+    ? loadPackedPackagesFromManifest(options.publishManifestPath)
+    : (() => {
+        run(PNPM, ["build:publish"]);
+        return packPublishedPackages();
+      })();
   const packedInstallApp = verifyPackedTarballInstall(packedPackages);
   const npmPrimaryPathApp = verifyNpmPrimaryPath(packedPackages);
   const npmSmokeApp = verifyNpmConsumerSmoke(npmPrimaryPathApp);
@@ -632,6 +676,7 @@ function main() {
     checkedAt: new Date().toISOString(),
     node: process.version,
     platform: os.platform(),
+    verificationMode: options.publishManifestPath ? "publish-manifest" : "workspace-pack",
     packedInstallApp,
     npmPrimaryPathApp: npmPrimaryPathApp.appDir,
     firstTestGateApp: npmSmokeApp,

--- a/scripts/verify-published-package-mode.mjs
+++ b/scripts/verify-published-package-mode.mjs
@@ -23,12 +23,18 @@ const packageRoot = path.join(outputRoot, "packages");
 function parseArgs(argv) {
   const options = {
     publishManifestPath: null,
+    publishManifestProvided: false,
   };
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === "--publish-manifest") {
-      options.publishManifestPath = argv[index + 1] ?? null;
+      const nextArg = argv[index + 1];
+      options.publishManifestProvided = true;
+      if (typeof nextArg !== "string" || nextArg.trim().length === 0) {
+        throw new Error("[published-package-mode] --publish-manifest requires a non-empty path.");
+      }
+      options.publishManifestPath = nextArg;
       index += 1;
     }
   }
@@ -658,7 +664,7 @@ function main() {
   ensureCleanDir(tarballRoot);
   ensureCleanDir(packageRoot);
 
-  const packedPackages = options.publishManifestPath
+  const packedPackages = options.publishManifestProvided
     ? loadPackedPackagesFromManifest(options.publishManifestPath)
     : (() => {
         run(PNPM, ["build:publish"]);
@@ -676,7 +682,7 @@ function main() {
     checkedAt: new Date().toISOString(),
     node: process.version,
     platform: os.platform(),
-    verificationMode: options.publishManifestPath ? "publish-manifest" : "workspace-pack",
+    verificationMode: options.publishManifestProvided ? "publish-manifest" : "workspace-pack",
     packedInstallApp,
     npmPrimaryPathApp: npmPrimaryPathApp.appDir,
     firstTestGateApp: npmSmokeApp,

--- a/scripts/verify-published-package-mode.mjs
+++ b/scripts/verify-published-package-mode.mjs
@@ -19,6 +19,7 @@ const tarCommand = "tar";
 const outputRoot = path.join(workspaceRoot, "tmp", "published-package-check");
 const tarballRoot = path.join(outputRoot, "tarballs");
 const packageRoot = path.join(outputRoot, "packages");
+const standalonePackageRoot = path.join(workspaceRoot, "tmp", "published-package-check-standalone");
 
 function parseArgs(argv) {
   const options = {
@@ -415,7 +416,7 @@ function verifyNpmConsumerSmoke(phaseAResult) {
 }
 
 function verifyPnpmStarterPath(packages) {
-  const appDir = path.resolve(workspaceRoot, "..", "tmp", "published-package-check-standalone", "pnpm-starter-path");
+  const appDir = path.join(standalonePackageRoot, "pnpm-starter-path");
   ensureCleanDir(appDir);
 
   const tarballDependencies = createTarballDependencyMap(packages);
@@ -465,7 +466,7 @@ function verifyPnpmStarterPath(packages) {
 }
 
 function verifyPnpmAdapterInstall(packages) {
-  const appDir = path.resolve(workspaceRoot, "..", "tmp", "published-package-check-standalone", "pnpm-adapter-path");
+  const appDir = path.join(standalonePackageRoot, "pnpm-adapter-path");
   ensureCleanDir(appDir);
 
   const tarballDependencies = createTarballDependencyMap(packages);
@@ -513,7 +514,7 @@ function verifyPnpmAdapterInstall(packages) {
 }
 
 function verifyPnpmTutorialModelGen(packages) {
-  const appDir = path.resolve(workspaceRoot, "..", "tmp", "published-package-check-standalone", "pnpm-tutorial-model-gen");
+  const appDir = path.join(standalonePackageRoot, "pnpm-tutorial-model-gen");
   ensureCleanDir(appDir);
 
   const tarballDependencies = createTarballDependencyMap(packages);

--- a/scripts/verify-published-package-mode.mjs
+++ b/scripts/verify-published-package-mode.mjs
@@ -21,6 +21,15 @@ const tarballRoot = path.join(outputRoot, "tarballs");
 const packageRoot = path.join(outputRoot, "packages");
 const standalonePackageRoot = path.join(workspaceRoot, "tmp", "published-package-check-standalone");
 
+function ensureStandaloneWorkspaceRoot() {
+  fs.mkdirSync(standalonePackageRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(standalonePackageRoot, "pnpm-workspace.yaml"),
+    "packages:\n  - '*'\n",
+    "utf8",
+  );
+}
+
 function parseArgs(argv) {
   const options = {
     publishManifestPath: null,
@@ -197,6 +206,14 @@ function runIn(directory, command, args, options = {}) {
     shell: options.shell ?? IS_WINDOWS,
     ...options,
   });
+}
+
+function getInstalledBinPath(directory, binName) {
+  return path.join(directory, "node_modules", ".bin", IS_WINDOWS ? `${binName}.cmd` : binName);
+}
+
+function runInstalledZtdCli(directory, args) {
+  return runIn(directory, getInstalledBinPath(directory, "ztd"), args);
 }
 
 function createTarballDependencyMap(packages) {
@@ -416,6 +433,7 @@ function verifyNpmConsumerSmoke(phaseAResult) {
 }
 
 function verifyPnpmStarterPath(packages) {
+  ensureStandaloneWorkspaceRoot();
   const appDir = path.join(standalonePackageRoot, "pnpm-starter-path");
   ensureCleanDir(appDir);
 
@@ -433,10 +451,7 @@ function verifyPnpmStarterPath(packages) {
   });
 
   runIn(appDir, PNPM, ["install", "--no-frozen-lockfile"]);
-  runIn(appDir, PNPM, [
-    "exec",
-    "--",
-    "ztd",
+  runInstalledZtdCli(appDir, [
     "init",
     "--starter",
     "--with-ai-guidance",
@@ -466,6 +481,7 @@ function verifyPnpmStarterPath(packages) {
 }
 
 function verifyPnpmAdapterInstall(packages) {
+  ensureStandaloneWorkspaceRoot();
   const appDir = path.join(standalonePackageRoot, "pnpm-adapter-path");
   ensureCleanDir(appDir);
 
@@ -483,10 +499,7 @@ function verifyPnpmAdapterInstall(packages) {
   });
 
   runIn(appDir, PNPM, ["install", "--no-frozen-lockfile"]);
-  runIn(appDir, PNPM, [
-    "exec",
-    "--",
-    "ztd",
+  runInstalledZtdCli(appDir, [
     "init",
     "--starter",
     "--with-ai-guidance",
@@ -514,6 +527,7 @@ function verifyPnpmAdapterInstall(packages) {
 }
 
 function verifyPnpmTutorialModelGen(packages) {
+  ensureStandaloneWorkspaceRoot();
   const appDir = path.join(standalonePackageRoot, "pnpm-tutorial-model-gen");
   ensureCleanDir(appDir);
 
@@ -531,10 +545,7 @@ function verifyPnpmTutorialModelGen(packages) {
   });
 
   runIn(appDir, PNPM, ["install", "--no-frozen-lockfile"]);
-  runIn(appDir, PNPM, [
-    "exec",
-    "--",
-    "ztd",
+  runInstalledZtdCli(appDir, [
     "init",
     "--starter",
     "--with-ai-guidance",
@@ -573,12 +584,9 @@ function verifyPnpmTutorialModelGen(packages) {
     "utf8",
   );
 
-  runIn(appDir, PNPM, ["exec", "--", "ztd", "ztd-config"]);
+  runInstalledZtdCli(appDir, ["ztd-config"]);
 
   const modelGenArgs = [
-    "exec",
-    "--",
-    "ztd",
     "model-gen",
     "--probe-mode",
     "ztd",
@@ -590,7 +598,7 @@ function verifyPnpmTutorialModelGen(packages) {
   ];
 
   if (process.env.ZTD_TEST_DATABASE_URL) {
-    runIn(appDir, PNPM, modelGenArgs);
+    runInstalledZtdCli(appDir, modelGenArgs);
     const generatedSpec = fs.readFileSync(
       path.join(appDir, "src", "features", "users", "persistence", "users.spec.ts"),
       "utf8",
@@ -599,7 +607,7 @@ function verifyPnpmTutorialModelGen(packages) {
       throw new Error("[packaging contract] tutorial model-gen did not write the expected spec output.");
     }
   } else {
-    const describeOutput = runIn(appDir, PNPM, [...modelGenArgs, "--describe-output", "--output", "json"]);
+    const describeOutput = runInstalledZtdCli(appDir, [...modelGenArgs, "--describe-output", "--output", "json"]);
 
     const parsed = JSON.parse(describeOutput.stdout);
     if (parsed?.data?.outputs?.spec !== "TypeScript QuerySpec scaffold") {


### PR DESCRIPTION
## Summary

Closes #739.

This change makes published-artifact verification a real release gate instead of a post-publish manual check.

For developers, the main value is operationally simple:

- day-to-day PR flow stays almost the same
- no new always-required manual verification step is introduced
- release-affecting changes are classified more aggressively for artifact-risk paths
- the manual publish entrypoint stays the same, but broken publish candidates are now blocked before `actual_publish`

## What changed

- Added a `verify_publish_artifacts` job to `.github/workflows/publish.yml`
  - downloads the built publish-candidate artifact contract
  - verifies the downloaded manifest/contract
  - runs packaged-artifact verification before `actual_publish`
- Made `actual_publish` depend on `verify_publish_artifacts`
- Extended `scripts/verify-published-package-mode.mjs`
  - it can now verify publish candidates directly from `--publish-manifest`
  - this reuses the actual workflow-built tarballs instead of repacking from workspace source
- Added `scripts/create-publish-proof-plan.mjs`
  - supports hosted proof runs on a branch without touching `main`
- Added a `verification_mode=proof` workflow-dispatch mode
  - exercises readiness/build/verify on hosted runners
  - intentionally skips the final publish step
- Tightened `scripts/release-readiness.js` classification for release-affecting changes
  - include package READMEs, onboarding docs, published-package verification docs, and publish-helper changes
- Added unit tests for:
  - publish workflow dependency structure
  - proof-mode behavior
  - release-readiness classification coverage

## Why this matters

The old failure mode was:

- source checks passed
- release PR/publish proceeded
- the packaged artifact turned out to be broken only after npm release

This PR moves that feedback earlier by mechanically proving the packaged consumer path before release.

The packaged-artifact contract now covers at least:

- tarball shape / dist presence
- manifest / exports / bin integrity
- standalone install from the built candidate artifact
- packaged CLI execution
- scaffold generation from packaged `@rawsql-ts/ztd-cli`
- generated project `ztd-config`
- generated project typecheck
- minimal smoke test path
- starter / adapter / tutorial-style packaged flows already exercised by `verify-published-package-mode`

## Verification

Local targeted checks:

- `pnpm --filter @rawsql-ts/ztd-cli test -- tests/publishWorkflow.unit.test.ts tests/releaseReadiness.unit.test.ts`
- `node scripts/build-publish-artifacts.mjs --plan tmp/publish-contracts/local-proof/publish-plan.json --output-dir tmp/publish-contracts/artifacts-local-proof`
- `node scripts/verify-published-package-mode.mjs --publish-manifest tmp/publish-contracts/artifacts-local-proof/publish-manifest.json`

Hosted proof run:

- workflow run: https://github.com/mk3008/rawsql-ts/actions/runs/24193763010
- branch: `739-リリース前の公開物検証工程が開発フローに組み込まれておらずpublish-しないと見えない不具合を防ぎきれない`
- result:
  - `verify_publish_readiness`: success
  - `build_publish_artifacts`: success
  - `verify_publish_artifacts`: success
  - `actual_publish`: skipped in `proof` mode

Hosted artifacts inspected from that run:

- publish manifest produced by the workflow-built candidate artifacts
- packaged-artifact verification summary with `verificationMode: "publish-manifest"`
- summary paths showing hosted packaged dogfooding for:
  - npm primary path
  - starter path
  - adapter path
  - tutorial model-gen path

## Notes

- I did not add docs-first process text as the primary mechanism here; the protection is in workflow structure and executable verification.
- A hosted failure proof run was not added in this PR. The dependency chain is enforced in workflow YAML and unit tests, and the hosted success proof run confirms the real candidate-build -> verify path on GitHub Actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "proof" verification mode to assess publish readiness without performing a release.
  * Introduced a gated artifact verification step that must pass before publishing (prevents publish in proof mode).
  * Added manifest-based package verification and a proof-plan generator to support non-publish verification runs.

* **Tests**
  * Added unit tests covering workflow wiring, artifact verification gating, proof mode behavior, and expanded release-readiness detection for docs and scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->