### PR TITLE
Add SSSQL list/remove authoring flow and reference docs

### DIFF
--- a/.changeset/sssql-cli-reference-and-remove-all.md
+++ b/.changeset/sssql-cli-reference-and-remove-all.md
@@ -1,0 +1,10 @@
+---
+"rawsql-ts": minor
+"@rawsql-ts/ztd-cli": minor
+---
+
+Expand SSSQL authoring and inspection across the core library and `ztd-cli`.
+
+`ztd query sssql` now supports `list`, `remove`, `remove --all`, richer scalar operators, and structured `EXISTS` / `NOT EXISTS` scaffold input with preview-friendly rewrite flows. The CLI also fails fast when a rewrite would drop existing SQL comments.
+
+`rawsql-ts` now exposes the branch metadata and removal helpers needed to inspect, remove, and bulk-remove recognized SSSQL branches while keeping runtime pruning explicit through `optionalConditionParameters`.

--- a/docs/dogfooding/dynamic-filter-routing.md
+++ b/docs/dogfooding/dynamic-filter-routing.md
@@ -1,6 +1,6 @@
 # Dynamic Filter Routing Dogfooding
 
-This scenario preserves the routing rule between `DynamicQueryBuilder` optional filters and `SSSQL` optional branches.
+This scenario preserves the routing rule between binding existing mandatory placeholders and authoring new `SSSQL` optional branches.
 
 ## Use this scenario when
 
@@ -13,8 +13,8 @@ Use this scenario when a prompt sounds like:
 ## Happy-path routing
 
 1. Check whether the requested filter only touches columns already available in the current query.
-2. If yes, prefer `DynamicQueryBuilder` filter injection.
-3. If the filter needs a table or branch the query does not already contain, switch to `SSSQL`.
+2. If the predicate already exists in SQL, bind the existing placeholder only.
+3. If the request would add a new removable condition, switch to `SSSQL`.
 4. Keep hardcoded predicates mandatory unless the SQL explicitly authors a removable SSSQL branch.
 5. Use `optionalConditionParameters` only for those explicitly removable branches.
 
@@ -27,6 +27,6 @@ Use this scenario when a prompt sounds like:
 
 ## What this scenario protects
 
-- AI chooses `DynamicQueryBuilder` before SSSQL for ordinary optional filters.
+- AI does not recommend runtime injection of new optional predicates.
 - AI switches to SSSQL when a filter needs tables that are not already in the query.
 - Mandatory hardcoded predicates are not confused with removable SSSQL branches.

--- a/docs/guide/dynamic-filter-routing.md
+++ b/docs/guide/dynamic-filter-routing.md
@@ -5,29 +5,33 @@ outline: deep
 
 # Dynamic Filter Routing
 
-Use this guide when the request is "add an optional search condition" and you need to decide whether the first move is **DynamicQueryBuilder filter injection** or **SSSQL optional-branch authoring**.
+Use this guide when the request is "add an optional search condition" and you need to decide whether the first move is **binding an existing mandatory placeholder** or **authoring a truthful SSSQL optional branch**.
 
-## Start with DynamicQueryBuilder when
+## Start with existing placeholder binding when
 
-Choose `DynamicQueryBuilder` filter injection first when all of the following are true:
+Choose `DynamicQueryBuilder` placeholder binding first when all of the following are true:
 
-- the optional predicate targets a column that already belongs to the current query graph
-- the base SQL already joins every table needed for the filter
-- the request is ordinary runtime filtering rather than SQL-shape branching
+- the predicate already exists in SQL as a mandatory placeholder-driven condition
+- the caller only needs to provide runtime values for that existing condition
+- no new removable SQL branch needs to be authored
 
 In that path, hardcoded predicates already present in SQL remain mandatory predicates.
-Filters passed through `filter` are optional runtime additions and are ignored when the caller omits them.
+`filter` may still bind existing placeholders, but it no longer injects new optional predicates at runtime.
 
 ## Escalate to SSSQL when
 
-Choose SSSQL when the optional condition needs SQL that `DynamicQueryBuilder` cannot truthfully inject by column matching alone.
+Choose SSSQL when the request would otherwise require inventing a new SQL fragment outside the saved SQL asset.
 Typical examples are:
 
 - the filter needs a table that the query does not otherwise reference
-- the optional condition needs an `EXISTS` branch or other removable SQL fragment
+- the optional condition needs an `EXISTS` / `NOT EXISTS` branch or other removable SQL fragment
 - the query should stay truthful in one SQL file instead of relying on out-of-band string assembly
 
-SSSQL is the fallback that covers removable branches such as `(:category_name IS NULL OR EXISTS (...))`.
+SSSQL covers removable branches such as:
+
+- `(:category_name IS NULL OR EXISTS (...))`
+- `(:archived_name IS NULL OR NOT EXISTS (...))`
+- `(:product_name IS NULL OR product_name ILIKE :product_name)`
 
 ## Mandatory vs removable predicates
 
@@ -45,18 +49,19 @@ That means these two statements can both be true without contradiction:
 
 | Request shape | First choice | Why |
 | --- | --- | --- |
-| Add an optional filter on a column already present in the current query | `DynamicQueryBuilder` `filter` | Lowest-friction path; no SQL shape change required |
-| Add an optional filter that needs a table or branch not present in the current query | SSSQL + `optionalConditionParameters` | Keeps the optional branch truthful in SQL |
 | Bind an already hardcoded mandatory parameter | `filter` binding of existing placeholders | Preserves the SQL's required predicate |
+| Add an optional filter on a column already present in the current query | SSSQL authoring | Runtime no longer injects new optional predicates |
+| Add an optional filter that needs a table or branch not present in the current query | SSSQL + `optionalConditionParameters` | Keeps the optional branch truthful in SQL |
 | Remove a branch when the caller passes `null` / `undefined` | SSSQL + `optionalConditionParameters` | Prunes only explicitly targeted optional branches |
 
 ## Recommended authoring loop
 
 1. Ask whether the requested filter only touches columns already present in the query.
-2. If yes, prefer `DynamicQueryBuilder` filter injection.
-3. If no, author the missing optional branch in SQL with SSSQL.
+2. If the predicate already exists in SQL, bind its required placeholders only.
+3. Otherwise, author the missing optional branch in SQL with SSSQL.
 4. Keep hardcoded required predicates separate from removable optional branches.
-5. Add or update the focused unit test that proves the routing choice.
+5. Use `ztd query sssql list` to inspect authored branches and `ztd query sssql remove --preview` when cleaning them up.
+6. Add or update the focused unit test that proves the routing choice.
 
 ## Related guides
 

--- a/docs/guide/feature-index.md
+++ b/docs/guide/feature-index.md
@@ -73,6 +73,7 @@ An at-a-glance index of easy-to-miss but important capabilities across the rawsq
 | SSSQL for Humans | [guide/sssql-for-humans](./sssql-for-humans.md) | Understand why SSSQL exists, where it fits, and how it complements DynamicQueryBuilder |
 | Dynamic Filter Routing | [guide/dynamic-filter-routing](./dynamic-filter-routing.md) | Decide whether DynamicQueryBuilder filters or SSSQL optional branches should be the first move |
 | ztd-cli SSSQL Authoring | [guide/ztd-cli-sssql-authoring](./ztd-cli-sssql-authoring.md) | Keep optional-condition requests on the SQL-first path while authoring ZTD SQL assets |
+| ztd-cli SSSQL Reference | [guide/ztd-cli-sssql-reference](./ztd-cli-sssql-reference.md) | Look up `list`, `scaffold`, `remove`, `refresh`, supported operators, and runtime pruning |
 | ztd-cli Agent Interface | [guide/ztd-cli-agent-interface](./ztd-cli-agent-interface.md) | Machine-readable CLI usage for automation and AI agents |
 | ztd-cli spawn EPERM investigation | [dogfooding/ztd-cli-spawn-eperm-investigation](../dogfooding/ztd-cli-spawn-eperm-investigation.md) | Review the local Vitest startup blocker before treating Issue #685 acceptance items as done |
 | ztd describe schema | [guide/ztd-cli-describe-schema](./ztd-cli-describe-schema.md) | Contract details for `ztd describe` JSON payloads |

--- a/docs/guide/sssql-optional-branch-pruning.md
+++ b/docs/guide/sssql-optional-branch-pruning.md
@@ -22,8 +22,12 @@ Supported branch forms:
 (:p IS NULL OR EXISTS (... :p ...))
 ```
 
-Scalar predicates currently accept the standard comparison operators handled by the matcher.
-`EXISTS` branches are only eligible when the subquery references the same parameter and no additional parameters appear in that branch.
+```sql
+(:p IS NULL OR NOT EXISTS (... :p ...))
+```
+
+Scalar predicates currently accept the comparison and match operators handled by the matcher.
+`EXISTS` / `NOT EXISTS` branches are only eligible when the subquery references the same parameter and no additional parameters appear in that branch.
 
 ## Unsupported syntax shapes
 

--- a/docs/guide/ztd-cli-sssql-authoring.md
+++ b/docs/guide/ztd-cli-sssql-authoring.md
@@ -5,7 +5,7 @@ outline: deep
 
 # ztd-cli SSSQL Authoring
 
-`ztd-cli` does not execute or rewrite SQL by itself, but it is part of the authoring loop that decides what kind of SQL gets saved under `src/sql/`.
+`ztd-cli` does not execute application SQL by itself, but it is part of the authoring loop that decides what kind of SQL gets saved under `src/sql/`.
 
 When the request is "add an optional filter" or "make this condition optional", prefer **SSSQL** before falling back to string-built SQL assembly outside the SQL file.
 
@@ -45,6 +45,15 @@ const query = builder.buildQuery(sql, {
   },
 });
 ```
+
+When the optional branch is already authored, the CLI can help inspect or undo it:
+
+```bash
+ztd query sssql list src/sql/products/list_products.sql
+ztd query sssql remove src/sql/products/list_products.sql --parameter category_name --preview
+```
+
+If the current rewrite would drop existing SQL comments, the command should fail fast instead of silently writing a damaged file.
 
 ## When to choose SSSQL first
 
@@ -133,14 +142,17 @@ When an AI or scripted caller receives requests like these, the first response s
 A good response shape is:
 
 1. edit the SQL asset with truthful optional predicates
-2. rerun `ztd model-gen --probe-mode ztd` if the contract changed
-3. rerun `ztd lint` and tests
-4. wire `optionalConditionParameters` only for branch pruning
+2. use `ztd query sssql scaffold`, `ztd query sssql list`, or `ztd query sssql remove --preview` when that shortens the authoring loop safely
+3. rerun `ztd model-gen --probe-mode ztd` if the contract changed
+4. rerun `ztd lint` and tests
+5. wire `optionalConditionParameters` only for branch pruning
 
 Do not steer these requests toward string-built `WHERE` concatenation or redundant `LEFT JOIN` scaffolding plus later cleanup.
+Do not suggest runtime optional predicate injection as if `DynamicQueryBuilder` still synthesizes new filter branches from `filter`.
 
 ## Read next
 
+- [ztd-cli SSSQL Reference](./ztd-cli-sssql-reference.md)
 - [What Is SSSQL?](./sssql-overview.md)
 - [SSSQL Optional Branch Pruning MVP](./sssql-optional-branch-pruning.md)
 - [Querybuilding Recipes](./querybuilding-recipes.md)

--- a/docs/guide/ztd-cli-sssql-reference.md
+++ b/docs/guide/ztd-cli-sssql-reference.md
@@ -1,0 +1,294 @@
+---
+title: ztd-cli SSSQL Reference
+outline: deep
+---
+
+# ztd-cli SSSQL Reference
+
+This page is the single reference for the `ztd query sssql ...` command family and the matching runtime pruning contract in `rawsql-ts`.
+
+Use it when you need to answer questions like:
+
+- Which command adds an optional branch?
+- How do I inspect authored branches before removing one?
+- What is the difference between `scaffold`, `remove`, and `refresh`?
+- Which operators and branch kinds are supported?
+
+For the conceptual introduction, read [What Is SSSQL?](./sssql-overview.md).
+For authoring guidance, read [ztd-cli SSSQL Authoring](./ztd-cli-sssql-authoring.md).
+
+## Command Summary
+
+| Command | What it does | Typical use |
+|---|---|---|
+| `ztd query sssql list <sqlFile>` | Inspect supported authored SSSQL branches in a SQL file | Confirm what is present before `remove` or `refresh` |
+| `ztd query sssql scaffold <sqlFile> ...` | Add one supported optional branch | Add a scalar or `EXISTS` / `NOT EXISTS` optional condition |
+| `ztd query sssql remove <sqlFile> ...` | Remove one supported authored branch | Undo a scaffold or clean up an old optional condition |
+| `ztd query sssql refresh <sqlFile>` | Re-anchor supported branches near the closest source query without changing predicate meaning | Re-run after query edits moved the best insertion point |
+
+All rewriting commands support `--preview`, which emits a unified diff instead of writing the file.
+
+## `list`
+
+Use `list` to inspect the branches the CLI can currently recognize and manage safely.
+
+```bash
+ztd query sssql list src/sql/products/list_products.sql
+ztd query sssql list src/sql/products/list_products.sql --format json
+```
+
+`list` is the safest first step before `remove`, and it is also useful for machine-readable automation.
+
+Supported branch kinds currently reported by `list`:
+
+- `scalar`
+- `exists`
+- `not-exists`
+- `expression`
+
+The output includes branch metadata such as `parameterName`, `kind`, and, when available, operator or target details.
+
+### Sample text output
+
+```text
+1. parameter: brand_name
+   kind: scalar
+   operator: =
+   target: p.brand_name
+   sql: (:brand_name is null or "p"."brand_name" = :brand_name)
+2. parameter: category_name
+   kind: exists
+   sql: (:category_name is null or exists (select 1 from "product_categories" as "pc" where "pc"."product_id" = "p"."product_id" and "pc"."category_name" = :category_name))
+```
+
+### Sample JSON output
+
+```json
+{
+  "command": "query sssql list",
+  "ok": true,
+  "data": {
+    "file": "src/sql/products/list_products.sql",
+    "branch_count": 2,
+    "branches": [
+      {
+        "index": 1,
+        "parameterName": "brand_name",
+        "kind": "scalar",
+        "operator": "=",
+        "target": "p.brand_name",
+        "sql": "(:brand_name is null or \"p\".\"brand_name\" = :brand_name)"
+      },
+      {
+        "index": 2,
+        "parameterName": "category_name",
+        "kind": "exists",
+        "operator": null,
+        "target": null,
+        "sql": "(:category_name is null or exists (...))"
+      }
+    ]
+  }
+}
+```
+
+If you only need the recognized parameter names, extract `branches[].parameterName` from the JSON output.
+
+## `scaffold`
+
+Use `scaffold` to add one supported optional branch to the closest query scope that owns the target columns.
+
+### Scalar scaffold
+
+```bash
+ztd query sssql scaffold src/sql/products/list_products.sql \
+  --filter p.brand_name \
+  --parameter brand_name \
+  --operator =
+```
+
+Supported scalar operators:
+
+- `=`
+- `<>`
+- `!=`
+- `<`
+- `<=`
+- `>`
+- `>=`
+- `like`
+- `ilike`
+
+Notes:
+
+- `<>` is the normalized SQL form.
+- `!=` is accepted as input and normalized to `<>`.
+- `ilike` is a PostgreSQL-specific extension, not SQL standard.
+
+### `EXISTS` / `NOT EXISTS` scaffold
+
+Use structured scaffold input when the optional condition depends on a table that is not already filtered directly in the outer `FROM` graph.
+
+```bash
+ztd query sssql scaffold src/sql/products/list_products.sql \
+  --parameter category_name \
+  --kind exists \
+  --query-file tmp/category_exists.sql \
+  --anchor-column p.product_id
+```
+
+```bash
+ztd query sssql scaffold src/sql/products/list_products.sql \
+  --parameter category_name \
+  --kind not-exists \
+  --query "select 1 from public.product_categories pc where pc.product_id = $c0 and pc.category_name = :category_name" \
+  --anchor-column p.product_id
+```
+
+Structured `EXISTS` / `NOT EXISTS` contract:
+
+- Pass exactly one subquery via `--query` or `--query-file`
+- Use `--kind exists` or `--kind not-exists`
+- Provide one or more `--anchor-column` values
+- Reference anchor columns inside the subquery as `$c0`, `$c1`, and so on
+- Keep the subquery to one statement only
+
+The CLI rewrites `$c0`, `$c1`, and similar placeholders to the resolved outer column expressions before inserting the branch.
+
+### Preview mode
+
+Use `--preview` whenever you want to inspect the diff before writing:
+
+```bash
+ztd query sssql scaffold src/sql/products/list_products.sql \
+  --filter p.brand_name \
+  --parameter brand_name \
+  --operator ilike \
+  --preview
+```
+
+### JSON mode
+
+Automation can use `--json` instead of many flags:
+
+```bash
+ztd query sssql scaffold src/sql/products/list_products.sql --json '{
+  "parameter": "category_name",
+  "kind": "exists",
+  "query": "select 1 from public.product_categories pc where pc.product_id = $c0 and pc.category_name = :category_name",
+  "anchorColumns": ["p.product_id"]
+}'
+```
+
+## `remove`
+
+Use `remove` to delete one supported optional branch safely.
+
+```bash
+ztd query sssql remove src/sql/products/list_products.sql --parameter category_name
+ztd query sssql remove src/sql/products/list_products.sql --parameter category_name --preview
+```
+
+### Required input
+
+`remove` requires either:
+
+- `<sqlFile>` and `--parameter <name>`
+- `<sqlFile>` and `--all`
+
+Primary identity is `--parameter`.
+When one parameter could match more than one branch, narrow the target with one or more of:
+
+- `--kind`
+- `--operator`
+- `--target`
+
+Example:
+
+```bash
+ztd query sssql remove src/sql/products/list_products.sql \
+  --parameter brand_name \
+  --kind scalar \
+  --operator <>
+```
+
+### What `remove` can remove
+
+`remove` removes one branch that the CLI can already recognize through `list`.
+
+- If `list` shows the branch, `remove` can target it
+- If `list` does not show the branch, `remove` does not manage it safely
+
+`remove` is idempotent.
+If the matching branch is already absent, the command becomes a no-op instead of damaging the query.
+
+### Remove all branches at once
+
+Use `--all` to remove every recognized SSSQL branch in the query:
+
+```bash
+ztd query sssql remove src/sql/products/list_products.sql --all
+ztd query sssql remove src/sql/products/list_products.sql --all --preview
+```
+
+Rules for `--all`:
+
+- it removes every branch that `list` can recognize
+- it is idempotent
+- use it by itself
+- do not combine it with `--parameter`, `--kind`, `--operator`, or `--target`
+
+This keeps bulk removal explicit and avoids accidental over-broad deletes from a partially specified targeted remove command.
+
+## `refresh`
+
+Use `refresh` after query edits changed the closest correct query scope for an authored SSSQL branch.
+
+```bash
+ztd query sssql refresh src/sql/products/list_products.sql
+ztd query sssql refresh src/sql/products/list_products.sql --preview
+```
+
+`refresh` does not invent new optional predicates.
+It only repositions supported authored branches so they stay attached to the best matching query block after query structure changes.
+
+## Safety Rules
+
+These commands are intentionally strict.
+
+- Repeated scaffold with the same semantic input is idempotent and does not duplicate the branch
+- Repeated remove is idempotent and becomes a no-op when the branch is already gone
+- Ambiguous remove or unsafe scaffold input fails fast
+- `EXISTS` / `NOT EXISTS` scaffold rejects empty SQL, semicolons, multiple statements, and `LATERAL`
+- If a rewrite would drop existing SQL comments, the command fails instead of silently writing a damaged file
+
+The goal is to prefer an explicit error over a quietly corrupted SQL file.
+
+## Runtime API
+
+The CLI authors the optional branch into the SQL file.
+Runtime behavior is still controlled explicitly by `optionalConditionParameters`.
+
+```ts
+const query = builder.buildQuery(sql, {
+  optionalConditionParameters: {
+    brand_name: input.brandName ?? null,
+    category_name: input.categoryName ?? null,
+  },
+});
+```
+
+Pruning rules:
+
+- present value: keep the branch
+- `null` or `undefined`: prune the optional branch
+- omit `optionalConditionParameters`: do not run pruning
+
+This means the CLI is for authoring, while runtime pruning is still an explicit application-level choice.
+
+## Choosing The Right Document
+
+- Concept and tradeoffs: [What Is SSSQL?](./sssql-overview.md)
+- SQL-first authoring workflow: [ztd-cli SSSQL Authoring](./ztd-cli-sssql-authoring.md)
+- Runtime pruning rules: [SSSQL Optional Branch Pruning MVP](./sssql-optional-branch-pruning.md)
+- Dynamic-vs-SSSQL decision: [Dynamic Filter Routing](./dynamic-filter-routing.md)

--- a/packages/core/src/transformers/SSSQLFilterBuilder.ts
+++ b/packages/core/src/transformers/SSSQLFilterBuilder.ts
@@ -4,15 +4,20 @@ import {
     BinaryExpression,
     ColumnReference,
     IdentifierString,
+    InlineQuery,
     LiteralValue,
     ParameterExpression,
     ParenExpression,
+    RawString,
+    UnaryExpression,
     type ValueComponent
 } from "../models/ValueComponent";
 import { SelectQueryParser } from "../parsers/SelectQueryParser";
 import { UpstreamSelectQueryFinder } from "./UpstreamSelectQueryFinder";
 import { SelectableColumnCollector, DuplicateDetectionMode } from "./SelectableColumnCollector";
 import { ColumnReferenceCollector } from "./ColumnReferenceCollector";
+import { ParameterCollector } from "./ParameterCollector";
+import { SqlFormatter } from "./SqlFormatter";
 import {
     collectSupportedOptionalConditionBranches,
     type SupportedOptionalConditionBranch
@@ -21,9 +26,45 @@ import {
 export type SSSQLFilterValue = unknown;
 export type SSSQLFilterInput = Record<string, SSSQLFilterValue>;
 export type SssqlScaffoldFilters = SSSQLFilterInput;
+export type SssqlScalarOperator = "=" | "<>" | "<" | "<=" | ">" | ">=" | "like" | "ilike";
+export type SssqlScalarOperatorInput = SssqlScalarOperator | "!=";
+export type SssqlBranchKind = "scalar" | "exists" | "not-exists" | "expression";
 
 export interface SssqlTransformResult {
     query: SelectQuery;
+}
+
+export interface SssqlBranchInfo {
+    parameterName: string;
+    kind: SssqlBranchKind;
+    operator?: SssqlScalarOperator;
+    target?: string;
+    query: SimpleSelectQuery;
+    expression: ValueComponent;
+    sql: string;
+}
+
+export interface SssqlScalarScaffoldSpec {
+    kind?: "scalar";
+    target: string;
+    parameterName?: string;
+    operator?: SssqlScalarOperatorInput;
+}
+
+export interface SssqlExistsScaffoldSpec {
+    kind: "exists" | "not-exists";
+    parameterName: string;
+    query: string;
+    anchorColumns: string[];
+}
+
+export type SssqlScaffoldSpec = SssqlScalarScaffoldSpec | SssqlExistsScaffoldSpec;
+
+export interface SssqlRemoveSpec {
+    parameterName: string;
+    kind?: SssqlBranchKind;
+    operator?: SssqlScalarOperatorInput;
+    target?: string;
 }
 
 interface ResolvedFilterTarget {
@@ -37,10 +78,36 @@ interface ParsedFilterName {
     column: string;
 }
 
+const formatter = new SqlFormatter();
+const SUPPORTED_SCALAR_OPERATORS = new Set<SssqlScalarOperator>(["=", "<>", "<", "<=", ">", ">=", "like", "ilike"]);
+
 const normalizeIdentifier = (value: string): string => value.trim().toLowerCase();
+
+const normalizeSql = (value: string): string => value.replace(/\s+/g, " ").trim().toLowerCase();
 
 const normalizeColumnReferenceKey = (reference: ColumnReference): string => {
     return `${normalizeIdentifier(reference.getNamespace())}.${normalizeIdentifier(reference.column.name)}`;
+};
+
+const normalizeColumnReferenceText = (reference: ColumnReference): string => {
+    const namespace = reference.getNamespace();
+    return namespace ? `${namespace}.${reference.column.name}` : reference.column.name;
+};
+
+const normalizeScalarOperator = (value: SssqlScalarOperatorInput | undefined): SssqlScalarOperator => {
+    if (!value) {
+        return "=";
+    }
+
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "!=") {
+        return "<>";
+    }
+    if (SUPPORTED_SCALAR_OPERATORS.has(normalized as SssqlScalarOperator)) {
+        return normalized as SssqlScalarOperator;
+    }
+
+    throw new Error(`Unsupported SSSQL operator '${value}'.`);
 };
 
 const isExplicitEqualityScaffoldValue = (value: unknown): boolean => {
@@ -81,35 +148,94 @@ const makeParameterName = (filterName: string): string => {
         .replace(/[^a-zA-Z0-9_]/g, "_");
 };
 
-const buildOptionalEqualityBranch = (column: ColumnReference, parameterName: string): ValueComponent => {
-    const parameter = new ParameterExpression(parameterName);
+const unwrapParens = (expression: ValueComponent): ValueComponent => {
+    let candidate = expression;
+    while (candidate instanceof ParenExpression) {
+        candidate = candidate.expression;
+    }
+    return candidate;
+};
+
+const isBinaryOperator = (expression: ValueComponent, operator: string): expression is BinaryExpression => {
+    return expression instanceof BinaryExpression && expression.operator.value.trim().toLowerCase() === operator;
+};
+
+const collectTopLevelAndTerms = (expression: ValueComponent): ValueComponent[] => {
+    const candidate = unwrapParens(expression);
+    if (!isBinaryOperator(candidate, "and")) {
+        return [expression];
+    }
+
+    return [
+        ...collectTopLevelAndTerms(candidate.left),
+        ...collectTopLevelAndTerms(candidate.right)
+    ];
+};
+
+const collectTopLevelOrTerms = (expression: ValueComponent): ValueComponent[] => {
+    const candidate = unwrapParens(expression);
+    if (!isBinaryOperator(candidate, "or")) {
+        return [expression];
+    }
+
+    return [
+        ...collectTopLevelOrTerms(candidate.left),
+        ...collectTopLevelOrTerms(candidate.right)
+    ];
+};
+
+const getGuardedParameterName = (expression: ValueComponent): string | null => {
+    const candidate = unwrapParens(expression);
+    if (!isBinaryOperator(candidate, "is")) {
+        return null;
+    }
+
+    if (!(candidate.left instanceof ParameterExpression)) {
+        return null;
+    }
+
+    const right = unwrapParens(candidate.right);
+    const isNull = (right instanceof LiteralValue && right.value === null)
+        || (right instanceof RawString && right.value.trim().toLowerCase() === "null");
+    if (!isNull) {
+        return null;
+    }
+
+    return candidate.left.name.value;
+};
+
+const buildOptionalScalarBranch = (
+    column: ColumnReference,
+    parameterName: string,
+    operator: SssqlScalarOperator
+): ValueComponent => {
     const guard = new BinaryExpression(new ParameterExpression(parameterName), "is", new LiteralValue(null));
-    const equality = new BinaryExpression(
+    const predicate = new BinaryExpression(
         new ColumnReference(column.getNamespace() || null, column.column.name),
-        "=",
-        parameter
+        operator,
+        new ParameterExpression(parameterName)
     );
-    return new ParenExpression(new BinaryExpression(guard, "or", equality));
+    return new ParenExpression(new BinaryExpression(guard, "or", predicate));
+};
+
+const buildOptionalExistsBranch = (
+    parameterName: string,
+    subquery: SelectQuery,
+    kind: "exists" | "not-exists"
+): ValueComponent => {
+    const guard = new BinaryExpression(new ParameterExpression(parameterName), "is", new LiteralValue(null));
+    const existsExpression = new UnaryExpression("exists", new InlineQuery(subquery));
+    const predicate = kind === "exists"
+        ? existsExpression
+        : new UnaryExpression("not", existsExpression);
+
+    return new ParenExpression(new BinaryExpression(guard, "or", predicate));
 };
 
 const rebuildWhereWithoutTerm = (query: SimpleSelectQuery, termToRemove: ValueComponent): void => {
     if (!query.whereClause) {
         return;
     }
-
-    const collectTopLevelAndTerms = (expression: ValueComponent): ValueComponent[] => {
-        if (
-            expression instanceof BinaryExpression &&
-            expression.operator.value.trim().toLowerCase() === "and"
-        ) {
-            return [
-                ...collectTopLevelAndTerms(expression.left),
-                ...collectTopLevelAndTerms(expression.right)
-            ];
-        }
-
-        return [expression];
-    };
 
     const terms = collectTopLevelAndTerms(query.whereClause.condition).filter(term => term !== termToRemove);
     if (terms.length === 0) {
@@ -125,6 +251,150 @@ const rebuildWhereWithoutTerm = (query: SimpleSelectQuery, termToRemove: ValueCo
     query.whereClause = new WhereClause(rebuilt);
 };
 
+const formatSqlComponent = (component: ValueComponent | SelectQuery): string => {
+    return formatter.format(component).formattedSql;
+};
+
+const enforceSubqueryConstraints = (sql: string): void => {
+    if (!sql.trim()) {
+        throw new Error("SSSQL EXISTS/NOT EXISTS scaffold query must not be empty.");
+    }
+    if (sql.includes(";")) {
+        throw new Error("SSSQL EXISTS/NOT EXISTS scaffold query must not contain semicolons or multiple statements.");
+    }
+    if (/\blateral\b/i.test(sql)) {
+        throw new Error("LATERAL is not supported in SSSQL EXISTS/NOT EXISTS scaffold.");
+    }
+};
+
+const substituteAnchorPlaceholders = (sql: string, formattedColumns: string[]): string => {
+    const usedIndexes = new Set<number>();
+    const replaced = sql.replace(/\$c(\d+)/g, (_, indexDigits) => {
+        const index = Number(indexDigits);
+        if (!Number.isInteger(index)) {
+            throw new Error(`Invalid placeholder '$c${indexDigits}' in SSSQL scaffold query.`);
+        }
+        if (index < 0 || index >= formattedColumns.length) {
+            throw new Error(`Placeholder '$c${index}' references a missing SSSQL scaffold anchor column.`);
+        }
+        usedIndexes.add(index);
+        return formattedColumns[index]!;
+    });
+
+    if (formattedColumns.length === 0) {
+        return replaced;
+    }
+
+    for (let index = 0; index < formattedColumns.length; index += 1) {
+        if (!usedIndexes.has(index)) {
+            throw new Error(`Missing placeholder '$c${index}' for SSSQL scaffold anchor column.`);
+        }
+    }
+
+    return replaced;
+};
+
+const getScalarBranchDetails = (
+    expression: ValueComponent,
+    parameterName: string
+): { operator: SssqlScalarOperator; target: string } | null => {
+    const meaningfulTerms = collectTopLevelOrTerms(expression)
+        .filter(term => getGuardedParameterName(term) !== parameterName);
+
+    if (meaningfulTerms.length !== 1) {
+        return null;
+    }
+
+    const predicate = unwrapParens(meaningfulTerms[0]!);
+    if (!(predicate instanceof BinaryExpression)) {
+        return null;
+    }
+
+    const operator = normalizeScalarOperator(predicate.operator.value as SssqlScalarOperatorInput);
+    const left = unwrapParens(predicate.left);
+    const right = unwrapParens(predicate.right);
+
+    if (left instanceof ColumnReference && right instanceof ParameterExpression && right.name.value === parameterName) {
+        return {
+            operator,
+            target: normalizeColumnReferenceText(left)
+        };
+    }
+
+    if (right instanceof ColumnReference && left instanceof ParameterExpression && left.name.value === parameterName) {
+        return {
+            operator,
+            target: normalizeColumnReferenceText(right)
+        };
+    }
+
+    return null;
+};
+
+const getExistsBranchKind = (
+    expression: ValueComponent,
+    parameterName: string
+): "exists" | "not-exists" | null => {
+    const meaningfulTerms = collectTopLevelOrTerms(expression)
+        .filter(term => getGuardedParameterName(term) !== parameterName);
+
+    if (meaningfulTerms.length !== 1) {
+        return null;
+    }
+
+    const predicate = unwrapParens(meaningfulTerms[0]!);
+    if (predicate instanceof UnaryExpression && predicate.operator.value.trim().toLowerCase() === "exists") {
+        return predicate.expression instanceof InlineQuery ? "exists" : null;
+    }
+
+    if (
+        predicate instanceof UnaryExpression &&
+        predicate.operator.value.trim().toLowerCase() === "not" &&
+        unwrapParens(predicate.expression) instanceof UnaryExpression
+    ) {
+        const nested = unwrapParens(predicate.expression) as UnaryExpression;
+        if (nested.operator.value.trim().toLowerCase() === "exists" && nested.expression instanceof InlineQuery) {
+            return "not-exists";
+        }
+    }
+
+    return null;
+};
+
+const getBranchInfo = (branch: SupportedOptionalConditionBranch): SssqlBranchInfo => {
+    const scalar = getScalarBranchDetails(branch.expression, branch.parameterName);
+    if (scalar) {
+        return {
+            parameterName: branch.parameterName,
+            kind: "scalar",
+            operator: scalar.operator,
+            target: scalar.target,
+            query: branch.query,
+            expression: branch.expression,
+            sql: formatSqlComponent(branch.expression)
+        };
+    }
+
+    const existsKind = getExistsBranchKind(branch.expression, branch.parameterName);
+    if (existsKind) {
+        return {
+            parameterName: branch.parameterName,
+            kind: existsKind,
+            query: branch.query,
+            expression: branch.expression,
+            sql: formatSqlComponent(branch.expression)
+        };
+    }
+
+    return {
+        parameterName: branch.parameterName,
+        kind: "expression",
+        query: branch.query,
+        expression: branch.expression,
+        sql: formatSqlComponent(branch.expression)
+    };
+};
+
 /**
  * Builds and refreshes truthful SSSQL optional filter branches.
  * Runtime callers should use pruning, not dynamic predicate injection.
@@ -136,20 +406,40 @@ export class SSSQLFilterBuilder {
         this.finder = new UpstreamSelectQueryFinder(this.tableColumnResolver);
     }
 
+    list(query: SelectQuery | string): SssqlBranchInfo[] {
+        const parsed = this.parseQuery(query);
+        return collectSupportedOptionalConditionBranches(parsed).map(getBranchInfo);
+    }
+
     scaffold(query: SelectQuery | string, filters: SSSQLFilterInput): SelectQuery {
         const parsed = this.parseQuery(query);
 
         for (const [filterName, filterValue] of Object.entries(filters)) {
             if (!isExplicitEqualityScaffoldValue(filterValue)) {
                 throw new Error(
-                    `SSSQL scaffold only supports equality filters in v1. Use refresh for pre-authored branches: '${filterName}'.`
+                    `SSSQL scaffold only supports equality filters in v1. Use structured scaffold or refresh for pre-authored branches: '${filterName}'.`
                 );
             }
 
-            const target = this.resolveTarget(parsed, filterName);
-            target.query.appendWhere(buildOptionalEqualityBranch(target.column, target.parameterName));
+            this.scaffoldBranch(parsed, {
+                target: filterName,
+                parameterName: makeParameterName(filterName),
+                operator: "="
+            });
         }
 
+        return parsed;
+    }
+
+    scaffoldBranch(query: SelectQuery | string, spec: SssqlScaffoldSpec): SelectQuery {
+        const parsed = this.parseQuery(query);
+
+        if (spec.kind === "exists" || spec.kind === "not-exists") {
+            this.scaffoldExistsBranch(parsed, spec as SssqlExistsScaffoldSpec);
+            return parsed;
+        }
+
+        this.scaffoldScalarBranch(parsed, spec as SssqlScalarScaffoldSpec);
         return parsed;
     }
 
@@ -168,7 +458,11 @@ export class SSSQLFilterBuilder {
                     );
                 }
 
-                target.query.appendWhere(buildOptionalEqualityBranch(target.column, target.parameterName));
+                this.scaffoldScalarBranch(parsed, {
+                    target: filterName,
+                    parameterName: target.parameterName,
+                    operator: "="
+                });
                 continue;
             }
 
@@ -193,8 +487,117 @@ export class SSSQLFilterBuilder {
         return parsed;
     }
 
+    remove(query: SelectQuery | string, spec: SssqlRemoveSpec): SelectQuery {
+        const parsed = this.parseQuery(query);
+        const matches = this.findMatchingBranchInfos(parsed, spec);
+
+        if (matches.length === 0) {
+            return parsed;
+        }
+
+        if (matches.length > 1) {
+            throw new Error(`Multiple SSSQL branches matched parameter ':${spec.parameterName}'. Remove is ambiguous.`);
+        }
+
+        const [match] = matches;
+        if (!match) {
+            return parsed;
+        }
+
+        rebuildWhereWithoutTerm(match.query, match.expression);
+        return parsed;
+    }
+
+    removeAll(query: SelectQuery | string): SelectQuery {
+        const parsed = this.parseQuery(query);
+        const matches = this.list(parsed);
+
+        for (const match of matches) {
+            rebuildWhereWithoutTerm(match.query, match.expression);
+        }
+
+        return parsed;
+    }
+
     private parseQuery(query: SelectQuery | string): SelectQuery {
         return typeof query === "string" ? SelectQueryParser.parse(query) : query;
+    }
+
+    private findMatchingBranchInfos(root: SelectQuery, spec: SssqlRemoveSpec): SssqlBranchInfo[] {
+        const normalizedOperator = spec.operator ? normalizeScalarOperator(spec.operator) : undefined;
+        const normalizedTarget = spec.target ? normalizeIdentifier(spec.target) : undefined;
+
+        return this.list(root).filter(branch => {
+            if (branch.parameterName !== spec.parameterName) {
+                return false;
+            }
+            if (spec.kind && branch.kind !== spec.kind) {
+                return false;
+            }
+            if (normalizedOperator && branch.operator !== normalizedOperator) {
+                return false;
+            }
+            if (normalizedTarget && (!branch.target || normalizeIdentifier(branch.target) !== normalizedTarget)) {
+                return false;
+            }
+            return true;
+        });
+    }
+
+    private scaffoldScalarBranch(root: SelectQuery, spec: SssqlScalarScaffoldSpec): void {
+        const target = this.resolveTarget(root, spec.target);
+        const parameterName = spec.parameterName?.trim() || target.parameterName;
+        const operator = normalizeScalarOperator(spec.operator);
+        const branch = buildOptionalScalarBranch(target.column, parameterName, operator);
+        const branchSql = normalizeSql(formatSqlComponent(branch));
+
+        const duplicate = this.list(root).find(existing =>
+            existing.query === target.query &&
+            normalizeSql(existing.sql) === branchSql
+        );
+        if (duplicate) {
+            return;
+        }
+
+        target.query.appendWhere(branch);
+    }
+
+    private scaffoldExistsBranch(root: SelectQuery, spec: SssqlExistsScaffoldSpec): void {
+        const parameterName = spec.parameterName.trim();
+        if (!parameterName) {
+            throw new Error("SSSQL EXISTS/NOT EXISTS scaffold requires parameterName.");
+        }
+
+        const anchorTargets = spec.anchorColumns.map(anchorColumn => this.resolveTarget(root, anchorColumn));
+        const targetQueries = [...new Set(anchorTargets.map(target => target.query))];
+        if (targetQueries.length !== 1) {
+            throw new Error("SSSQL EXISTS/NOT EXISTS scaffold anchor columns must resolve within one query scope.");
+        }
+
+        const targetQuery = targetQueries[0]!;
+        const formattedColumns = anchorTargets.map(target => formatSqlComponent(target.column));
+        const substitutedSql = substituteAnchorPlaceholders(spec.query, formattedColumns).trim();
+        enforceSubqueryConstraints(substitutedSql);
+
+        const subquery = SelectQueryParser.parse(substitutedSql);
+        const parameterNames = new Set(ParameterCollector.collect(subquery).map(parameter => parameter.name.value));
+        if (parameterNames.size !== 1 || !parameterNames.has(parameterName)) {
+            throw new Error(
+                `SSSQL ${spec.kind.toUpperCase()} scaffold query must reference only parameter ':${parameterName}'.`
+            );
+        }
+
+        const branch = buildOptionalExistsBranch(parameterName, subquery, spec.kind);
+        const branchSql = normalizeSql(formatSqlComponent(branch));
+        const duplicate = this.list(root).find(existing =>
+            existing.query === targetQuery &&
+            normalizeSql(existing.sql) === branchSql
+        );
+        if (duplicate) {
+            return;
+        }
+
+        targetQuery.appendWhere(branch);
     }
 
     private resolveTarget(root: SelectQuery, filterName: string): ResolvedFilterTarget {

--- a/packages/core/src/transformers/SSSQLFilterBuilder.ts
+++ b/packages/core/src/transformers/SSSQLFilterBuilder.ts
@@ -14,8 +14,8 @@ import {
 } from "../models/ValueComponent";
 import { SelectQueryParser } from "../parsers/SelectQueryParser";
 import { UpstreamSelectQueryFinder } from "./UpstreamSelectQueryFinder";
-import { SelectableColumnCollector, DuplicateDetectionMode } from "./SelectableColumnCollector";
 import { ColumnReferenceCollector } from "./ColumnReferenceCollector";
+import { SelectableColumnCollector, DuplicateDetectionMode } from "./SelectableColumnCollector";
 import { ParameterCollector } from "./ParameterCollector";
 import { SqlFormatter } from "./SqlFormatter";
 import {
@@ -310,22 +310,29 @@ const getScalarBranchDetails = (
         return null;
     }
 
-    const operator = normalizeScalarOperator(predicate.operator.value as SssqlScalarOperatorInput);
     const left = unwrapParens(predicate.left);
     const right = unwrapParens(predicate.right);
 
     if (left instanceof ColumnReference && right instanceof ParameterExpression && right.name.value === parameterName) {
-        return {
-            operator,
-            target: normalizeColumnReferenceText(left)
-        };
+        try {
+            return {
+                operator: normalizeScalarOperator(predicate.operator.value as SssqlScalarOperatorInput),
+                target: normalizeColumnReferenceText(left)
+            };
+        } catch {
+            return null;
+        }
     }
 
     if (right instanceof ColumnReference && left instanceof ParameterExpression && left.name.value === parameterName) {
-        return {
-            operator,
-            target: normalizeColumnReferenceText(right)
-        };
+        try {
+            return {
+                operator: normalizeScalarOperator(predicate.operator.value as SssqlScalarOperatorInput),
+                target: normalizeColumnReferenceText(right)
+            };
+        } catch {
+            return null;
+        }
     }
 
     return null;
@@ -566,6 +573,9 @@ export class SSSQLFilterBuilder {
         const parameterName = spec.parameterName.trim();
         if (!parameterName) {
             throw new Error("SSSQL EXISTS/NOT EXISTS scaffold requires parameterName.");
+        }
+        if (spec.anchorColumns.length === 0) {
+            throw new Error("SSSQL EXISTS/NOT EXISTS scaffold requires at least one anchorColumn.");
         }
 
         const anchorTargets = spec.anchorColumns.map(anchorColumn => this.resolveTarget(root, anchorColumn));

--- a/packages/core/tests/transformers/PruneOptionalConditionBranches.test.ts
+++ b/packages/core/tests/transformers/PruneOptionalConditionBranches.test.ts
@@ -84,6 +84,28 @@ describe('pruneOptionalConditionBranches', () => {
         expect(formattedSql).not.toContain('where');
     });
 
+    it('prunes a top-level optional not-exists branch when the targeted parameter is null', () => {
+        const sql = `
+            SELECT p.product_id
+            FROM products p
+            WHERE (
+                :archived_name IS NULL
+                OR NOT EXISTS (
+                    SELECT 1
+                    FROM archived_products ap
+                    WHERE ap.product_id = p.product_id
+                      AND ap.product_name = :archived_name
+                )
+            )
+        `;
+
+        const formattedSql = formatSql(sql, { archived_name: null });
+
+        expect(formattedSql).toBe('select "p"."product_id" from "products" as "p"');
+        expect(formattedSql).not.toContain('not exists');
+        expect(formattedSql).not.toContain(':archived_name');
+    });
+
     it('prunes only the null-targeted branch when multiple optional branches are present', () => {
         const sql = `
             SELECT p.product_id

--- a/packages/core/tests/transformers/SSSQLFilterBuilder.test.ts
+++ b/packages/core/tests/transformers/SSSQLFilterBuilder.test.ts
@@ -79,4 +79,150 @@ describe('SSSQLFilterBuilder', () => {
         const normalized = normalizeSql(new SqlFormatter().format(refreshed).formattedSql);
         expect(normalized).toContain('where "p"."active" = true and (:products_product_name is null or "p"."product_name" = :products_product_name)');
     });
+
+    it('scaffolds operator-based branches idempotently and normalizes != to <>', () => {
+        const builder = new SSSQLFilterBuilder();
+        const once = builder.scaffoldBranch(
+            `
+                SELECT p.product_id, p.brand_name
+                FROM products p
+            `,
+            {
+                target: 'products.brand_name',
+                parameterName: 'brand_name',
+                operator: '!='
+            }
+        );
+
+        const twice = builder.scaffoldBranch(once, {
+            target: 'products.brand_name',
+            parameterName: 'brand_name',
+            operator: '<>'
+        });
+
+        const normalized = normalizeSql(new SqlFormatter().format(twice).formattedSql);
+        expect(normalized).toContain('(:brand_name is null or "p"."brand_name" <> :brand_name)');
+        expect(normalized.match(/:brand_name is null or "p"\."brand_name" <> :brand_name/g)?.length).toBe(1);
+    });
+
+    it('scaffolds exists and not-exists branches from explicit subquery input', () => {
+        const builder = new SSSQLFilterBuilder();
+        const existsQuery = builder.scaffoldBranch(
+            `
+                SELECT p.product_id, p.product_name
+                FROM products p
+            `,
+            {
+                kind: 'exists',
+                parameterName: 'category_name',
+                anchorColumns: ['products.product_id'],
+                query: `
+                    SELECT 1
+                    FROM product_categories pc
+                    JOIN categories c
+                      ON c.category_id = pc.category_id
+                    WHERE pc.product_id = $c0
+                      AND c.category_name = :category_name
+                `
+            }
+        );
+
+        const notExistsQuery = builder.scaffoldBranch(existsQuery, {
+            kind: 'not-exists',
+            parameterName: 'archived_name',
+            anchorColumns: ['products.product_id'],
+            query: `
+                SELECT 1
+                FROM archived_products ap
+                WHERE ap.product_id = $c0
+                  AND ap.product_name = :archived_name
+            `
+        });
+
+        const normalized = normalizeSql(new SqlFormatter().format(notExistsQuery).formattedSql);
+        expect(normalized).toContain(':category_name is null or exists');
+        expect(normalized).toContain('"pc"."product_id" = "p"."product_id"');
+        expect(normalized).toContain(':archived_name is null or not exists');
+    });
+
+    it('lists supported branch metadata and removes a targeted branch idempotently', () => {
+        const builder = new SSSQLFilterBuilder();
+        const scaffolded = builder.scaffoldBranch(
+            `
+                SELECT p.product_id, p.product_name
+                FROM products p
+            `,
+            {
+                target: 'products.product_name',
+                parameterName: 'product_name',
+                operator: 'ilike'
+            }
+        );
+
+        const withExists = builder.scaffoldBranch(scaffolded, {
+            kind: 'exists',
+            parameterName: 'category_name',
+            anchorColumns: ['products.product_id'],
+            query: `
+                SELECT 1
+                FROM product_categories pc
+                WHERE pc.product_id = $c0
+                  AND pc.category_name = :category_name
+            `
+        });
+
+        const listed = builder.list(withExists);
+        expect(listed).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                parameterName: 'product_name',
+                kind: 'scalar',
+                operator: 'ilike',
+                target: 'p.product_name'
+            }),
+            expect.objectContaining({
+                parameterName: 'category_name',
+                kind: 'exists'
+            })
+        ]));
+
+        const removed = builder.remove(withExists, { parameterName: 'category_name', kind: 'exists' });
+        const normalized = normalizeSql(new SqlFormatter().format(removed).formattedSql);
+        expect(normalized).not.toContain(':category_name');
+        expect(normalized).toContain(':product_name is null or "p"."product_name" ilike :product_name');
+
+        const removedAgain = builder.remove(removed, { parameterName: 'category_name', kind: 'exists' });
+        expect(normalizeSql(new SqlFormatter().format(removedAgain).formattedSql)).toBe(normalized);
+    });
+
+    it('removes all recognized branches in one call', () => {
+        const builder = new SSSQLFilterBuilder();
+        const scaffolded = builder.scaffoldBranch(
+            `
+                SELECT p.product_id, p.product_name
+                FROM products p
+            `,
+            {
+                target: 'products.product_name',
+                parameterName: 'product_name',
+                operator: 'ilike'
+            }
+        );
+
+        const withExists = builder.scaffoldBranch(scaffolded, {
+            kind: 'exists',
+            parameterName: 'category_name',
+            anchorColumns: ['products.product_id'],
+            query: `
+                SELECT 1
+                FROM product_categories pc
+                WHERE pc.product_id = $c0
+                  AND pc.category_name = :category_name
+            `
+        });
+
+        const removed = builder.removeAll(withExists);
+        const normalized = normalizeSql(new SqlFormatter().format(removed).formattedSql);
+        expect(normalized).toBe('select "p"."product_id", "p"."product_name" from "products" as "p"');
+    });
+
 });

--- a/packages/core/tests/transformers/SSSQLFilterBuilder.test.ts
+++ b/packages/core/tests/transformers/SSSQLFilterBuilder.test.ts
@@ -194,6 +194,42 @@ describe('SSSQLFilterBuilder', () => {
         expect(normalizeSql(new SqlFormatter().format(removedAgain).formattedSql)).toBe(normalized);
     });
 
+    it('removes not-exists branches idempotently', () => {
+        const builder = new SSSQLFilterBuilder();
+        const scaffolded = builder.scaffoldBranch(
+            `
+                SELECT p.product_id, p.product_name
+                FROM products p
+            `,
+            {
+                kind: 'not-exists',
+                parameterName: 'archived_name',
+                anchorColumns: ['products.product_id'],
+                query: `
+                    SELECT 1
+                    FROM archived_products ap
+                    WHERE ap.product_id = $c0
+                      AND ap.product_name = :archived_name
+                `
+            }
+        );
+
+        expect(builder.list(scaffolded)).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                parameterName: 'archived_name',
+                kind: 'not-exists'
+            })
+        ]));
+
+        const removed = builder.remove(scaffolded, { parameterName: 'archived_name', kind: 'not-exists' });
+        const normalized = normalizeSql(new SqlFormatter().format(removed).formattedSql);
+        expect(normalized).toBe('select "p"."product_id", "p"."product_name" from "products" as "p"');
+
+        const removedAgain = builder.remove(removed, { parameterName: 'archived_name', kind: 'not-exists' });
+        expect(normalizeSql(new SqlFormatter().format(removedAgain).formattedSql)).toBe(normalized);
+        expect(normalizeSql(new SqlFormatter().format(builder.removeAll(scaffolded)).formattedSql)).toBe(normalized);
+    });
+
     it('removes all recognized branches in one call', () => {
         const builder = new SSSQLFilterBuilder();
         const scaffolded = builder.scaffoldBranch(
@@ -223,6 +259,28 @@ describe('SSSQLFilterBuilder', () => {
         const removed = builder.removeAll(withExists);
         const normalized = normalizeSql(new SqlFormatter().format(removed).formattedSql);
         expect(normalized).toBe('select "p"."product_id", "p"."product_name" from "products" as "p"');
+    });
+
+    it('fails fast when exists scaffolding has no anchor columns', () => {
+        const builder = new SSSQLFilterBuilder();
+
+        expect(() => builder.scaffoldBranch(
+            `
+                SELECT p.product_id, p.product_name
+                FROM products p
+            `,
+            {
+                kind: 'exists',
+                parameterName: 'category_name',
+                anchorColumns: [],
+                query: `
+                    SELECT 1
+                    FROM product_categories pc
+                    WHERE pc.product_id = $c0
+                      AND pc.category_name = :category_name
+                `
+            }
+        )).toThrow(/at least one anchorcolumn/i);
     });
 
 });

--- a/packages/ztd-cli/README.md
+++ b/packages/ztd-cli/README.md
@@ -183,7 +183,11 @@ npx vitest run
 
 If you want a deeper walkthrough, keep that in the linked guides instead of expanding this README.
 
-## Commands
+## Command Index
+
+This section is a reader-facing index of the main `ztd-cli` entry points.
+It is not the exhaustive command reference for every subcommand and flag.
+Use `ztd describe` for machine-readable discovery, and follow the linked guides when one command family has a deeper workflow.
 
 | Command | Purpose |
 |---|---|
@@ -197,7 +201,7 @@ If you want a deeper walkthrough, keep that in the linked guides instead of expa
 | `ztd model-gen` | Generate query-boundary scaffolding from SQL assets. |
 | `ztd query uses` | Find impacted SQL before changing a table or column. |
 | `ztd query match-observed` | Rank likely source SQL assets from observed SELECT text. |
-| `ztd query sssql scaffold` / `ztd query sssql refresh` | Author and refresh SQL-first optional filter branches. |
+| `ztd query sssql list` / `scaffold` / `remove` / `refresh` | Inspect, author, undo, and re-anchor SQL-first optional filter branches. See [ztd-cli SSSQL Reference](../../docs/guide/ztd-cli-sssql-reference.md). |
 | `ztd ddl pull` / `ztd ddl diff` | Inspect a target and prepare migration SQL. |
 | `ztd perf init` / `ztd perf run` | Run the tuning loop for index or pipeline investigation. |
 | `ztd describe` | Inspect commands in machine-readable form. |
@@ -232,6 +236,7 @@ If you want a deeper walkthrough, keep that in the linked guides instead of expa
 - [Release And Merge Readiness](../../docs/guide/release-readiness.md) - PR-body contract for baseline exceptions, CLI migration packets, and scaffold proof
 - [What Is SSSQL?](../../docs/guide/sssql-overview.md) - the shortest intro to truthful optional-filter SQL
 - [SSSQL for Humans](../../docs/guide/sssql-for-humans.md) - why SSSQL exists and where it fits in the toolchain
+- [ztd-cli SSSQL Reference](../../docs/guide/ztd-cli-sssql-reference.md) - one-page command and runtime reference for `ztd query sssql`
 - [ztd-cli Telemetry Philosophy](../../docs/guide/ztd-cli-telemetry-philosophy.md) - when to enable telemetry and why it stays opt-in
 - [ztd-cli Telemetry Policy](../../docs/guide/ztd-cli-telemetry-policy.md) - which event fields are allowed and how redaction works
 - [ztd-cli Telemetry Export Modes](../../docs/guide/ztd-cli-telemetry-export-modes.md) - how to send telemetry to console, debug, file, or OTLP

--- a/packages/ztd-cli/src/commands/query.ts
+++ b/packages/ztd-cli/src/commands/query.ts
@@ -1,4 +1,5 @@
 import { Command, Option } from 'commander';
+import { createTwoFilesPatch } from 'diff';
 import { applyQueryOutputControls, formatQueryUsageReport } from '../query/format';
 import { applyQueryPatch } from '../query/patch';
 import { buildQueryLintReport, formatQueryLintReport, type QueryLintFormat } from '../query/lint';
@@ -21,10 +22,15 @@ import {
 import { getAgentOutputFormat, isJsonOutput, parseJsonPayload, writeCommandEnvelope } from '../utils/agentCli';
 import { withSpanSync } from '../utils/telemetry';
 import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
 import {
   collectSupportedOptionalConditionBranches,
   SelectQueryParser,
   SSSQLFilterBuilder,
+  type SssqlBranchInfo,
+  type SssqlBranchKind,
+  type SssqlRemoveSpec,
+  type SssqlScaffoldSpec,
   type SssqlScaffoldFilters,
   SqlFormatter
 } from 'rawsql-ts';
@@ -75,14 +81,41 @@ interface QuerySssqlScaffoldOptions {
   format?: string;
   out?: string;
   json?: string;
-  filter?: Record<string, unknown>;
+  preview?: boolean;
+  filter?: unknown;
   filters?: Record<string, unknown>;
+  parameter?: string;
+  operator?: string;
+  kind?: string;
+  query?: string;
+  queryFile?: string;
+  anchorColumns?: unknown;
+  anchorColumn?: unknown;
 }
 
 interface QuerySssqlRefreshOptions {
   format?: string;
   out?: string;
   json?: string;
+  preview?: boolean;
+}
+
+interface QuerySssqlListOptions {
+  format?: string;
+  out?: string;
+  json?: string;
+}
+
+interface QuerySssqlRemoveOptions {
+  format?: string;
+  out?: string;
+  json?: string;
+  preview?: boolean;
+  all?: boolean;
+  parameter?: string;
+  kind?: string;
+  operator?: string;
+  target?: string;
 }
 
 interface QueryMatchObservedOptions {
@@ -268,10 +301,28 @@ Notes:
   const sssql = query.command('sssql').description('Generate and refresh SQL-first optional filter scaffolds');
 
   sssql
+    .command('list <sqlFile>')
+    .description('List supported SSSQL optional branches discovered in the query')
+    .option('--format <format>', 'Output format (text|json)', 'text')
+    .option('--json <payload>', 'Pass command options as a JSON object')
+    .option('--out <path>', 'Write output to file')
+    .action((sqlFile: string, options: QuerySssqlListOptions) => {
+      runQuerySssqlListCommand(sqlFile, options);
+    });
+
+  sssql
     .command('scaffold <sqlFile>')
     .description('Generate SSSQL optional filter scaffolds near the closest source query')
     .option('--format <format>', 'Output format (text|json)', 'text')
     .option('--json <payload>', 'Pass command options as a JSON object')
+    .option('--filter <name>', 'Target column for scalar scaffold, or primary anchor column for EXISTS/NOT EXISTS')
+    .option('--parameter <name>', 'Explicit parameter name for structured SSSQL scaffold')
+    .option('--operator <operator>', 'Scalar operator (=, <>, !=, <, <=, >, >=, like, ilike)')
+    .option('--kind <kind>', 'Structured branch kind (scalar|exists|not-exists)')
+    .option('--query <sql>', 'Subquery SQL for EXISTS/NOT EXISTS scaffold')
+    .option('--query-file <path>', 'Read subquery SQL for EXISTS/NOT EXISTS scaffold from a file')
+    .option('--anchor-column <names>', 'Comma-separated anchor columns used by $c0, $c1 placeholders')
+    .option('--preview', 'Emit a unified diff without writing files')
     .option('--out <path>', 'Write output to file')
     .action((sqlFile: string, options: QuerySssqlScaffoldOptions) => {
       runQuerySssqlScaffoldCommand(sqlFile, options);
@@ -282,9 +333,26 @@ Notes:
     .description('Refresh existing SSSQL optional filter scaffolds without changing predicate meaning')
     .option('--format <format>', 'Output format (text|json)', 'text')
     .option('--json <payload>', 'Pass command options as a JSON object')
+    .option('--preview', 'Emit a unified diff without writing files')
     .option('--out <path>', 'Write output to file')
     .action((sqlFile: string, options: QuerySssqlRefreshOptions) => {
       runQuerySssqlRefreshCommand(sqlFile, options);
+    });
+
+  sssql
+    .command('remove <sqlFile>')
+    .description('Remove one supported SSSQL optional filter branch safely')
+    .option('--format <format>', 'Output format (text|json)', 'text')
+    .option('--json <payload>', 'Pass command options as a JSON object')
+    .option('--all', 'Remove all recognized SSSQL branches in the query')
+    .option('--parameter <name>', 'Parameter name that identifies the target branch')
+    .option('--kind <kind>', 'Optional branch kind filter (scalar|exists|not-exists|expression)')
+    .option('--operator <operator>', 'Optional scalar operator filter when removing scalar branches')
+    .option('--target <target>', 'Optional target column filter when removing scalar branches')
+    .option('--preview', 'Emit a unified diff without writing files')
+    .option('--out <path>', 'Write output to file')
+    .action((sqlFile: string, options: QuerySssqlRemoveOptions) => {
+      runQuerySssqlRemoveCommand(sqlFile, options);
     });
 
   query
@@ -517,68 +585,103 @@ function runQueryPatchApplyCommand(sqlFile: string, options: QueryPatchApplyOpti
   process.stdout.write('\n');
 }
 
-function runQuerySssqlScaffoldCommand(sqlFile: string, options: QuerySssqlScaffoldOptions): void {
+function runQuerySssqlListCommand(sqlFile: string, options: QuerySssqlListOptions): void {
   const resolved = options.json
     ? { ...options, ...parseJsonPayload<Record<string, unknown>>(options.json, '--json') }
     : options;
-  const filters = normalizeSssqlFilters(resolved.filter ?? resolved.filters);
   const sql = readFileSync(sqlFile, 'utf8');
-  const result = new SSSQLFilterBuilder().scaffold(sql, filters);
-  const formatted = new SqlFormatter().format(result).formattedSql;
-  const outputFile = normalizeStringOption(resolved.out);
+  const branches = new SSSQLFilterBuilder().list(sql);
   const format = normalizeFormat(normalizeStringOption(resolved.format) ?? getAgentOutputFormat());
+  const outputFile = normalizeStringOption(resolved.out);
+  const contents = format === 'json'
+    ? JSON.stringify({
+      command: 'query sssql list',
+      ok: true,
+      data: {
+        file: sqlFile,
+        branch_count: branches.length,
+        branches: branches.map((branch, index) => serializeSssqlBranch(branch, index))
+      }
+    })
+    : formatSssqlBranchList(branches);
 
   if (outputFile) {
-    writeFileSync(outputFile, `${formatted}\n`, 'utf8');
+    writeQueryUsageOutput(outputFile, contents);
     if (format !== 'json') {
       return;
     }
   }
 
   if (format === 'json') {
-    writeCommandEnvelope('query sssql scaffold', {
-      file: sqlFile,
-      output_file: outputFile ?? null,
-      written: Boolean(outputFile),
-      sql: formatted,
-    });
+    process.stdout.write(outputFile ? `${contents}\n` : contents);
     return;
   }
 
-  process.stdout.write(`${formatted}\n`);
+  process.stdout.write(contents.endsWith('\n') ? contents : `${contents}\n`);
+}
+
+function runQuerySssqlScaffoldCommand(sqlFile: string, options: QuerySssqlScaffoldOptions): void {
+  const resolved = options.json
+    ? { ...options, ...parseJsonPayload<Record<string, unknown>>(options.json, '--json') }
+    : options;
+  const filters = normalizeSssqlFilters(resolved.filters ?? (isLegacyFilterObject(resolved.filter) ? resolved.filter : undefined));
+  const spec = buildStructuredSssqlScaffoldSpec(resolved);
+  const report = applySssqlRewrite(sqlFile, {
+    commandName: 'query sssql scaffold',
+    out: normalizeStringOption(resolved.out),
+    preview: normalizeBooleanOption(resolved.preview),
+    transform: (sql) => {
+      const builder = new SSSQLFilterBuilder();
+      if (spec) {
+        return builder.scaffoldBranch(sql, spec);
+      }
+      return builder.scaffold(sql, filters);
+    }
+  });
+
+  emitSssqlRewriteReport(report, normalizeFormat(normalizeStringOption(resolved.format) ?? getAgentOutputFormat()));
 }
 
 function runQuerySssqlRefreshCommand(sqlFile: string, options: QuerySssqlRefreshOptions): void {
   const resolved = options.json
     ? { ...options, ...parseJsonPayload<Record<string, unknown>>(options.json, '--json') }
     : options;
-  const sql = readFileSync(sqlFile, 'utf8');
-  const parsed = SelectQueryParser.parse(sql);
-  const existingBranches = collectSupportedOptionalConditionBranches(parsed);
-  const filters = Object.fromEntries(existingBranches.map((branch) => [branch.parameterName, null]));
-  const result = new SSSQLFilterBuilder().refresh(parsed, filters);
-  const formatted = new SqlFormatter().format(result).formattedSql;
-  const outputFile = normalizeStringOption(resolved.out);
-  const format = normalizeFormat(normalizeStringOption(resolved.format) ?? getAgentOutputFormat());
-
-  if (outputFile) {
-    writeFileSync(outputFile, `${formatted}\n`, 'utf8');
-    if (format !== 'json') {
-      return;
+  const report = applySssqlRewrite(sqlFile, {
+    commandName: 'query sssql refresh',
+    out: normalizeStringOption(resolved.out),
+    preview: normalizeBooleanOption(resolved.preview),
+    transform: (sql) => {
+      const parsed = SelectQueryParser.parse(sql);
+      const existingBranches = collectSupportedOptionalConditionBranches(parsed);
+      const filters = Object.fromEntries(existingBranches.map((branch) => [branch.parameterName, null]));
+      return new SSSQLFilterBuilder().refresh(parsed, filters);
     }
-  }
+  });
 
-  if (format === 'json') {
-    writeCommandEnvelope('query sssql refresh', {
-      file: sqlFile,
-      output_file: outputFile ?? null,
-      written: Boolean(outputFile),
-      sql: formatted,
-    });
-    return;
-  }
+  emitSssqlRewriteReport(report, normalizeFormat(normalizeStringOption(resolved.format) ?? getAgentOutputFormat()));
+}
 
-  process.stdout.write(`${formatted}\n`);
+function runQuerySssqlRemoveCommand(sqlFile: string, options: QuerySssqlRemoveOptions): void {
+  const resolved = options.json
+    ? { ...options, ...parseJsonPayload<Record<string, unknown>>(options.json, '--json') }
+    : options;
+  const report = applySssqlRewrite(sqlFile, {
+    commandName: 'query sssql remove',
+    out: normalizeStringOption(resolved.out),
+    preview: normalizeBooleanOption(resolved.preview),
+    transform: (sql) => {
+      const builder = new SSSQLFilterBuilder();
+      if (normalizeBooleanOption(resolved.all)) {
+        assertNoTargetedRemoveOptions(resolved);
+        return builder.removeAll(sql);
+      }
+
+      const spec = normalizeSssqlRemoveSpec(resolved);
+      return builder.remove(sql, spec);
+    }
+  });
+
+  emitSssqlRewriteReport(report, normalizeFormat(normalizeStringOption(resolved.format) ?? getAgentOutputFormat()));
 }
 
 function normalizeLimit(value: unknown): number | undefined {
@@ -665,6 +768,241 @@ function normalizeSssqlFilters(value: unknown): SssqlScaffoldFilters {
   }
 
   return normalized;
+}
+
+function isLegacyFilterObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function buildStructuredSssqlScaffoldSpec(value: QuerySssqlScaffoldOptions): SssqlScaffoldSpec | undefined {
+  const explicitFilter = normalizeStringOption(value.filter);
+  const explicitKind = normalizeStringOption(value.kind)?.trim().toLowerCase();
+  const explicitQuery = normalizeStringOption(value.query);
+  const explicitQueryFile = normalizeStringOption(value.queryFile);
+  const operator = normalizeStringOption(value.operator);
+  const parameter = normalizeStringOption(value.parameter);
+  const anchorColumns = normalizeListOption(value.anchorColumns ?? value.anchorColumn, '--anchor-column');
+
+  const hasStructuredInputs = Boolean(explicitFilter || explicitKind || explicitQuery || explicitQueryFile || operator || parameter || anchorColumns?.length);
+  if (!hasStructuredInputs) {
+    return undefined;
+  }
+
+  const target = explicitFilter;
+  const query = resolveSssqlSubqueryInput(explicitQuery, explicitQueryFile);
+
+  if (explicitKind === 'exists' || explicitKind === 'not-exists' || query) {
+    return {
+      kind: normalizeSssqlExistsKind(explicitKind),
+      parameterName: normalizeRequiredStringOption(parameter, '--parameter'),
+      query: normalizeRequiredStringOption(query, '--query or --query-file'),
+      anchorColumns: anchorColumns ?? [normalizeRequiredStringOption(target, '--filter')]
+    };
+  }
+
+  return {
+    target: normalizeRequiredStringOption(target, '--filter'),
+    parameterName: parameter,
+    operator: operator as SssqlScaffoldSpec extends infer _ ? string : never
+  } as SssqlScaffoldSpec;
+}
+
+function normalizeSssqlExistsKind(value: string | undefined): 'exists' | 'not-exists' {
+  if (!value || value === 'exists') {
+    return 'exists';
+  }
+  if (value === 'not-exists') {
+    return 'not-exists';
+  }
+  throw new Error(`Unsupported SSSQL branch kind: ${value}. Use exists or not-exists.`);
+}
+
+function normalizeSssqlRemoveSpec(value: QuerySssqlRemoveOptions): SssqlRemoveSpec {
+  const kindValue = normalizeStringOption(value.kind)?.trim().toLowerCase();
+  return {
+    parameterName: normalizeRequiredStringOption(value.parameter, '--parameter'),
+    kind: kindValue ? normalizeSssqlBranchKind(kindValue) : undefined,
+    operator: normalizeStringOption(value.operator) as SssqlRemoveSpec['operator'],
+    target: normalizeStringOption(value.target)
+  };
+}
+
+function assertNoTargetedRemoveOptions(value: QuerySssqlRemoveOptions): void {
+  if (
+    normalizeStringOption(value.parameter) ||
+    normalizeStringOption(value.kind) ||
+    normalizeStringOption(value.operator) ||
+    normalizeStringOption(value.target)
+  ) {
+    throw new Error('Use --all by itself. Do not combine it with --parameter, --kind, --operator, or --target.');
+  }
+}
+
+function normalizeSssqlBranchKind(value: string): SssqlBranchKind {
+  if (value === 'scalar' || value === 'exists' || value === 'not-exists' || value === 'expression') {
+    return value;
+  }
+  throw new Error(`Unsupported SSSQL branch kind: ${value}.`);
+}
+
+function resolveSssqlSubqueryInput(sqlText: string | undefined, sqlFile: string | undefined): string | undefined {
+  if (sqlText && sqlFile) {
+    throw new Error('Use either --query or --query-file, not both.');
+  }
+
+  if (sqlText) {
+    return sqlText;
+  }
+
+  if (sqlFile) {
+    return readFileSync(sqlFile, 'utf8');
+  }
+
+  return undefined;
+}
+
+function serializeSssqlBranch(branch: SssqlBranchInfo, index: number): Record<string, unknown> {
+  return {
+    index: index + 1,
+    parameterName: branch.parameterName,
+    kind: branch.kind,
+    operator: branch.operator ?? null,
+    target: branch.target ?? null,
+    sql: branch.sql
+  };
+}
+
+function formatSssqlBranchList(branches: SssqlBranchInfo[]): string {
+  if (branches.length === 0) {
+    return 'No supported SSSQL branches found.\n';
+  }
+
+  const lines: string[] = [];
+  branches.forEach((branch, index) => {
+    lines.push(`${index + 1}. parameter: ${branch.parameterName}`);
+    lines.push(`   kind: ${branch.kind}`);
+    if (branch.operator) {
+      lines.push(`   operator: ${branch.operator}`);
+    }
+    if (branch.target) {
+      lines.push(`   target: ${branch.target}`);
+    }
+    lines.push(`   sql: ${branch.sql}`);
+  });
+
+  return `${lines.join('\n')}\n`;
+}
+
+interface SssqlRewriteReport {
+  commandName: string;
+  file: string;
+  output_file: string | null;
+  preview: boolean;
+  changed: boolean;
+  written: boolean;
+  sql: string;
+  diff: string;
+}
+
+function applySssqlRewrite(
+  sqlFile: string,
+  options: {
+    commandName: string;
+    out?: string;
+    preview?: boolean;
+    transform: (sql: string) => unknown;
+  }
+): SssqlRewriteReport {
+  const absoluteInputPath = path.resolve(sqlFile);
+  const originalSql = readFileSync(absoluteInputPath, 'utf8');
+  const transformed = options.transform(originalSql);
+  const formatted = new SqlFormatter().format(transformed as never).formattedSql;
+  const updatedSql = `${formatted}\n`;
+  assertNoCommentLoss(originalSql, updatedSql, options.commandName);
+
+  SelectQueryParser.parse(updatedSql);
+
+  const outputFile = options.out ? path.resolve(options.out) : null;
+  const preview = Boolean(options.preview);
+  const changed = normalizeLineEndings(originalSql) !== normalizeLineEndings(updatedSql);
+  const diff = createTwoFilesPatch(
+    normalizePath(absoluteInputPath),
+    normalizePath(outputFile ?? absoluteInputPath),
+    normalizeLineEndings(originalSql),
+    normalizeLineEndings(updatedSql),
+    '',
+    '',
+    { context: 3 }
+  );
+
+  if (outputFile && !preview) {
+    writeFileSync(outputFile, updatedSql, 'utf8');
+  }
+
+  return {
+    commandName: options.commandName,
+    file: absoluteInputPath,
+    output_file: outputFile,
+    preview,
+    changed,
+    written: Boolean(outputFile) && !preview,
+    sql: formatted,
+    diff
+  };
+}
+
+function emitSssqlRewriteReport(report: SssqlRewriteReport, format: 'text' | 'json'): void {
+  if (format === 'json') {
+    writeCommandEnvelope(report.commandName, {
+      file: report.file,
+      output_file: report.output_file,
+      preview: report.preview,
+      changed: report.changed,
+      written: report.written,
+      sql: report.sql,
+      diff: report.diff
+    });
+    return;
+  }
+
+  if (report.preview) {
+    process.stdout.write(report.diff.endsWith('\n') ? report.diff : `${report.diff}\n`);
+    return;
+  }
+
+  if (report.output_file) {
+    return;
+  }
+
+  process.stdout.write(`${report.sql}\n`);
+}
+
+function normalizeLineEndings(value: string): string {
+  return value.replace(/\r\n/g, '\n');
+}
+
+function normalizePath(value: string): string {
+  return value.split(path.sep).join('/');
+}
+
+function assertNoCommentLoss(before: string, after: string, commandName: string): void {
+  const beforeComments = extractSqlCommentFragments(before);
+  if (beforeComments.length === 0) {
+    return;
+  }
+
+  const normalizedAfter = normalizeLineEndings(after);
+  const missing = beforeComments.filter(comment => !normalizedAfter.includes(comment));
+  if (missing.length > 0) {
+    throw new Error(`${commandName} would drop SQL comments during rewrite. Remove or relocate the comments before applying this command.`);
+  }
+}
+
+function extractSqlCommentFragments(sql: string): string[] {
+  const normalized = normalizeLineEndings(sql);
+  const matches = normalized.match(/--.*$/gm) ?? [];
+  const blockMatches = normalized.match(/\/\*[\s\S]*?\*\//g) ?? [];
+  return [...matches, ...blockMatches].map(comment => comment.trim()).filter(Boolean);
 }
 
 function resolveObservedSqlInput(options: QueryMatchObservedOptions): string {

--- a/packages/ztd-cli/src/commands/query.ts
+++ b/packages/ztd-cli/src/commands/query.ts
@@ -922,12 +922,12 @@ function applySssqlRewrite(
 
   SelectQueryParser.parse(updatedSql);
 
-  const outputFile = options.out ? path.resolve(options.out) : null;
   const preview = Boolean(options.preview);
+  const outputFile = path.resolve(options.out ?? absoluteInputPath);
   const changed = normalizeLineEndings(originalSql) !== normalizeLineEndings(updatedSql);
   const diff = createTwoFilesPatch(
     normalizePath(absoluteInputPath),
-    normalizePath(outputFile ?? absoluteInputPath),
+    normalizePath(outputFile),
     normalizeLineEndings(originalSql),
     normalizeLineEndings(updatedSql),
     '',
@@ -935,7 +935,7 @@ function applySssqlRewrite(
     { context: 3 }
   );
 
-  if (outputFile && !preview) {
+  if (!preview) {
     writeFileSync(outputFile, updatedSql, 'utf8');
   }
 
@@ -945,7 +945,7 @@ function applySssqlRewrite(
     output_file: outputFile,
     preview,
     changed,
-    written: Boolean(outputFile) && !preview,
+    written: !preview,
     sql: formatted,
     diff
   };
@@ -970,11 +970,7 @@ function emitSssqlRewriteReport(report: SssqlRewriteReport, format: 'text' | 'js
     return;
   }
 
-  if (report.output_file) {
-    return;
-  }
-
-  process.stdout.write(`${report.sql}\n`);
+  return;
 }
 
 function normalizeLineEndings(value: string): string {

--- a/packages/ztd-cli/tests/cliCommands.test.ts
+++ b/packages/ztd-cli/tests/cliCommands.test.ts
@@ -802,8 +802,10 @@ test(
   () => {
     const result = runCli(['query', 'sssql', '--help']);
     assertCliSuccess(result, 'query sssql --help');
+    expect(result.stdout).toContain('list [options] <sqlFile>');
     expect(result.stdout).toContain('scaffold [options] <sqlFile>');
     expect(result.stdout).toContain('refresh [options] <sqlFile>');
+    expect(result.stdout).toContain('remove [options] <sqlFile>');
   },
   60000,
 );
@@ -948,6 +950,352 @@ test(
 
     const contents = readFileSync(outFile, 'utf8').replace(/\r\n/g, '\n').trim().toLowerCase();
     expect(contents).toContain('(:status is null or "u"."status" = :status)');
+  },
+  60000,
+);
+
+test(
+  'query sssql list reports discovered branches in json mode',
+  () => {
+    const workspace = createSqlWorkspace('query-sssql-list', path.join('src', 'sql', 'users.sql'));
+    writeFileSync(
+      workspace.sqlFile,
+      `
+        SELECT u.id, u.status
+        FROM users u
+        WHERE (:status IS NULL OR u.status = :status)
+      `,
+      'utf8'
+    );
+
+    const result = runCli(
+      ['query', 'sssql', 'list', workspace.sqlFile, '--format', 'json'],
+      {},
+      workspace.rootDir
+    );
+
+    assertCliSuccess(result, 'query sssql list');
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed).toMatchObject({
+      command: 'query sssql list',
+      ok: true,
+      data: {
+        file: workspace.sqlFile,
+        branch_count: 1,
+        branches: [
+          expect.objectContaining({
+            parameterName: 'status',
+            kind: 'scalar',
+            operator: '=',
+          })
+        ]
+      }
+    });
+  },
+  60000,
+);
+
+test(
+  'query sssql scaffold supports structured operator input and preview diff',
+  () => {
+    const workspace = createSqlWorkspace('query-sssql-operator-preview', path.join('src', 'sql', 'products.sql'));
+    writeFileSync(
+      workspace.sqlFile,
+      `
+        SELECT p.product_id, p.product_name
+        FROM products p
+      `,
+      'utf8'
+    );
+
+    const result = runCli(
+      [
+        'query',
+        'sssql',
+        'scaffold',
+        workspace.sqlFile,
+        '--filter',
+        'products.product_name',
+        '--parameter',
+        'product_name',
+        '--operator',
+        'ilike',
+        '--preview'
+      ],
+      {},
+      workspace.rootDir
+    );
+
+    assertCliSuccess(result, 'query sssql scaffold preview');
+    expect(result.stdout.toLowerCase()).toContain('---');
+    expect(result.stdout.toLowerCase()).toContain('+++');
+    expect(result.stdout.toLowerCase()).toContain('(:product_name is null or "p"."product_name" ilike :product_name)');
+    expect(readNormalizedFile(workspace.sqlFile).toLowerCase()).not.toContain('ilike');
+  },
+  60000,
+);
+
+test(
+  'query sssql scaffold supports structured exists authoring',
+  () => {
+    const workspace = createSqlWorkspace('query-sssql-exists', path.join('src', 'sql', 'products.sql'));
+    writeFileSync(
+      workspace.sqlFile,
+      `
+        SELECT p.product_id, p.product_name
+        FROM products p
+      `,
+      'utf8'
+    );
+
+    const subqueryFile = path.join(workspace.rootDir, 'category-subquery.sql');
+    writeFileSync(
+      subqueryFile,
+      `
+        SELECT 1
+        FROM product_categories pc
+        WHERE pc.product_id = $c0
+          AND pc.category_name = :category_name
+      `,
+      'utf8'
+    );
+
+    const outFile = path.join(workspace.rootDir, 'products.sssql.sql');
+    const result = runCli(
+      [
+        'query',
+        'sssql',
+        'scaffold',
+        workspace.sqlFile,
+        '--format',
+        'json',
+        '--filter',
+        'products.product_id',
+        '--parameter',
+        'category_name',
+        '--kind',
+        'exists',
+        '--query-file',
+        subqueryFile,
+        '--out',
+        outFile
+      ],
+      {},
+      workspace.rootDir
+    );
+
+    assertCliSuccess(result, 'query sssql scaffold exists');
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed).toMatchObject({
+      command: 'query sssql scaffold',
+      ok: true,
+      data: {
+        file: workspace.sqlFile,
+        output_file: outFile,
+        written: true
+      }
+    });
+
+    const contents = readNormalizedFile(outFile).toLowerCase();
+    expect(contents).toContain(':category_name is null or exists');
+    expect(contents).toContain('"pc"."product_id" = "p"."product_id"');
+  },
+  60000,
+);
+
+test(
+  'query sssql remove removes one branch safely and remains idempotent',
+  () => {
+    const workspace = createSqlWorkspace('query-sssql-remove', path.join('src', 'sql', 'users.sql'));
+    writeFileSync(
+      workspace.sqlFile,
+      `
+        SELECT u.id, u.status
+        FROM users u
+        WHERE (:status IS NULL OR u.status = :status)
+      `,
+      'utf8'
+    );
+
+    const removedFile = path.join(workspace.rootDir, 'users.removed.sql');
+    const first = runCli(
+      [
+        'query',
+        'sssql',
+        'remove',
+        workspace.sqlFile,
+        '--parameter',
+        'status',
+        '--out',
+        removedFile
+      ],
+      {},
+      workspace.rootDir
+    );
+
+    assertCliSuccess(first, 'query sssql remove');
+    expect(readNormalizedFile(removedFile).toLowerCase()).not.toContain(':status');
+
+    const secondOut = path.join(workspace.rootDir, 'users.removed-twice.sql');
+    const second = runCli(
+      [
+        'query',
+        'sssql',
+        'remove',
+        removedFile,
+        '--parameter',
+        'status',
+        '--format',
+        'json',
+        '--out',
+        secondOut
+      ],
+      {},
+      workspace.rootDir
+    );
+
+    assertCliSuccess(second, 'query sssql remove idempotent');
+    const parsed = JSON.parse(second.stdout);
+    expect(parsed).toMatchObject({
+      command: 'query sssql remove',
+      ok: true,
+      data: {
+        changed: false,
+        written: true
+      }
+    });
+    expect(readNormalizedFile(secondOut)).toBe(readNormalizedFile(removedFile));
+  },
+  60000,
+);
+
+test(
+  'query sssql remove --all removes every recognized branch in the query',
+  () => {
+    const workspace = createSqlWorkspace('query-sssql-remove-all', path.join('src', 'sql', 'products.sql'));
+    writeFileSync(
+      workspace.sqlFile,
+      `
+        SELECT p.product_id, p.product_name
+        FROM products p
+        WHERE (:product_name IS NULL OR p.product_name ILIKE :product_name)
+          AND (
+            :category_name IS NULL
+            OR EXISTS (
+              SELECT 1
+              FROM product_categories pc
+              WHERE pc.product_id = p.product_id
+                AND pc.category_name = :category_name
+            )
+          )
+      `,
+      'utf8'
+    );
+
+    const removedFile = path.join(workspace.rootDir, 'products.removed.sql');
+    const result = runCli(
+      [
+        'query',
+        'sssql',
+        'remove',
+        workspace.sqlFile,
+        '--all',
+        '--format',
+        'json',
+        '--out',
+        removedFile
+      ],
+      {},
+      workspace.rootDir
+    );
+
+    assertCliSuccess(result, 'query sssql remove --all');
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed).toMatchObject({
+      command: 'query sssql remove',
+      ok: true,
+      data: {
+        changed: true,
+        written: true
+      }
+    });
+
+    const contents = readNormalizedFile(removedFile).toLowerCase();
+    expect(contents).not.toContain(':product_name');
+    expect(contents).not.toContain(':category_name');
+    expect(contents).not.toContain('exists');
+  },
+  60000,
+);
+
+test(
+  'query sssql remove --all rejects targeted remove flags',
+  () => {
+    const workspace = createSqlWorkspace('query-sssql-remove-all-invalid', path.join('src', 'sql', 'users.sql'));
+    writeFileSync(
+      workspace.sqlFile,
+      `
+        SELECT u.id, u.status
+        FROM users u
+        WHERE (:status IS NULL OR u.status = :status)
+      `,
+      'utf8'
+    );
+
+    const result = runCli(
+      [
+        'query',
+        'sssql',
+        'remove',
+        workspace.sqlFile,
+        '--all',
+        '--parameter',
+        'status'
+      ],
+      {},
+      workspace.rootDir
+    );
+
+    assertCliFailure(result, 'query sssql remove --all invalid');
+    expect(result.stderr || result.stdout).toContain('Use --all by itself');
+  },
+  60000,
+);
+
+test(
+  'query sssql scaffold fails fast when rewrite would drop SQL comments',
+  () => {
+    const workspace = createSqlWorkspace('query-sssql-comment-guard', path.join('src', 'sql', 'users.sql'));
+    writeFileSync(
+      workspace.sqlFile,
+      `
+        SELECT
+          u.id, -- keep me
+          u.status
+        FROM users u
+      `,
+      'utf8'
+    );
+
+    const result = runCli(
+      [
+        'query',
+        'sssql',
+        'scaffold',
+        workspace.sqlFile,
+        '--filter',
+        'users.status',
+        '--parameter',
+        'status',
+        '--operator',
+        '='
+      ],
+      {},
+      workspace.rootDir
+    );
+
+    assertCliFailure(result, 'query sssql scaffold comment guard');
+    expect(result.stderr || result.stdout).toContain('would drop SQL comments');
   },
   60000,
 );

--- a/packages/ztd-cli/tests/cliCommands.test.ts
+++ b/packages/ztd-cli/tests/cliCommands.test.ts
@@ -905,6 +905,54 @@ test(
 );
 
 test(
+  'query sssql scaffold overwrites the input file by default on non-preview runs',
+  () => {
+    const workspace = createSqlWorkspace('query-sssql-scaffold-overwrite', path.join('src', 'sql', 'users.sql'));
+    writeFileSync(
+      workspace.sqlFile,
+      `
+        SELECT u.id, u.status
+        FROM users u
+      `,
+      'utf8'
+    );
+
+    const result = runCli(
+      [
+        'query',
+        'sssql',
+        'scaffold',
+        workspace.sqlFile,
+        '--format',
+        'json',
+        '--json',
+        JSON.stringify({
+          filters: { status: 'premium' }
+        })
+      ],
+      {},
+      workspace.rootDir
+    );
+
+    assertCliSuccess(result, 'query sssql scaffold overwrite');
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed).toMatchObject({
+      command: 'query sssql scaffold',
+      ok: true,
+      data: {
+        file: workspace.sqlFile,
+        output_file: workspace.sqlFile,
+        written: true
+      }
+    });
+
+    const contents = readNormalizedFile(workspace.sqlFile).toLowerCase();
+    expect(contents).toContain('(:status is null or "u"."status" = :status)');
+  },
+  60000,
+);
+
+test(
   'query sssql refresh accepts a JSON payload for machine-readable automation',
   () => {
     const workspace = createSqlWorkspace('query-sssql-refresh-json', path.join('src', 'sql', 'users.sql'));


### PR DESCRIPTION
## Issue
- Closes #764

## Customer Value
- Developers can now inspect, author, refresh, remove, and bulk-remove recognized SSSQL branches from the CLI instead of editing optional-condition SQL by hand.
- The SSSQL workflow is easier to understand because the command surface and runtime pruning contract now have a single reader-facing reference page.

## Outcome
- Added `ztd query sssql list` to report recognized SSSQL branches in text and JSON forms.
- Added structured `ztd query sssql scaffold` support for scalar operators plus `EXISTS` / `NOT EXISTS` authoring with preview mode, idempotency, and fail-fast validation.
- Added `ztd query sssql remove` for single-branch removal and `ztd query sssql remove --all` for bulk removal of all recognized branches.
- Kept `refresh` focused on re-anchoring existing recognized scalar branches without inventing new runtime predicates.
- Updated docs and routing guidance so README stays an entry-point index while SSSQL behavior lives in dedicated guides.

## Acceptance Criteria
- [x] `ztd query sssql list <sqlFile>` reports recognized authored branches in machine-readable and human-readable forms.
- [x] `ztd query sssql remove <sqlFile>` removes exactly one targeted recognized branch safely, supports preview, and stays idempotent when the target is already absent.
- [x] `ztd query sssql remove <sqlFile> --all` removes every recognized branch explicitly and rejects mixed targeted flags.
- [x] `ztd query sssql scaffold <sqlFile>` supports richer scalar operators and structured `EXISTS` / `NOT EXISTS` authoring.
- [x] Scaffold, refresh, and remove flows remain idempotent and fail fast on ambiguous or unsafe input.
- [x] Runtime pruning still depends on explicit `optionalConditionParameters` and supports authored scalar, `EXISTS`, and `NOT EXISTS` branches.
- [x] Docs describe the current CLI/API surface and routing behavior accurately.

## Verification
- `pnpm exec vitest run packages/core/tests/transformers/SSSQLFilterBuilder.test.ts`
- `pnpm exec vitest run packages/ztd-cli/tests/cliCommands.test.ts -t "query sssql"`
- `pnpm --filter @rawsql-ts/ztd-cli build`

## Repository Evidence
- Core SSSQL authoring and removal helpers: `packages/core/src/transformers/SSSQLFilterBuilder.ts`
- Focused pruning and builder coverage: `packages/core/tests/transformers/SSSQLFilterBuilder.test.ts`
- CLI surface and rewrite reporting: `packages/ztd-cli/src/commands/query.ts`
- CLI behavior coverage: `packages/ztd-cli/tests/cliCommands.test.ts`
- Reader-facing docs: `docs/guide/ztd-cli-sssql-reference.md`, `docs/guide/ztd-cli-sssql-authoring.md`, `packages/ztd-cli/README.md`
- Changeset: `.changeset/sssql-cli-reference-and-remove-all.md`

## Supplementary Evidence
- DB-dependent CLI tests were skipped locally because `pg_dump` is not available in PATH.
- I did not run a full docs site build in this branch.

## Open Questions
- The current `refresh` implementation still keys off recognized scalar branch targets. I did not extend it to infer and move correlated `EXISTS` / `NOT EXISTS` branches because that behavior is not yet safely proven.

## Merge Blockers
- No known code blockers.
- Reviewer should confirm the changeset release type is correct for `rawsql-ts` and `@rawsql-ts/ztd-cli`.

## Merge Readiness
- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

## CLI Surface Migration
- [ ] No migration packet required for this CLI change.
- [x] CLI/user-facing surface change and migration packet completed.
Upgrade note: `ztd query sssql` now includes `list`, structured `scaffold`, targeted `remove`, and `remove --all`; non-preview rewrites overwrite the source SQL file by default unless `--out` is supplied.
Deprecation/removal plan or issue: No deprecation is introduced in this PR.
Docs/help/examples updated: Added `docs/guide/ztd-cli-sssql-reference.md` and updated `docs/guide/ztd-cli-sssql-authoring.md` plus `packages/ztd-cli/README.md`.
Release/changeset wording: Covered by `.changeset/sssql-cli-reference-and-remove-all.md`.

## Scaffold Contract Proof
- [ ] No scaffold contract proof required for this PR.
- [x] Scaffold contract proof completed.
Non-edit assertion: `query sssql list` inspects recognized branches without mutating the SQL file.
Fail-fast input-contract proof: Added coverage for empty `anchorColumns` and preserved fail-fast handling for unsupported scalar operator parsing.
Generated-output viability proof: Focused CLI tests verify preview/apply flows, overwrite-by-default behavior, branch removal, and bulk removal.
