### PR TITLE
fix(ci): repair refresh demo bundle PR creation

### DIFF
--- a/.github/workflows/refresh-demo-bundle.yml
+++ b/.github/workflows/refresh-demo-bundle.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HUSKY: 0
+      CHANGESETS_TOKEN: ${{ secrets.CHANGESETS_TOKEN }}
 
     steps:
       - name: Checkout
@@ -68,10 +69,21 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4
 
+      - name: Require refresh PR token
+        shell: bash
+        run: |
+          if [ -z "${CHANGESETS_TOKEN}" ]; then
+            echo "Refresh demo browser bundle requires the CHANGESETS_TOKEN secret."
+            echo "A workflow-created PR must use a PAT so pull_request checks can run on the bot-created PR branch."
+            exit 1
+          fi
+        env:
+          CHANGESETS_TOKEN: ${{ env.CHANGESETS_TOKEN }}
+
       - name: Create PR with refreshed bundle
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.CHANGESETS_TOKEN }}
           commit-message: 'chore: refresh demo browser bundle'
           branch: 'refresh-demo-bundle-${{ github.run_id }}'
           title: Refresh demo browser bundle
@@ -79,6 +91,8 @@ jobs:
             ## Summary
             - rebuild the rawsql-ts browser output via `pnpm --filter rawsql-ts build:browser`
             - regenerate `docs/public/demo/vendor/rawsql.browser.js` via esbuild
+          add-paths: |
+            docs/public/demo/vendor/rawsql.browser.js
           labels: demo
           base: main
           delete-branch: true


### PR DESCRIPTION
## Summary

- require a PAT-backed token before the refresh-demo-bundle workflow creates a PR
- use `CHANGESETS_TOKEN` for the workflow-created PR so downstream `pull_request` checks can attach
- stage only `docs/public/demo/vendor/rawsql.browser.js` when opening the refresh PR

## Verification

- confirmed PR #762 was blocked and its bot-created commit had zero check runs
- inspected `.github/workflows/refresh-demo-bundle.yml` after the patch
- ran `git diff --check`

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue:
Scoped checks run:
Why full baseline is not required:

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: This PR only adjusts the GitHub Actions token and staged-path behavior for the demo bundle refresh workflow; it does not change CLI commands, flags, output, or user-facing docs/help contracts.
Upgrade note:
Deprecation/removal plan or issue:
Docs/help/examples updated:
Release/changeset wording:

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: The change is limited to `.github/workflows/refresh-demo-bundle.yml` and does not modify scaffold commands, templates, or generated project outputs.
Non-edit assertion:
Fail-fast input-contract proof:
Generated-output viability proof:
