### PR TITLE
fix: repair release quality gates

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -3,6 +3,7 @@ name: PR Check
 on:
   pull_request:
     branches: [ main, develop ]
+    types: [opened, reopened, synchronize, edited, ready_for_review]
 
 jobs:
   quick-check:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -12,6 +12,7 @@ jobs:
     env:
       # Disable git hooks (e.g. husky) so the Changesets commit can't fail in CI.
       HUSKY: 0
+      CHANGESETS_TOKEN: ${{ secrets.CHANGESETS_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
@@ -27,6 +28,15 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Require release PR token
+        shell: bash
+        run: |
+          if [ -z "${CHANGESETS_TOKEN}" ]; then
+            echo "Release PR requires the CHANGESETS_TOKEN secret."
+            echo "A workflow-created PR must use a PAT so pull_request checks can run on the release PR branch."
+            exit 1
+          fi
+
       - name: Create/Update Release PR
         uses: changesets/action@v1
         with:
@@ -36,5 +46,5 @@ jobs:
           # Use git commits to avoid GitHub Contents API limitations (e.g., executable file modes in the repo).
           commitMode: git-cli
         env:
-          # Use a PAT if provided, since the default GITHUB_TOKEN may be restricted from creating PRs by repo settings.
-          GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN || secrets.GITHUB_TOKEN }}
+          # Release PRs must use a PAT so downstream pull_request checks attach to the bot-created PR.
+          GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN }}

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -21,13 +21,19 @@ npm install rawsql-ts
 ```typescript
 import { DynamicQueryBuilder, SqlFormatter } from 'rawsql-ts';
 
-const baseSql = 'SELECT id, name, email, created_at FROM users WHERE active = true';
+const baseSql = `
+  SELECT id, name, email, status, created_at
+  FROM users
+  WHERE active = true
+    AND (:status IS NULL OR status = :status)
+`;
 
 const builder = new DynamicQueryBuilder();
 const query = builder.buildQuery(baseSql, {
-  filter: { status: 'premium', created_at: { '>': '2024-01-01' } },
+  filter: { status: 'premium' },
   sort: { created_at: { desc: true }, name: { asc: true } },
-  paging: { page: 2, pageSize: 10 }
+  paging: { page: 2, pageSize: 10 },
+  optionalConditionParameters: { status: 'premium' }
 });
 
 const formatter = new SqlFormatter();

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -37,13 +37,19 @@ Or use directly in the browser via CDN:
 ```typescript
 import { DynamicQueryBuilder, SqlFormatter } from "rawsql-ts";
 
-const baseSql = "SELECT id, name, email, created_at FROM users WHERE active = true";
+const baseSql = `
+  SELECT id, name, email, status, created_at
+  FROM users
+  WHERE active = true
+    AND (:status IS NULL OR status = :status)
+`;
 
 const builder = new DynamicQueryBuilder();
 const query = builder.buildQuery(baseSql, {
-  filter: { status: "premium", created_at: { ">": "2024-01-01" } },
+  filter: { status: "premium" },
   sort: { created_at: { desc: true }, name: { asc: true } },
   paging: { page: 2, pageSize: 10 },
+  optionalConditionParameters: { status: "premium" },
 });
 
 const formatter = new SqlFormatter();

--- a/packages/ztd-cli/tests/prReadiness.unit.test.ts
+++ b/packages/ztd-cli/tests/prReadiness.unit.test.ts
@@ -1,9 +1,19 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { expect, test } from 'vitest';
 
 const {
+  classifyPullRequestContext,
   classifyPrReadiness,
   validatePrReadiness,
 } = require('../../../scripts/check-pr-readiness.js') as {
+  classifyPullRequestContext(eventPath: string): {
+    isReleasePr: boolean;
+    headRef: string;
+    title: string;
+    authorLogin: string;
+  };
   classifyPrReadiness(changedFiles: string[]): {
     changedFiles: string[];
     requiresCliMigrationPacket: boolean;
@@ -19,6 +29,12 @@ const {
       requiresScaffoldContractProof: boolean;
       cliMatchedFiles: string[];
       scaffoldMatchedFiles: string[];
+    };
+    pullRequestContext?: {
+      isReleasePr: boolean;
+      headRef: string;
+      title: string;
+      authorLogin: string;
     };
   }): {
     ok: boolean;
@@ -194,4 +210,42 @@ test('pr-readiness rejects scaffold changes without the three proof classes', ()
 
   expect(validation.ok).toBe(false);
   expect(validation.errors.some((error) => error.includes('Scaffold contract proof must include a fail-fast input-contract proof.'))).toBe(true);
+});
+
+test('pr-readiness skips the human-authored body contract for release PRs', () => {
+  const validation = validatePrReadiness({
+    body: 'This PR was opened by the Changesets release GitHub action.',
+    classification: classifyPrReadiness([
+      'packages/ztd-cli/package.json',
+      'packages/core/CHANGELOG.md',
+    ]),
+    pullRequestContext: {
+      isReleasePr: true,
+      headRef: 'changeset-release/main',
+      title: 'chore(release): version packages',
+      authorLogin: 'github-actions[bot]',
+    },
+  });
+
+  expect(validation.ok).toBe(true);
+  expect(validation.errors).toEqual([]);
+});
+
+test('pr-readiness classifies a changeset release branch as a release PR', () => {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), 'pr-readiness-event-'));
+  const eventPath = path.join(rootDir, 'event.json');
+  writeFileSync(eventPath, JSON.stringify({
+    pull_request: {
+      head: { ref: 'changeset-release/main' },
+      title: 'chore(release): version packages',
+      user: { login: 'github-actions[bot]' },
+    },
+  }), 'utf8');
+
+  expect(classifyPullRequestContext(eventPath)).toEqual({
+    isReleasePr: true,
+    headRef: 'changeset-release/main',
+    title: 'chore(release): version packages',
+    authorLogin: 'github-actions[bot]',
+  });
 });

--- a/packages/ztd-cli/tests/publishWorkflow.unit.test.ts
+++ b/packages/ztd-cli/tests/publishWorkflow.unit.test.ts
@@ -4,6 +4,8 @@ import { expect, test } from 'vitest';
 
 const publishWorkflowPath = path.resolve(__dirname, '../../../.github/workflows/publish.yml');
 const publishWorkflow = fs.readFileSync(publishWorkflowPath, 'utf8');
+const prCheckWorkflowPath = path.resolve(__dirname, '../../../.github/workflows/pr-check.yml');
+const prCheckWorkflow = fs.readFileSync(prCheckWorkflowPath, 'utf8');
 const releasePrWorkflowPath = path.resolve(__dirname, '../../../.github/workflows/release-pr.yml');
 const releasePrWorkflow = fs.readFileSync(releasePrWorkflowPath, 'utf8');
 const publishedPackageModePath = path.resolve(__dirname, '../../../scripts/verify-published-package-mode.mjs');
@@ -30,6 +32,10 @@ test('release PR workflow requires the changesets PAT instead of silently fallin
   expect(releasePrWorkflow).toContain('Release PR requires the CHANGESETS_TOKEN secret.');
   expect(releasePrWorkflow).toContain('GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN }}');
   expect(releasePrWorkflow).not.toContain('secrets.CHANGESETS_TOKEN || secrets.GITHUB_TOKEN');
+});
+
+test('pr check reruns when the PR body is edited or the draft is marked ready for review', () => {
+  expect(prCheckWorkflow).toContain('types: [opened, reopened, synchronize, edited, ready_for_review]');
 });
 
 test('standalone pnpm proof apps use the installed ztd bin helper instead of pnpm exec', () => {

--- a/packages/ztd-cli/tests/publishWorkflow.unit.test.ts
+++ b/packages/ztd-cli/tests/publishWorkflow.unit.test.ts
@@ -4,6 +4,8 @@ import { expect, test } from 'vitest';
 
 const publishWorkflowPath = path.resolve(__dirname, '../../../.github/workflows/publish.yml');
 const publishWorkflow = fs.readFileSync(publishWorkflowPath, 'utf8');
+const releasePrWorkflowPath = path.resolve(__dirname, '../../../.github/workflows/release-pr.yml');
+const releasePrWorkflow = fs.readFileSync(releasePrWorkflowPath, 'utf8');
 const publishedPackageModePath = path.resolve(__dirname, '../../../scripts/verify-published-package-mode.mjs');
 const publishedPackageModeScript = fs.readFileSync(publishedPackageModePath, 'utf8');
 
@@ -21,6 +23,13 @@ test('proof mode skips the main-branch requirement and actual publish', () => {
   expect(publishWorkflow).toContain("if: ${{ inputs.verification_mode != 'proof' }}");
   expect(publishWorkflow).toContain("if: ${{ needs.verify_publish_readiness.outputs.should_publish == 'true' && inputs.verification_mode != 'proof' }}");
   expect(publishWorkflow).toContain('create-publish-proof-plan.mjs');
+});
+
+test('release PR workflow requires the changesets PAT instead of silently falling back to GITHUB_TOKEN', () => {
+  expect(releasePrWorkflow).toContain('name: Require release PR token');
+  expect(releasePrWorkflow).toContain('Release PR requires the CHANGESETS_TOKEN secret.');
+  expect(releasePrWorkflow).toContain('GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN }}');
+  expect(releasePrWorkflow).not.toContain('secrets.CHANGESETS_TOKEN || secrets.GITHUB_TOKEN');
 });
 
 test('standalone pnpm proof apps use the installed ztd bin helper instead of pnpm exec', () => {
@@ -48,4 +57,23 @@ test('standalone pnpm proof apps use the installed ztd bin helper instead of pnp
   );
   expect(tutorialSection).toContain('runInstalledZtdCli(appDir,');
   expect(tutorialSection).not.toContain('"exec",');
+});
+
+test('published-package mode includes the rawsql-ts getting-started smoke path', () => {
+  expect(publishedPackageModeScript).toContain('function verifyCoreGettingStarted(packages) {');
+  expect(publishedPackageModeScript).toContain("name: \"rawsql-ts-getting-started-check\"");
+  expect(publishedPackageModeScript).toContain("await import('rawsql-ts')");
+  expect(publishedPackageModeScript).toContain('const builder = new DynamicQueryBuilder();');
+  expect(publishedPackageModeScript).toContain('const formatter = new SqlFormatter();');
+});
+
+test('overwrite safety uses the installed ztd bin so npm does not consume --force', () => {
+  const overwriteSection = publishedPackageModeScript.slice(
+    publishedPackageModeScript.indexOf('function verifyOverwriteSafety(packages) {'),
+    publishedPackageModeScript.indexOf('function main() {'),
+  );
+
+  expect(overwriteSection).toContain('runInstalledZtdCli(appDir, ["init", "--yes", "--workflow", "demo", "--validator", "zod"])');
+  expect(overwriteSection).toContain('runInstalledZtdCli(appDir, ["init", "--yes", "--force", "--workflow", "demo", "--validator", "zod"])');
+  expect(overwriteSection).not.toContain('"exec"');
 });

--- a/packages/ztd-cli/tests/releaseReadiness.unit.test.ts
+++ b/packages/ztd-cli/tests/releaseReadiness.unit.test.ts
@@ -7,6 +7,7 @@ const {
   classifyReleaseReadiness,
   evaluateChangesetGuardrail,
   listPendingChangesetFiles,
+  readPullRequestContext,
   readPullRequestLabels,
 } = require('../../../scripts/release-readiness.js') as {
   classifyReleaseReadiness(
@@ -28,6 +29,13 @@ const {
     hasNoReleaseLabel: boolean;
   };
   listPendingChangesetFiles(rootDir: string): string[];
+  readPullRequestContext(eventPath: string): {
+    isReleasePr: boolean;
+    headRef: string;
+    title: string;
+    authorLogin: string;
+    labelNames: string[];
+  };
   readPullRequestLabels(eventPath: string): string[];
 };
 
@@ -50,6 +58,7 @@ test('release-readiness treats package source and package READMEs as release-aff
   const classification = classifyReleaseReadiness([
     'packages/core/src/transformers/SelectValueCollector.ts',
     'packages/ztd-cli/README.md',
+    'docs/guide/getting-started.md',
   ]);
 
   expect(classification.releaseAffecting).toBe(true);
@@ -61,6 +70,10 @@ test('release-readiness treats package source and package READMEs as release-aff
     },
     {
       filePath: 'packages/ztd-cli/README.md',
+      kinds: ['package-surface'],
+    },
+    {
+      filePath: 'docs/guide/getting-started.md',
       kinds: ['package-surface'],
     },
   ]);
@@ -156,6 +169,33 @@ test('readPullRequestLabels returns sorted label names from a pull_request paylo
   ]);
 });
 
+test('readPullRequestContext detects release PR metadata from the event payload', () => {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), 'release-readiness-context-'));
+  const eventPath = path.join(rootDir, 'event.json');
+  writeFileSync(eventPath, JSON.stringify({
+    pull_request: {
+      head: { ref: 'changeset-release/main' },
+      title: 'chore(release): version packages',
+      user: { login: 'github-actions[bot]' },
+      labels: [
+        { name: 'z-release' },
+        { name: 'A-label' },
+      ],
+    },
+  }), 'utf8');
+
+  expect(readPullRequestContext(eventPath)).toEqual({
+    isReleasePr: true,
+    headRef: 'changeset-release/main',
+    title: 'chore(release): version packages',
+    authorLogin: 'github-actions[bot]',
+    labelNames: [
+      'A-label',
+      'z-release',
+    ],
+  });
+});
+
 test('changeset guardrail fails release-affecting PRs without a changeset or no-release label', () => {
   expect(
     evaluateChangesetGuardrail({
@@ -168,6 +208,7 @@ test('changeset guardrail fails release-affecting PRs without a changeset or no-
     guardrailPassed: false,
     hasChangeset: false,
     hasNoReleaseLabel: false,
+    isReleasePr: false,
   });
 });
 
@@ -183,6 +224,7 @@ test('changeset guardrail passes when a release-affecting PR includes a changese
     guardrailPassed: true,
     hasChangeset: true,
     hasNoReleaseLabel: false,
+    isReleasePr: false,
   });
 });
 
@@ -198,5 +240,23 @@ test('changeset guardrail passes when a release-affecting PR carries the no-rele
     guardrailPassed: true,
     hasChangeset: false,
     hasNoReleaseLabel: true,
+    isReleasePr: false,
+  });
+});
+
+test('changeset guardrail skips the pending changeset requirement for release PRs', () => {
+  expect(
+    evaluateChangesetGuardrail({
+      releaseAffecting: true,
+      changesetFiles: [],
+      labelNames: [],
+      isReleasePr: true,
+    }),
+  ).toEqual({
+    guardrailRequired: false,
+    guardrailPassed: true,
+    hasChangeset: false,
+    hasNoReleaseLabel: false,
+    isReleasePr: true,
   });
 });

--- a/scripts/check-pr-readiness.js
+++ b/scripts/check-pr-readiness.js
@@ -22,6 +22,7 @@ const CLI_NO_PACKET_LABEL = 'No migration packet required for this CLI change.';
 const CLI_PACKET_LABEL = 'CLI/user-facing surface change and migration packet completed.';
 const SCAFFOLD_NO_PROOF_LABEL = 'No scaffold contract proof required for this PR.';
 const SCAFFOLD_PROOF_LABEL = 'Scaffold contract proof completed.';
+const RELEASE_PR_HEAD_PREFIX = 'changeset-release/';
 
 function normalizePath(filePath) {
   return String(filePath).replace(/\\/gu, '/').replace(/^\.\//u, '');
@@ -55,6 +56,30 @@ function parseArgs(argv) {
   }
 
   return options;
+}
+
+function classifyPullRequestContext(eventPath) {
+  if (!eventPath || !fs.existsSync(eventPath)) {
+    return {
+      isReleasePr: false,
+      headRef: '',
+      title: '',
+      authorLogin: '',
+    };
+  }
+
+  const payload = JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+  const pullRequest = payload.pull_request ?? {};
+  const headRef = typeof pullRequest.head?.ref === 'string' ? pullRequest.head.ref : '';
+  const title = typeof pullRequest.title === 'string' ? pullRequest.title : '';
+  const authorLogin = typeof pullRequest.user?.login === 'string' ? pullRequest.user.login : '';
+
+  return {
+    isReleasePr: headRef.startsWith(RELEASE_PR_HEAD_PREFIX),
+    headRef,
+    title,
+    authorLogin,
+  };
 }
 
 function getChangedFiles(baseSha, headSha) {
@@ -134,9 +159,19 @@ function requireField(errors, body, label, description, validator = null) {
   }
 }
 
-function validatePrReadiness({ body, classification }) {
+function validatePrReadiness({ body, classification, pullRequestContext = null }) {
   const errors = [];
   const normalizedBody = typeof body === 'string' ? body : '';
+  const context = pullRequestContext ?? { isReleasePr: false };
+
+  if (context.isReleasePr) {
+    return {
+      ok: true,
+      errors,
+      classification,
+      skippedBecause: 'release-pr',
+    };
+  }
 
   if (!/##\s+Merge Readiness/iu.test(normalizedBody)) {
     errors.push('Missing "## Merge Readiness" section from the PR body.');
@@ -282,9 +317,13 @@ function runCheck(argv) {
   const changedFiles = getChangedFiles(options.baseSha, options.headSha);
   const classification = classifyPrReadiness(changedFiles);
   const body = readPullRequestBody(options.eventPath);
-  const validation = validatePrReadiness({ body, classification });
+  const pullRequestContext = classifyPullRequestContext(options.eventPath);
+  const validation = validatePrReadiness({ body, classification, pullRequestContext });
 
   console.log(`[pr-readiness] changed files: ${classification.changedFiles.length}`);
+  if (pullRequestContext.isReleasePr) {
+    console.log(`[pr-readiness] release PR detected on ${pullRequestContext.headRef}; skipping human-authored PR body contract.`);
+  }
   if (classification.requiresCliMigrationPacket) {
     console.log(`[pr-readiness] CLI migration packet required for: ${classification.cliMatchedFiles.join(', ')}`);
   }
@@ -314,6 +353,7 @@ if (require.main === module) {
 module.exports = {
   CLI_SURFACE_PATTERNS,
   SCAFFOLD_CONTRACT_PATTERNS,
+  classifyPullRequestContext,
   classifyPrReadiness,
   validatePrReadiness,
 };

--- a/scripts/release-readiness.js
+++ b/scripts/release-readiness.js
@@ -1,6 +1,7 @@
 const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
+const RELEASE_PR_HEAD_PREFIX = 'changeset-release/';
 
 const RELEASE_READINESS_PATTERNS = [
   {
@@ -8,6 +9,7 @@ const RELEASE_READINESS_PATTERNS = [
     patterns: [
       /^package\.json$/u,
       /^pnpm-lock\.yaml$/u,
+      /^docs\/guide\/getting-started\.md$/u,
       /^packages\/(?:[^/]+\/)+src\//u,
       /^packages\/(?:[^/]+\/)+templates\//u,
       /^packages\/(?:[^/]+\/)+package\.json$/u,
@@ -135,18 +137,46 @@ function readPullRequestLabels(eventPath) {
     .sort();
 }
 
-function evaluateChangesetGuardrail({ releaseAffecting, changesetFiles, labelNames }) {
+function readPullRequestContext(eventPath) {
+  if (!eventPath || !fs.existsSync(eventPath)) {
+    return {
+      isReleasePr: false,
+      headRef: '',
+      title: '',
+      authorLogin: '',
+      labelNames: [],
+    };
+  }
+
+  const payload = JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+  const pullRequest = payload?.pull_request ?? {};
+  const labels = Array.isArray(pullRequest.labels) ? pullRequest.labels : [];
+
+  return {
+    isReleasePr: typeof pullRequest.head?.ref === 'string' && pullRequest.head.ref.startsWith(RELEASE_PR_HEAD_PREFIX),
+    headRef: typeof pullRequest.head?.ref === 'string' ? pullRequest.head.ref : '',
+    title: typeof pullRequest.title === 'string' ? pullRequest.title : '',
+    authorLogin: typeof pullRequest.user?.login === 'string' ? pullRequest.user.login : '',
+    labelNames: labels
+      .map((label) => String(label?.name ?? '').trim())
+      .filter(Boolean)
+      .sort(),
+  };
+}
+
+function evaluateChangesetGuardrail({ releaseAffecting, changesetFiles, labelNames, isReleasePr = false }) {
   const normalizedLabels = (labelNames ?? []).map((label) => String(label).trim().toLowerCase());
   const hasNoReleaseLabel = normalizedLabels.includes('no-release');
   const hasChangeset = (changesetFiles ?? []).length > 0;
-  const guardrailRequired = releaseAffecting;
-  const guardrailPassed = !guardrailRequired || hasChangeset || hasNoReleaseLabel;
+  const guardrailRequired = releaseAffecting && !isReleasePr;
+  const guardrailPassed = isReleasePr || !guardrailRequired || hasChangeset || hasNoReleaseLabel;
 
   return {
     guardrailRequired,
     guardrailPassed,
     hasChangeset,
     hasNoReleaseLabel,
+    isReleasePr,
   };
 }
 
@@ -192,11 +222,13 @@ function runDetect(argv) {
   const options = parseArgs(argv);
   const classification = classifyReleaseReadiness(getChangedFiles(options.baseSha, options.headSha));
   const changesetFiles = listPendingChangesetFiles(process.cwd());
-  const labelNames = readPullRequestLabels(options.eventPath ?? process.env.GITHUB_EVENT_PATH);
+  const pullRequestContext = readPullRequestContext(options.eventPath ?? process.env.GITHUB_EVENT_PATH);
+  const labelNames = pullRequestContext.labelNames;
   const guardrail = evaluateChangesetGuardrail({
     releaseAffecting: classification.releaseAffecting,
     changesetFiles,
     labelNames,
+    isReleasePr: pullRequestContext.isReleasePr,
   });
 
   console.log(`[release-readiness] changed files: ${classification.changedFiles.length}`);
@@ -215,6 +247,9 @@ function runDetect(argv) {
     if (!guardrail.guardrailPassed) {
       console.log('[release-readiness] guardrail failed: release-affecting changes need a changeset or the no-release label.');
     }
+  }
+  if (pullRequestContext.isReleasePr) {
+    console.log(`[release-readiness] release PR detected on ${pullRequestContext.headRef}; changeset guardrail is skipped for bot-authored version bump PRs.`);
   }
 
   appendGitHubOutputs(options.githubOutputPath, {
@@ -253,6 +288,7 @@ module.exports = {
   evaluateChangesetGuardrail,
   getMatchingKinds,
   listPendingChangesetFiles,
+  readPullRequestContext,
   readPullRequestLabels,
   runReleaseReadinessChecks,
 };

--- a/scripts/verify-published-package-mode.mjs
+++ b/scripts/verify-published-package-mode.mjs
@@ -353,6 +353,49 @@ function verifyPackedTarballInstall(packages) {
   return appDir;
 }
 
+function verifyCoreGettingStarted(packages) {
+  const appDir = path.join(packageRoot, "rawsql-ts-getting-started");
+  ensureCleanDir(appDir);
+
+  writePackageJson(appDir, {
+    name: "rawsql-ts-getting-started-check",
+    private: true,
+    version: "0.0.0",
+    type: "module",
+    devDependencies: {
+      "rawsql-ts": createTarballDependencyMap(packages)["rawsql-ts"],
+    },
+  });
+
+  runIn(appDir, NPM, ["install"]);
+  runIn(appDir, process.execPath, [
+    "--input-type=module",
+    "-e",
+    [
+      "const { DynamicQueryBuilder, SqlFormatter } = await import('rawsql-ts');",
+      "const baseSql = `",
+      "  SELECT id, name, email, status, created_at",
+      "  FROM users",
+      "  WHERE active = true",
+      "    AND (:status IS NULL OR status = :status)",
+      "`;",
+      "const builder = new DynamicQueryBuilder();",
+      "const query = builder.buildQuery(baseSql, {",
+      "  filter: { status: 'premium' },",
+      "  sort: { created_at: { desc: true }, name: { asc: true } },",
+      "  paging: { page: 2, pageSize: 10 },",
+      "  optionalConditionParameters: { status: 'premium' },",
+      "});",
+      "const formatter = new SqlFormatter();",
+      "const { formattedSql, params } = formatter.format(query);",
+      "if (!String(formattedSql).includes('users')) throw new Error('formatted SQL did not include the expected table reference');",
+      "if (params == null) throw new Error('formatter did not return params');",
+    ].join(" "),
+  ], { shell: false });
+
+  return appDir;
+}
+
 function verifyNpmPrimaryPath(packages) {
   const appDir = path.join(packageRoot, "npm-primary-path");
   ensureCleanDir(appDir);
@@ -640,7 +683,7 @@ function verifyOverwriteSafety(packages) {
 
   let overwriteFailed = false;
   try {
-    runIn(appDir, NPM, ["exec", "--", "ztd", "init", "--yes", "--workflow", "demo", "--validator", "zod"]);
+    runInstalledZtdCli(appDir, ["init", "--yes", "--workflow", "demo", "--validator", "zod"]);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (!message.includes("--force") && !message.includes("already exists")) {
@@ -657,7 +700,7 @@ function verifyOverwriteSafety(packages) {
     throw new Error("[scaffold safety] DDL changed even though init without --force failed.");
   }
 
-  runIn(appDir, NPM, ["exec", "--", "ztd", "init", "--yes", "--force", "--workflow", "demo", "--validator", "zod"]);
+  runInstalledZtdCli(appDir, ["init", "--yes", "--force", "--workflow", "demo", "--validator", "zod"]);
 
   const schemaContents = fs.readFileSync(ddlPath, "utf8");
   if (schemaContents === originalSchema) {
@@ -680,6 +723,7 @@ function main() {
         return packPublishedPackages();
       })();
   const packedInstallApp = verifyPackedTarballInstall(packedPackages);
+  const coreGettingStartedApp = verifyCoreGettingStarted(packedPackages);
   const npmPrimaryPathApp = verifyNpmPrimaryPath(packedPackages);
   const npmSmokeApp = verifyNpmConsumerSmoke(npmPrimaryPathApp);
   const pnpmStarterApp = verifyPnpmStarterPath(packedPackages);
@@ -693,6 +737,7 @@ function main() {
     platform: os.platform(),
     verificationMode: options.publishManifestProvided ? "publish-manifest" : "workspace-pack",
     packedInstallApp,
+    coreGettingStartedApp,
     npmPrimaryPathApp: npmPrimaryPathApp.appDir,
     firstTestGateApp: npmSmokeApp,
     npmSmokeApp,


### PR DESCRIPTION
## Summary

- require `CHANGESETS_TOKEN` for the release PR workflow so bot-authored release PRs can trigger downstream `pull_request` checks
- treat changeset release PRs as release-specific PRs in readiness scripts so they skip human PR body contracts and pending-changeset guardrails that do not apply to version-bump PRs
- strengthen published-package verification with a packaged rawsql-ts getting-started smoke and fix the overwrite-safety proof so `--force` reaches the installed `ztd` binary
- update the getting-started docs to match the current supported `DynamicQueryBuilder` usage

## Verification

- `pnpm --filter @rawsql-ts/ztd-cli exec vitest run --config vitest.config.ts tests/publishWorkflow.unit.test.ts tests/prReadiness.unit.test.ts tests/releaseReadiness.unit.test.ts`
- `pnpm verify:published-package-mode`

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue:
Scoped checks run:
Why full baseline is not required:

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: This PR changes release workflow wiring, release-readiness classification, and packaged verification coverage only. It does not change a customer-facing CLI command contract.
Upgrade note:
Deprecation/removal plan or issue:
Docs/help/examples updated:
Release/changeset wording:

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: This PR does not change scaffold templates or scaffold output layout. It only verifies packaged getting-started behavior and fixes the packaged overwrite-safety proof harness.
Non-edit assertion:
Fail-fast input-contract proof:
Generated-output viability proof:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated getting-started examples to demonstrate optional parameter filtering and additional field selection in database queries.

* **Chores**
  * Improved release automation configuration and validation for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->