### PR TITLE
test(ci): guard standalone proof app CLI wiring

### DIFF
--- a/packages/ztd-cli/tests/publishWorkflow.unit.test.ts
+++ b/packages/ztd-cli/tests/publishWorkflow.unit.test.ts
@@ -4,6 +4,8 @@ import { expect, test } from 'vitest';
 
 const publishWorkflowPath = path.resolve(__dirname, '../../../.github/workflows/publish.yml');
 const publishWorkflow = fs.readFileSync(publishWorkflowPath, 'utf8');
+const publishedPackageModePath = path.resolve(__dirname, '../../../scripts/verify-published-package-mode.mjs');
+const publishedPackageModeScript = fs.readFileSync(publishedPackageModePath, 'utf8');
 
 test('publish workflow verifies built artifacts before actual publish', () => {
   expect(publishWorkflow).toContain('verify_publish_artifacts:');
@@ -19,4 +21,31 @@ test('proof mode skips the main-branch requirement and actual publish', () => {
   expect(publishWorkflow).toContain("if: ${{ inputs.verification_mode != 'proof' }}");
   expect(publishWorkflow).toContain("if: ${{ needs.verify_publish_readiness.outputs.should_publish == 'true' && inputs.verification_mode != 'proof' }}");
   expect(publishWorkflow).toContain('create-publish-proof-plan.mjs');
+});
+
+test('standalone pnpm proof apps use the installed ztd bin helper instead of pnpm exec', () => {
+  expect(publishedPackageModeScript).toContain('function getInstalledBinPath(directory, binName) {');
+  expect(publishedPackageModeScript).toContain('function runInstalledZtdCli(directory, args) {');
+  expect(publishedPackageModeScript).toContain('pnpm-workspace.yaml');
+
+  const starterSection = publishedPackageModeScript.slice(
+    publishedPackageModeScript.indexOf('function verifyPnpmStarterPath(packages) {'),
+    publishedPackageModeScript.indexOf('function verifyPnpmAdapterInstall(packages) {'),
+  );
+  expect(starterSection).toContain('runInstalledZtdCli(appDir,');
+  expect(starterSection).not.toContain('"exec"');
+
+  const adapterSection = publishedPackageModeScript.slice(
+    publishedPackageModeScript.indexOf('function verifyPnpmAdapterInstall(packages) {'),
+    publishedPackageModeScript.indexOf('function verifyPnpmTutorialModelGen(packages) {'),
+  );
+  expect(adapterSection).toContain('runInstalledZtdCli(appDir,');
+  expect(adapterSection).not.toContain('"exec"');
+
+  const tutorialSection = publishedPackageModeScript.slice(
+    publishedPackageModeScript.indexOf('function verifyPnpmTutorialModelGen(packages) {'),
+    publishedPackageModeScript.indexOf('function verifyOverwriteSafety(packages) {'),
+  );
+  expect(tutorialSection).toContain('runInstalledZtdCli(appDir,');
+  expect(tutorialSection).not.toContain('"exec",');
 });


### PR DESCRIPTION
## Summary

Add a lightweight guardrail test for the proof-app CLI wiring introduced by #742.

This follow-up does not change behavior. It mechanically locks in the intended fix:

- standalone pnpm proof apps should use the installed `ztd` bin helper
- they should not drift back to `pnpm exec ztd` in those standalone sections
- the standalone proof area should keep its own `pnpm-workspace.yaml` marker

## Why

#742 fixed a real GitHub Actions failure caused by pnpm workspace bleed after moving standalone proof apps under repo-local `tmp/`.

A temporary retro note would be too weak here because the failure mode is subtle and easy to reintroduce during refactors. This PR adds a small unit test so the design intent is checked mechanically without adding a heavier CI job.

## Verification

- `pnpm --filter @rawsql-ts/ztd-cli test -- tests/publishWorkflow.unit.test.ts`

## Scope

- source-level guardrail test only
- no workflow or runtime behavior changes