### PR TITLE
[codex] add additive query scaffold for existing boundaries

### DIFF
--- a/packages/ztd-cli/README.md
+++ b/packages/ztd-cli/README.md
@@ -111,6 +111,20 @@ npx ztd feature scaffold --table users --action insert
 Scaffold the `users-insert` feature with co-located SQL, boundaries, and a thin tests entrypoint.
 Starter-owned shared support lives under `tests/support/ztd/`; `.ztd/` remains the tool-managed workspace for generated metadata and support files.
 
+When an existing boundary needs one more child query boundary, add it without regenerating the parent boundary:
+
+```bash
+npx ztd feature query scaffold --feature users-insert --query-name insert-user-audit --table user_audit --action insert
+```
+
+If the boundary is deeper in a VSA-style folder tree, point at the exact boundary folder instead:
+
+```bash
+npx ztd feature query scaffold --boundary-dir src/features/orders/write/sales-insert --query-name insert-sales-detail --table sales_detail --action insert
+```
+
+That additive scaffold creates `queries/<query-name>/boundary.ts` plus `queries/<query-name>/<query-name>.sql`, creates `queries/` when it is missing, and does not edit the parent `boundary.ts`. Parent orchestration, transaction decisions, and response shaping stay human/AI-owned.
+
 After you finish the SQL and DTO edits, run `npx ztd feature tests scaffold --feature <feature-name>`.
 That command refreshes `src/features/<feature-name>/queries/<query-name>/tests/generated/TEST_PLAN.md` and `analysis.json`, refreshes `src/features/<feature-name>/queries/<query-name>/tests/boundary-ztd-types.ts`, and creates the thin Vitest entrypoint `src/features/<feature-name>/queries/<query-name>/tests/<query-name>.boundary.ztd.test.ts` only if it is missing.
 Persistent case files under `src/features/<feature-name>/queries/<query-name>/tests/cases/` are human/AI-owned and are not overwritten.
@@ -167,6 +181,7 @@ If you want a deeper walkthrough, keep that in the linked guides instead of expa
 |---|---|
 | `ztd init --starter` | Scaffold the starter project with smoke, DDL, compose, and local Postgres wiring. |
 | `ztd feature scaffold --table <table> --action <insert/update/delete/get-by-id/list>` | Scaffold a feature-local CRUD/SELECT slice with SQL, `boundary.ts` entrypoints, README, and a thin tests entrypoint. |
+| `ztd feature query scaffold --query-name <name> --table <table> --action <insert/update/delete/get-by-id/list>` | Add one child query boundary under an existing boundary folder without rewriting the parent boundary. |
 | `ztd feature tests scaffold --feature <feature-name>` | Refresh `tests/generated/TEST_PLAN.md` and `analysis.json`, create the thin `<query-name>.boundary.ztd.test.ts` Vitest entrypoint when missing, and keep `tests/cases/` as human/AI-owned persistent cases. |
 | `ztd agents init` | Add the optional Codex bootstrap files. |
 | `ztd ztd-config` | Regenerate `TestRowMap` and runtime fixture metadata from DDL without Docker. |

--- a/packages/ztd-cli/README.md
+++ b/packages/ztd-cli/README.md
@@ -181,7 +181,7 @@ If you want a deeper walkthrough, keep that in the linked guides instead of expa
 |---|---|
 | `ztd init --starter` | Scaffold the starter project with smoke, DDL, compose, and local Postgres wiring. |
 | `ztd feature scaffold --table <table> --action <insert/update/delete/get-by-id/list>` | Scaffold a feature-local CRUD/SELECT slice with SQL, `boundary.ts` entrypoints, README, and a thin tests entrypoint. |
-| `ztd feature query scaffold --query-name <name> --table <table> --action <insert/update/delete/get-by-id/list>` | Add one child query boundary under an existing boundary folder without rewriting the parent boundary. |
+| `ztd feature query scaffold --query-name <name> --table <table> --action <insert/update/delete/get-by-id/list>` | Add one child query boundary under an existing boundary folder without rewriting the parent boundary. Target selection uses `--feature` first, then `--boundary-dir`, then the current working directory. |
 | `ztd feature tests scaffold --feature <feature-name>` | Refresh `tests/generated/TEST_PLAN.md` and `analysis.json`, create the thin `<query-name>.boundary.ztd.test.ts` Vitest entrypoint when missing, and keep `tests/cases/` as human/AI-owned persistent cases. |
 | `ztd agents init` | Add the optional Codex bootstrap files. |
 | `ztd ztd-config` | Regenerate `TestRowMap` and runtime fixture metadata from DDL without Docker. |

--- a/packages/ztd-cli/src/commands/feature.ts
+++ b/packages/ztd-cli/src/commands/feature.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { Command } from 'commander';
 import {
@@ -21,8 +21,6 @@ type FeatureAction = (typeof FEATURE_ACTIONS)[number];
 const DEFAULT_PAGE_SIZE = 50;
 const FEATURE_SHARED_EXECUTOR_IMPORT_PATH = '#features/_shared/featureQueryExecutor.js';
 const FEATURE_SHARED_LOAD_SQL_RESOURCE_IMPORT_PATH = '#features/_shared/loadSqlResource.js';
-const FEATURE_SHARED_EXECUTOR_RELATIVE_IMPORT_PATH = '../../../_shared/featureQueryExecutor.js';
-const FEATURE_SHARED_LOAD_SQL_RESOURCE_RELATIVE_IMPORT_PATH = '../../../_shared/loadSqlResource.js';
 const FIXED_LAYOUT_DESCRIPTION = [
   'src/features/<feature-name>/',
   '  boundary.ts',
@@ -49,6 +47,17 @@ type FeatureCommandOptions = {
   dryRun?: boolean;
   force?: boolean;
   rootDir?: string;
+};
+
+type ExistingBoundaryQueryCommandOptions = {
+  table?: string;
+  action?: string;
+  queryName?: string;
+  feature?: string;
+  boundaryDir?: string;
+  dryRun?: boolean;
+  rootDir?: string;
+  workingDir?: string;
 };
 
 type FeatureScaffoldSourceName = 'generated-metadata' | 'ddl';
@@ -95,8 +104,30 @@ interface FeatureScaffoldPaths {
   loadSqlResourceFile: string;
 }
 
+interface ExistingBoundaryQueryScaffoldPaths {
+  boundaryDir: string;
+  queriesDir: string;
+  queryDir: string;
+  querySpecFile: string;
+  querySqlFile: string;
+  entrySpecFile: string;
+  createsQueriesDir: boolean;
+}
+
 interface FeatureScaffoldResult {
   featureName: string;
+  queryName: string;
+  action: FeatureAction;
+  table: string;
+  primaryKeyColumn: string;
+  source: FeatureScaffoldSourceName;
+  dryRun: boolean;
+  outputs: Array<{ path: string; written: boolean; kind: 'directory' | 'file' }>;
+}
+
+interface ExistingBoundaryQueryScaffoldResult {
+  boundaryPath: string;
+  resolutionSource: 'feature' | 'boundary-dir' | 'cwd';
   queryName: string;
   action: FeatureAction;
   table: string;
@@ -109,6 +140,9 @@ interface FeatureScaffoldResult {
 export function registerFeatureCommand(program: Command): void {
   const feature = program.command('feature').description('Scaffold feature-local files from schema metadata');
   registerFeatureTestsScaffoldCommand(feature);
+  const featureQuery = feature
+    .command('query')
+    .description('Add a child query boundary under an existing boundary folder');
 
   feature
     .command('scaffold')
@@ -139,6 +173,41 @@ export function registerFeatureCommand(program: Command): void {
       `- Run \`ztd feature tests scaffold --feature ${result.featureName}\` after you finish SQL and DTO edits.`,
       `- That command will refresh src/features/${result.featureName}/queries/${result.queryName}/tests/generated/TEST_PLAN.md and analysis.json, while AI-authored cases stay in src/features/${result.featureName}/queries/${result.queryName}/tests/cases/.`
     ];
+      process.stdout.write(`${lines.join('\n')}\n`);
+    });
+
+  featureQuery
+    .command('scaffold')
+    .description('Scaffold one additive query boundary under an existing boundary folder without rewriting the parent boundary')
+    .requiredOption('--table <table>', 'Target table name for the new query boundary')
+    .requiredOption('--action <action>', 'Query action template to scaffold (v1 supports insert, update, delete, get-by-id, and list)')
+    .requiredOption('--query-name <name>', 'Name of the query boundary to add under queries/')
+    .option('--feature <name>', 'Resolve the target boundary as src/features/<feature-name>')
+    .option('--boundary-dir <path>', 'Explicit existing boundary folder path; defaults to the current working directory when omitted')
+    .option('--dry-run', 'Validate inputs and emit the planned scaffold without writing files', false)
+    .action(async (options: ExistingBoundaryQueryCommandOptions) => {
+      const result = await runExistingBoundaryQueryScaffoldCommand(options);
+      if (isJsonOutput()) {
+        writeCommandEnvelope('feature query scaffold', result);
+        return;
+      }
+
+      const lines = [
+        `Existing-boundary query scaffold ${result.dryRun ? 'plan' : 'completed'}: ${result.queryName}`,
+        `Boundary: ${result.boundaryPath}`,
+        `Resolved by: ${result.resolutionSource}`,
+        `Action: ${result.action}`,
+        `Table: ${result.table}`,
+        `Primary key: ${result.primaryKeyColumn}`,
+        `Source: ${result.source}`,
+        '',
+        'Created by CLI:',
+        ...result.outputs.map((output) => `- ${output.path}`),
+        '',
+        'Reserved for AI/human follow-up (not done by the CLI):',
+        '- Wire the new query boundary into the parent boundary explicitly.',
+        '- Decide orchestration, transaction boundaries, and response shaping at the parent boundary.'
+      ];
       process.stdout.write(`${lines.join('\n')}\n`);
     });
 }
@@ -226,6 +295,81 @@ export async function runFeatureScaffoldCommand(options: FeatureCommandOptions):
   };
 }
 
+export async function runExistingBoundaryQueryScaffoldCommand(
+  options: ExistingBoundaryQueryCommandOptions
+): Promise<ExistingBoundaryQueryScaffoldResult> {
+  const rootDir = options.rootDir ?? process.cwd();
+  const action = normalizeFeatureAction(options.action);
+  const queryName = normalizeChildQueryName(options.queryName);
+  const config = loadZtdProjectConfig(rootDir);
+  const generatedMetadataAssessment = assessGeneratedMetadataCapability(rootDir);
+  const input = resolveFeatureScaffoldInput({
+    projectRoot: rootDir,
+    table: options.table ?? '',
+    config,
+    generatedMetadataAssessment
+  });
+  const primaryKeyColumn = resolvePrimaryKeyColumn(input.table);
+  const resolvedBoundary = resolveExistingBoundaryFolder(rootDir, options);
+  assertExistingBoundaryFolderContract(rootDir, resolvedBoundary.boundaryDir);
+  const paths = buildExistingBoundaryQueryScaffoldPaths(resolvedBoundary.boundaryDir, queryName);
+  assertExistingBoundaryQueryWriteSafety(paths);
+  const contents = renderExistingBoundaryQueryScaffoldFiles({
+    rootDir,
+    boundaryDir: resolvedBoundary.boundaryDir,
+    boundaryRelativeDir: resolvedBoundary.boundaryPath,
+    queryName,
+    action,
+    table: input.table,
+    primaryKeyColumn
+  });
+
+  const outputs: ExistingBoundaryQueryScaffoldResult['outputs'] = [
+    ...(paths.createsQueriesDir
+      ? [{ path: toProjectRelativePath(rootDir, paths.queriesDir), written: !options.dryRun, kind: 'directory' as const }]
+      : []),
+    { path: toProjectRelativePath(rootDir, paths.queryDir), written: !options.dryRun, kind: 'directory' },
+    { path: toProjectRelativePath(rootDir, paths.querySpecFile), written: !options.dryRun, kind: 'file' },
+    { path: toProjectRelativePath(rootDir, paths.querySqlFile), written: !options.dryRun, kind: 'file' },
+  ];
+
+  if (options.dryRun) {
+    return {
+      boundaryPath: resolvedBoundary.boundaryPath,
+      resolutionSource: resolvedBoundary.resolutionSource,
+      queryName,
+      action,
+      table: input.table.canonicalName,
+      primaryKeyColumn,
+      source: input.source,
+      dryRun: true,
+      outputs
+    };
+  }
+
+  ensureDirectory(paths.queriesDir);
+  ensureDirectory(paths.queryDir);
+  writeFileSync(paths.querySpecFile, contents.querySpecFile, 'utf8');
+  writeFileSync(paths.querySqlFile, contents.querySqlFile, 'utf8');
+
+  emitDiagnostic({
+    code: 'feature-query-scaffold.parent-follow-up',
+    message: `CLI added ${resolvedBoundary.boundaryPath}/queries/${queryName}, but it did not modify ${resolvedBoundary.boundaryPath}/boundary.ts. Wire orchestration explicitly in the parent boundary.`
+  });
+
+  return {
+    boundaryPath: resolvedBoundary.boundaryPath,
+    resolutionSource: resolvedBoundary.resolutionSource,
+    queryName,
+    action,
+    table: input.table.canonicalName,
+    primaryKeyColumn,
+    source: input.source,
+    dryRun: false,
+    outputs
+  };
+}
+
 export function deriveFeatureName(tableName: string, action: string): string {
   const resourceSegment = toFeatureResourceSegment(tableName);
   return `${resourceSegment}-${action.trim().toLowerCase()}`;
@@ -245,6 +389,14 @@ export function normalizeFeatureName(value: string): string {
     throw new Error(
       'Feature name must use resource-action kebab-case, start with a letter, and look like users-insert.'
     );
+  }
+  return normalized;
+}
+
+export function normalizeChildQueryName(value: string | undefined): string {
+  const normalized = (value ?? '').trim().toLowerCase();
+  if (!/^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/.test(normalized)) {
+    throw new Error('Query name must use kebab-case, start with a letter, and look like insert-sales-detail.');
   }
   return normalized;
 }
@@ -503,6 +655,23 @@ function buildFeatureScaffoldPaths(rootDir: string, featureName: string, queryNa
   };
 }
 
+function buildExistingBoundaryQueryScaffoldPaths(
+  boundaryDir: string,
+  queryName: string
+): ExistingBoundaryQueryScaffoldPaths {
+  const queriesDir = path.join(boundaryDir, 'queries');
+  const queryDir = path.join(queriesDir, queryName);
+  return {
+    boundaryDir,
+    queriesDir,
+    queryDir,
+    querySpecFile: path.join(queryDir, 'boundary.ts'),
+    querySqlFile: path.join(queryDir, `${queryName}.sql`),
+    entrySpecFile: path.join(boundaryDir, 'boundary.ts'),
+    createsQueriesDir: !existsSync(queriesDir)
+  };
+}
+
 function renderFeatureScaffoldFiles(params: {
   rootDir: string;
   featureName: string;
@@ -519,17 +688,11 @@ function renderFeatureScaffoldFiles(params: {
   featureQueryExecutorFile: string;
   loadSqlResourceFile: string;
 } {
-  const importAliasSupport = inspectImportAliasSupport(params.rootDir, {
-    packageImportKey: '#features/*.js',
-    tsconfigPathKey: '#features/*',
-    vitestAliasPrefix: '#features'
-  });
-  if (importAliasSupport === 'partial') {
-    throw new Error(
-      'Feature scaffold found partial #features alias configuration. Configure package.json#imports, tsconfig.json compilerOptions.paths, and vitest.config.ts resolve.alias together, or remove the partial alias setup.'
-    );
-  }
-  const useStableSharedImports = importAliasSupport === 'supported';
+  const sharedImports = resolveFeatureSharedImportPaths(
+    params.rootDir,
+    path.join(params.rootDir, 'src', 'features', params.featureName, 'queries', params.queryName),
+    'Feature scaffold'
+  );
   const pascalName = toPascalCase(params.featureName);
   const entryCamelName = toCamelCase(params.featureName);
   const queryPascalName = toPascalCase(params.queryName);
@@ -569,12 +732,13 @@ function renderFeatureScaffoldFiles(params: {
   const querySpecFile = renderQuerySpecFile({
     action: params.action,
     queryName: params.queryName,
-    featureName: params.featureName,
+    boundaryRelativeDir: normalizeCliPath(path.join('src', 'features', params.featureName)),
     queryPascalName,
     queryCamelName,
     requestFields,
     responseFields,
-    useStableSharedImports
+    sharedExecutorImportPath: sharedImports.executorImportPath,
+    sharedLoadSqlResourceImportPath: sharedImports.loadSqlResourceImportPath
   });
   const readmeFile = renderReadmeFile({
     action: params.action,
@@ -634,6 +798,153 @@ function deriveQueryName(tableName: string, action: FeatureAction): string {
     return action;
   }
   return `${action}-${toFeatureResourceSegment(tableName)}`;
+}
+
+function resolveExistingBoundaryFolder(
+  rootDir: string,
+  options: ExistingBoundaryQueryCommandOptions
+): {
+  boundaryDir: string;
+  boundaryPath: string;
+  resolutionSource: 'feature' | 'boundary-dir' | 'cwd';
+} {
+  if (options.feature && options.boundaryDir) {
+    throw new Error('Use either --feature or --boundary-dir, not both.');
+  }
+
+  if (options.feature) {
+    const featureName = normalizeFeatureName(options.feature);
+    const boundaryDir = path.join(rootDir, 'src', 'features', featureName);
+    return {
+      boundaryDir,
+      boundaryPath: toProjectRelativePath(rootDir, boundaryDir),
+      resolutionSource: 'feature'
+    };
+  }
+
+  if (options.boundaryDir) {
+    const boundaryDir = path.resolve(rootDir, options.boundaryDir);
+    return {
+      boundaryDir,
+      boundaryPath: toProjectRelativePath(rootDir, boundaryDir),
+      resolutionSource: 'boundary-dir'
+    };
+  }
+
+  const boundaryDir = options.workingDir ?? process.cwd();
+  return {
+    boundaryDir,
+    boundaryPath: toProjectRelativePath(rootDir, boundaryDir),
+    resolutionSource: 'cwd'
+  };
+}
+
+function renderExistingBoundaryQueryScaffoldFiles(params: {
+  rootDir: string;
+  boundaryDir: string;
+  boundaryRelativeDir: string;
+  queryName: string;
+  action: FeatureAction;
+  table: DdlTableMetadata;
+  primaryKeyColumn: string;
+}): {
+  querySpecFile: string;
+  querySqlFile: string;
+} {
+  const sharedImports = resolveFeatureSharedImportPaths(
+    params.rootDir,
+    path.join(params.boundaryDir, 'queries', params.queryName),
+    'Feature query scaffold'
+  );
+  const queryPascalName = toPascalCase(params.queryName);
+  const queryCamelName = toCamelCase(params.queryName);
+  const actionPlan = buildActionPlan(params.action, params.table, params.primaryKeyColumn);
+  const requestFields = actionPlan.requestColumns.map((column) => toRenderField(column));
+  const responseFields = actionPlan.resultColumns.map((column) => toRenderField(column));
+
+  return {
+    querySpecFile: renderQuerySpecFile({
+      action: params.action,
+      queryName: params.queryName,
+      boundaryRelativeDir: params.boundaryRelativeDir,
+      queryPascalName,
+      queryCamelName,
+      requestFields,
+      responseFields,
+      sharedExecutorImportPath: sharedImports.executorImportPath,
+      sharedLoadSqlResourceImportPath: sharedImports.loadSqlResourceImportPath
+    }),
+    querySqlFile: renderActionSql(actionPlan, params.table.canonicalName, params.primaryKeyColumn)
+  };
+}
+
+function assertExistingBoundaryFolderContract(rootDir: string, boundaryDir: string): void {
+  const relativeBoundary = toProjectRelativePath(rootDir, boundaryDir);
+  if (relativeBoundary.startsWith('..')) {
+    throw new Error(`Boundary folder must stay inside the project root: ${boundaryDir}.`);
+  }
+  if (!existsSync(boundaryDir)) {
+    throw new Error(`Existing boundary folder not found: ${relativeBoundary}.`);
+  }
+  if (!statSync(boundaryDir).isDirectory()) {
+    throw new Error(`Boundary target must be a directory: ${relativeBoundary}.`);
+  }
+
+  const entrySpecFile = path.join(boundaryDir, 'boundary.ts');
+  if (!existsSync(entrySpecFile)) {
+    throw new Error(`Boundary folder must contain boundary.ts: ${relativeBoundary}.`);
+  }
+  if (!statSync(entrySpecFile).isFile()) {
+    throw new Error(`Boundary entrypoint must be a file: ${normalizeCliPath(path.join(relativeBoundary, 'boundary.ts'))}.`);
+  }
+
+  const queriesDir = path.join(boundaryDir, 'queries');
+  if (existsSync(queriesDir) && !statSync(queriesDir).isDirectory()) {
+    throw new Error(`Expected queries/ to be a directory under ${relativeBoundary}.`);
+  }
+}
+
+function assertExistingBoundaryQueryWriteSafety(paths: ExistingBoundaryQueryScaffoldPaths): void {
+  if (existsSync(paths.queryDir)) {
+    throw new Error(
+      `Query boundary already exists: ${normalizeCliPath(path.join(path.basename(paths.boundaryDir), 'queries', path.basename(paths.queryDir)))}.`
+    );
+  }
+}
+
+function resolveFeatureSharedImportPaths(
+  rootDir: string,
+  queryDir: string,
+  commandLabel: string
+): {
+  executorImportPath: string;
+  loadSqlResourceImportPath: string;
+} {
+  const importAliasSupport = inspectImportAliasSupport(rootDir, {
+    packageImportKey: '#features/*.js',
+    tsconfigPathKey: '#features/*',
+    vitestAliasPrefix: '#features'
+  });
+  if (importAliasSupport === 'partial') {
+    throw new Error(
+      `${commandLabel} found partial #features alias configuration. Configure package.json#imports, tsconfig.json compilerOptions.paths, and vitest.config.ts resolve.alias together, or remove the partial alias setup.`
+    );
+  }
+  if (importAliasSupport === 'supported') {
+    return {
+      executorImportPath: FEATURE_SHARED_EXECUTOR_IMPORT_PATH,
+      loadSqlResourceImportPath: FEATURE_SHARED_LOAD_SQL_RESOURCE_IMPORT_PATH
+    };
+  }
+
+  return {
+    executorImportPath: normalizeCliPath(
+      path.relative(queryDir, path.join(rootDir, 'src', 'features', '_shared', 'featureQueryExecutor.js'))
+    ),
+    loadSqlResourceImportPath: normalizeCliPath(
+      path.relative(queryDir, path.join(rootDir, 'src', 'features', '_shared', 'loadSqlResource.js'))
+    )
+  };
 }
 
 function buildActionPlan(
@@ -1087,12 +1398,13 @@ function renderEntrySpecTestFile(params: {
 function renderQuerySpecFile(params: {
   action: FeatureAction;
   queryName: string;
-  featureName: string;
+  boundaryRelativeDir: string;
   queryPascalName: string;
   queryCamelName: string;
   requestFields: RenderField[];
   responseFields: RenderField[];
-  useStableSharedImports: boolean;
+  sharedExecutorImportPath: string;
+  sharedLoadSqlResourceImportPath: string;
 }): string {
   if (params.action === 'get-by-id') {
     return renderGetByIdQuerySpecFile(params);
@@ -1125,8 +1437,8 @@ function renderQuerySpecFile(params: {
     "import { dirname } from 'node:path';",
     "import { fileURLToPath } from 'node:url';",
     '',
-    `import type { FeatureQueryExecutor } from '${params.useStableSharedImports ? FEATURE_SHARED_EXECUTOR_IMPORT_PATH : FEATURE_SHARED_EXECUTOR_RELATIVE_IMPORT_PATH}';`,
-    `import { loadSqlResource } from '${params.useStableSharedImports ? FEATURE_SHARED_LOAD_SQL_RESOURCE_IMPORT_PATH : FEATURE_SHARED_LOAD_SQL_RESOURCE_RELATIVE_IMPORT_PATH}';`,
+    `import type { FeatureQueryExecutor } from '${params.sharedExecutorImportPath}';`,
+    `import { loadSqlResource } from '${params.sharedLoadSqlResourceImportPath}';`,
     '',
     'const __dirname = dirname(fileURLToPath(import.meta.url));',
     `const ${params.queryCamelName}SqlResource = loadSqlResource(__dirname, '${params.queryName}.sql');`,
@@ -1640,12 +1952,13 @@ function renderListEntrySpecFile(params: {
 function renderGetByIdQuerySpecFile(params: {
   action: FeatureAction;
   queryName: string;
-  featureName: string;
+  boundaryRelativeDir: string;
   queryPascalName: string;
   queryCamelName: string;
   requestFields: RenderField[];
   responseFields: RenderField[];
-  useStableSharedImports: boolean;
+  sharedExecutorImportPath: string;
+  sharedLoadSqlResourceImportPath: string;
 }): string {
   const paramsSchema = renderZodObjectSchema('QueryParamsSchema', params.requestFields, {
     trimStrings: false,
@@ -1665,8 +1978,8 @@ function renderGetByIdQuerySpecFile(params: {
     "import { dirname } from 'node:path';",
     "import { fileURLToPath } from 'node:url';",
     '',
-    `import type { FeatureQueryExecutor } from '${params.useStableSharedImports ? FEATURE_SHARED_EXECUTOR_IMPORT_PATH : FEATURE_SHARED_EXECUTOR_RELATIVE_IMPORT_PATH}';`,
-    `import { loadSqlResource } from '${params.useStableSharedImports ? FEATURE_SHARED_LOAD_SQL_RESOURCE_IMPORT_PATH : FEATURE_SHARED_LOAD_SQL_RESOURCE_RELATIVE_IMPORT_PATH}';`,
+    `import type { FeatureQueryExecutor } from '${params.sharedExecutorImportPath}';`,
+    `import { loadSqlResource } from '${params.sharedLoadSqlResourceImportPath}';`,
     '',
     'const __dirname = dirname(fileURLToPath(import.meta.url));',
     `const ${params.queryCamelName}SqlResource = loadSqlResource(__dirname, '${params.queryName}.sql');`,
@@ -1730,12 +2043,13 @@ function renderGetByIdQuerySpecFile(params: {
 function renderListQuerySpecFile(params: {
   action: FeatureAction;
   queryName: string;
-  featureName: string;
+  boundaryRelativeDir: string;
   queryPascalName: string;
   queryCamelName: string;
   requestFields: RenderField[];
   responseFields: RenderField[];
-  useStableSharedImports: boolean;
+  sharedExecutorImportPath: string;
+  sharedLoadSqlResourceImportPath: string;
 }): string {
   const paramsSchema = renderZodObjectSchema('QueryParamsSchema', params.requestFields, {
     trimStrings: false,
@@ -1755,9 +2069,9 @@ function renderListQuerySpecFile(params: {
     "import { dirname } from 'node:path';",
     "import { fileURLToPath } from 'node:url';",
     '',
-    `import type { FeatureQueryExecutor } from '${params.useStableSharedImports ? FEATURE_SHARED_EXECUTOR_IMPORT_PATH : FEATURE_SHARED_EXECUTOR_RELATIVE_IMPORT_PATH}';`,
+    `import type { FeatureQueryExecutor } from '${params.sharedExecutorImportPath}';`,
     "import { createCatalogExecutor, type QuerySpec } from '@rawsql-ts/sql-contract';",
-    `import { loadSqlResource } from '${params.useStableSharedImports ? FEATURE_SHARED_LOAD_SQL_RESOURCE_IMPORT_PATH : FEATURE_SHARED_LOAD_SQL_RESOURCE_RELATIVE_IMPORT_PATH}';`,
+    `import { loadSqlResource } from '${params.sharedLoadSqlResourceImportPath}';`,
     '',
     `const DEFAULT_PAGE_SIZE = ${DEFAULT_PAGE_SIZE};`,
     'const __dirname = dirname(fileURLToPath(import.meta.url));',
@@ -1792,8 +2106,8 @@ function renderListQuerySpecFile(params: {
     '}',
     '',
     `const ${params.queryCamelName}CatalogSpec: QuerySpec<${params.queryPascalName}CatalogQueryParams, ${params.queryPascalName}Row> = {`,
-    `  id: '${params.featureName}/queries/${params.queryName}/spec',`,
-    `  sqlFile: 'src/features/${params.featureName}/queries/${params.queryName}/${params.queryName}.sql',`,
+    `  id: '${params.boundaryRelativeDir}/queries/${params.queryName}/spec',`,
+    `  sqlFile: '${params.boundaryRelativeDir}/queries/${params.queryName}/${params.queryName}.sql',`,
     '  params: {',
     "    shape: 'named',",
     '    example: {',

--- a/packages/ztd-cli/src/commands/feature.ts
+++ b/packages/ztd-cli/src/commands/feature.ts
@@ -111,6 +111,9 @@ interface ExistingBoundaryQueryScaffoldPaths {
   querySpecFile: string;
   querySqlFile: string;
   entrySpecFile: string;
+  sharedDir: string;
+  featureQueryExecutorFile: string;
+  loadSqlResourceFile: string;
   createsQueriesDir: boolean;
 }
 
@@ -312,7 +315,7 @@ export async function runExistingBoundaryQueryScaffoldCommand(
   const primaryKeyColumn = resolvePrimaryKeyColumn(input.table);
   const resolvedBoundary = resolveExistingBoundaryFolder(rootDir, options);
   assertExistingBoundaryFolderContract(rootDir, resolvedBoundary.boundaryDir);
-  const paths = buildExistingBoundaryQueryScaffoldPaths(resolvedBoundary.boundaryDir, queryName);
+  const paths = buildExistingBoundaryQueryScaffoldPaths(rootDir, resolvedBoundary.boundaryDir, queryName);
   assertExistingBoundaryQueryWriteSafety(paths);
   const contents = renderExistingBoundaryQueryScaffoldFiles({
     rootDir,
@@ -325,6 +328,7 @@ export async function runExistingBoundaryQueryScaffoldCommand(
   });
 
   const outputs: ExistingBoundaryQueryScaffoldResult['outputs'] = [
+    ...buildSharedOutputs(rootDir, paths, !options.dryRun),
     ...(paths.createsQueriesDir
       ? [{ path: toProjectRelativePath(rootDir, paths.queriesDir), written: !options.dryRun, kind: 'directory' as const }]
       : []),
@@ -347,8 +351,11 @@ export async function runExistingBoundaryQueryScaffoldCommand(
     };
   }
 
+  ensureDirectory(paths.sharedDir);
   ensureDirectory(paths.queriesDir);
   ensureDirectory(paths.queryDir);
+  writeFileIfMissing(paths.featureQueryExecutorFile, contents.featureQueryExecutorFile);
+  writeFileIfMissing(paths.loadSqlResourceFile, contents.loadSqlResourceFile);
   writeFileSync(paths.querySpecFile, contents.querySpecFile, 'utf8');
   writeFileSync(paths.querySqlFile, contents.querySqlFile, 'utf8');
 
@@ -656,11 +663,13 @@ function buildFeatureScaffoldPaths(rootDir: string, featureName: string, queryNa
 }
 
 function buildExistingBoundaryQueryScaffoldPaths(
+  rootDir: string,
   boundaryDir: string,
   queryName: string
 ): ExistingBoundaryQueryScaffoldPaths {
   const queriesDir = path.join(boundaryDir, 'queries');
   const queryDir = path.join(queriesDir, queryName);
+  const sharedDir = path.join(rootDir, 'src', 'features', '_shared');
   return {
     boundaryDir,
     queriesDir,
@@ -668,6 +677,9 @@ function buildExistingBoundaryQueryScaffoldPaths(
     querySpecFile: path.join(queryDir, 'boundary.ts'),
     querySqlFile: path.join(queryDir, `${queryName}.sql`),
     entrySpecFile: path.join(boundaryDir, 'boundary.ts'),
+    sharedDir,
+    featureQueryExecutorFile: path.join(sharedDir, 'featureQueryExecutor.ts'),
+    loadSqlResourceFile: path.join(sharedDir, 'loadSqlResource.ts'),
     createsQueriesDir: !existsSync(queriesDir)
   };
 }
@@ -701,23 +713,7 @@ function renderFeatureScaffoldFiles(params: {
   const requestFields = actionPlan.requestColumns.map((column) => toRenderField(column));
   const responseFields = actionPlan.resultColumns.map((column) => toRenderField(column));
   const sqlFile = renderActionSql(actionPlan, params.table.canonicalName, params.primaryKeyColumn);
-  const featureQueryExecutorFile = [
-    '// Shared runtime contract for scaffolded features.',
-    '// Inject your DB execution implementation at this seam from the application runtime.',
-    'export interface FeatureQueryExecutor {',
-    '  query<T = unknown>(sql: string, params: Record<string, unknown>): Promise<T[]>;',
-    '}',
-    ''
-  ].join('\n');
-  const loadSqlResourceFile = [
-    "import { readFileSync } from 'node:fs';",
-    "import path from 'node:path';",
-    '',
-    'export function loadSqlResource(currentDir: string, relativePath: string): string {',
-    "  return readFileSync(path.join(currentDir, relativePath), 'utf8');",
-    '}',
-    ''
-  ].join('\n');
+  const sharedSupportFiles = renderFeatureSharedSupportFiles();
   const entrySpecFile = renderEntrySpecFile({
     action: params.action,
     featureName: params.featureName,
@@ -765,8 +761,8 @@ function renderFeatureScaffoldFiles(params: {
     querySpecFile,
     querySqlFile: sqlFile,
     readmeFile,
-    featureQueryExecutorFile,
-    loadSqlResourceFile
+    featureQueryExecutorFile: sharedSupportFiles.featureQueryExecutorFile,
+    loadSqlResourceFile: sharedSupportFiles.loadSqlResourceFile
   };
 }
 
@@ -850,6 +846,8 @@ function renderExistingBoundaryQueryScaffoldFiles(params: {
 }): {
   querySpecFile: string;
   querySqlFile: string;
+  featureQueryExecutorFile: string;
+  loadSqlResourceFile: string;
 } {
   const sharedImports = resolveFeatureSharedImportPaths(
     params.rootDir,
@@ -861,6 +859,7 @@ function renderExistingBoundaryQueryScaffoldFiles(params: {
   const actionPlan = buildActionPlan(params.action, params.table, params.primaryKeyColumn);
   const requestFields = actionPlan.requestColumns.map((column) => toRenderField(column));
   const responseFields = actionPlan.resultColumns.map((column) => toRenderField(column));
+  const sharedSupportFiles = renderFeatureSharedSupportFiles();
 
   return {
     querySpecFile: renderQuerySpecFile({
@@ -874,7 +873,9 @@ function renderExistingBoundaryQueryScaffoldFiles(params: {
       sharedExecutorImportPath: sharedImports.executorImportPath,
       sharedLoadSqlResourceImportPath: sharedImports.loadSqlResourceImportPath
     }),
-    querySqlFile: renderActionSql(actionPlan, params.table.canonicalName, params.primaryKeyColumn)
+    querySqlFile: renderActionSql(actionPlan, params.table.canonicalName, params.primaryKeyColumn),
+    featureQueryExecutorFile: sharedSupportFiles.featureQueryExecutorFile,
+    loadSqlResourceFile: sharedSupportFiles.loadSqlResourceFile
   };
 }
 
@@ -926,11 +927,12 @@ function resolveFeatureSharedImportPaths(
     vitestAliasPrefix: '#features'
   });
   if (importAliasSupport === 'partial') {
-    throw new Error(
-      `${commandLabel} found partial #features alias configuration. Configure package.json#imports, tsconfig.json compilerOptions.paths, and vitest.config.ts resolve.alias together, or remove the partial alias setup.`
-    );
-  }
-  if (importAliasSupport === 'supported') {
+    emitDiagnostic({
+      code: 'feature-scaffold.partial-alias-fallback',
+      severity: 'warning',
+      message: `${commandLabel} found partial #features alias configuration. Falling back to relative imports for generated files. Configure package.json#imports, tsconfig.json compilerOptions.paths, and vitest.config.ts resolve.alias together to enable stable #features imports.`
+    });
+  } else if (importAliasSupport === 'supported') {
     return {
       executorImportPath: FEATURE_SHARED_EXECUTOR_IMPORT_PATH,
       loadSqlResourceImportPath: FEATURE_SHARED_LOAD_SQL_RESOURCE_IMPORT_PATH
@@ -944,6 +946,31 @@ function resolveFeatureSharedImportPaths(
     loadSqlResourceImportPath: normalizeCliPath(
       path.relative(queryDir, path.join(rootDir, 'src', 'features', '_shared', 'loadSqlResource.js'))
     )
+  };
+}
+
+function renderFeatureSharedSupportFiles(): {
+  featureQueryExecutorFile: string;
+  loadSqlResourceFile: string;
+} {
+  return {
+    featureQueryExecutorFile: [
+      '// Shared runtime contract for scaffolded features.',
+      '// Inject your DB execution implementation at this seam from the application runtime.',
+      'export interface FeatureQueryExecutor {',
+      '  query<T = unknown>(sql: string, params: Record<string, unknown>): Promise<T[]>;',
+      '}',
+      ''
+    ].join('\n'),
+    loadSqlResourceFile: [
+      "import { readFileSync } from 'node:fs';",
+      "import path from 'node:path';",
+      '',
+      'export function loadSqlResource(currentDir: string, relativePath: string): string {',
+      "  return readFileSync(path.join(currentDir, relativePath), 'utf8');",
+      '}',
+      ''
+    ].join('\n')
   };
 }
 
@@ -2250,7 +2277,7 @@ function toFeatureResourceSegment(tableName: string): string {
 
 function buildSharedOutputs(
   rootDir: string,
-  paths: FeatureScaffoldPaths,
+  paths: Pick<FeatureScaffoldPaths, 'sharedDir' | 'featureQueryExecutorFile' | 'loadSqlResourceFile'>,
   written: boolean
 ): FeatureScaffoldResult['outputs'] {
   const outputs: FeatureScaffoldResult['outputs'] = [];

--- a/packages/ztd-cli/tests/cliCommands.test.ts
+++ b/packages/ztd-cli/tests/cliCommands.test.ts
@@ -410,6 +410,7 @@ test(
       'src/features/sales-insert/queries/insert-sales-detail/boundary.ts',
       'src/features/sales-insert/queries/insert-sales-detail/insert-sales-detail.sql'
     ]));
+    expect(plannedPaths).not.toContain('src/features/sales-insert/boundary.ts');
   },
   60000,
 );

--- a/packages/ztd-cli/tests/cliCommands.test.ts
+++ b/packages/ztd-cli/tests/cliCommands.test.ts
@@ -271,6 +271,22 @@ test(
 );
 
 test(
+  'feature query scaffold help exposes the additive child-boundary scaffold contract',
+  () => {
+    const result = runCli(['feature', 'query', 'scaffold', '--help']);
+    assertCliSuccess(result, 'feature query scaffold --help');
+    expect(result.stdout).toContain('--table <table>');
+    expect(result.stdout).toContain('--action <action>');
+    expect(result.stdout).toContain('--query-name <name>');
+    expect(result.stdout).toContain('--feature <name>');
+    expect(result.stdout).toContain('--boundary-dir <path>');
+    expect(result.stdout).toContain('Scaffold one additive query boundary');
+    expect(result.stdout).toContain('rewriting the parent boundary');
+  },
+  60000,
+);
+
+test(
   'feature scaffold dry-run emits JSON and reserves test files for AI follow-up',
   () => {
     const workspace = createTempDir('feature-scaffold-dry-run');
@@ -329,6 +345,71 @@ test(
     ]));
     expect(plannedPaths.some((entry: string) => entry.endsWith('.boundary.ztd.test.ts'))).toBe(false);
     expect(plannedPaths.some((entry: string) => entry.endsWith('.boundary.test.ts'))).toBe(true);
+  },
+  60000,
+);
+
+test(
+  'feature query scaffold dry-run emits JSON and keeps parent orchestration as follow-up work',
+  () => {
+    const workspace = createTempDir('feature-query-scaffold-dry-run');
+    const ddlDir = path.join(workspace, 'db', 'ddl');
+    const featureDir = path.join(workspace, 'src', 'features', 'sales-insert');
+    mkdirSync(ddlDir, { recursive: true });
+    mkdirSync(featureDir, { recursive: true });
+    writeFileSync(path.join(featureDir, 'boundary.ts'), '// existing parent boundary\n', 'utf8');
+    writeFileSync(
+      path.join(ddlDir, 'sales_detail.sql'),
+      [
+        'create table public.sales_detail (',
+        '  id serial primary key,',
+        '  sales_id integer not null,',
+        '  amount numeric not null',
+        ');'
+      ].join('\n'),
+      'utf8'
+    );
+
+    const result = runCli([
+      '--output',
+      'json',
+      'feature',
+      'query',
+      'scaffold',
+      '--feature',
+      'sales-insert',
+      '--query-name',
+      'insert-sales-detail',
+      '--table',
+      'sales_detail',
+      '--action',
+      'insert',
+      '--dry-run'
+    ], {}, workspace);
+
+    assertCliSuccess(result, 'feature query scaffold dry-run json');
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed).toMatchObject({
+      command: 'feature query scaffold',
+      ok: true,
+      data: {
+        boundaryPath: 'src/features/sales-insert',
+        resolutionSource: 'feature',
+        queryName: 'insert-sales-detail',
+        action: 'insert',
+        table: 'public.sales_detail',
+        primaryKeyColumn: 'id',
+        source: 'ddl',
+        dryRun: true
+      }
+    });
+    const plannedPaths = parsed.data.outputs.map((entry: { path: string }) => entry.path);
+    expect(plannedPaths).toEqual(expect.arrayContaining([
+      'src/features/sales-insert/queries',
+      'src/features/sales-insert/queries/insert-sales-detail',
+      'src/features/sales-insert/queries/insert-sales-detail/boundary.ts',
+      'src/features/sales-insert/queries/insert-sales-detail/insert-sales-detail.sql'
+    ]));
   },
   60000,
 );

--- a/packages/ztd-cli/tests/featureScaffold.unit.test.ts
+++ b/packages/ztd-cli/tests/featureScaffold.unit.test.ts
@@ -4,10 +4,12 @@ import { expect, test } from 'vitest';
 import {
   assessGeneratedMetadataCapability,
   deriveFeatureName,
+  normalizeChildQueryName,
   normalizeFeatureAction,
   normalizeFeatureName,
   resolveFeatureScaffoldInput,
   resolvePrimaryKeyColumn,
+  runExistingBoundaryQueryScaffoldCommand,
   runFeatureScaffoldCommand
 } from '../src/commands/feature';
 import { DEFAULT_ZTD_CONFIG } from '../src/utils/ztdProjectConfig';
@@ -91,6 +93,12 @@ test('normalizeFeatureName enforces resource-action kebab-case', () => {
   expect(normalizeFeatureName('users-insert')).toBe('users-insert');
   expect(() => normalizeFeatureName('users')).toThrow(/resource-action/i);
   expect(() => normalizeFeatureName('3users-insert')).toThrow(/start with a letter/i);
+});
+
+test('normalizeChildQueryName enforces kebab-case child-boundary names', () => {
+  expect(normalizeChildQueryName('insert-sales-detail')).toBe('insert-sales-detail');
+  expect(() => normalizeChildQueryName('insert_sales_detail')).toThrow(/kebab-case/i);
+  expect(() => normalizeChildQueryName('3-insert-sales-detail')).toThrow(/start with a letter/i);
 });
 
 test('generated metadata assessment reports missing PK contract even when manifest exists', () => {
@@ -205,6 +213,203 @@ test('resolvePrimaryKeyColumn rejects missing and composite primary keys', () =>
       columns: []
     })
   ).toThrow(/composite primary keys/i);
+});
+
+test('runExistingBoundaryQueryScaffoldCommand dry-run plans an additive query under an existing feature boundary', async () => {
+  const workspace = createTempDir('feature-query-scaffold-dry-run');
+  const ddlDir = path.join(workspace, 'db', 'ddl');
+  const featureDir = path.join(workspace, 'src', 'features', 'sales-insert');
+  mkdirSync(ddlDir, { recursive: true });
+  mkdirSync(featureDir, { recursive: true });
+  writeFileSync(path.join(featureDir, 'boundary.ts'), '// existing parent boundary\n', 'utf8');
+  writeFileSync(
+    path.join(ddlDir, 'sales_detail.sql'),
+    [
+      'create table public.sales_detail (',
+      '  id serial primary key,',
+      '  sales_id integer not null,',
+      '  amount numeric not null',
+      ');'
+    ].join('\n'),
+    'utf8'
+  );
+
+  const result = await runExistingBoundaryQueryScaffoldCommand({
+    feature: 'sales-insert',
+    table: 'sales_detail',
+    action: 'insert',
+    queryName: 'insert-sales-detail',
+    dryRun: true,
+    rootDir: workspace
+  });
+
+  expect(result.boundaryPath).toBe('src/features/sales-insert');
+  expect(result.resolutionSource).toBe('feature');
+  expect(result.outputs.map((output) => output.path)).toEqual(expect.arrayContaining([
+    'src/features/sales-insert/queries',
+    'src/features/sales-insert/queries/insert-sales-detail',
+    'src/features/sales-insert/queries/insert-sales-detail/boundary.ts',
+    'src/features/sales-insert/queries/insert-sales-detail/insert-sales-detail.sql'
+  ]));
+});
+
+test('runExistingBoundaryQueryScaffoldCommand writes a child query boundary without touching the parent boundary', async () => {
+  const workspace = createTempDir('feature-query-scaffold-write');
+  const ddlDir = path.join(workspace, 'db', 'ddl');
+  const featureDir = path.join(workspace, 'src', 'features', 'sales-insert');
+  mkdirSync(ddlDir, { recursive: true });
+  mkdirSync(featureDir, { recursive: true });
+  const parentBoundary = path.join(featureDir, 'boundary.ts');
+  writeFileSync(parentBoundary, '// existing parent boundary\n', 'utf8');
+  writeFileSync(
+    path.join(ddlDir, 'sales_detail.sql'),
+    [
+      'create table public.sales_detail (',
+      '  id serial primary key,',
+      '  sales_id integer not null,',
+      '  amount numeric not null',
+      ');'
+    ].join('\n'),
+    'utf8'
+  );
+
+  await runExistingBoundaryQueryScaffoldCommand({
+    boundaryDir: path.join('src', 'features', 'sales-insert'),
+    table: 'sales_detail',
+    action: 'insert',
+    queryName: 'insert-sales-detail',
+    rootDir: workspace
+  });
+
+  expect(readFileSync(parentBoundary, 'utf8')).toBe('// existing parent boundary\n');
+  expect(existsSync(path.join(featureDir, 'queries', 'insert-sales-detail', 'boundary.ts'))).toBe(true);
+  expect(existsSync(path.join(featureDir, 'queries', 'insert-sales-detail', 'insert-sales-detail.sql'))).toBe(true);
+  expect(existsSync(path.join(featureDir, 'README.md'))).toBe(false);
+});
+
+test('runExistingBoundaryQueryScaffoldCommand renders dynamic shared imports for nested boundaries', async () => {
+  const workspace = createTempDir('feature-query-scaffold-nested');
+  const ddlDir = path.join(workspace, 'db', 'ddl');
+  const boundaryDir = path.join(workspace, 'src', 'features', 'orders', 'write', 'sales-insert');
+  mkdirSync(ddlDir, { recursive: true });
+  mkdirSync(boundaryDir, { recursive: true });
+  writeFileSync(path.join(boundaryDir, 'boundary.ts'), '// nested parent boundary\n', 'utf8');
+  writeFileSync(
+    path.join(ddlDir, 'sales_detail.sql'),
+    [
+      'create table public.sales_detail (',
+      '  id serial primary key,',
+      '  sales_id integer not null,',
+      '  amount numeric not null',
+      ');'
+    ].join('\n'),
+    'utf8'
+  );
+
+  await runExistingBoundaryQueryScaffoldCommand({
+    boundaryDir: path.join('src', 'features', 'orders', 'write', 'sales-insert'),
+    table: 'sales_detail',
+    action: 'insert',
+    queryName: 'insert-sales-detail',
+    rootDir: workspace
+  });
+
+  const querySpecFile = readFileSync(
+    path.join(boundaryDir, 'queries', 'insert-sales-detail', 'boundary.ts'),
+    'utf8'
+  );
+  expect(querySpecFile).toContain("import type { FeatureQueryExecutor } from '../../../../../_shared/featureQueryExecutor.js';");
+  expect(querySpecFile).toContain("import { loadSqlResource } from '../../../../../_shared/loadSqlResource.js';");
+});
+
+test('runExistingBoundaryQueryScaffoldCommand fails fast when the parent boundary contract is invalid', async () => {
+  const workspace = createTempDir('feature-query-scaffold-invalid-boundary');
+  const ddlDir = path.join(workspace, 'db', 'ddl');
+  const boundaryDir = path.join(workspace, 'src', 'features', 'sales-insert');
+  mkdirSync(ddlDir, { recursive: true });
+  mkdirSync(boundaryDir, { recursive: true });
+  writeFileSync(
+    path.join(ddlDir, 'sales_detail.sql'),
+    [
+      'create table public.sales_detail (',
+      '  id serial primary key,',
+      '  sales_id integer not null,',
+      '  amount numeric not null',
+      ');'
+    ].join('\n'),
+    'utf8'
+  );
+
+  await expect(
+    runExistingBoundaryQueryScaffoldCommand({
+      boundaryDir: path.join('src', 'features', 'sales-insert'),
+      table: 'sales_detail',
+      action: 'insert',
+      queryName: 'insert-sales-detail',
+      rootDir: workspace
+    })
+  ).rejects.toThrow(/must contain boundary\.ts/i);
+});
+
+test('runExistingBoundaryQueryScaffoldCommand fails fast when queries is not a directory', async () => {
+  const workspace = createTempDir('feature-query-scaffold-invalid-queries');
+  const ddlDir = path.join(workspace, 'db', 'ddl');
+  const featureDir = path.join(workspace, 'src', 'features', 'sales-insert');
+  mkdirSync(ddlDir, { recursive: true });
+  mkdirSync(featureDir, { recursive: true });
+  writeFileSync(path.join(featureDir, 'boundary.ts'), '// existing parent boundary\n', 'utf8');
+  writeFileSync(
+    path.join(ddlDir, 'sales_detail.sql'),
+    [
+      'create table public.sales_detail (',
+      '  id serial primary key,',
+      '  sales_id integer not null,',
+      '  amount numeric not null',
+      ');'
+    ].join('\n'),
+    'utf8'
+  );
+
+  writeFileSync(path.join(featureDir, 'queries'), 'not a directory\n', 'utf8');
+  await expect(
+    runExistingBoundaryQueryScaffoldCommand({
+      boundaryDir: path.join('src', 'features', 'sales-insert'),
+      table: 'sales_detail',
+      action: 'insert',
+      queryName: 'insert-sales-detail',
+      rootDir: workspace
+    })
+  ).rejects.toThrow(/queries\/ to be a directory/i);
+});
+
+test('runExistingBoundaryQueryScaffoldCommand fails fast when the target query already exists', async () => {
+  const workspace = createTempDir('feature-query-scaffold-existing-query');
+  const ddlDir = path.join(workspace, 'db', 'ddl');
+  const featureDir = path.join(workspace, 'src', 'features', 'sales-insert');
+  mkdirSync(ddlDir, { recursive: true });
+  mkdirSync(path.join(featureDir, 'queries', 'insert-sales-detail'), { recursive: true });
+  writeFileSync(path.join(featureDir, 'boundary.ts'), '// existing parent boundary\n', 'utf8');
+  writeFileSync(
+    path.join(ddlDir, 'sales_detail.sql'),
+    [
+      'create table public.sales_detail (',
+      '  id serial primary key,',
+      '  sales_id integer not null,',
+      '  amount numeric not null',
+      ');'
+    ].join('\n'),
+    'utf8'
+  );
+
+  await expect(
+    runExistingBoundaryQueryScaffoldCommand({
+      boundaryDir: path.join('src', 'features', 'sales-insert'),
+      table: 'sales_detail',
+      action: 'insert',
+      queryName: 'insert-sales-detail',
+      rootDir: workspace
+    })
+  ).rejects.toThrow(/already exists/i);
 });
 
 test('runFeatureScaffoldCommand dry-run creates the new insert layout without test files', async () => {

--- a/packages/ztd-cli/tests/featureScaffold.unit.test.ts
+++ b/packages/ztd-cli/tests/featureScaffold.unit.test.ts
@@ -284,6 +284,8 @@ test('runExistingBoundaryQueryScaffoldCommand writes a child query boundary with
   expect(readFileSync(parentBoundary, 'utf8')).toBe('// existing parent boundary\n');
   expect(existsSync(path.join(featureDir, 'queries', 'insert-sales-detail', 'boundary.ts'))).toBe(true);
   expect(existsSync(path.join(featureDir, 'queries', 'insert-sales-detail', 'insert-sales-detail.sql'))).toBe(true);
+  expect(existsSync(path.join(workspace, 'src', 'features', '_shared', 'featureQueryExecutor.ts'))).toBe(true);
+  expect(existsSync(path.join(workspace, 'src', 'features', '_shared', 'loadSqlResource.ts'))).toBe(true);
   expect(existsSync(path.join(featureDir, 'README.md'))).toBe(false);
 });
 
@@ -410,6 +412,37 @@ test('runExistingBoundaryQueryScaffoldCommand fails fast when the target query a
       rootDir: workspace
     })
   ).rejects.toThrow(/already exists/i);
+});
+
+test('runExistingBoundaryQueryScaffoldCommand rejects feature and boundaryDir together', async () => {
+  const workspace = createTempDir('feature-query-scaffold-exclusive-flags');
+  const ddlDir = path.join(workspace, 'db', 'ddl');
+  const featureDir = path.join(workspace, 'src', 'features', 'sales-insert');
+  mkdirSync(ddlDir, { recursive: true });
+  mkdirSync(featureDir, { recursive: true });
+  writeFileSync(path.join(featureDir, 'boundary.ts'), '// existing parent boundary\n', 'utf8');
+  writeFileSync(
+    path.join(ddlDir, 'sales_detail.sql'),
+    [
+      'create table public.sales_detail (',
+      '  id serial primary key,',
+      '  sales_id integer not null,',
+      '  amount numeric not null',
+      ');'
+    ].join('\n'),
+    'utf8'
+  );
+
+  await expect(
+    runExistingBoundaryQueryScaffoldCommand({
+      feature: 'sales-insert',
+      boundaryDir: path.join('src', 'features', 'sales-insert'),
+      table: 'sales_detail',
+      action: 'insert',
+      queryName: 'insert-sales-detail',
+      rootDir: workspace
+    })
+  ).rejects.toThrow(/feature.*boundary-dir|boundary-dir.*feature|not both/i);
 });
 
 test('runFeatureScaffoldCommand dry-run creates the new insert layout without test files', async () => {
@@ -644,7 +677,7 @@ test('runFeatureScaffoldCommand uses stable shared imports when the workspace su
   expect(querySpecFile).toContain("import { loadSqlResource } from '#features/_shared/loadSqlResource.js';");
 });
 
-test('runFeatureScaffoldCommand fails fast when #features alias support is partial', async () => {
+test('runFeatureScaffoldCommand falls back to relative imports when #features alias support is partial', async () => {
   const workspace = createTempDir('feature-scaffold-partial-import-alias');
   const ddlDir = path.join(workspace, 'db', 'ddl');
   mkdirSync(ddlDir, { recursive: true });
@@ -674,13 +707,18 @@ test('runFeatureScaffoldCommand fails fast when #features alias support is parti
     'utf8'
   );
 
-  await expect(
-    runFeatureScaffoldCommand({
-      table: 'users',
-      action: 'insert',
-      rootDir: workspace
-    })
-  ).rejects.toThrow(/partial #features alias configuration/i);
+  await runFeatureScaffoldCommand({
+    table: 'users',
+    action: 'insert',
+    rootDir: workspace
+  });
+
+  const querySpecFile = readFileSync(
+    path.join(workspace, 'src', 'features', 'users-insert', 'queries', 'insert-users', 'boundary.ts'),
+    'utf8'
+  );
+  expect(querySpecFile).toContain("import type { FeatureQueryExecutor } from '../../../_shared/featureQueryExecutor.js';");
+  expect(querySpecFile).toContain("import { loadSqlResource } from '../../../_shared/loadSqlResource.js';");
 });
 
 test('runFeatureScaffoldCommand uses default values when every insert column is DB-generated', async () => {

--- a/packages/ztd-cli/tests/furtherReading.docs.test.ts
+++ b/packages/ztd-cli/tests/furtherReading.docs.test.ts
@@ -164,6 +164,8 @@ test('Further Reading docs stay aligned with the current standalone and CLI beha
         'If an AI-authored ZTD test fails, do not assume the prompt or case file is the only problem; check whether `ztd-cli` or `rawsql-ts` changed the manifest or rewrite path.',
         'If you see `user_id: null`, compare the direct database `INSERT ... RETURNING ...` result with the ZTD result and inspect `.ztd/generated/ztd-fixture-manifest.generated.ts` first.',
         'If a local-source workspace is meant to reflect a source change, verify that it resolves `rawsql-ts` from the local source tree rather than a registry copy.',
+        'npx ztd feature query scaffold --feature users-insert --query-name insert-user-audit --table user_audit --action insert',
+        'does not edit the parent `boundary.ts`',
         'After you finish the SQL and DTO edits, run `npx ztd feature tests scaffold --feature <feature-name>`.',
         'creates the thin Vitest entrypoint `src/features/<feature-name>/queries/<query-name>/tests/<query-name>.boundary.ztd.test.ts` only if it is missing.',
         'Persistent case files under `src/features/<feature-name>/queries/<query-name>/tests/cases/` are human/AI-owned and are not overwritten.',


### PR DESCRIPTION
## Issue
Closes #719.

## Customer Value
`ztd-cli` users can add one new query boundary to an existing boundary folder without recreating the parent feature or letting the CLI guess orchestration.

## Outcome
- Added `ztd feature query scaffold` for additive query-boundary creation under an existing boundary folder.
- Added `--feature` convenience for top-level feature roots and `--boundary-dir` for deeper VSA-style boundary trees.
- Kept parent `boundary.ts` untouched and documented that orchestration remains human/AI-owned.
- Added fail-fast checks for missing/invalid parent boundaries, invalid `queries/` containers, and duplicate target query folders.
- Updated README/help coverage and test coverage for the new flow.

## Acceptance Criteria
- [x] A command exists for adding a query boundary to an existing boundary folder.
- [x] The command can target an existing boundary by explicit folder path, with feature-name convenience for top-level features.
- [x] The command creates `queries/<query-name>/boundary.ts` and `queries/<query-name>/<query-name>.sql`.
- [x] The command creates the `queries/` container when missing.
- [x] The command does not rewrite the parent boundary file.
- [x] The command fails fast when the target boundary folder is missing, the parent boundary contract is invalid, `queries` is not a directory, or the target query already exists.
- [x] Help/README text explains that the new query is not wired into the parent boundary automatically.
- [x] Tests cover additive scaffold success paths and fail-fast cases.

## Verification
- `pnpm --filter @rawsql-ts/ztd-cli test -- tests/featureScaffold.unit.test.ts tests/cliCommands.test.ts tests/furtherReading.docs.test.ts`
- Pre-commit hook also ran and passed:
- `pnpm --filter @rawsql-ts/ztd-cli test:essential`
- `pnpm --filter @rawsql-ts/ztd-cli build`
- `pnpm --filter @rawsql-ts/ztd-cli lint`

## Repository Evidence
- `packages/ztd-cli/src/commands/feature.ts`
- `packages/ztd-cli/tests/featureScaffold.unit.test.ts`
- `packages/ztd-cli/tests/cliCommands.test.ts`
- `packages/ztd-cli/README.md`
- `packages/ztd-cli/tests/furtherReading.docs.test.ts`

## Supplementary Evidence
- None.

## Open Questions
- The command surface is implemented as `feature query scaffold` rather than `query scaffold`, to keep additive child-boundary creation grouped with feature-local scaffolding while still satisfying the issue's functional goal.

## Merge Blockers
- None from this change.
- PR is draft for reviewer confirmation of the command surface choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `feature query scaffold` CLI subcommand to scaffold additional child query boundaries under existing boundaries without regenerating parent configurations.

* **Documentation**
  * Updated CLI documentation with usage examples and expected outputs for the new query scaffolding functionality.

* **Tests**
  * Added comprehensive test coverage for the new query scaffolding feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->