### PR TITLE
feat(sssql): support correlated EXISTS/NOT EXISTS refresh relocation

### DIFF
--- a/.changeset/correlated-refresh-exists-relocation.md
+++ b/.changeset/correlated-refresh-exists-relocation.md
@@ -1,0 +1,10 @@
+---
+"rawsql-ts": minor
+"@rawsql-ts/ztd-cli": minor
+---
+
+Improve SSSQL `refresh` so correlated `EXISTS` / `NOT EXISTS` branches can be safely re-anchored after query structure changes.
+
+`rawsql-ts` now relocates correlated optional branches by inferring a single anchor from outer references, rebases aliases when moving branches across query scopes, and fails fast when anchor inference is missing or ambiguous.
+
+`@rawsql-ts/ztd-cli` adds regression coverage for correlated `refresh` round-trips and `remove --all` interoperability so SQL-first optional branch maintenance stays deterministic after scaffolding.

--- a/docs/guide/ztd-cli-sssql-reference.md
+++ b/docs/guide/ztd-cli-sssql-reference.md
@@ -252,6 +252,16 @@ ztd query sssql refresh src/sql/products/list_products.sql --preview
 `refresh` does not invent new optional predicates.
 It only repositions supported authored branches so they stay attached to the best matching query block after query structure changes.
 
+`refresh` also supports correlated `EXISTS` / `NOT EXISTS` branches.
+When a branch is still attached to an outer query but the anchor column now belongs in an inner query or CTE, `refresh` can move the whole branch and rebase the correlated alias safely.
+
+Correlated `EXISTS` / `NOT EXISTS` refresh rules:
+
+- infer one anchor candidate from the correlated outer reference
+- fail fast when zero anchor candidates are found
+- fail fast when multiple anchor candidates are found
+- keep scalar branch behavior unchanged
+
 ## Safety Rules
 
 These commands are intentionally strict.

--- a/packages/core/src/transformers/SSSQLFilterBuilder.ts
+++ b/packages/core/src/transformers/SSSQLFilterBuilder.ts
@@ -1,4 +1,4 @@
-import { WhereClause, type SourceExpression, TableSource } from "../models/Clause";
+import { WhereClause, type SourceExpression, SubQuerySource, TableSource } from "../models/Clause";
 import { SelectQuery, SimpleSelectQuery } from "../models/SelectQuery";
 import {
     BinaryExpression,
@@ -18,6 +18,7 @@ import { ColumnReferenceCollector } from "./ColumnReferenceCollector";
 import { SelectableColumnCollector, DuplicateDetectionMode } from "./SelectableColumnCollector";
 import { ParameterCollector } from "./ParameterCollector";
 import { SqlFormatter } from "./SqlFormatter";
+import { CTECollector } from "./CTECollector";
 import {
     collectSupportedOptionalConditionBranches,
     type SupportedOptionalConditionBranch
@@ -76,6 +77,21 @@ interface ResolvedFilterTarget {
 interface ParsedFilterName {
     table: string;
     column: string;
+}
+
+interface ExistsPredicateDetails {
+    kind: "exists" | "not-exists";
+    subquery: SelectQuery;
+}
+
+interface CorrelatedAnchorReference {
+    namespace: string;
+    column: string;
+}
+
+interface CorrelatedRefreshPlan {
+    target: ResolvedFilterTarget;
+    sourceAlias: string;
 }
 
 const formatter = new SqlFormatter();
@@ -338,6 +354,45 @@ const getScalarBranchDetails = (
     return null;
 };
 
+const hasSelectQuery = (value: unknown): value is { selectQuery: SelectQuery } => {
+    return typeof value === "object" && value !== null && "selectQuery" in value;
+};
+
+const collectColumnReferencesDeep = (value: unknown): ColumnReference[] => {
+    const references: ColumnReference[] = [];
+    const visited = new WeakSet<object>();
+
+    const walk = (candidate: unknown): void => {
+        if (!candidate || typeof candidate !== "object") {
+            return;
+        }
+
+        if (candidate instanceof ColumnReference) {
+            references.push(candidate);
+            return;
+        }
+
+        if (visited.has(candidate)) {
+            return;
+        }
+        visited.add(candidate);
+
+        if (Array.isArray(candidate)) {
+            for (const item of candidate) {
+                walk(item);
+            }
+            return;
+        }
+
+        for (const child of Object.values(candidate as Record<string, unknown>)) {
+            walk(child);
+        }
+    };
+
+    walk(value);
+    return references;
+};
+
 const getExistsBranchKind = (
     expression: ValueComponent,
     parameterName: string
@@ -350,8 +405,16 @@ const getExistsBranchKind = (
     }
 
     const predicate = unwrapParens(meaningfulTerms[0]!);
+    const isInlineQueryValue = (value: ValueComponent): value is InlineQuery => {
+        return value instanceof InlineQuery || hasSelectQuery(value);
+    };
+
     if (predicate instanceof UnaryExpression && predicate.operator.value.trim().toLowerCase() === "exists") {
-        return predicate.expression instanceof InlineQuery ? "exists" : null;
+        return isInlineQueryValue(unwrapParens(predicate.expression)) ? "exists" : null;
+    }
+
+    if (predicate instanceof UnaryExpression && predicate.operator.value.trim().toLowerCase() === "not exists") {
+        return isInlineQueryValue(unwrapParens(predicate.expression)) ? "not-exists" : null;
     }
 
     if (
@@ -360,8 +423,67 @@ const getExistsBranchKind = (
         unwrapParens(predicate.expression) instanceof UnaryExpression
     ) {
         const nested = unwrapParens(predicate.expression) as UnaryExpression;
-        if (nested.operator.value.trim().toLowerCase() === "exists" && nested.expression instanceof InlineQuery) {
+        if (
+            nested.operator.value.trim().toLowerCase() === "exists"
+            && isInlineQueryValue(unwrapParens(nested.expression))
+        ) {
             return "not-exists";
+        }
+    }
+
+    return null;
+};
+
+const getExistsPredicateDetails = (
+    expression: ValueComponent,
+    parameterName: string
+): ExistsPredicateDetails | null => {
+    const meaningfulTerms = collectTopLevelOrTerms(expression)
+        .filter(term => getGuardedParameterName(term) !== parameterName);
+
+    if (meaningfulTerms.length !== 1) {
+        return null;
+    }
+
+    const predicate = unwrapParens(meaningfulTerms[0]!);
+    const isInlineQueryValue = (value: ValueComponent): value is InlineQuery => {
+        return value instanceof InlineQuery || hasSelectQuery(value);
+    };
+
+    if (predicate instanceof UnaryExpression && predicate.operator.value.trim().toLowerCase() === "exists") {
+        const candidate = unwrapParens(predicate.expression);
+        if (isInlineQueryValue(candidate)) {
+            return {
+                kind: "exists",
+                subquery: candidate.selectQuery
+            };
+        }
+        return null;
+    }
+
+    if (predicate instanceof UnaryExpression && predicate.operator.value.trim().toLowerCase() === "not exists") {
+        const candidate = unwrapParens(predicate.expression);
+        if (isInlineQueryValue(candidate)) {
+            return {
+                kind: "not-exists",
+                subquery: candidate.selectQuery
+            };
+        }
+        return null;
+    }
+
+    if (
+        predicate instanceof UnaryExpression &&
+        predicate.operator.value.trim().toLowerCase() === "not" &&
+        unwrapParens(predicate.expression) instanceof UnaryExpression
+    ) {
+        const nested = unwrapParens(predicate.expression) as UnaryExpression;
+        const candidate = unwrapParens(nested.expression);
+        if (nested.operator.value.trim().toLowerCase() === "exists" && isInlineQueryValue(candidate)) {
+            return {
+                kind: "not-exists",
+                subquery: candidate.selectQuery
+            };
         }
     }
 
@@ -454,11 +576,23 @@ export class SSSQLFilterBuilder {
         const parsed = this.parseQuery(query);
 
         for (const [filterName, filterValue] of Object.entries(filters)) {
-            const target = this.resolveTarget(parsed, filterName);
-            const matches = collectSupportedOptionalConditionBranches(parsed)
-                .filter(branch => branch.parameterName === target.parameterName);
+            let parameterName = filterName;
+            let target: ResolvedFilterTarget | null = null;
+            let matches = collectSupportedOptionalConditionBranches(parsed)
+                .filter(branch => branch.parameterName === parameterName);
 
             if (matches.length === 0) {
+                target = this.resolveTarget(parsed, filterName);
+                parameterName = target.parameterName;
+                matches = collectSupportedOptionalConditionBranches(parsed)
+                    .filter(branch => branch.parameterName === parameterName);
+            }
+
+            if (matches.length === 0) {
+                if (!target) {
+                    target = this.resolveTarget(parsed, filterName);
+                    parameterName = target.parameterName;
+                }
                 if (!isExplicitEqualityScaffoldValue(filterValue)) {
                     throw new Error(
                         `No existing SSSQL branch was found for '${filterName}', and v1 scaffold only supports equality filters.`
@@ -474,7 +608,7 @@ export class SSSQLFilterBuilder {
             }
 
             if (matches.length > 1) {
-                throw new Error(`Multiple SSSQL branches matched parameter ':${target.parameterName}'. Refresh is ambiguous.`);
+                throw new Error(`Multiple SSSQL branches matched parameter ':${parameterName}'. Refresh is ambiguous.`);
             }
 
             const [match] = matches;
@@ -482,13 +616,26 @@ export class SSSQLFilterBuilder {
                 continue;
             }
 
-            if (match.query === target.query) {
+            const correlatedPlan = this.buildCorrelatedRefreshPlan(parsed, match);
+            if (correlatedPlan) {
+                if (correlatedPlan.target.query === match.query) {
+                    continue;
+                }
+
+                this.rebaseMovedBranchByAlias(match.expression, correlatedPlan.sourceAlias, correlatedPlan.target.column);
+                rebuildWhereWithoutTerm(match.query, match.expression);
+                correlatedPlan.target.query.appendWhere(match.expression);
                 continue;
             }
 
-            this.rebaseMovedBranch(match.expression, match.query, target.column);
-            rebuildWhereWithoutTerm(match.query, match.expression);
-            target.query.appendWhere(match.expression);
+            if (!target) {
+                target = this.resolveTarget(parsed, filterName);
+            }
+            if (match.query !== target.query) {
+                this.rebaseMovedBranch(match.expression, match.query, target.column);
+                rebuildWhereWithoutTerm(match.query, match.expression);
+                target.query.appendWhere(match.expression);
+            }
         }
 
         return parsed;
@@ -733,6 +880,203 @@ export class SSSQLFilterBuilder {
         return source.getAliasName() ?? source.datasource.table.name;
     }
 
+    private buildCorrelatedRefreshPlan(
+        root: SelectQuery,
+        branch: SupportedOptionalConditionBranch
+    ): CorrelatedRefreshPlan | null {
+        const details = getExistsPredicateDetails(branch.expression, branch.parameterName);
+        if (!details) {
+            return null;
+        }
+
+        const sourceAliases = this.collectSourceAliases(branch.query);
+        const candidatesByKey = new Map<string, CorrelatedAnchorReference>();
+
+        for (const reference of new ColumnReferenceCollector().collect(details.subquery)) {
+            const namespace = normalizeIdentifier(reference.getNamespace());
+            if (!namespace || !sourceAliases.has(namespace)) {
+                continue;
+            }
+
+            const column = normalizeIdentifier(reference.column.name);
+            const key = `${namespace}.${column}`;
+            if (!candidatesByKey.has(key)) {
+                candidatesByKey.set(key, { namespace, column });
+            }
+        }
+
+        const candidates = [...candidatesByKey.values()];
+        if (candidates.length === 0) {
+            throw new Error(
+                `SSSQL refresh could not infer a correlated anchor for ':${branch.parameterName}'.`
+            );
+        }
+        if (candidates.length > 1) {
+            const listed = candidates.map(candidate => `${candidate.namespace}.${candidate.column}`).join(", ");
+            throw new Error(
+                `SSSQL refresh found multiple correlated anchor candidates for ':${branch.parameterName}' (${listed}).`
+            );
+        }
+
+        const [anchor] = candidates;
+        if (!anchor) {
+            throw new Error(
+                `SSSQL refresh could not infer a correlated anchor for ':${branch.parameterName}'.`
+            );
+        }
+
+        return {
+            target: this.resolveCorrelatedAnchorTarget(root, branch.query, anchor, branch.parameterName),
+            sourceAlias: anchor.namespace
+        };
+    }
+
+    private collectSourceAliases(query: SimpleSelectQuery): Set<string> {
+        const aliases = new Set<string>();
+        for (const source of query.fromClause?.getSources() ?? []) {
+            const sourceAlias = this.getSourceAlias(source);
+            if (sourceAlias) {
+                aliases.add(sourceAlias);
+            }
+        }
+        return aliases;
+    }
+
+    private resolveCorrelatedAnchorTarget(
+        root: SelectQuery,
+        sourceQuery: SimpleSelectQuery,
+        anchor: CorrelatedAnchorReference,
+        parameterName: string
+    ): ResolvedFilterTarget {
+        const sourceExpression = this.findSourceExpressionByAlias(sourceQuery, anchor.namespace, parameterName);
+        const upstreamQuery = this.resolveSourceExpressionToUpstreamQuery(root, sourceExpression, parameterName);
+        if (!upstreamQuery) {
+            return {
+                query: sourceQuery,
+                column: new ColumnReference(anchor.namespace, anchor.column),
+                parameterName
+            };
+        }
+
+        return this.resolveAnchorTargetInQuery(upstreamQuery, anchor, parameterName);
+    }
+
+    private findSourceExpressionByAlias(
+        query: SimpleSelectQuery,
+        alias: string,
+        parameterName: string
+    ): SourceExpression {
+        const matches = (query.fromClause?.getSources() ?? [])
+            .filter(source => this.getSourceAlias(source) === alias);
+
+        if (matches.length === 0) {
+            throw new Error(
+                `SSSQL refresh could not resolve correlated alias '${alias}' for ':${parameterName}'.`
+            );
+        }
+        if (matches.length > 1) {
+            throw new Error(
+                `SSSQL refresh found multiple correlated sources for alias '${alias}' and ':${parameterName}'.`
+            );
+        }
+
+        return matches[0]!;
+    }
+
+    private resolveSourceExpressionToUpstreamQuery(
+        root: SelectQuery,
+        source: SourceExpression,
+        parameterName: string
+    ): SimpleSelectQuery | null {
+        if (source.datasource instanceof SubQuerySource) {
+            if (source.datasource.query instanceof SimpleSelectQuery) {
+                return source.datasource.query;
+            }
+            throw new Error(
+                `SSSQL refresh requires a simple query anchor for ':${parameterName}'.`
+            );
+        }
+
+        if (!(source.datasource instanceof TableSource)) {
+            return null;
+        }
+
+        const cteName = normalizeIdentifier(source.datasource.table.name);
+        const cteMatches = new CTECollector()
+            .collect(root)
+            .filter(cte => normalizeIdentifier(cte.getSourceAliasName()) === cteName);
+
+        if (cteMatches.length === 0) {
+            return null;
+        }
+        if (cteMatches.length > 1) {
+            throw new Error(
+                `SSSQL refresh found multiple CTE anchors for ':${parameterName}' (${source.datasource.table.name}).`
+            );
+        }
+
+        const [cte] = cteMatches;
+        if (!cte) {
+            return null;
+        }
+
+        const cteQuery = cte.query as unknown;
+        if (!(cteQuery instanceof SimpleSelectQuery)) {
+            throw new Error(
+                `SSSQL refresh requires a simple CTE anchor for ':${parameterName}'.`
+            );
+        }
+
+        return cteQuery;
+    }
+
+    private resolveAnchorTargetInQuery(
+        query: SimpleSelectQuery,
+        anchor: CorrelatedAnchorReference,
+        parameterName: string
+    ): ResolvedFilterTarget {
+        const collector = new SelectableColumnCollector(
+            this.tableColumnResolver,
+            false,
+            DuplicateDetectionMode.FullName,
+            { upstream: true }
+        );
+
+        const matches = collector.collect(query)
+            .filter((entry): entry is { name: string; value: ColumnReference } => entry.value instanceof ColumnReference)
+            .filter(entry => normalizeIdentifier(entry.name) === anchor.column);
+
+        if (matches.length === 0) {
+            throw new Error(
+                `SSSQL refresh could not resolve correlated anchor column '${anchor.column}' for ':${parameterName}'.`
+            );
+        }
+        if (matches.length > 1) {
+            throw new Error(
+                `SSSQL refresh found multiple correlated anchor columns '${anchor.column}' for ':${parameterName}'.`
+            );
+        }
+
+        return {
+            query,
+            column: matches[0]!.value,
+            parameterName
+        };
+    }
+
+    private getSourceAlias(source: SourceExpression): string | null {
+        const explicitAlias = source.getAliasName();
+        if (explicitAlias) {
+            return normalizeIdentifier(explicitAlias);
+        }
+
+        if (source.datasource instanceof TableSource) {
+            return normalizeIdentifier(source.datasource.table.name);
+        }
+
+        return null;
+    }
+
     private rebaseMovedBranch(
         expression: ValueComponent,
         sourceQuery: SimpleSelectQuery,
@@ -743,8 +1087,7 @@ export class SSSQLFilterBuilder {
             : null;
         const targetColumnName = normalizeIdentifier(targetColumn.column.name);
         const sourceAliases = new Set(
-            new ColumnReferenceCollector()
-                .collect(expression)
+            collectColumnReferencesDeep(expression)
                 .filter(reference => normalizeIdentifier(reference.column.name) === targetColumnName)
                 .map(reference => normalizeIdentifier(reference.getNamespace()))
                 .filter(namespace => namespace.length > 0)
@@ -773,8 +1116,31 @@ export class SSSQLFilterBuilder {
             return;
         }
 
-        for (const reference of new ColumnReferenceCollector().collect(expression)) {
+        for (const reference of collectColumnReferencesDeep(expression)) {
             if (normalizeIdentifier(reference.getNamespace()) !== sourceAlias) {
+                continue;
+            }
+
+            reference.qualifiedName.namespaces = targetNamespace?.map(namespace => new IdentifierString(namespace)) ?? null;
+        }
+    }
+
+    private rebaseMovedBranchByAlias(
+        expression: ValueComponent,
+        sourceAlias: string,
+        targetColumn: ColumnReference
+    ): void {
+        const normalizedSourceAlias = normalizeIdentifier(sourceAlias);
+        if (!normalizedSourceAlias) {
+            return;
+        }
+
+        const targetNamespace = targetColumn.qualifiedName.namespaces
+            ? targetColumn.qualifiedName.namespaces.map(namespace => namespace.name)
+            : null;
+
+        for (const reference of collectColumnReferencesDeep(expression)) {
+            if (normalizeIdentifier(reference.getNamespace()) !== normalizedSourceAlias) {
                 continue;
             }
 

--- a/packages/core/tests/transformers/SSSQLFilterBuilder.test.ts
+++ b/packages/core/tests/transformers/SSSQLFilterBuilder.test.ts
@@ -145,6 +145,110 @@ describe('SSSQLFilterBuilder', () => {
         expect(normalized).toContain(':archived_name is null or not exists');
     });
 
+    it('refresh relocates correlated exists branches and rebases the outer alias safely', () => {
+        const builder = new SSSQLFilterBuilder();
+        const refreshed = builder.refresh(
+            `
+                WITH base_products AS (
+                    SELECT p.product_id, p.product_name
+                    FROM products p
+                )
+                SELECT bp.product_id
+                FROM base_products bp
+                WHERE (
+                    :category_name IS NULL
+                    OR EXISTS (
+                        SELECT 1
+                        FROM product_categories pc
+                        WHERE pc.product_id = bp.product_id
+                          AND pc.category_name = :category_name
+                    )
+                )
+            `,
+            { category_name: null }
+        );
+
+        const normalized = normalizeSql(new SqlFormatter().format(refreshed).formattedSql);
+        expect(normalized).toContain('with "base_products" as (select "p"."product_id", "p"."product_name" from "products" as "p" where (:category_name is null or exists');
+        expect(normalized).toContain('"pc"."product_id" = "p"."product_id"');
+        expect(normalized).not.toContain('from "base_products" as "bp" where (:category_name is null or exists');
+    });
+
+    it('refresh relocates correlated not-exists branches and rebases the outer alias safely', () => {
+        const builder = new SSSQLFilterBuilder();
+        const refreshed = builder.refresh(
+            `
+                WITH base_products AS (
+                    SELECT p.product_id, p.product_name
+                    FROM products p
+                )
+                SELECT bp.product_id
+                FROM base_products bp
+                WHERE (
+                    :archived_name IS NULL
+                    OR NOT EXISTS (
+                        SELECT 1
+                        FROM archived_products ap
+                        WHERE ap.product_id = bp.product_id
+                          AND ap.product_name = :archived_name
+                    )
+                )
+            `,
+            { archived_name: null }
+        );
+
+        const normalized = normalizeSql(new SqlFormatter().format(refreshed).formattedSql);
+        expect(normalized).toContain('with "base_products" as (select "p"."product_id", "p"."product_name" from "products" as "p" where (:archived_name is null or not exists');
+        expect(normalized).toContain('"ap"."product_id" = "p"."product_id"');
+        expect(normalized).not.toContain('from "base_products" as "bp" where (:archived_name is null or not exists');
+    });
+
+    it('refresh fails fast when correlated exists anchors are ambiguous', () => {
+        const builder = new SSSQLFilterBuilder();
+
+        expect(() => builder.refresh(
+            `
+                WITH base_products AS (
+                    SELECT p.product_id, p.product_name
+                    FROM products p
+                )
+                SELECT bp.product_id
+                FROM base_products bp
+                WHERE (
+                    :category_name IS NULL
+                    OR EXISTS (
+                        SELECT 1
+                        FROM product_categories pc
+                        WHERE pc.product_id = bp.product_id
+                          AND pc.product_name = bp.product_name
+                          AND pc.category_name = :category_name
+                    )
+                )
+            `,
+            { category_name: null }
+        )).toThrow(/multiple correlated anchor candidates/i);
+    });
+
+    it('refresh fails fast when correlated exists anchors cannot be inferred', () => {
+        const builder = new SSSQLFilterBuilder();
+
+        expect(() => builder.refresh(
+            `
+                SELECT p.product_id
+                FROM products p
+                WHERE (
+                    :category_name IS NULL
+                    OR EXISTS (
+                        SELECT 1
+                        FROM product_categories pc
+                        WHERE pc.category_name = :category_name
+                    )
+                )
+            `,
+            { category_name: null }
+        )).toThrow(/could not infer a correlated anchor/i);
+    });
+
     it('lists supported branch metadata and removes a targeted branch idempotently', () => {
         const builder = new SSSQLFilterBuilder();
         const scaffolded = builder.scaffoldBranch(

--- a/packages/ztd-cli/tests/cliCommands.test.ts
+++ b/packages/ztd-cli/tests/cliCommands.test.ts
@@ -1004,6 +1004,151 @@ test(
 );
 
 test(
+  'query sssql scaffold -> refresh -> remove --all works for exists/not-exists branches',
+  () => {
+    const workspace = createSqlWorkspace('query-sssql-roundtrip-exists', path.join('src', 'sql', 'products.sql'));
+    writeFileSync(
+      workspace.sqlFile,
+      `
+        SELECT p.product_id, p.product_name
+        FROM products p
+      `,
+      'utf8'
+    );
+
+    const authoredFile = path.join(workspace.rootDir, 'products.authored.sql');
+    const scaffoldExists = runCli(
+      [
+        'query',
+        'sssql',
+        'scaffold',
+        workspace.sqlFile,
+        '--kind',
+        'exists',
+        '--parameter',
+        'category_name',
+        '--filter',
+        'products.product_id',
+        '--query',
+        'select 1 from product_categories pc where pc.product_id = $c0 and pc.category_name = :category_name',
+        '--out',
+        authoredFile
+      ],
+      {},
+      workspace.rootDir
+    );
+    assertCliSuccess(scaffoldExists, 'query sssql scaffold exists round-trip');
+
+    const scaffoldNotExists = runCli(
+      [
+        'query',
+        'sssql',
+        'scaffold',
+        authoredFile,
+        '--kind',
+        'not-exists',
+        '--parameter',
+        'archived_name',
+        '--filter',
+        'products.product_id',
+        '--query',
+        'select 1 from archived_products ap where ap.product_id = $c0 and ap.product_name = :archived_name'
+      ],
+      {},
+      workspace.rootDir
+    );
+    assertCliSuccess(scaffoldNotExists, 'query sssql scaffold not-exists round-trip');
+
+    const refreshedFile = path.join(workspace.rootDir, 'products.refreshed.sql');
+    const refresh = runCli(
+      ['query', 'sssql', 'refresh', authoredFile, '--out', refreshedFile],
+      {},
+      workspace.rootDir
+    );
+    assertCliSuccess(refresh, 'query sssql refresh round-trip');
+
+    const refreshed = readNormalizedFile(refreshedFile).toLowerCase();
+    expect(refreshed).toContain(':category_name is null or exists');
+    expect(refreshed).toContain(':archived_name is null or not exists');
+
+    const removedFile = path.join(workspace.rootDir, 'products.removed-all.sql');
+    const removeAll = runCli(
+      ['query', 'sssql', 'remove', refreshedFile, '--all', '--out', removedFile],
+      {},
+      workspace.rootDir
+    );
+    assertCliSuccess(removeAll, 'query sssql remove --all round-trip');
+
+    const removed = readNormalizedFile(removedFile).toLowerCase();
+    expect(removed).not.toContain(':category_name');
+    expect(removed).not.toContain(':archived_name');
+    expect(removed).not.toContain('exists');
+  },
+  60000,
+);
+
+test(
+  'query sssql refresh relocates correlated exists once and stays idempotent on rerun',
+  () => {
+    const workspace = createSqlWorkspace('query-sssql-refresh-correlated', path.join('src', 'sql', 'products.sql'));
+    writeFileSync(
+      workspace.sqlFile,
+      `
+        WITH base_products AS (
+          SELECT p.product_id, p.product_name
+          FROM products p
+        )
+        SELECT bp.product_id
+        FROM base_products bp
+        WHERE (
+          :category_name IS NULL
+          OR EXISTS (
+            SELECT 1
+            FROM product_categories pc
+            WHERE pc.product_id = bp.product_id
+              AND pc.category_name = :category_name
+          )
+        )
+      `,
+      'utf8'
+    );
+
+    const onceFile = path.join(workspace.rootDir, 'products.refreshed.once.sql');
+    const first = runCli(
+      ['query', 'sssql', 'refresh', workspace.sqlFile, '--out', onceFile],
+      {},
+      workspace.rootDir
+    );
+    assertCliSuccess(first, 'query sssql refresh correlated first');
+
+    const once = readNormalizedFile(onceFile).toLowerCase();
+    expect(once).toContain('with "base_products" as (select "p"."product_id", "p"."product_name" from "products" as "p" where (:category_name is null or exists');
+    expect(once).toContain('"pc"."product_id" = "p"."product_id"');
+    expect(once).not.toContain('from "base_products" as "bp" where (:category_name is null or exists');
+
+    const twiceFile = path.join(workspace.rootDir, 'products.refreshed.twice.sql');
+    const second = runCli(
+      ['query', 'sssql', 'refresh', onceFile, '--format', 'json', '--out', twiceFile],
+      {},
+      workspace.rootDir
+    );
+    assertCliSuccess(second, 'query sssql refresh correlated second');
+    const payload = JSON.parse(second.stdout);
+    expect(payload).toMatchObject({
+      command: 'query sssql refresh',
+      ok: true,
+      data: {
+        changed: false,
+        written: true
+      }
+    });
+
+    expect(readNormalizedFile(twiceFile)).toBe(readNormalizedFile(onceFile));
+  },
+  60000,
+);
+
+test(
   'query sssql list reports discovered branches in json mode',
   () => {
     const workspace = createSqlWorkspace('query-sssql-list', path.join('src', 'sql', 'users.sql'));


### PR DESCRIPTION
## Summary

- Resolve #768 by extending SSSQL `refresh` to relocate correlated `EXISTS` / `NOT EXISTS` branches.
- Add fail-fast anchor inference rules for correlated refresh (`0` candidates or multiple candidates now error explicitly).
- Preserve scalar refresh behavior while adding correlated branch rebasing and relocation coverage.
- Add round-trip CLI regression tests (`scaffold -> refresh`, `refresh -> refresh`, and `remove --all` interplay).
- Document correlated refresh support and fail-fast rules in the SSSQL CLI reference.
- Add a changeset for `rawsql-ts` and `@rawsql-ts/ztd-cli`.

## Verification

- `pnpm --filter rawsql-ts test -- SSSQLFilterBuilder.test.ts` (pass)
- `pnpm --filter @rawsql-ts/ztd-cli test -- cliCommands.test.ts` (pass; DB-dependent tests skipped as expected when `pg_dump` is missing)
- `pnpm --filter rawsql-ts build` (pass)
- `pnpm --filter rawsql-ts lint` (pass)

## Merge Readiness

- [ ] No baseline exception requested.
- [x] Baseline exception requested and linked below.

Tracking issue: #768
Scoped checks run: `pnpm --filter rawsql-ts test -- SSSQLFilterBuilder.test.ts`; `pnpm --filter @rawsql-ts/ztd-cli test -- cliCommands.test.ts`; `pnpm --filter rawsql-ts build`; `pnpm --filter rawsql-ts lint`
Why full baseline is not required: repository-wide baseline currently has pre-existing failures outside this change scope (for example `packages/ztd-cli/tests/directoryFinding.docs.test.ts`, `packages/ztd-cli/tests/setupEnv.unit.test.ts`, and `packages/ztd-cli/tests/agentsPolicy.unit.test.ts`) observed during pre-commit full-workspace test execution.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: `ztd query sssql refresh` behavior is extended for correlated branch relocation without introducing a new command or required flag change.
Upgrade note: Existing `ztd query sssql refresh <sqlFile>` now also handles correlated `EXISTS` / `NOT EXISTS` relocation with explicit fail-fast behavior on ambiguous/missing anchors.
Deprecation/removal plan or issue: none
Docs/help/examples updated: `docs/guide/ztd-cli-sssql-reference.md`
Release/changeset wording: `.changeset/correlated-refresh-exists-relocation.md`

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: this PR does not change feature/query scaffold output contracts.
Non-edit assertion: parent boundary non-edit behavior is unchanged.
Fail-fast input-contract proof: covered by correlated anchor ambiguity/missing tests.
Generated-output viability proof: covered by updated core and CLI regression tests.
