### PR TITLE
feat(dev): guard branch session before push

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,8 @@
 #!/bin/sh
 set -e
 
+echo "[pre-push] Checking branch session..."
+node scripts/branch-session-guard.js check
+
 echo "[pre-push] Checking retro gate..."
 node scripts/check-retro-clean.js

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -17,6 +17,12 @@
 - Do not use DDL execution as a repair path for ZTD validation failures.
 - If the database is reachable, treat relation or missing-table errors as a shadowing, fixture, or repository problem before considering schema changes.
 
+## Branch Session Guard
+- After switching to the intended branch for this local worktree, record it with `pnpm guard:branch-session expect-current`.
+- If you need to record a named branch explicitly, use `pnpm guard:branch-session expect --branch <branch-name>`.
+- `pre-push` blocks when no expected branch is recorded, when the current branch differs from the recorded branch, or when the worktree is in detached HEAD state.
+- The guard proves only that this local worktree is still on the branch declared for the session; it does not prove task correctness or prevent bypass outside the local hook path.
+
 ## Docs and Demo Operations
 - Rebuild browser bundle for parser/formatter behavior updates.
 - Re-bundle docs demo and update bundled assets.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "playground:typecheck": "pnpm --filter ztd-playground typecheck",
     "playground:test": "pnpm --filter ztd-playground test",
     "prepare": "husky",
+    "guard:branch-session": "node scripts/branch-session-guard.js",
     "verify:publish-readiness": "node scripts/publish-plan.mjs",
     "verify:publish-contract": "node scripts/verify-publish-contract.mjs",
     "verify:runtime-prereqs": "node scripts/verify-runtime-prereqs.mjs",

--- a/packages/ztd-cli/tests/branchSessionGuard.unit.test.ts
+++ b/packages/ztd-cli/tests/branchSessionGuard.unit.test.ts
@@ -1,0 +1,205 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, expect, test } from 'vitest';
+
+const {
+  SESSION_GIT_PATH,
+  checkBranchExpectation,
+  clearExpectedBranch,
+  parseCliArgs,
+  recordExpectedBranch,
+  resolveSessionFilePath,
+} = require('../../../scripts/branch-session-guard.js') as {
+  SESSION_GIT_PATH: string;
+  checkBranchExpectation(
+    cwd?: string,
+    helpers?: {
+      runGit?: (args: string[], cwd?: string) => string;
+      sessionFilePath?: string;
+      currentBranch?: string;
+      expectedBranch?: string | null;
+      readFile?: (filePath: string, encoding: string) => string;
+      exists?: (filePath: string) => boolean;
+    },
+  ): { ok: boolean; code: string; message: string; sessionFilePath: string };
+  clearExpectedBranch(
+    cwd?: string,
+    helpers?: {
+      runGit?: (args: string[], cwd?: string) => string;
+      sessionFilePath?: string;
+      exists?: (filePath: string) => boolean;
+      unlink?: (filePath: string) => void;
+    },
+  ): string;
+  parseCliArgs(argv: string[]): { command: string; options: Record<string, unknown> };
+  recordExpectedBranch(
+    expectedBranch: string,
+    cwd?: string,
+    helpers?: {
+      runGit?: (args: string[], cwd?: string) => string;
+      sessionFilePath?: string;
+      currentBranch?: string;
+    },
+  ): { expectedBranch: string; sessionFilePath: string };
+  resolveSessionFilePath(cwd?: string, runGit?: (args: string[], cwd?: string) => string): string;
+};
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const directory = tempDirs.pop();
+    if (directory) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  }
+});
+
+function createTempDir(): string {
+  const directory = mkdtempSync(path.join(os.tmpdir(), 'branch-session-guard-'));
+  tempDirs.push(directory);
+  return directory;
+}
+
+function gitPathRunner(gitPath: string, currentBranch = 'codex/749-branch-session-guard') {
+  return (args: string[]) => {
+    if (args[0] === 'rev-parse') {
+      return gitPath;
+    }
+    if (args[0] === 'branch') {
+      return currentBranch;
+    }
+    throw new Error(`Unexpected git args: ${args.join(' ')}`);
+  };
+}
+
+test('parseCliArgs keeps branch arguments explicit', () => {
+  expect(parseCliArgs(['expect', '--branch', 'codex/749-branch-session-guard'])).toEqual({
+    command: 'expect',
+    options: { branch: 'codex/749-branch-session-guard' },
+  });
+});
+
+test('resolveSessionFilePath uses git-owned metadata path', () => {
+  const cwd = createTempDir();
+  const resolved = resolveSessionFilePath(cwd, gitPathRunner('.git/worktrees/redo/rawsql/expected-branch'));
+
+  expect(resolved).toBe(path.resolve(cwd, '.git/worktrees/redo/rawsql/expected-branch'));
+  expect(SESSION_GIT_PATH).toBe('rawsql/expected-branch');
+});
+
+test('recordExpectedBranch writes the expected branch to the session file', () => {
+  const cwd = createTempDir();
+  const sessionFilePath = path.join(cwd, '.git', 'rawsql', 'expected-branch');
+
+  const result = recordExpectedBranch('codex/749-branch-session-guard', cwd, {
+    runGit: gitPathRunner('.git/rawsql/expected-branch'),
+    sessionFilePath,
+    currentBranch: 'codex/749-branch-session-guard',
+  });
+
+  expect(result.expectedBranch).toBe('codex/749-branch-session-guard');
+  expect(readFileSync(sessionFilePath, 'utf8')).toBe('codex/749-branch-session-guard\n');
+});
+
+test('checkBranchExpectation fails when no expected branch is recorded', () => {
+  const cwd = createTempDir();
+  const sessionFilePath = path.join(cwd, '.git', 'rawsql', 'expected-branch');
+
+  const result = checkBranchExpectation(cwd, {
+    runGit: gitPathRunner('.git/rawsql/expected-branch'),
+    sessionFilePath,
+    currentBranch: 'codex/749-branch-session-guard',
+  });
+
+  expect(result.ok).toBe(false);
+  expect(result.code).toBe('missing-expected-branch');
+  expect(result.message).toContain('No expected branch is recorded');
+});
+
+test('checkBranchExpectation passes when current and expected branches match', () => {
+  const cwd = createTempDir();
+  const sessionFilePath = path.join(cwd, '.git', 'rawsql', 'expected-branch');
+
+  recordExpectedBranch('codex/749-branch-session-guard', cwd, {
+    runGit: gitPathRunner('.git/rawsql/expected-branch'),
+    sessionFilePath,
+    currentBranch: 'codex/749-branch-session-guard',
+  });
+
+  const result = checkBranchExpectation(cwd, {
+    runGit: gitPathRunner('.git/rawsql/expected-branch'),
+    sessionFilePath,
+    currentBranch: 'codex/749-branch-session-guard',
+  });
+
+  expect(result.ok).toBe(true);
+  expect(result.code).toBe('ok');
+});
+
+test('checkBranchExpectation fails on mismatched branch', () => {
+  const cwd = createTempDir();
+  const sessionFilePath = path.join(cwd, '.git', 'rawsql', 'expected-branch');
+
+  recordExpectedBranch('codex/749-branch-session-guard', cwd, {
+    runGit: gitPathRunner('.git/rawsql/expected-branch'),
+    sessionFilePath,
+    currentBranch: 'codex/749-branch-session-guard',
+  });
+
+  const result = checkBranchExpectation(cwd, {
+    runGit: gitPathRunner('.git/rawsql/expected-branch', 'codex/another-task'),
+    sessionFilePath,
+    currentBranch: 'codex/another-task',
+  });
+
+  expect(result.ok).toBe(false);
+  expect(result.code).toBe('branch-mismatch');
+  expect(result.message).toContain('Expected branch: codex/749-branch-session-guard');
+  expect(result.message).toContain('Current branch: codex/another-task');
+});
+
+test('checkBranchExpectation fails on detached HEAD', () => {
+  const cwd = createTempDir();
+  const sessionFilePath = path.join(cwd, '.git', 'rawsql', 'expected-branch');
+
+  const result = checkBranchExpectation(cwd, {
+    runGit: gitPathRunner('.git/rawsql/expected-branch', ''),
+    sessionFilePath,
+    currentBranch: '',
+    expectedBranch: 'codex/749-branch-session-guard',
+  });
+
+  expect(result.ok).toBe(false);
+  expect(result.code).toBe('detached-head');
+});
+
+test('clearExpectedBranch removes the session file', () => {
+  const cwd = createTempDir();
+  const sessionFilePath = path.join(cwd, '.git', 'rawsql', 'expected-branch');
+
+  recordExpectedBranch('codex/749-branch-session-guard', cwd, {
+    runGit: gitPathRunner('.git/rawsql/expected-branch'),
+    sessionFilePath,
+    currentBranch: 'codex/749-branch-session-guard',
+  });
+  expect(existsSync(sessionFilePath)).toBe(true);
+
+  clearExpectedBranch(cwd, {
+    runGit: gitPathRunner('.git/rawsql/expected-branch'),
+    sessionFilePath,
+  });
+
+  expect(existsSync(sessionFilePath)).toBe(false);
+});
+
+test('pre-push checks branch session before retro gate', () => {
+  const prePushHook = readFileSync(path.resolve(__dirname, '../../../.husky/pre-push'), 'utf8');
+
+  const branchIndex = prePushHook.indexOf('node scripts/branch-session-guard.js check');
+  const retroIndex = prePushHook.indexOf('node scripts/check-retro-clean.js');
+
+  expect(branchIndex).toBeGreaterThanOrEqual(0);
+  expect(retroIndex).toBeGreaterThan(branchIndex);
+});

--- a/packages/ztd-cli/tests/devNotes.docs.test.ts
+++ b/packages/ztd-cli/tests/devNotes.docs.test.ts
@@ -17,3 +17,11 @@ test('DEV_NOTES.md documents the SQL shadowing troubleshooting order', () => {
   expect(devNotes).toContain('Do not use DDL execution as a repair path for ZTD validation failures.');
   expect(devNotes).toContain('If the database is reachable, treat relation or missing-table errors as a shadowing, fixture, or repository problem before considering schema changes.');
 });
+
+test('DEV_NOTES.md documents branch session guard setup and limits', () => {
+  const devNotes = readNormalizedFile('DEV_NOTES.md');
+
+  expect(devNotes).toContain('After switching to the intended branch for this local worktree, record it with `pnpm guard:branch-session expect-current`.');
+  expect(devNotes).toContain('`pre-push` blocks when no expected branch is recorded');
+  expect(devNotes).toContain('The guard proves only that this local worktree is still on the branch declared for the session;');
+});

--- a/scripts/branch-session-guard.js
+++ b/scripts/branch-session-guard.js
@@ -1,0 +1,244 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const SESSION_GIT_PATH = 'rawsql/expected-branch';
+
+function defaultRunGit(args, cwd = process.cwd()) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+}
+
+function parseCliArgs(argv) {
+  const [command, ...rest] = argv;
+  const options = {};
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const token = rest[index];
+    if (token === '--branch') {
+      options.branch = rest[index + 1];
+      index += 1;
+      continue;
+    }
+    if (token === '--json') {
+      options.json = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${token}`);
+  }
+
+  return {
+    command: command || 'status',
+    options,
+  };
+}
+
+function resolveSessionFilePath(cwd = process.cwd(), runGit = defaultRunGit) {
+  const gitPath = runGit(['rev-parse', '--git-path', SESSION_GIT_PATH], cwd);
+  return path.resolve(cwd, gitPath);
+}
+
+function getCurrentBranch(cwd = process.cwd(), runGit = defaultRunGit) {
+  return runGit(['branch', '--show-current'], cwd).trim();
+}
+
+function readExpectedBranch(sessionFilePath, readFile = fs.readFileSync, exists = fs.existsSync) {
+  if (!exists(sessionFilePath)) {
+    return null;
+  }
+
+  const value = readFile(sessionFilePath, 'utf8').trim();
+  return value.length > 0 ? value : null;
+}
+
+function writeExpectedBranch(sessionFilePath, expectedBranch, mkdir = fs.mkdirSync, writeFile = fs.writeFileSync) {
+  mkdir(path.dirname(sessionFilePath), { recursive: true });
+  writeFile(sessionFilePath, `${expectedBranch}\n`, 'utf8');
+}
+
+function recordExpectedBranch(expectedBranch, cwd = process.cwd(), helpers = {}) {
+  const runGit = helpers.runGit || defaultRunGit;
+  const sessionFilePath = helpers.sessionFilePath || resolveSessionFilePath(cwd, runGit);
+  const currentBranch = helpers.currentBranch || getCurrentBranch(cwd, runGit);
+
+  if (!expectedBranch || expectedBranch.trim().length === 0) {
+    throw new Error('Expected branch must be a non-empty string.');
+  }
+
+  if (!currentBranch) {
+    throw new Error('Cannot record branch session in detached HEAD state.');
+  }
+
+  if (currentBranch !== expectedBranch) {
+    throw new Error(
+      `Current branch "${currentBranch}" does not match the expected branch "${expectedBranch}". Switch first, then record the session.`,
+    );
+  }
+
+  writeExpectedBranch(
+    sessionFilePath,
+    expectedBranch,
+    helpers.mkdir || fs.mkdirSync,
+    helpers.writeFile || fs.writeFileSync,
+  );
+
+  return {
+    currentBranch,
+    expectedBranch,
+    sessionFilePath,
+  };
+}
+
+function checkBranchExpectation(cwd = process.cwd(), helpers = {}) {
+  const runGit = helpers.runGit || defaultRunGit;
+  const sessionFilePath = helpers.sessionFilePath || resolveSessionFilePath(cwd, runGit);
+  const currentBranch = helpers.currentBranch || getCurrentBranch(cwd, runGit);
+  const expectedBranch = helpers.expectedBranch !== undefined
+    ? helpers.expectedBranch
+    : readExpectedBranch(
+      sessionFilePath,
+      helpers.readFile || fs.readFileSync,
+      helpers.exists || fs.existsSync,
+    );
+
+  if (!currentBranch) {
+    return {
+      ok: false,
+      code: 'detached-head',
+      currentBranch: '',
+      expectedBranch,
+      sessionFilePath,
+      message: [
+        '[branch-session] Detached HEAD is not allowed for guarded push.',
+        '[branch-session] Switch to the intended branch, then run `pnpm guard:branch-session expect-current`.',
+      ].join('\n'),
+    };
+  }
+
+  if (!expectedBranch) {
+    return {
+      ok: false,
+      code: 'missing-expected-branch',
+      currentBranch,
+      expectedBranch: null,
+      sessionFilePath,
+      message: [
+        '[branch-session] No expected branch is recorded for this worktree session.',
+        `[branch-session] Current branch: ${currentBranch}`,
+        `[branch-session] Session file: ${sessionFilePath}`,
+        '[branch-session] Run `pnpm guard:branch-session expect-current` after switching to the intended branch.',
+      ].join('\n'),
+    };
+  }
+
+  if (currentBranch !== expectedBranch) {
+    return {
+      ok: false,
+      code: 'branch-mismatch',
+      currentBranch,
+      expectedBranch,
+      sessionFilePath,
+      message: [
+        '[branch-session] Branch mismatch detected.',
+        `[branch-session] Expected branch: ${expectedBranch}`,
+        `[branch-session] Current branch: ${currentBranch}`,
+        `[branch-session] Session file: ${sessionFilePath}`,
+        '[branch-session] Stop and switch back, or explicitly re-record the new intended branch before pushing.',
+      ].join('\n'),
+    };
+  }
+
+  return {
+    ok: true,
+    code: 'ok',
+    currentBranch,
+    expectedBranch,
+    sessionFilePath,
+    message: [
+      '[branch-session] Branch session matches.',
+      `[branch-session] Current branch: ${currentBranch}`,
+      `[branch-session] Session file: ${sessionFilePath}`,
+    ].join('\n'),
+  };
+}
+
+function clearExpectedBranch(cwd = process.cwd(), helpers = {}) {
+  const runGit = helpers.runGit || defaultRunGit;
+  const sessionFilePath = helpers.sessionFilePath || resolveSessionFilePath(cwd, runGit);
+  const exists = helpers.exists || fs.existsSync;
+  const unlink = helpers.unlink || fs.unlinkSync;
+
+  if (exists(sessionFilePath)) {
+    unlink(sessionFilePath);
+  }
+
+  return sessionFilePath;
+}
+
+function main() {
+  const { command, options } = parseCliArgs(process.argv.slice(2));
+
+  try {
+    switch (command) {
+      case 'expect-current': {
+        const currentBranch = getCurrentBranch();
+        const result = recordExpectedBranch(currentBranch);
+        console.log(`[branch-session] Recorded expected branch: ${result.expectedBranch}`);
+        console.log(`[branch-session] Session file: ${result.sessionFilePath}`);
+        return;
+      }
+      case 'expect': {
+        const result = recordExpectedBranch(options.branch);
+        console.log(`[branch-session] Recorded expected branch: ${result.expectedBranch}`);
+        console.log(`[branch-session] Session file: ${result.sessionFilePath}`);
+        return;
+      }
+      case 'check': {
+        const result = checkBranchExpectation();
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(result.message);
+        }
+        if (!result.ok) {
+          process.exit(1);
+        }
+        return;
+      }
+      case 'clear': {
+        const sessionFilePath = clearExpectedBranch();
+        console.log(`[branch-session] Cleared expected branch session: ${sessionFilePath}`);
+        return;
+      }
+      case 'status': {
+        const result = checkBranchExpectation();
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(result.message);
+        }
+        return;
+      }
+      default:
+        throw new Error(`Unknown command: ${command}`);
+    }
+  } catch (error) {
+    console.error(`[branch-session] ${error.message}`);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  SESSION_GIT_PATH,
+  checkBranchExpectation,
+  clearExpectedBranch,
+  getCurrentBranch,
+  parseCliArgs,
+  readExpectedBranch,
+  recordExpectedBranch,
+  resolveSessionFilePath,
+  writeExpectedBranch,
+};
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
## Summary
- add a worktree-local branch session guard that records the expected branch in git-owned local metadata
- run that guard from `.husky/pre-push` before the existing retro gate so push-time branch mismatches fail automatically
- document the setup command and guarantee limits in `DEV_NOTES.md`, and add unit/docs coverage for the new guard

## Why
Closes #749.

This targets the specific failure mode where a session intended for one branch continues on another branch without a mechanical stop. The guard is intentionally based on `expected branch for this session` rather than issue-number parsing, so it still works for existing remote branches and issue-less small tasks.

## Verification
- `pnpm --filter @rawsql-ts/ztd-cli test -- branchSessionGuard.unit.test.ts devNotes.docs.test.ts precommitEnforcement.unit.test.ts repoGuidance.unit.test.ts`
- `pnpm guard:branch-session expect-current`
- `pnpm guard:branch-session check`
- observed `pre-push` pass with both branch-session guard and retro gate after push

## Known limits
- the guard proves only that the current local worktree is still on the branch recorded for the session
- it does not prove task correctness and it does not protect flows that bypass the local hook path entirely
- PR-creation-specific auto-triggering is still follow-up work; this change ships push-time enforcement first

## Additional notes
A full `pnpm test` run from the pre-commit hook is currently blocked by pre-existing failures outside this change:
- `packages/ztd-cli/tests/agentsPolicy.unit.test.ts`
- `packages/ztd-cli/tests/setupEnv.unit.test.ts`

Those failures reproduce without touching the files changed in this PR, so the verification above stays targeted to the new guard and its docs.
