### PR TITLE
fix: quote build:publish filter for CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "coverage:workspaces": "pnpm -r --if-present coverage",
     "build": "pnpm -r --if-present build",
     "build:core": "pnpm --filter rawsql-ts build",
-    "build:publish": "pnpm -r --workspace-concurrency=1 --filter ./packages/** --if-present run build",
+    "build:publish": "pnpm -r --workspace-concurrency=1 --filter \"./packages/**\" --if-present run build",
     "build:publish-artifacts": "node scripts/build-publish-artifacts.mjs",
     "changeset": "changeset",
     "changesets:version": "changeset version",


### PR DESCRIPTION
## Summary
- Quote the root build:publish workspace glob so bash does not expand it before pnpm sees it
- This keeps workspace package builds running in CI/Linux generated-project verification

## Verification
- `npx -y node@20.20.2 scripts/verify-generated-project-mode.mjs` ✅
- `docker run ... pnpm build:publish` on Linux container ✅

## Merge Readiness
- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue:
Scoped checks run:
Why full baseline is not required:

## Notes
- The change is limited to root `package.json`
- It addresses the generated-project prebuild step, not the package entry itself
