### PR TITLE
fix: unblock release PR verification

### DIFF
--- a/packages/ztd-cli/tests/publishWorkflow.unit.test.ts
+++ b/packages/ztd-cli/tests/publishWorkflow.unit.test.ts
@@ -96,7 +96,8 @@ test('generated-project mode skips the initial install and reapplies local-sourc
   expect(generatedProjectModeScript).toContain('"--skip-install"');
   expect(generatedProjectModeScript).toContain('function applyLocalSourceOverrides(appDir) {');
   expect(generatedProjectModeScript).toContain('runIn(generatedProjectRoot, PNPM, ["install", "--ignore-workspace", "--no-frozen-lockfile"])');
-  expect(generatedProjectModeScript).toContain('runIn(generatedProjectRoot, PNPM, [');
-  expect(generatedProjectModeScript).toContain('"run"');
+  expect(generatedProjectModeScript).toContain('runIn(generatedProjectRoot, process.execPath, [');
+  expect(generatedProjectModeScript).toContain('path.join(generatedProjectRoot, "scripts", "local-source-guard.mjs")');
   expect(generatedProjectModeScript).toContain('"ztd"');
+  expect(generatedProjectModeScript).toContain('shell: false');
 });

--- a/packages/ztd-cli/tests/publishWorkflow.unit.test.ts
+++ b/packages/ztd-cli/tests/publishWorkflow.unit.test.ts
@@ -10,6 +10,8 @@ const releasePrWorkflowPath = path.resolve(__dirname, '../../../.github/workflow
 const releasePrWorkflow = fs.readFileSync(releasePrWorkflowPath, 'utf8');
 const publishedPackageModePath = path.resolve(__dirname, '../../../scripts/verify-published-package-mode.mjs');
 const publishedPackageModeScript = fs.readFileSync(publishedPackageModePath, 'utf8');
+const generatedProjectModePath = path.resolve(__dirname, '../../../scripts/verify-generated-project-mode.mjs');
+const generatedProjectModeScript = fs.readFileSync(generatedProjectModePath, 'utf8');
 
 test('publish workflow verifies built artifacts before actual publish', () => {
   expect(publishWorkflow).toContain('verify_publish_artifacts:');
@@ -82,4 +84,19 @@ test('overwrite safety uses the installed ztd bin so npm does not consume --forc
   expect(overwriteSection).toContain('runInstalledZtdCli(appDir, ["init", "--yes", "--workflow", "demo", "--validator", "zod"])');
   expect(overwriteSection).toContain('runInstalledZtdCli(appDir, ["init", "--yes", "--force", "--workflow", "demo", "--validator", "zod"])');
   expect(overwriteSection).not.toContain('"exec"');
+});
+
+test('standalone pnpm proof apps pin tarball overrides at the workspace root', () => {
+  expect(publishedPackageModeScript).toContain('function syncStandaloneWorkspacePackageJson(overrides) {');
+  expect(publishedPackageModeScript).toContain('writePackageJson(standalonePackageRoot, {');
+  expect(publishedPackageModeScript).toContain('syncStandaloneWorkspacePackageJson(tarballDependencies);');
+});
+
+test('generated-project mode skips the initial install and reapplies local-source overrides before pnpm install', () => {
+  expect(generatedProjectModeScript).toContain('"--skip-install"');
+  expect(generatedProjectModeScript).toContain('function applyLocalSourceOverrides(appDir) {');
+  expect(generatedProjectModeScript).toContain('runIn(generatedProjectRoot, PNPM, ["install", "--ignore-workspace", "--no-frozen-lockfile"])');
+  expect(generatedProjectModeScript).toContain('runIn(generatedProjectRoot, PNPM, [');
+  expect(generatedProjectModeScript).toContain('"run"');
+  expect(generatedProjectModeScript).toContain('"ztd"');
 });

--- a/scripts/verify-generated-project-mode.mjs
+++ b/scripts/verify-generated-project-mode.mjs
@@ -246,7 +246,7 @@ async function main() {
         "ztd init --starter --yes --skip-install --local-source-root <repo-root>",
         "write pnpm.overrides for local rawsql-ts workspace packages",
         "pnpm install --ignore-workspace --no-frozen-lockfile",
-        "pnpm run ztd -- feature scaffold --table users --action insert",
+        "node scripts/local-source-guard.mjs ztd feature scaffold --table users --action insert",
         "docker run -d --rm --name generated-project-check-postgres -P postgres:18",
         "docker port generated-project-check-postgres 5432/tcp",
         "write .env with the mapped Postgres port",

--- a/scripts/verify-generated-project-mode.mjs
+++ b/scripts/verify-generated-project-mode.mjs
@@ -6,6 +6,7 @@ import {
   IS_WINDOWS,
   PNPM,
   ensureCleanDir,
+  getWorkspacePackages,
   run,
   runWithOutput,
   writeJson,
@@ -17,6 +18,14 @@ const generatedProjectRoot = path.join(outputRoot, "starter-app");
 const cliEntryPoint = path.join(workspaceRoot, "packages", "ztd-cli", "dist", "index.js");
 const postgresContainerName = "generated-project-check-postgres";
 
+function isPublishTarget(pkg) {
+  return (
+    !pkg.private
+    && pkg.dir.startsWith(path.join(workspaceRoot, "packages"))
+    && !pkg.dir.includes(`${path.sep}templates${path.sep}`)
+  );
+}
+
 function runIn(directory, command, args, options = {}) {
   return runWithOutput(command, args, {
     cwd: directory,
@@ -27,6 +36,32 @@ function runIn(directory, command, args, options = {}) {
 
 function readPackageJson(directory) {
   return JSON.parse(fs.readFileSync(path.join(directory, "package.json"), "utf8"));
+}
+
+function writePackageJson(directory, packageJson) {
+  fs.writeFileSync(path.join(directory, "package.json"), `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
+}
+
+function toLocalFileDependency(rootDir, targetDir) {
+  const relativeTarget = path.relative(rootDir, targetDir).replace(/\\/gu, "/");
+  const withDotPrefix = relativeTarget.startsWith(".") ? relativeTarget : `./${relativeTarget}`;
+  return `file:${withDotPrefix}`;
+}
+
+function buildLocalSourceOverrides(rootDir) {
+  const packages = [...getWorkspacePackages(workspaceRoot).values()].filter(isPublishTarget);
+  return Object.fromEntries(
+    packages.map((pkg) => [pkg.name, toLocalFileDependency(rootDir, pkg.dir)]),
+  );
+}
+
+function applyLocalSourceOverrides(appDir) {
+  const packageJson = readPackageJson(appDir);
+  packageJson.pnpm = {
+    ...(packageJson.pnpm ?? {}),
+    overrides: buildLocalSourceOverrides(appDir),
+  };
+  writePackageJson(appDir, packageJson);
 }
 
 function assertExists(filePath, description) {
@@ -137,17 +172,20 @@ async function main() {
       "init",
       "--starter",
       "--yes",
+      "--skip-install",
       "--local-source-root",
       workspaceRoot,
     ], {
       shell: false,
     });
 
+    applyLocalSourceOverrides(generatedProjectRoot);
+    runIn(generatedProjectRoot, PNPM, ["install", "--ignore-workspace", "--no-frozen-lockfile"]);
+
     verifyStarterScaffold(generatedProjectRoot);
 
-    runIn(generatedProjectRoot, PNPM, [
-      "exec",
-      "--",
+    runIn(generatedProjectRoot, process.execPath, [
+      path.join(generatedProjectRoot, "scripts", "local-source-guard.mjs"),
       "ztd",
       "feature",
       "scaffold",
@@ -155,7 +193,9 @@ async function main() {
       "users",
       "--action",
       "insert",
-    ]);
+    ], {
+      shell: false,
+    });
     verifyFeatureScaffold(generatedProjectRoot);
 
     runIn(generatedProjectRoot, "docker", [
@@ -203,8 +243,10 @@ async function main() {
       dbPort: starterDbPort,
       commands: [
         "build:publish",
-        "ztd init --starter --yes --local-source-root <repo-root>",
-        "ztd feature scaffold --table users --action insert",
+        "ztd init --starter --yes --skip-install --local-source-root <repo-root>",
+        "write pnpm.overrides for local rawsql-ts workspace packages",
+        "pnpm install --ignore-workspace --no-frozen-lockfile",
+        "pnpm run ztd -- feature scaffold --table users --action insert",
         "docker run -d --rm --name generated-project-check-postgres -P postgres:18",
         "docker port generated-project-check-postgres 5432/tcp",
         "write .env with the mapped Postgres port",

--- a/scripts/verify-published-package-mode.mjs
+++ b/scripts/verify-published-package-mode.mjs
@@ -30,6 +30,17 @@ function ensureStandaloneWorkspaceRoot() {
   );
 }
 
+function syncStandaloneWorkspacePackageJson(overrides) {
+  writePackageJson(standalonePackageRoot, {
+    name: "published-package-check-standalone",
+    private: true,
+    version: "0.0.0",
+    pnpm: {
+      overrides,
+    },
+  });
+}
+
 function parseArgs(argv) {
   const options = {
     publishManifestPath: null,
@@ -481,15 +492,13 @@ function verifyPnpmStarterPath(packages) {
   ensureCleanDir(appDir);
 
   const tarballDependencies = createTarballDependencyMap(packages);
+  syncStandaloneWorkspacePackageJson(tarballDependencies);
   writePackageJson(appDir, {
     name: "pnpm-starter-path-check",
     private: true,
     version: "0.0.0",
     devDependencies: {
       "@rawsql-ts/ztd-cli": tarballDependencies["@rawsql-ts/ztd-cli"],
-    },
-    pnpm: {
-      overrides: tarballDependencies,
     },
   });
 
@@ -510,10 +519,6 @@ function verifyPnpmStarterPath(packages) {
       tarballDependencies[dependencyName] ?? version,
     ]),
   );
-  scaffoldPackageJson.pnpm = {
-    ...(scaffoldPackageJson.pnpm ?? {}),
-    overrides: tarballDependencies,
-  };
   assertNoWorkspaceProtocols(scaffoldPackageJson, "starter-scaffold");
 
   // Rebind workspace packages to the freshly packed tarballs so the scaffold install exercises the published manifests.
@@ -529,15 +534,13 @@ function verifyPnpmAdapterInstall(packages) {
   ensureCleanDir(appDir);
 
   const tarballDependencies = createTarballDependencyMap(packages);
+  syncStandaloneWorkspacePackageJson(tarballDependencies);
   writePackageJson(appDir, {
     name: "pnpm-adapter-path-check",
     private: true,
     version: "0.0.0",
     devDependencies: {
       "@rawsql-ts/ztd-cli": tarballDependencies["@rawsql-ts/ztd-cli"],
-    },
-    pnpm: {
-      overrides: tarballDependencies,
     },
   });
 
@@ -555,10 +558,6 @@ function verifyPnpmAdapterInstall(packages) {
   scaffoldPackageJson.devDependencies = {
     ...(scaffoldPackageJson.devDependencies ?? {}),
     "@rawsql-ts/adapter-node-pg": tarballDependencies["@rawsql-ts/adapter-node-pg"],
-  };
-  scaffoldPackageJson.pnpm = {
-    ...(scaffoldPackageJson.pnpm ?? {}),
-    overrides: tarballDependencies,
   };
   assertNoWorkspaceProtocols(scaffoldPackageJson, "adapter-scaffold");
 
@@ -575,15 +574,13 @@ function verifyPnpmTutorialModelGen(packages) {
   ensureCleanDir(appDir);
 
   const tarballDependencies = createTarballDependencyMap(packages);
+  syncStandaloneWorkspacePackageJson(tarballDependencies);
   writePackageJson(appDir, {
     name: "pnpm-tutorial-model-gen-check",
     private: true,
     version: "0.0.0",
     devDependencies: {
       "@rawsql-ts/ztd-cli": tarballDependencies["@rawsql-ts/ztd-cli"],
-    },
-    pnpm: {
-      overrides: tarballDependencies,
     },
   });
 
@@ -601,10 +598,6 @@ function verifyPnpmTutorialModelGen(packages) {
   scaffoldPackageJson.devDependencies = {
     ...(scaffoldPackageJson.devDependencies ?? {}),
     "@rawsql-ts/adapter-node-pg": tarballDependencies["@rawsql-ts/adapter-node-pg"],
-  };
-  scaffoldPackageJson.pnpm = {
-    ...(scaffoldPackageJson.pnpm ?? {}),
-    overrides: tarballDependencies,
   };
   assertNoWorkspaceProtocols(scaffoldPackageJson, "tutorial-model-gen-scaffold");
 


### PR DESCRIPTION
## Summary
- pin standalone pnpm verification to release-candidate tarballs at the workspace root
- re-run generated-project verification with local-source overrides after scaffold init
- execute the local-source guard via direct node invocation so Windows release verification does not break on spaced paths

## Verification
- `pnpm verify:generated-project-mode`
- `pnpm verify:published-package-mode`
- `pnpm --filter @rawsql-ts/ztd-cli exec vitest run --config vitest.config.ts tests/publishWorkflow.unit.test.ts`

## Merge Readiness
- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue:
Scoped checks run:
Why full baseline is not required:

## CLI Surface Migration
- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: This PR only adjusts release verification harnesses and their coverage. It does not change a customer-facing CLI contract.
Upgrade note:
Deprecation/removal plan or issue:
Docs/help/examples updated:
Release/changeset wording:

## Scaffold Contract Proof
- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: This PR does not change scaffold templates or generated output contracts. It only changes how release verification installs and executes the already-generated flows.
Non-edit assertion:
Fail-fast input-contract proof:
Generated-output viability proof:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Extended verification suite with new cases validating both generated-project and published-package verification flows, including checks for produced package manifests, install behavior, and local-source guard execution.

* **Chores**
  * Updated generated-project initialization to skip automatic install, apply local dependency overrides, then run an explicit install.
  * Improved synchronization of workspace package data used during publication verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->