### PR TITLE
feat(ztd-cli): add test-kind support for feature tests scaffold

### DIFF
--- a/.changeset/fair-apes-tie.md
+++ b/.changeset/fair-apes-tie.md
@@ -1,0 +1,12 @@
+---
+"@rawsql-ts/ztd-cli": minor
+---
+
+Add `--test-kind ztd|traditional` to `ztd feature tests scaffold` and keep `ztd` as the default.
+
+This update enables side-by-side lane scaffolding for query tests without breaking existing ZTD-only workflows:
+
+- `ztd` lane keeps generating the current files (`<query>.boundary.ztd.test.ts`, `generated/TEST_PLAN.md`, `generated/analysis.json`).
+- `traditional` lane generates lane-specific scaffold files (`<query>.boundary.traditional.test.ts`, `boundary-traditional-types.ts`, `generated/TEST_PLAN.traditional.md`, `generated/analysis.traditional.json`, and `cases/basic.traditional.case.ts`).
+
+The new lane scaffold is intentionally thin and keeps mode execution responsibility in the library layer.

--- a/docs/guide/ztd-cli-traditional-lane-followup-plan.md
+++ b/docs/guide/ztd-cli-traditional-lane-followup-plan.md
@@ -6,7 +6,7 @@ It is intentionally scoped as a design/plan artifact, not an implementation comm
 ## Status
 
 - Current status: `done` (planning artifact for Issue #767)
-- Implementation status: `not done` (separate issues/PRs are expected)
+- Implementation status: `partial` (CLI lane-aware scaffold is shipped; library adapter wiring remains follow-up)
 
 ## Objective
 
@@ -69,9 +69,9 @@ src/features/<feature>/queries/<query>/tests/
   <query>.boundary.traditional.test.ts
   cases/
   generated/
-    TEST_PLAN.ztd.md
+    TEST_PLAN.md
     TEST_PLAN.traditional.md
-    analysis.ztd.json
+    analysis.json
     analysis.traditional.json
 ```
 

--- a/docs/guide/ztd-cli-traditional-lane-followup-plan.md
+++ b/docs/guide/ztd-cli-traditional-lane-followup-plan.md
@@ -1,0 +1,211 @@
+# ztd-cli Traditional Lane Follow-up Plan
+
+This document defines the follow-up expansion plan for exposing `ztd | traditional` test lanes in `ztd-cli`.
+It is intentionally scoped as a design/plan artifact, not an implementation commit.
+
+## Status
+
+- Current status: `done` (planning artifact for Issue #767)
+- Implementation status: `not done` (separate issues/PRs are expected)
+
+## Objective
+
+Enable `ztd-cli` users to choose a test lane (`ztd` or `traditional`) per query/test intent without moving mode implementation responsibility into CLI.
+
+## User Value
+
+- Keep fast contract validation in ZTD lane.
+- Use traditional lane for migration/seeding/index/physical-state verification.
+- Select the right lane per query or test file based on purpose.
+- Make the selected lane traceable from scaffold layout and test evidence.
+
+## Non-Goal
+
+- Do not re-implement mode runtime behavior in CLI.
+- Do not make this issue a delivery gate for starter acceptance, `mode=ztd` evidence rollout, or SQL trace rollout.
+
+## Current Baseline (Observed in `ztd-cli`)
+
+- `feature tests scaffold` currently emits ZTD-only entrypoints and metadata:
+  - `<query>.boundary.ztd.test.ts`
+  - `generated/TEST_PLAN.md` with `testKind: ztd`
+  - `generated/analysis.json` with `testKind: ztd`
+- Existing behavior and generated assets are tested as ZTD-first contracts.
+
+## CLI Surface Proposal
+
+### Proposed Option
+
+Add a `--test-kind` selector to `feature tests scaffold`.
+
+```bash
+ztd feature tests scaffold --feature <feature-name> --test-kind ztd
+ztd feature tests scaffold --feature <feature-name> --test-kind traditional
+```
+
+- Allowed values: `ztd | traditional`
+- Default: `ztd` (for backward compatibility and onboarding simplicity)
+- Keep existing invocations valid when `--test-kind` is omitted.
+
+### Optional Future Extension
+
+If multi-lane generation in one run becomes useful:
+
+```bash
+ztd feature tests scaffold --feature <feature-name> --test-kind both
+```
+
+`both` is explicitly out of initial scope to keep behavior predictable.
+
+## Coexisting Scaffold Layout
+
+Two layout candidates were compared.
+
+### Candidate A: File Suffix (Recommended)
+
+```text
+src/features/<feature>/queries/<query>/tests/
+  <query>.boundary.ztd.test.ts
+  <query>.boundary.traditional.test.ts
+  cases/
+  generated/
+    TEST_PLAN.ztd.md
+    TEST_PLAN.traditional.md
+    analysis.ztd.json
+    analysis.traditional.json
+```
+
+Benefits:
+
+- Preserves current directory shape.
+- Easy per-file lane selection in editor/CI.
+- Lower migration cost from existing ZTD-only scaffold.
+
+Costs:
+
+- More files in one directory.
+- Requires lane-aware naming discipline.
+
+### Candidate B: Lane Directories
+
+```text
+src/features/<feature>/queries/<query>/tests/
+  ztd/
+    <query>.boundary.test.ts
+    cases/
+    generated/
+  traditional/
+    <query>.boundary.test.ts
+    cases/
+    generated/
+```
+
+Benefits:
+
+- Strong physical separation by lane.
+- Clear ownership per lane.
+
+Costs:
+
+- Larger scaffold diff footprint.
+- Higher risk of duplicated helper paths and import churn.
+- Harder backward compatibility with current single-lane structure.
+
+### Decision
+
+Start with Candidate A (suffix strategy). Revisit directory strategy only if suffix-based growth becomes unmanageable.
+
+## Responsibility Boundary (CLI vs Library)
+
+- Library owns execution mode semantics (`ztd | traditional` runtime behavior).
+- CLI owns:
+  - lane selection UX (`--test-kind`)
+  - lane-specific scaffold wiring (entrypoints, generated plan/analysis files)
+  - evidence visibility in scaffold artifacts
+- Generated helpers for both lanes must stay thin adapters that call library mode APIs.
+- CLI must not re-implement migration/seeding/cleanup internals.
+
+## Mode Switching Granularity
+
+Recommended policy:
+
+- Primary switching unit: test file.
+- Practical organization unit: query boundary.
+- Optional coordination unit: feature-level conventions (documented, not enforced).
+
+Rationale:
+
+- Test-file switching allows mixed intent within one query boundary.
+- Query-level default still stays readable in filesystem layout.
+
+## Traditional Lane Adapter Policy
+
+- Traditional lane entrypoints must call the same library-facing boundary contract style as ZTD lane.
+- Only lane-specific wiring changes are allowed (e.g., runner selection and evidence tags).
+- No independent lifecycle stack in generated CLI helpers.
+
+## Starter UX Decision Points
+
+Initial recommendation:
+
+- Starter default remains ZTD-first.
+- Mention traditional lane existence in docs/help.
+- Do not include full traditional sample by default in starter scaffold.
+
+Decision criteria for exposing traditional by default later:
+
+- onboarding complexity delta
+- maintenance overhead of dual-lane starter artifacts
+- support request frequency for physical-state verification
+
+## Evidence Contract Alignment
+
+Lane coexistence should preserve machine-readable evidence alignment.
+
+- ZTD lane keeps current expectations (`mode=ztd`, `physicalSetupUsed=false`).
+- Traditional lane must emit its own lane-consistent evidence contract and clear metadata separation.
+- Generated artifacts should be lane-qualified so CI/reporting can summarize by lane without ambiguity.
+
+## Acceptance Criteria for Follow-up Implementation
+
+- CLI surface explicitly documents and supports `--test-kind ztd|traditional` with default `ztd`.
+- Coexisting scaffold strategy is implemented with explicit trade-off rationale preserved.
+- CLI-library responsibility boundary remains intact.
+- Traditional generated helper path stays a thin library-mode adapter.
+- Mode switching policy at query/test-file level is documented and testable.
+- Starter UX decision is documented with explicit criteria.
+
+## Verification Plan (Prototype/Implementation Phase)
+
+- Unit tests for argument parsing and defaults (`--test-kind` behavior).
+- Snapshot/fixture tests for generated file names and lane-qualified artifacts.
+- Regression tests proving omitted `--test-kind` matches current ZTD behavior.
+- Contract tests that generated helpers call library mode APIs rather than local lifecycle logic.
+- Evidence-schema tests verifying lane-disambiguated output.
+
+## Scope In
+
+- CLI surface design for traditional test kind
+- Coexisting lane scaffold design
+- Query/test-file mode switching policy
+- Starter exposure decision framework
+
+## Scope Out
+
+- Immediate starter acceptance gate implementation
+- Immediate `mode=ztd` evidence rollout changes
+- Immediate opt-in SQL trace rollout changes
+- Immediate first-pass mode delegation restructuring
+
+## Risks
+
+- UX expansion before boundary hardening may reintroduce CLI responsibility creep.
+- Coexisting lane files can increase scaffold complexity if naming rules are weak.
+- Overexposing traditional lane too early may degrade first-run onboarding.
+
+## Open Questions
+
+- Should feature-level defaults be configurable, or only test-file explicit?
+- Is suffix naming enough for long-lived repos, or will directory lanes become necessary?
+- Where should lane summary live first: CLI output, JSON artifact, or generated docs?
+- What is the minimum traditional evidence contract needed for release confidence?

--- a/packages/ztd-cli/README.md
+++ b/packages/ztd-cli/README.md
@@ -230,6 +230,7 @@ Use `ztd describe` for machine-readable discovery, and follow the linked guides 
 - [Repository Telemetry Setup](../../docs/guide/repository-telemetry-setup.md) - how to edit the scaffold, emit logs, and investigate with `queryId`
 - [Observed SQL Investigation](../../docs/guide/observed-sql-investigation.md) - how to use `ztd query match-observed` when `queryId` is missing
 - [ztd-cli Agent Interface](../../docs/guide/ztd-cli-agent-interface.md) - machine-readable command surface
+- [Traditional Lane Follow-up Plan](../../docs/guide/ztd-cli-traditional-lane-followup-plan.md) - design plan for exposing `--test-kind ztd|traditional` and coexisting lane scaffolds
 
 ### Advanced User Guides
 

--- a/packages/ztd-cli/src/commands/featureTests.ts
+++ b/packages/ztd-cli/src/commands/featureTests.ts
@@ -460,7 +460,7 @@ function buildTestPlanDetails(params: {
     fixtureCandidateTables,
     writesTables,
     validationScenarioHints: buildValidationScenarioHints(requestFields, params.queryLayout.queryName),
-    dbScenarioHints: buildDbScenarioHints(writesTables, params.queryLayout.queryName, fixtureCandidateTables),
+    dbScenarioHints: buildDbScenarioHints(params.testKind, writesTables, params.queryLayout.queryName, fixtureCandidateTables),
     resultCardinality,
     queryInputFields: resolvedInputFields,
     queryOutputFields: resolvedOutputFields,
@@ -494,15 +494,29 @@ function buildValidationScenarioHints(requestFields: string[], queryName: string
   return hints;
 }
 
-function buildDbScenarioHints(writesTables: string[], queryName: string, fixtureCandidateTables: string[]): string[] {
-  const hints = [
-    'Use the fixed app-level harness and query-local cases to keep the ZTD path thin.',
-    'Keep db/input/output visible in the case file so the AI can fill the query contract without re-deriving the scaffold.'
-  ];
+function buildDbScenarioHints(
+  testKind: FeatureTestKind,
+  writesTables: string[],
+  queryName: string,
+  fixtureCandidateTables: string[]
+): string[] {
+  const hints = testKind === 'ztd'
+    ? [
+      'Use the fixed app-level harness and query-local cases to keep the ZTD path thin.',
+      'Keep db/input/output visible in the case file so the AI can fill the query contract without re-deriving the scaffold.'
+    ]
+    : [
+      'Use this scaffold as a lane-specific starting point and wire execution through the library traditional mode API adapter.',
+      'Keep db/input/output/afterDb visible in the case file so physical-state verification intent stays explicit.'
+    ];
 
   if (writesTables.length > 0) {
     hints.push(`Write tables for ${queryName}: ${writesTables.map((table) => `\`${table}\``).join(', ')}.`);
-    hints.push('Switch to a traditional DB-state lane when you need post-execution table assertions.');
+    hints.push(
+      testKind === 'ztd'
+        ? 'Switch to a traditional DB-state lane when you need post-execution table assertions.'
+        : 'Add post-execution table assertions in this lane when physical-state verification is required.'
+    );
   } else if (fixtureCandidateTables.length > 0) {
     hints.push(`Read tables for ${queryName}: ${fixtureCandidateTables.map((table) => `\`${table}\``).join(', ')}.`);
     hints.push('DB-backed cases should seed the minimum fixture rows needed to make the query result shape obvious.');

--- a/packages/ztd-cli/src/commands/featureTests.ts
+++ b/packages/ztd-cli/src/commands/featureTests.ts
@@ -8,10 +8,13 @@ import { inspectImportAliasSupport } from '../utils/importAliasSupport';
 
 const TESTS_SUPPORT_HARNESS_IMPORT_PATH = '#tests/support/ztd/harness.js';
 const TESTS_SUPPORT_CASE_TYPES_IMPORT_PATH = '#tests/support/ztd/case-types.js';
+const FEATURE_TEST_KINDS = ['ztd', 'traditional'] as const;
+type FeatureTestKind = (typeof FEATURE_TEST_KINDS)[number];
 
 type FeatureTestsCommandOptions = {
   feature?: string;
   query?: string;
+  testKind?: string;
   dryRun?: boolean;
   force?: boolean;
   rootDir?: string;
@@ -20,6 +23,7 @@ type FeatureTestsCommandOptions = {
 interface FeatureTestsScaffoldResult {
   featureName: string;
   queryName: string;
+  testKind: FeatureTestKind;
   dryRun: boolean;
   outputs: Array<{ path: string; written: boolean; kind: 'directory' | 'file' }>;
 }
@@ -43,7 +47,7 @@ interface QueryLayout {
 interface FeatureTestAnalysis {
   schemaVersion: 1;
   featureId: string;
-  testKind: 'ztd';
+  testKind: FeatureTestKind;
   fixtureCandidateTables: string[];
   writesTables: string[];
   validationScenarioHints: string[];
@@ -76,6 +80,7 @@ export function registerFeatureTestsScaffoldCommand(featureCommand: Command): vo
     .description('Refresh query-boundary generated analysis, refresh the generated type file, and keep persistent case files untouched')
     .requiredOption('--feature <name>', 'Target feature name')
     .option('--query <name>', 'Target query directory when the feature has more than one query')
+    .option('--test-kind <kind>', 'Scaffold lane kind (ztd or traditional)', 'ztd')
     .option('--dry-run', 'Validate inputs and emit the planned scaffold without writing files', false)
     .option('--force', 'Overwrite scaffold-owned generated files when they already exist', false)
     .action(async (options: FeatureTestsCommandOptions) => {
@@ -88,15 +93,16 @@ export function registerFeatureTestsScaffoldCommand(featureCommand: Command): vo
       const lines = [
         `Feature tests scaffold ${result.dryRun ? 'plan' : 'completed'}: ${result.featureName}`,
         `Query: ${result.queryName}`,
+        `Test kind: ${result.testKind}`,
         '',
         'Created by CLI:',
         ...result.outputs.map((output) => `- ${output.path}`),
         '',
         'CLI-owned generated files:',
-        `- src/features/${result.featureName}/queries/${result.queryName}/tests/${result.queryName}.boundary.ztd.test.ts (created only when missing)`,
-        `- src/features/${result.featureName}/queries/${result.queryName}/tests/boundary-ztd-types.ts`,
-        `- src/features/${result.featureName}/queries/${result.queryName}/tests/generated/TEST_PLAN.md`,
-        `- src/features/${result.featureName}/queries/${result.queryName}/tests/generated/analysis.json`,
+        `- src/features/${result.featureName}/queries/${result.queryName}/tests/${result.queryName}.boundary.${result.testKind}.test.ts (created only when missing)`,
+        `- src/features/${result.featureName}/queries/${result.queryName}/tests/boundary-${result.testKind}-types.ts`,
+        `- src/features/${result.featureName}/queries/${result.queryName}/tests/generated/${result.testKind === 'ztd' ? 'TEST_PLAN.md' : 'TEST_PLAN.traditional.md'}`,
+        `- src/features/${result.featureName}/queries/${result.queryName}/tests/generated/${result.testKind === 'ztd' ? 'analysis.json' : 'analysis.traditional.json'}`,
         '',
         'AI-authored files:',
         `- src/features/${result.featureName}/queries/${result.queryName}/tests/cases/`
@@ -107,27 +113,32 @@ export function registerFeatureTestsScaffoldCommand(featureCommand: Command): vo
 
 export async function runFeatureTestsScaffoldCommand(options: FeatureTestsCommandOptions): Promise<FeatureTestsScaffoldResult> {
   const rootDir = options.rootDir ?? process.cwd();
+  const testKind = normalizeFeatureTestKind(options.testKind);
   const featureName = normalizeFeatureName(options.feature ?? '');
   const featureDir = path.join(rootDir, 'src', 'features', featureName);
   if (!existsSync(featureDir)) {
     throw new Error(`Feature not found for tests scaffold: ${featureName}. Run feature scaffold first.`);
   }
 
-  const queryLayout = resolveQueryLayout(featureDir, featureName, options.query);
-  assertSharedZtdTestSupport(rootDir);
+  const queryLayout = resolveQueryLayout(featureDir, featureName, options.query, testKind);
+  if (testKind === 'ztd') {
+    assertSharedZtdTestSupport(rootDir);
+  }
   assertGeneratedWriteSafety([queryLayout.planFile, queryLayout.analysisFile], options.force === true);
 
   const planDetails = buildTestPlanDetails({
     rootDir,
     featureDir,
-    queryLayout
+    queryLayout,
+    testKind
   });
 
   const files = renderFeatureTestScaffoldFiles({
     rootDir,
     featureName,
     queryName: queryLayout.queryName,
-    planDetails
+    planDetails,
+    testKind
   });
 
   const outputs: FeatureTestsScaffoldResult['outputs'] = [
@@ -145,6 +156,7 @@ export async function runFeatureTestsScaffoldCommand(options: FeatureTestsComman
     return {
       featureName,
       queryName: queryLayout.queryName,
+      testKind,
       dryRun: true,
       outputs
     };
@@ -165,12 +177,13 @@ export async function runFeatureTestsScaffoldCommand(options: FeatureTestsComman
 
   emitDiagnostic({
     code: 'feature-tests-scaffold.ai-follow-up',
-    message: `CLI refreshed generated analysis under src/features/${featureName}/queries/${queryLayout.queryName}/tests/generated/, refreshed boundary-ztd-types.ts, created the thin Vitest entrypoint only if it was missing, and left AI-authored cases under src/features/${featureName}/queries/${queryLayout.queryName}/tests/cases/ untouched.`
+    message: `CLI refreshed generated analysis under src/features/${featureName}/queries/${queryLayout.queryName}/tests/generated/ for test-kind=${testKind}, refreshed boundary-${testKind}-types.ts, created the thin Vitest entrypoint only if it was missing, and left AI-authored cases under src/features/${featureName}/queries/${queryLayout.queryName}/tests/cases/ untouched.`
   });
 
   return {
     featureName,
     queryName: queryLayout.queryName,
+    testKind,
     dryRun: false,
     outputs
   };
@@ -201,6 +214,7 @@ function renderFeatureTestScaffoldFiles(params: {
   featureName: string;
   queryName: string;
   planDetails: TestPlanDetails;
+  testKind: FeatureTestKind;
 }): {
   testPlanFile: string;
   analysisFile: string;
@@ -219,6 +233,7 @@ function renderFeatureTestScaffoldFiles(params: {
     );
   }
   const useStableTestSupportImports = importAliasSupport === 'supported';
+  const isZtdLane = params.testKind === 'ztd';
   const fixtureCandidateTablesLine = params.planDetails.fixtureCandidateTables.length > 0
     ? params.planDetails.fixtureCandidateTables.map((field) => `- ${field}`).join('\n')
     : '- TODO: inspect the scaffolded SQL and DDL for fixture candidate tables.';
@@ -274,10 +289,19 @@ function renderFeatureTestScaffoldFiles(params: {
     '',
     '## After DB Semantics',
     '',
-    '- ZTD queryspec execution is fixture-rewrite based and does not perform physical DB setup.',
-    '- `mode=ztd`, `physicalSetupUsed=false`, and `rewriteApplied` are returned as machine-checkable evidence.',
-    '- This ZTD lane does not expose `afterDb`; use output assertions or a traditional DB-state lane for post-state checks.',
-    '- Set `ZTD_SQL_TRACE=1` to emit per-case SQL trace JSON; optionally set `ZTD_SQL_TRACE_DIR` to override the output directory.',
+    ...(isZtdLane
+      ? [
+        '- ZTD queryspec execution is fixture-rewrite based and does not perform physical DB setup.',
+        '- `mode=ztd`, `physicalSetupUsed=false`, and `rewriteApplied` are returned as machine-checkable evidence.',
+        '- This ZTD lane does not expose `afterDb`; use output assertions or a traditional DB-state lane for post-state checks.',
+        '- Set `ZTD_SQL_TRACE=1` to emit per-case SQL trace JSON; optionally set `ZTD_SQL_TRACE_DIR` to override the output directory.'
+      ]
+      : [
+        '- Traditional lane should execute against physical DB state and keep evidence lane-tagged as `mode=traditional`.',
+        '- Post-state assertions can be modeled in this lane (for example migration/index/physical-state effects).',
+        '- Generated scaffold stays thin and must delegate mode behavior to library APIs instead of re-implementing lifecycle logic.',
+        '- Use this scaffold as a follow-up wiring point while preserving query-local case ownership.'
+      ]),
     '',
     '## Ownership',
     '',
@@ -306,11 +330,11 @@ function renderFeatureTestScaffoldFiles(params: {
   const harnessImportPath = useStableTestSupportImports
     ? TESTS_SUPPORT_HARNESS_IMPORT_PATH
     : '../../../../../../tests/support/ztd/harness.js';
-  const casesImportPath = './cases/basic.case.js';
+  const casesImportPath = isZtdLane ? './cases/basic.case.js' : './cases/basic.traditional.case.js';
   const executorName = readExportedFunctionName(params.planDetails.querySpecSourcePath, 'execute', 'QuerySpec');
   const queryTypePrefix = toPascalCase(params.queryName);
-  const queryCaseTypeName = `${queryTypePrefix}QueryBoundaryZtdCase`;
-  const queryTypesImportPath = './boundary-ztd-types.js';
+  const queryCaseTypeName = isZtdLane ? `${queryTypePrefix}QueryBoundaryZtdCase` : `${queryTypePrefix}QueryBoundaryTraditionalCase`;
+  const queryTypesImportPath = isZtdLane ? './boundary-ztd-types.js' : './boundary-traditional-types.js';
   const beforeDbTypeLiteral = buildQueryFixtureTypeLiteral(
     params.planDetails.fixtureCandidateTables,
     buildQueryFixtureRowTypeLiteral(params.planDetails.queryFixtureRowFields)
@@ -318,25 +342,40 @@ function renderFeatureTestScaffoldFiles(params: {
   const beforeDbValueLiteral = buildQueryFixtureValueLiteral(params.planDetails.fixtureCandidateTables);
   const queryInputTypeLiteral = buildRecordShapeTypeLiteral(params.planDetails.queryInputFields);
   const queryOutputTypeLiteral = buildRecordShapeTypeLiteral(params.planDetails.queryOutputFields);
-  const vitestEntrypointFile = [
-    `import { expect, test } from 'vitest';`,
-    '',
-    `import { runQuerySpecZtdCases } from '${harnessImportPath}';`,
-    `import { ${executorName} } from '${querySpecImportPath}';`,
-    `import cases from '${casesImportPath}';`,
-    `import type { ${queryCaseTypeName} } from '${queryTypesImportPath}';`,
-    '',
-    `test('${params.featureName}/${params.queryName} boundary ZTD cases run through the fixed app-level harness', async () => {`,
-    '  expect(cases.length).toBeGreaterThan(0);',
-    `  const evidence = await runQuerySpecZtdCases(cases, ${executorName});`,
-    "  expect(evidence.every((entry) => entry.mode === 'ztd')).toBe(true);",
-    '  expect(evidence.every((entry) => entry.physicalSetupUsed === false)).toBe(true);',
-    '});',
-    ''
-  ].join('\n');
+  const vitestEntrypointFile = isZtdLane
+    ? [
+      `import { expect, test } from 'vitest';`,
+      '',
+      `import { runQuerySpecZtdCases } from '${harnessImportPath}';`,
+      `import { ${executorName} } from '${querySpecImportPath}';`,
+      `import cases from '${casesImportPath}';`,
+      `import type { ${queryCaseTypeName} } from '${queryTypesImportPath}';`,
+      '',
+      `test('${params.featureName}/${params.queryName} boundary ZTD cases run through the fixed app-level harness', async () => {`,
+      '  expect(cases.length).toBeGreaterThan(0);',
+      `  const evidence = await runQuerySpecZtdCases(cases, ${executorName});`,
+      "  expect(evidence.every((entry) => entry.mode === 'ztd')).toBe(true);",
+      '  expect(evidence.every((entry) => entry.physicalSetupUsed === false)).toBe(true);',
+      '});',
+      ''
+    ].join('\n')
+    : [
+      `import { expect, test } from 'vitest';`,
+      '',
+      `import { ${executorName} } from '${querySpecImportPath}';`,
+      `import cases from '${casesImportPath}';`,
+      `import type { ${queryCaseTypeName} } from '${queryTypesImportPath}';`,
+      '',
+      `test.skip('${params.featureName}/${params.queryName} boundary traditional lane scaffold placeholder', async () => {`,
+      '  expect(cases.length).toBeGreaterThan(0);',
+      '  // TODO(issue-767 follow-up): wire this lane to the library traditional mode API.',
+      `  void ${executorName};`,
+      '});',
+      ''
+    ].join('\n');
 
   const basicCaseFile = [
-    `import type { ${queryTypePrefix}BeforeDb, ${queryTypePrefix}Input, ${queryTypePrefix}Output, ${queryCaseTypeName} } from '../boundary-ztd-types.js';`,
+    `import type { ${queryTypePrefix}BeforeDb, ${queryTypePrefix}Input, ${queryTypePrefix}Output, ${queryCaseTypeName} } from '${isZtdLane ? '../boundary-ztd-types.js' : '../boundary-traditional-types.js'}';`,
     '',
     `const cases: readonly ${queryCaseTypeName}[] = [`,
     '  {',
@@ -351,20 +390,35 @@ function renderFeatureTestScaffoldFiles(params: {
     ''
   ].join('\n');
 
-  const queryTypesFile = [
-    `import type { QuerySpecZtdCase } from '${useStableTestSupportImports ? TESTS_SUPPORT_CASE_TYPES_IMPORT_PATH : '../../../../../../tests/support/ztd/case-types.js'}';`,
-    '',
-    `export type ${queryTypePrefix}BeforeDb = ${beforeDbTypeLiteral};`,
-    `export type ${queryTypePrefix}Input = ${queryInputTypeLiteral};`,
-    `export type ${queryTypePrefix}Output = ${queryOutputTypeLiteral};`,
-    '',
-    `export type ${queryCaseTypeName} = QuerySpecZtdCase<`,
-    `  ${queryTypePrefix}BeforeDb,`,
-    `  ${queryTypePrefix}Input,`,
-    `  ${queryTypePrefix}Output`,
-    '>;',
-    ''
-  ].join('\n');
+  const queryTypesFile = isZtdLane
+    ? [
+      `import type { QuerySpecZtdCase } from '${useStableTestSupportImports ? TESTS_SUPPORT_CASE_TYPES_IMPORT_PATH : '../../../../../../tests/support/ztd/case-types.js'}';`,
+      '',
+      `export type ${queryTypePrefix}BeforeDb = ${beforeDbTypeLiteral};`,
+      `export type ${queryTypePrefix}Input = ${queryInputTypeLiteral};`,
+      `export type ${queryTypePrefix}Output = ${queryOutputTypeLiteral};`,
+      '',
+      `export type ${queryCaseTypeName} = QuerySpecZtdCase<`,
+      `  ${queryTypePrefix}BeforeDb,`,
+      `  ${queryTypePrefix}Input,`,
+      `  ${queryTypePrefix}Output`,
+      '>;',
+      ''
+    ].join('\n')
+    : [
+      `export type ${queryTypePrefix}BeforeDb = ${beforeDbTypeLiteral};`,
+      `export type ${queryTypePrefix}Input = ${queryInputTypeLiteral};`,
+      `export type ${queryTypePrefix}Output = ${queryOutputTypeLiteral};`,
+      '',
+      `export type ${queryCaseTypeName} = {`,
+      '  readonly name: string;',
+      `  readonly beforeDb: ${queryTypePrefix}BeforeDb;`,
+      `  readonly input: ${queryTypePrefix}Input;`,
+      `  readonly output: ${queryTypePrefix}Output;`,
+      '  readonly afterDb?: Record<string, unknown>;',
+      '};',
+      ''
+    ].join('\n');
 
   return {
     testPlanFile,
@@ -379,6 +433,7 @@ function buildTestPlanDetails(params: {
   rootDir: string;
   featureDir: string;
   queryLayout: QueryLayout;
+  testKind: FeatureTestKind;
 }): TestPlanDetails {
   const entrySpecFile = path.join(params.featureDir, 'boundary.ts');
   const entrySpecSource = readFileSync(entrySpecFile, 'utf8');
@@ -401,7 +456,7 @@ function buildTestPlanDetails(params: {
   return {
     schemaVersion: 1,
     featureId: path.basename(params.featureDir),
-    testKind: 'ztd',
+    testKind: params.testKind,
     fixtureCandidateTables,
     writesTables,
     validationScenarioHints: buildValidationScenarioHints(requestFields, params.queryLayout.queryName),
@@ -418,7 +473,9 @@ function buildTestPlanDetails(params: {
     generatedDirPath: toProjectRelativePath(params.rootDir, params.queryLayout.generatedDir),
     casesDirPath: toProjectRelativePath(params.rootDir, params.queryLayout.casesDir),
     analysisPath: toProjectRelativePath(params.rootDir, params.queryLayout.analysisFile),
-    fixedVerifierPath: 'tests/support/ztd/harness.ts'
+    fixedVerifierPath: params.testKind === 'ztd'
+      ? 'tests/support/ztd/harness.ts'
+      : 'TODO: library traditional mode API adapter'
   };
 }
 
@@ -620,7 +677,12 @@ function normalizeSqlTableName(value: string): string {
     .join('.');
 }
 
-function resolveQueryLayout(featureDir: string, featureName: string, selectedQueryName?: string): QueryLayout {
+function resolveQueryLayout(
+  featureDir: string,
+  featureName: string,
+  selectedQueryName: string | undefined,
+  testKind: FeatureTestKind
+): QueryLayout {
   const queriesRoot = path.join(featureDir, 'queries');
   if (!existsSync(queriesRoot)) {
     throw new Error(`No queries directory was discovered under ${featureDir}. Run feature scaffold first.`);
@@ -636,7 +698,7 @@ function resolveQueryLayout(featureDir: string, featureName: string, selectedQue
     if (!queryDirectories.includes(selectedQueryName)) {
       throw new Error(`Query directory not found for tests scaffold: ${selectedQueryName}.`);
     }
-    return buildQueryLayout(featureDir, featureName, selectedQueryName);
+    return buildQueryLayout(featureDir, featureName, selectedQueryName, testKind);
   }
 
   if (queryDirectories.length === 0) {
@@ -647,14 +709,15 @@ function resolveQueryLayout(featureDir: string, featureName: string, selectedQue
     throw new Error(`Multiple query directories were discovered under ${featureDir}. Re-run with --query <name>.`);
   }
 
-  return buildQueryLayout(featureDir, featureName, queryDirectories[0]);
+  return buildQueryLayout(featureDir, featureName, queryDirectories[0], testKind);
 }
 
-function buildQueryLayout(featureDir: string, featureName: string, queryName: string): QueryLayout {
+function buildQueryLayout(featureDir: string, featureName: string, queryName: string, testKind: FeatureTestKind): QueryLayout {
   const queryDir = path.join(featureDir, 'queries', queryName);
   const testsDir = path.join(queryDir, 'tests');
   const generatedDir = path.join(testsDir, 'generated');
   const casesDir = path.join(testsDir, 'cases');
+  const isZtdLane = testKind === 'ztd';
   return {
     featureName,
     queryName,
@@ -662,14 +725,23 @@ function buildQueryLayout(featureDir: string, featureName: string, queryName: st
     testsDir,
     generatedDir,
     casesDir,
-    entrypointFile: path.join(testsDir, `${queryName}.boundary.ztd.test.ts`),
-    queryTypesFile: path.join(testsDir, 'boundary-ztd-types.ts'),
-    planFile: path.join(generatedDir, 'TEST_PLAN.md'),
-    analysisFile: path.join(generatedDir, 'analysis.json'),
-    basicCaseFile: path.join(casesDir, 'basic.case.ts'),
+    entrypointFile: path.join(testsDir, `${queryName}.boundary.${testKind}.test.ts`),
+    queryTypesFile: path.join(testsDir, isZtdLane ? 'boundary-ztd-types.ts' : 'boundary-traditional-types.ts'),
+    planFile: path.join(generatedDir, isZtdLane ? 'TEST_PLAN.md' : 'TEST_PLAN.traditional.md'),
+    analysisFile: path.join(generatedDir, isZtdLane ? 'analysis.json' : 'analysis.traditional.json'),
+    basicCaseFile: path.join(casesDir, isZtdLane ? 'basic.case.ts' : 'basic.traditional.case.ts'),
     querySpecFile: path.join(queryDir, 'boundary.ts'),
     querySqlFile: path.join(queryDir, `${queryName}.sql`)
   };
+}
+
+function normalizeFeatureTestKind(value: string | undefined): FeatureTestKind {
+  const normalized = (value ?? 'ztd').trim().toLowerCase();
+  if (FEATURE_TEST_KINDS.includes(normalized as FeatureTestKind)) {
+    return normalized as FeatureTestKind;
+  }
+
+  throw new Error(`Feature test kind supports only ${FEATURE_TEST_KINDS.join(', ')}.`);
 }
 
 function normalizeFeatureName(value: string): string {

--- a/packages/ztd-cli/tests/cliCommands.test.ts
+++ b/packages/ztd-cli/tests/cliCommands.test.ts
@@ -263,6 +263,7 @@ test(
     assertCliSuccess(result, 'feature tests scaffold --help');
     expect(result.stdout).toContain('--feature <name>');
     expect(result.stdout).toContain('--query <name>');
+    expect(result.stdout).toContain('--test-kind <kind>');
     expect(result.stdout).toContain('--dry-run');
     expect(result.stdout).toContain('--force');
     expect(result.stdout).toContain('Refresh query-boundary generated analysis');

--- a/packages/ztd-cli/tests/featureTestsScaffold.unit.test.ts
+++ b/packages/ztd-cli/tests/featureTestsScaffold.unit.test.ts
@@ -110,6 +110,7 @@ test('runFeatureTestsScaffoldCommand writes query-local ZTD scaffolds from the c
   expect(result).toMatchObject({
     featureName: 'users-insert',
     queryName: 'insert-users',
+    testKind: 'ztd',
     dryRun: false
   });
   expect(result.outputs.map((output) => output.path)).toEqual(
@@ -349,4 +350,84 @@ test('runFeatureTestsScaffoldCommand fails fast when starter-owned ZTD support i
       rootDir: workspace
     })
   ).rejects.toThrow(/tests\/support\/ztd/);
+});
+
+test('runFeatureTestsScaffoldCommand writes traditional lane scaffolds without overwriting ztd lane artifacts', async () => {
+  const workspace = createTempDir('feature-tests-traditional-scaffold');
+  const featureDir = path.join(workspace, 'src', 'features', 'users-insert');
+  const queryDir = path.join(featureDir, 'queries', 'insert-users');
+  mkdirSync(queryDir, { recursive: true });
+  seedSharedZtdSupport(workspace);
+
+  writeFileSync(path.join(featureDir, 'boundary.ts'), 'export const RequestSchema = null;\n', 'utf8');
+  writeFileSync(path.join(queryDir, 'boundary.ts'), 'export async function executeInsertUsersBoundary() { return {}; }\n', 'utf8');
+  writeFileSync(path.join(queryDir, 'insert-users.sql'), 'insert into public.users (email) values (:email) returning user_id;', 'utf8');
+
+  await runFeatureTestsScaffoldCommand({
+    feature: 'users-insert',
+    rootDir: workspace
+  });
+
+  const result = await runFeatureTestsScaffoldCommand({
+    feature: 'users-insert',
+    rootDir: workspace,
+    testKind: 'traditional'
+  });
+
+  expect(result).toMatchObject({
+    featureName: 'users-insert',
+    queryName: 'insert-users',
+    testKind: 'traditional',
+    dryRun: false
+  });
+  expect(result.outputs.map((output) => output.path)).toEqual(
+    expect.arrayContaining([
+      'src/features/users-insert/queries/insert-users/tests/insert-users.boundary.traditional.test.ts',
+      'src/features/users-insert/queries/insert-users/tests/boundary-traditional-types.ts',
+      'src/features/users-insert/queries/insert-users/tests/cases/basic.traditional.case.ts',
+      'src/features/users-insert/queries/insert-users/tests/generated/TEST_PLAN.traditional.md',
+      'src/features/users-insert/queries/insert-users/tests/generated/analysis.traditional.json'
+    ])
+  );
+
+  const traditionalEntrypoint = readFileSync(
+    path.join(featureDir, 'queries', 'insert-users', 'tests', 'insert-users.boundary.traditional.test.ts'),
+    'utf8'
+  );
+  expect(traditionalEntrypoint).toContain("test.skip('users-insert/insert-users boundary traditional lane scaffold placeholder'");
+
+  const traditionalAnalysis = JSON.parse(
+    readFileSync(path.join(featureDir, 'queries', 'insert-users', 'tests', 'generated', 'analysis.traditional.json'), 'utf8')
+  ) as { testKind: string };
+  expect(traditionalAnalysis.testKind).toBe('traditional');
+
+  expect(
+    existsSync(path.join(featureDir, 'queries', 'insert-users', 'tests', 'insert-users.boundary.ztd.test.ts'))
+  ).toBe(true);
+  expect(
+    existsSync(path.join(featureDir, 'queries', 'insert-users', 'tests', 'generated', 'TEST_PLAN.md'))
+  ).toBe(true);
+  expect(
+    existsSync(path.join(featureDir, 'queries', 'insert-users', 'tests', 'generated', 'analysis.json'))
+  ).toBe(true);
+});
+
+test('runFeatureTestsScaffoldCommand rejects unsupported test-kind values', async () => {
+  const workspace = createTempDir('feature-tests-invalid-kind');
+  const featureDir = path.join(workspace, 'src', 'features', 'users-insert');
+  const queryDir = path.join(featureDir, 'queries', 'insert-users');
+  mkdirSync(queryDir, { recursive: true });
+  seedSharedZtdSupport(workspace);
+
+  writeFileSync(path.join(featureDir, 'boundary.ts'), 'export const RequestSchema = null;\n', 'utf8');
+  writeFileSync(path.join(queryDir, 'boundary.ts'), 'export async function executeInsertUsersBoundary() { return {}; }\n', 'utf8');
+  writeFileSync(path.join(queryDir, 'insert-users.sql'), 'select 1;', 'utf8');
+
+  await expect(
+    runFeatureTestsScaffoldCommand({
+      feature: 'users-insert',
+      rootDir: workspace,
+      testKind: 'legacy'
+    })
+  ).rejects.toThrow(/supports only ztd, traditional/i);
 });

--- a/packages/ztd-cli/tests/featureTestsScaffold.unit.test.ts
+++ b/packages/ztd-cli/tests/featureTestsScaffold.unit.test.ts
@@ -398,8 +398,10 @@ test('runFeatureTestsScaffoldCommand writes traditional lane scaffolds without o
 
   const traditionalAnalysis = JSON.parse(
     readFileSync(path.join(featureDir, 'queries', 'insert-users', 'tests', 'generated', 'analysis.traditional.json'), 'utf8')
-  ) as { testKind: string };
+  ) as { testKind: string; dbScenarioHints: string[] };
   expect(traditionalAnalysis.testKind).toBe('traditional');
+  expect(traditionalAnalysis.dbScenarioHints.join('\n')).toContain('library traditional mode API adapter');
+  expect(traditionalAnalysis.dbScenarioHints.join('\n')).not.toContain('fixed app-level harness');
 
   expect(
     existsSync(path.join(featureDir, 'queries', 'insert-users', 'tests', 'insert-users.boundary.ztd.test.ts'))


### PR DESCRIPTION
## Summary

- Add `--test-kind <kind>` to `ztd feature tests scaffold` with `ztd` as the default.
- Implement lane-aware scaffold outputs for `ztd` and `traditional` so both can coexist under the same query tests directory.
- Keep backward compatibility for existing ZTD-only workflows and add tests for traditional lane generation and invalid `--test-kind` fail-fast behavior.
- Add a follow-up design guide and include release notes via changeset.

## Verification

- `pnpm --filter @rawsql-ts/ztd-cli build`
- `pnpm --filter @rawsql-ts/ztd-cli test -- featureTestsScaffold.unit.test.ts cliCommands.test.ts`
- `pre-commit` gate suite passed during commit (includes `test:essential`, build, lint)

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue:
Scoped checks run:
Why full baseline is not required:

## CLI Surface Migration

- [ ] No migration packet required for this CLI change.
- [x] CLI/user-facing surface change and migration packet completed.

No-migration rationale:
Upgrade note: `ztd feature tests scaffold` now accepts `--test-kind ztd|traditional`. Default remains `ztd`.
Deprecation/removal plan or issue: None. No existing flag or behavior was removed.
Docs/help/examples updated: Yes. CLI help coverage updated in `packages/ztd-cli/tests/cliCommands.test.ts`; follow-up plan linked from `packages/ztd-cli/README.md`.
Release/changeset wording: Added `.changeset/fair-apes-tie.md` as `@rawsql-ts/ztd-cli minor`.

## Scaffold Contract Proof

- [ ] No scaffold contract proof required for this PR.
- [x] Scaffold contract proof completed.

No-proof rationale:
Non-edit assertion: Existing ZTD scaffold assets are preserved (`<query>.boundary.ztd.test.ts`, `generated/TEST_PLAN.md`, `generated/analysis.json`) and traditional lane files are generated as additional, lane-qualified artifacts.
Fail-fast input-contract proof: Unsupported `--test-kind` values fail fast with an explicit error (`Feature test kind supports only ztd, traditional.`), covered by unit test.
Generated-output viability proof: Traditional lane now generates `*.boundary.traditional.test.ts`, `boundary-traditional-types.ts`, `cases/basic.traditional.case.ts`, `generated/TEST_PLAN.traditional.md`, and `generated/analysis.traditional.json`, covered by unit test.

Closes #767


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--test-kind` CLI option for `ztd feature tests scaffold`, allowing users to select between `ztd` and `traditional` test scaffolding approaches. Defaults to ZTD for backward compatibility, with each mode generating appropriate scaffold outputs.

* **Documentation**
  * Added guide describing the traditional lane follow-up expansion plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->