### PR TITLE
feat(ztd-cli): rename query uses scope flag

### DIFF
--- a/docs/dogfooding/ztd-migration-lifecycle.md
+++ b/docs/dogfooding/ztd-migration-lifecycle.md
@@ -17,7 +17,7 @@ These prompts are intended to be copied into a separate AI instance, so the tuto
 
 ## Preferred CLI by scenario
 
-- DDL repair: `npx ztd query uses column users.email --specs-dir src/features/users/persistence --any-schema --view detail`
+- DDL repair: `npx ztd query uses column users.email --scope-dir src/features/users/persistence --any-schema --view detail`
 - SQL repair: `npx ztd model-gen --probe-mode ztd src/features/users/persistence/users.sql --out src/features/users/persistence/users.spec.ts`
 - DTO repair: `npx vitest run`
 - migration artifact creation: `npx ztd ztd-config`, optionally `npx ztd ddl pull --url <target-db-url>` to inspect the target, then `npx ztd ddl diff --url <target-db-url> --out tmp/users.diff.sql` to generate review output plus SQL; if you hand-edit the migration afterward, run `npx ztd ddl risk --file tmp/users.diff.sql` to re-evaluate the final SQL with the same structured risk contract
@@ -30,7 +30,7 @@ These prompts are intended to be copied into a separate AI instance, so the tuto
 ```text
 I changed the DDL for users.
 Read the nearest AGENTS.md files first.
-Run `npx ztd query uses column users.email --specs-dir src/features/users/persistence --any-schema --view detail` to find the affected SQL files before you edit anything. The feature folder is one narrowed spec set inside the normal project-wide discovery flow.
+Run `npx ztd query uses column users.email --scope-dir src/features/users/persistence --any-schema --view detail` to find the affected SQL files before you edit anything. The feature folder is one narrowed scan scope inside the normal project-wide discovery flow.
 Fix the tests and feature code that now fail.
 Do not apply migrations automatically.
 ```

--- a/docs/guide/query-uses-impact-checks.md
+++ b/docs/guide/query-uses-impact-checks.md
@@ -14,7 +14,7 @@ This page covers the `table` and `column` impact checks with examples based on a
 
 Implementation note: the CLI command is provided by `@rawsql-ts/ztd-cli`, while the reusable analysis engine now lives in `@rawsql-ts/sql-grep-core`.
 
-The active scan set is **project-wide by default**. `query uses` discovers QuerySpec entries under the current project root and follows each spec's `sqlFile`. Use `--specs-dir` only when you want to narrow the scan to one slice or sub-tree.
+The active scan set is **project-wide by default**. `query uses` discovers QuerySpec entries under the current project root and follows each spec's `sqlFile`. Use `--scope-dir` only when you want to narrow the scan to one slice or sub-tree. `--specs-dir` remains as a deprecated compatibility alias for now.
 
 ## Quick start
 
@@ -238,7 +238,7 @@ npx ztd query uses table public.users --sql-root src/sql
 For feature-local layouts, keep the spec and SQL together and let the default resolver work without `--sql-root`:
 
 ```bash
-npx ztd query uses column users.email --specs-dir src/features/users/persistence --any-schema --view detail
+npx ztd query uses column users.email --scope-dir src/features/users/persistence --any-schema --view detail
 ```
 
 ### Matches look noisy
@@ -259,6 +259,6 @@ npx ztd query uses table public.sale_items --view detail --exclude-generated
 
 1. Start with the default `impact` view.
 2. Add `--exclude-generated` for rename or type-change checks.
-3. Use `--specs-dir` only when you need to narrow a project-wide search to one feature.
+3. Use `--scope-dir` only when you need to narrow a project-wide search to one feature.
 4. Use `--view detail` only when you need line-level evidence.
 5. Treat `unresolved sql files` as a signal that the scan setup needs attention before you trust the result.

--- a/docs/guide/query-uses-overview.md
+++ b/docs/guide/query-uses-overview.md
@@ -29,7 +29,7 @@ project-root/
 ```
 
 - **Spec files are required.** Plain `.sql` files without a spec are not scanned. If you have not run `ztd init` yet, start there.
-- **Project-wide discovery is the default.** QuerySpec files are discovered recursively under the project root unless you narrow the scan with `--specs-dir`.
+- **Project-wide discovery is the default.** QuerySpec files are discovered recursively under the project root unless you narrow the scan with `--scope-dir`.
 - **Feature-local specs are first-class.** The preferred contract is a spec that keeps `sqlFile` relative to the spec itself, for example `./users.sql`.
 - **Shared SQL roots still work.** If your project intentionally keeps SQL in one shared tree, you can still use `--sql-root` as a fallback resolver.
 - **No database connection is needed.** The analysis is purely static. It parses SQL text, not a live schema.

--- a/docs/guide/sql-first-end-to-end-tutorial.md
+++ b/docs/guide/sql-first-end-to-end-tutorial.md
@@ -22,7 +22,7 @@ README gives the first-run copy-paste path. This tutorial gives the scenario-lev
 
 | Scenario | Primary CLI | Why |
 | --- | --- | --- |
-| DDL repair | `npx ztd query uses column users.email --specs-dir src/features/users-insert --any-schema --view detail` | Find the impacted feature-local SQL files before editing them |
+| DDL repair | `npx ztd query uses column users.email --scope-dir src/features/users-insert --any-schema --view detail` | Find the impacted feature-local SQL files before editing them |
 | SQL repair | `npx ztd model-gen --probe-mode ztd src/features/users-insert/queries/insert-users/insert-users.sql` | Inspect the generated contract on stdout before updating the handwritten query boundary |
 | DTO repair | `npx vitest run` after the DTO change | Verify the feature-local runtime and tests after the shape change |
 | migration | `npx ztd ztd-config`, optionally `npx ztd ddl pull --url <target-db-url>` to inspect the target, then `npx ztd ddl diff --url <target-db-url> --out tmp/users.diff.sql` to prepare review output plus apply SQL | Prepare a manually applied migration without asking ztd-cli to deploy it |
@@ -169,7 +169,7 @@ Use the same `users` project for each scenario:
 
 Each scenario should end with `vitest` passing again.
 
-For DDL repair, run `npx ztd query uses column users.email --specs-dir src/features/users-insert --any-schema --view detail` first so the impacted SQL files come from the CLI, not from guesswork. Passing the feature folder as `--specs-dir` is a normal way to narrow the project-wide scan, not a workaround for feature-local layouts.
+For DDL repair, run `npx ztd query uses column users.email --scope-dir src/features/users-insert --any-schema --view detail` first so the impacted SQL files come from the CLI, not from guesswork. Passing the feature folder as `--scope-dir` is a normal way to narrow the project-wide scan, not a workaround for feature-local layouts. The older `--specs-dir` flag still works as a deprecated alias during the transition.
 
 For SQL repair, keep the SQL assets under `src/features/users-insert/queries/insert-users/`, keep the query on the starter DDL's `users` table, and rerun `model-gen` against `src/features/users-insert/queries/insert-users/insert-users.sql` directly to inspect the generated contract on stdout before you update the handwritten query boundary. If you want to save that output for reference or gradual migration, write it to a dedicated generated-contract file with `--out` instead of overwriting handwritten runtime files. Do not target `src/features/users-insert/queries/insert-users/boundary.ts` with `--out`, because that file is the runtime boundary that also owns `loadSqlResource` and the execution flow. In VSA layouts, `model-gen` now treats the SQL file location as the primary contract source, so `--sql-root` is only needed for older shared-root layouts.
 

--- a/packages/sql-grep-core/src/query/report.ts
+++ b/packages/sql-grep-core/src/query/report.ts
@@ -118,9 +118,9 @@ export function buildQueryUsageReport(params: BuildQueryUsageReportParams): Quer
         code: 'no-catalog-specs-found',
         message: params.specsDir
           ? `No QuerySpec entries found under ${activeScope}.
-Hint: pass a narrower --specs-dir only when you need to limit the active spec set.`
+Hint: pass a narrower --scope-dir only when you need to limit the active scan.`
           : `No QuerySpec entries were discovered under ${activeScope}.
-Hint: run "ztd init" or place feature-local specs under your project tree. Use --specs-dir only when you need to narrow the scan.`,
+Hint: run "ztd init" or place feature-local specs under your project tree. Use --scope-dir only when you need to narrow the scan.`,
       });
     }
 

--- a/packages/ztd-cli/src/commands/query.ts
+++ b/packages/ztd-cli/src/commands/query.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import { applyQueryOutputControls, formatQueryUsageReport } from '../query/format';
 import { applyQueryPatch } from '../query/patch';
 import { buildQueryLintReport, formatQueryLintReport, type QueryLintFormat } from '../query/lint';
@@ -31,6 +31,7 @@ import {
 
 interface QueryUsesOptions {
   format?: string;
+  scopeDir?: string;
   specsDir?: string;
   sqlRoot?: string;
   excludeGenerated?: boolean;
@@ -103,6 +104,9 @@ export const QUERY_USES_COMMAND_SPANS = {
   renderOutput: 'render-query-usage-output',
 } as const;
 
+const QUERY_SCOPE_DIR_HELP = 'Limit discovery to one boundary or QuerySpec subtree instead of scanning the whole project';
+const QUERY_SCOPE_DIR_ALIAS_HELP = 'Deprecated alias for --scope-dir';
+
 /**
  * Register strict-first impact investigation commands on the CLI root.
  */
@@ -130,7 +134,7 @@ Notes:
   - Impact is the default view. Use --view detail for edit-ready locations/snippets.
   - Impact representatives may omit select snippets; use --view detail for edit-ready SELECT occurrences.
   - Project-wide discovery is the default. query uses scans QuerySpec entries discovered under the current project root.
-  - Use --specs-dir only to narrow the active spec set to one slice or sub-tree.
+  - Use --scope-dir only to narrow the active scan to one boundary or sub-tree.
   - Use --sql-root only when specs intentionally point into a shared SQL root instead of staying feature-local.
   - Use --exclude-generated to skip QuerySpec files under generated directories when those files are review-only noise.
   - Static column analysis is inherently uncertain and labels ambiguity via confidence/notes.
@@ -149,7 +153,8 @@ Notes:
     .description('Find statements that use a table target')
     .option('--format <format>', 'Output format (text|json)', 'text')
     .option('--view <view>', 'Investigation view (impact|detail)', 'impact')
-    .option('--specs-dir <path>', 'Limit discovery to one QuerySpec subtree instead of scanning the whole project')
+    .addOption(new Option('--scope-dir <path>', QUERY_SCOPE_DIR_HELP))
+    .addOption(new Option('--specs-dir <path>', QUERY_SCOPE_DIR_ALIAS_HELP).hideHelp())
     .option('--sql-root <path>', 'Optional fallback root for shared sqlFile layouts when specs are not feature-local')
     .option('--exclude-generated', 'Exclude QuerySpec files under generated directories from scan targets')
     .option('--out <path>', 'Write output to file')
@@ -167,7 +172,8 @@ Notes:
     .description('Find statements that use a column target')
     .option('--format <format>', 'Output format (text|json)', 'text')
     .option('--view <view>', 'Investigation view (impact|detail)', 'impact')
-    .option('--specs-dir <path>', 'Limit discovery to one QuerySpec subtree instead of scanning the whole project')
+    .addOption(new Option('--scope-dir <path>', QUERY_SCOPE_DIR_HELP))
+    .addOption(new Option('--specs-dir <path>', QUERY_SCOPE_DIR_ALIAS_HELP).hideHelp())
     .option('--sql-root <path>', 'Optional fallback root for shared sqlFile layouts when specs are not feature-local')
     .option('--exclude-generated', 'Exclude QuerySpec files under generated directories from scan targets')
     .option('--out <path>', 'Write output to file')
@@ -182,7 +188,7 @@ Notes:
 Notes:
   - Impact is the default view. Use --view detail if you need edit-ready locations/snippets.
   - Impact representatives may omit select snippets; use --view detail for edit-ready SELECT occurrences.
-  - Project-wide discovery is the default. Use --specs-dir only when you want to narrow the active spec set.
+  - Project-wide discovery is the default. Use --scope-dir only when you want to narrow the active scan.
   - Feature-local spec-relative sqlFile values are the preferred contract. Use --sql-root only for shared-root fallback.
   - exprHints: best-effort only. Absence of exprHints does not imply the feature is not present.
 `
@@ -322,11 +328,16 @@ function runQueryUsesCommand(kind: 'table' | 'column', target: string | undefine
     jsonPayload: Boolean(options.json),
   });
 
+  const scopeDir = normalizeStringOption(resolved.merged.scopeDir) ?? normalizeStringOption(resolved.merged.specsDir);
+  if (!normalizeStringOption(resolved.merged.scopeDir) && normalizeStringOption(resolved.merged.specsDir)) {
+    console.error('Warning: --specs-dir is deprecated for `query uses`; use --scope-dir instead.');
+  }
+
   const report = buildQueryUsageReport({
     kind,
     rawTarget: resolved.resolvedTarget,
     rootDir: process.env.ZTD_PROJECT_ROOT,
-    specsDir: normalizeStringOption(resolved.merged.specsDir),
+    specsDir: scopeDir,
     sqlRoot: normalizeStringOption(resolved.merged.sqlRoot),
     excludeGenerated: normalizeBooleanOption(resolved.merged.excludeGenerated),
     view: resolved.view,

--- a/packages/ztd-cli/tests/furtherReading.docs.test.ts
+++ b/packages/ztd-cli/tests/furtherReading.docs.test.ts
@@ -52,8 +52,9 @@ test('Further Reading docs stay aligned with the current standalone and CLI beha
         'The starter setup derives `ZTD_DB_URL` from `.env`',
         'If port `5432` is already in use, update `ZTD_DB_PORT` in `.env` before you rerun the compose path, for example:',
         'Copy-Item .env.example .env',
-        'npx ztd query uses column users.email --specs-dir src/features/users-insert --any-schema --view detail',
-        'Passing the feature folder as `--specs-dir` is a normal way to narrow the project-wide scan, not a workaround for feature-local layouts.',
+        'npx ztd query uses column users.email --scope-dir src/features/users-insert --any-schema --view detail',
+        'Passing the feature folder as `--scope-dir` is a normal way to narrow the project-wide scan, not a workaround for feature-local layouts.',
+        'The older `--specs-dir` flag still works as a deprecated alias during the transition.',
         'npx ztd model-gen --probe-mode ztd src/features/users-insert/queries/insert-users/insert-users.sql',
         'Do not target `src/features/users-insert/queries/insert-users/boundary.ts` with `--out`, because that file is the runtime boundary that also owns `loadSqlResource` and the execution flow.',
         'model-gen` now treats the SQL file location as the primary contract source',
@@ -88,7 +89,7 @@ test('Further Reading docs stay aligned with the current standalone and CLI beha
         'npx ztd model-gen --probe-mode ztd src/features/users/persistence/users.sql --out src/features/users/persistence/users.spec.ts',
         '`ZTD_DB_URL` is the only implicit database owned by ztd-cli.',
         'Use `--url` or a full `--db-*` flag set for any other inspection target.',
-        'The feature folder is one narrowed spec set inside the normal project-wide discovery flow.',
+        'The feature folder is one narrowed scan scope inside the normal project-wide discovery flow.',
         'inspect the structured risks second',
         'Do not apply migrations automatically.'
       ]
@@ -97,9 +98,10 @@ test('Further Reading docs stay aligned with the current standalone and CLI beha
       docPath: 'docs/guide/query-uses-impact-checks.md',
       phrases: [
         'The active scan set is **project-wide by default**.',
-        'Use `--specs-dir` only when you want to narrow the scan to one slice or sub-tree.',
+        'Use `--scope-dir` only when you want to narrow the scan to one slice or sub-tree.',
+        '`--specs-dir` remains as a deprecated compatibility alias for now.',
         'prefers feature-local spec-relative paths, then tries project-relative paths',
-        'npx ztd query uses column users.email --specs-dir src/features/users/persistence --any-schema --view detail'
+        'npx ztd query uses column users.email --scope-dir src/features/users/persistence --any-schema --view detail'
       ]
     },
     {

--- a/packages/ztd-cli/tests/queryUses.unit.test.ts
+++ b/packages/ztd-cli/tests/queryUses.unit.test.ts
@@ -229,6 +229,67 @@ test('query usage report discovers scaffolded feature-local queryspec files that
   ]);
 });
 
+test('query uses command accepts --scope-dir for boundary-first narrowing', async () => {
+  const root = createWorkspace('query-uses-scope-dir-command');
+  mkdirSync(path.join(root, 'src', 'features', 'users-insert', 'insert-users'), { recursive: true });
+  writeFileSync(
+    path.join(root, 'src', 'features', 'users-insert', 'insert-users', 'queryspec.ts'),
+    [
+      "import { loadSqlResource } from '../../_shared/loadSqlResource';",
+      '',
+      "const insertUsersSqlResource = loadSqlResource(__dirname, 'insert-users.sql');",
+      '',
+      'export async function executeInsertUsersQuerySpec() {',
+      '  return insertUsersSqlResource;',
+      '}',
+      ''
+    ].join('\n'),
+    'utf8'
+  );
+  writeFileSync(
+    path.join(root, 'src', 'features', 'users-insert', 'insert-users', 'insert-users.sql'),
+    'insert into public.users (email) values (:email) returning user_id;',
+    'utf8'
+  );
+  process.env.ZTD_PROJECT_ROOT = root;
+  const capture = { stdout: [] as string[], stderr: [] as string[] };
+  const program = createProgram(capture);
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((value?: unknown) => {
+    capture.stdout.push(String(value ?? ''));
+  });
+
+  await program.parseAsync(
+    [
+      'query',
+      'uses',
+      'column',
+      'users.email',
+      '--scope-dir',
+      'src/features/users-insert',
+      '--any-schema',
+      '--view',
+      'detail',
+      '--format',
+      'json'
+    ],
+    { from: 'user' }
+  );
+  logSpy.mockRestore();
+
+  const parsed = JSON.parse(capture.stdout.join(''));
+  expect(parsed.summary).toMatchObject({
+    catalogsScanned: 1,
+    matches: 1,
+  });
+  expect(parsed.matches).toEqual([
+    expect.objectContaining({
+      kind: 'detail',
+      sql_file: 'src/features/users-insert/insert-users/insert-users.sql',
+    }),
+  ]);
+  expect(capture.stderr).toEqual([]);
+});
+
 test('impact view resolves sql-root-relative sqlFile values before the legacy spec-relative fallback', () => {
   const root = createWorkspace('query-uses-sql-root-relative');
   mkdirSync(path.join(root, 'src', 'sql', 'sales'), { recursive: true });
@@ -468,6 +529,63 @@ test('query uses command accepts --json payload options and target', async () =>
   });
   expect(parsed.matches).toEqual([]);
   expect(capture.stderr).toEqual([]);
+});
+
+test('query uses command keeps --specs-dir as a deprecated alias for --scope-dir', async () => {
+  const root = createWorkspace('query-uses-deprecated-specs-dir');
+  mkdirSync(path.join(root, 'src', 'features', 'users', 'persistence'), { recursive: true });
+  writeFileSync(
+    path.join(root, 'src', 'features', 'users', 'persistence', 'queryspec.ts'),
+    [
+      "import { loadSqlResource } from '../../_shared/loadSqlResource';",
+      '',
+      "const usersSqlResource = loadSqlResource(__dirname, 'users.sql');",
+      '',
+      'export async function executeUsersQuerySpec() {',
+      '  return usersSqlResource;',
+      '}',
+      ''
+    ].join('\n'),
+    'utf8'
+  );
+  writeFileSync(
+    path.join(root, 'src', 'features', 'users', 'persistence', 'users.sql'),
+    'select email from public.users;',
+    'utf8'
+  );
+  process.env.ZTD_PROJECT_ROOT = root;
+  const capture = { stdout: [] as string[], stderr: [] as string[] };
+  const program = createProgram(capture);
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((value?: unknown) => {
+    capture.stdout.push(String(value ?? ''));
+  });
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation((value?: unknown) => {
+    capture.stderr.push(String(value ?? ''));
+  });
+
+  await program.parseAsync(
+    [
+      'query',
+      'uses',
+      'column',
+      'users.email',
+      '--specs-dir',
+      'src/features/users/persistence',
+      '--any-schema',
+      '--format',
+      'json'
+    ],
+    { from: 'user' }
+  );
+  logSpy.mockRestore();
+  errorSpy.mockRestore();
+
+  const parsed = JSON.parse(capture.stdout.join(''));
+  expect(parsed.summary).toMatchObject({
+    catalogsScanned: 1,
+    matches: 1,
+  });
+  expect(capture.stderr).toContain('Warning: --specs-dir is deprecated for `query uses`; use --scope-dir instead.');
 });
 
 test('query usage report excludes generated specs under a custom specsDir', () => {
@@ -799,6 +917,7 @@ test('detail view emits parse warnings, fallback rows, and no-catalog guidance d
     }
   ]);
   expect(formatQueryUsageReport(emptyReport, 'text')).toContain('No QuerySpec entries were discovered under .');
+  expect(formatQueryUsageReport(emptyReport, 'text')).toContain('Use --scope-dir only when you need to narrow the scan.');
 });
 
 test('table impact finds tables referenced from EXISTS subqueries through their FROM nodes', () => {

--- a/packages/ztd-cli/tests/sqlFirstTutorial.docs.test.ts
+++ b/packages/ztd-cli/tests/sqlFirstTutorial.docs.test.ts
@@ -31,7 +31,7 @@ test('the tutorial preserves the shortest DDL to first test path', () => {
   expectInOrder(tutorial, [
     'This tutorial shows the shortest path from `ztd init --starter` to a small `users` feature that can be changed, broken, and repaired with AI help.',
     'The tutorial uses one starter project, one `smoke` feature, and one `users` feature.',
-    'DDL repair | `npx ztd query uses column users.email --specs-dir src/features/users-insert --any-schema --view detail`',
+    'DDL repair | `npx ztd query uses column users.email --scope-dir src/features/users-insert --any-schema --view detail`',
     'SQL repair | `npx ztd model-gen --probe-mode ztd src/features/users-insert/queries/insert-users/insert-users.sql`',
     'DTO repair | `npx vitest run` after the DTO change',
     'migration | `npx ztd ztd-config`, optionally `npx ztd ddl pull --url <target-db-url>` to inspect the target, then `npx ztd ddl diff --url <target-db-url> --out tmp/users.diff.sql` to prepare review output plus apply SQL',
@@ -77,8 +77,9 @@ test('the tutorial preserves the shortest DDL to first test path', () => {
   expect(tutorial).toContain('If the returned id is null, stop and fix the scaffold or DDL instead of weakening the test.');
   expect(tutorial).toContain('Before writing the success-path assertion, inspect `insert-users.sql` and `boundary.ts`. If the scaffold does not actually return a non-null id, report that mismatch instead of inventing fixture data or schema overrides.');
   expect(tutorial).toContain('When the cases are ready, run `npx vitest run src/features/users-insert/queries/insert-users/tests/insert-users.boundary.ztd.test.ts` to execute the ZTD query test.');
-  expect(tutorial).toContain('npx ztd query uses column users.email --specs-dir src/features/users-insert --any-schema --view detail');
-  expect(tutorial).toContain('Passing the feature folder as `--specs-dir` is a normal way to narrow the project-wide scan, not a workaround for feature-local layouts.');
+  expect(tutorial).toContain('npx ztd query uses column users.email --scope-dir src/features/users-insert --any-schema --view detail');
+  expect(tutorial).toContain('Passing the feature folder as `--scope-dir` is a normal way to narrow the project-wide scan, not a workaround for feature-local layouts.');
+  expect(tutorial).toContain('The older `--specs-dir` flag still works as a deprecated alias during the transition.');
   expect(tutorial).toContain('For SQL repair, keep the SQL assets under `src/features/users-insert/queries/insert-users/`, keep the query on the starter DDL\'s `users` table, and rerun `model-gen` against `src/features/users-insert/queries/insert-users/insert-users.sql` directly to inspect the generated contract on stdout before you update the handwritten query boundary.');
   expect(tutorial).toContain('If you want to save that output for reference or gradual migration, write it to a dedicated generated-contract file with `--out` instead of overwriting handwritten runtime files.');
   expect(tutorial).toContain('Do not target `src/features/users-insert/queries/insert-users/boundary.ts` with `--out`, because that file is the runtime boundary that also owns `loadSqlResource` and the execution flow.');


### PR DESCRIPTION
## Source issue
- Closes #731

## Why it matters
- `ztd query uses` is now commonly narrowed to feature or boundary subtrees, so `--specs-dir` teaches an outdated QuerySpec-folder mental model.
- The CLI and docs should teach a boundary-first scope name without breaking existing callers abruptly.

## What changed
- Added `--scope-dir` as the primary narrowing flag for `ztd query uses table|column`.
- Kept `--specs-dir` as a hidden deprecated compatibility alias and emit a deprecation warning when it is used.
- Updated `query uses` help text, no-results guidance, tutorial/how-to docs, and the related docs assertions to teach `--scope-dir`.

## Acceptance items
- Acceptance item: `ztd query uses ... --scope-dir <path>` works for table and column usage commands.
  - Status: done
  - Repository evidence: CLI wiring in `packages/ztd-cli/src/commands/query.ts`; coverage in `packages/ztd-cli/tests/queryUses.unit.test.ts`.
  - Supplementary evidence: targeted Vitest run listed below.
  - Gap: none for the targeted command surface.
- Acceptance item: Help text, docs, and examples teach `--scope-dir` for the boundary-first narrowing flow.
  - Status: done
  - Repository evidence: updated docs under `docs/guide/` and `docs/dogfooding/`; docs assertions in `packages/ztd-cli/tests/furtherReading.docs.test.ts` and `packages/ztd-cli/tests/sqlFirstTutorial.docs.test.ts`.
  - Supplementary evidence: targeted Vitest run listed below.
  - Gap: none for the updated tutorial/how-to path.
- Acceptance item: `--specs-dir` remains as a temporary deprecated compatibility alias for `query uses`, and the compatibility behavior is covered by tests.
  - Status: done
  - Repository evidence: deprecated alias handling in `packages/ztd-cli/src/commands/query.ts`; compatibility coverage in `packages/ztd-cli/tests/queryUses.unit.test.ts`.
  - Supplementary evidence: targeted Vitest run listed below.
  - Gap: none for the alias behavior covered here.

## Verification basis
- Treated targeted `@rawsql-ts/ztd-cli` test coverage plus passing docs assertions as sufficient evidence for the changed external surface.
- Did not treat a full workspace green run as satisfied, because the repository currently has unrelated failing tests/checks outside this change.

## Verification
- `pnpm --filter @rawsql-ts/ztd-cli test -- tests/queryUses.unit.test.ts tests/furtherReading.docs.test.ts tests/sqlFirstTutorial.docs.test.ts tests/describe.cli.test.ts`
  - Passed
- `git commit` pre-commit hook
  - Partial
  - The hook ran workspace typecheck and full workspace tests, then failed on unrelated existing tests outside this change:
    - `packages/ztd-cli/tests/agentsPolicy.unit.test.ts`
    - `packages/ztd-cli/tests/setupEnv.unit.test.ts`
    - `packages/ztd-cli/tests/commandTelemetry.unit.test.ts`
  - Decision weight: local pre-commit gate
  - Why proceeding is acceptable for this PR: the changed command/docs/tests were verified directly, and the failing checks were not introduced by this diff.

## Guarantee limits
- This PR only renames the public `query uses` narrowing flag and related user-facing guidance.
- It does not rename internal `specsDir` symbols broadly.
- It does not change `--specs-dir` on `check-contract` or `test-evidence`.

## Outstanding gaps
- Full workspace pre-commit is still not green locally because of the unrelated failing tests listed above.

## What the human should decide next
- Confirm whether this PR should remain draft until the unrelated workspace failures are handled separately, or whether the targeted verification here is sufficient to review and merge this scoped rename change now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--scope-dir` option to the `ztd query uses` command for controlling query scope narrowing.

* **Documentation**
  * Updated guides to document the new `--scope-dir` option as the recommended approach.
  * `--specs-dir` retained as a deprecated compatibility alias; transition period includes deprecation warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->