### PR TITLE
feat(ztd-cli): align starter directory taxonomy

### DIFF
--- a/.changeset/green-apples-drum.md
+++ b/.changeset/green-apples-drum.md
@@ -1,0 +1,9 @@
+---
+"@rawsql-ts/ztd-cli": minor
+---
+
+Align the starter scaffold and guidance with the canonical directory taxonomy.
+
+Starter projects now treat `src/features`, `src/adapters`, and `src/libraries` as the app-code roots, keep `db/` for DDL and migration assets, keep shared verification support under `tests/support/*`, and keep `.ztd/*` tool-managed.
+
+The scaffolded `SqlClient` and telemetry seams now follow that layout, and the generated README, AGENTS guidance, and tutorial docs describe the same ownership model.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A monorepo for **rawsql-ts**: a SQL-first toolkit for parsing, testing, inspecti
 By parsing SQL into abstract syntax trees, rawsql-ts enables type-safe query building, static validation, and transparent result mapping — all while preserving the expressiveness and control of handwritten SQL. AST-based rewriting also powers Zero Table Dependency (ZTD) testing, which transforms application queries to run against in-memory fixtures instead of physical tables, enabling deterministic unit tests without database setup overhead. The repo additionally covers AST-based impact analysis, deterministic test evidence, schema documentation, and `ztd-cli` workflows for inspection and SQL artifact generation.
 
 The `ztd init` scaffold now starts from a feature-first layout under `src/features/<feature>/` and includes `src/features/smoke/` as the removable teaching feature.
+Shared feature seams live under `src/features/_shared/`, driver-neutral runtime contracts under `src/libraries/`, driver or sink bindings under `src/adapters/<tech>/`, shared verification seams under `tests/support/`, and tool-managed assets under `.ztd/`.
 `src/catalog` may still exist as internal support, but it is no longer the user-facing standard location.
 
 > [!Note]
@@ -128,7 +129,7 @@ See the [Core Package Documentation](./packages/core/README.md) for usage exampl
 
 Treat each query as one unit: 1 SQL file / 1 QuerySpec / 1 repository entrypoint / 1 DTO.
 
-Keep handwritten SQL assets close to each feature in `src/features/<feature>/persistence/` so the SQL, specs, and tests stay in one place.
+Keep handwritten SQL assets close to each feature in `src/features/<feature>/queries/<query>/` so the SQL, boundary contract, and query-local tests stay in one place.
 
 Use this repo by treating DDL and SQL as source assets, and generated specs, repositories, and tests as downstream artifacts that must stay in sync.
 

--- a/docs/guide/feature-index.md
+++ b/docs/guide/feature-index.md
@@ -43,8 +43,10 @@ An at-a-glance index of easy-to-miss but important capabilities across the rawsq
 
 | Feature | Location | When to use |
 |---------|----------|-------------|
-| SqlClient interface | `src/db/sql-client.ts` | Define the app ↔ driver boundary |
-| SqlClient adapter (pg) | `src/db/sql-client-adapters.ts` | Convert `pg` Client/Pool to SqlClient |
+| SqlClient interface | `src/libraries/sql/sql-client.ts` | Define the app ↔ driver boundary |
+| SqlClient adapter (pg) | `src/adapters/pg/sql-client.ts` | Convert `pg` Client/Pool to `SqlClient` |
+| Repository telemetry contract | `src/libraries/telemetry/repositoryTelemetry.ts` | Keep the shared telemetry seam driver-neutral |
+| Repository telemetry console sink | `src/adapters/console/repositoryTelemetry.ts` | Emit safe local logs without widening the shared contract |
 | Runtime coercions | `src/catalog/runtime/_coercions.ts` | Driver-type normalization before validation |
 | Internal agent manifest | `.ztd/agents/*` | Default AI-assisted development context |
 | Spec files | `src/catalog/specs/` | Define catalog contracts with validators |

--- a/docs/guide/multiple-db-clients-in-one-workflow.md
+++ b/docs/guide/multiple-db-clients-in-one-workflow.md
@@ -1,6 +1,6 @@
 # Multiple DB Clients in One Workflow
 
-`ztd-config` can produce separate artifacts for multiple DB contexts. At runtime, treat each context as its own `SqlClient` and keep the clients side by side when a single workflow needs to talk to more than one database.
+`ztd-config` can produce separate artifacts for multiple DB contexts. At runtime, treat each context as its own `SqlClient` from `src/libraries/sql/sql-client.ts` and keep the clients side by side when a single workflow needs to talk to more than one database.
 
 ```ts
 type AppClients = {

--- a/docs/guide/repository-telemetry-setup.md
+++ b/docs/guide/repository-telemetry-setup.md
@@ -10,9 +10,9 @@ Use this guide after `ztd init --starter` when you want repository telemetry tha
 
 Start with these files in the generated project:
 
-- `src/infrastructure/telemetry/types.ts`
-- `src/infrastructure/telemetry/repositoryTelemetry.ts`
-- `src/infrastructure/telemetry/consoleRepositoryTelemetry.ts`
+- `src/libraries/telemetry/types.ts`
+- `src/libraries/telemetry/repositoryTelemetry.ts`
+- `src/adapters/console/repositoryTelemetry.ts`
 
 Then wire telemetry into the repository or service layer that actually runs SQL.
 
@@ -31,7 +31,7 @@ import {
   defaultRepositoryTelemetry,
   resolveRepositoryTelemetry,
   type RepositoryTelemetry
-} from './infrastructure/telemetry/repositoryTelemetry.js';
+} from './libraries/telemetry/repositoryTelemetry.js';
 
 type RepositoryDeps = {
   telemetry?: RepositoryTelemetry;
@@ -73,7 +73,7 @@ export class UsersRepository {
 For a console sink, the generated scaffold already provides `createConsoleRepositoryTelemetry()`. You can pass your own logger later:
 
 ```ts
-import { createConsoleRepositoryTelemetry } from './infrastructure/telemetry/repositoryTelemetry.js';
+import { createConsoleRepositoryTelemetry } from './adapters/console/repositoryTelemetry.js';
 
 const telemetry = createConsoleRepositoryTelemetry({
   logger: console

--- a/docs/guide/sql-first-end-to-end-tutorial.md
+++ b/docs/guide/sql-first-end-to-end-tutorial.md
@@ -120,6 +120,8 @@ That v1 scaffold fixes the initial layout to the recursive boundary rule:
 - `src/features/users-insert/README.md`
 
 Each folder is a boundary, each `boundary.ts` is that boundary's public surface, and each boundary keeps its own `tests/` group nearby.
+Outside feature-owned boundaries, keep shared feature seams under `src/features/_shared/*`, keep shared verification seams under `tests/support/*`, keep driver-neutral contracts under `src/libraries/*`, keep driver or sink bindings under `src/adapters/<tech>/*`, and keep `.ztd/*` tool-managed.
+Keep `db/` reserved for DDL, migration, and schema assets; do not place runtime clients or adapters there.
 
 The feature scaffold creates the boundary files, SQL file, feature-root boundary test, and the query-local `tests/generated/` plus `tests/cases/` directories.
 
@@ -146,6 +148,7 @@ Add a users insert feature to this feature-first project.
 Read the nearest AGENTS.md files first. Then read `.codex/agents/*` and `.ztd/agents/*` if present.
 Start with `npx ztd feature scaffold --table users --action insert`.
 Keep `boundary.ts`, the query-local `boundary.ts`, and the query-local SQL resource inside `src/features/users-insert`.
+Keep shared feature seams under `src/features/_shared/*`, shared verification seams under `tests/support/*`, driver-neutral contracts under `src/libraries/*`, and driver or sink bindings under `src/adapters/<tech>/*`.
 Before you edit DTOs or write persistent query cases, run `npx ztd feature tests scaffold --feature users-insert`. That command refreshes `src/features/users-insert/queries/insert-users/tests/generated/TEST_PLAN.md` and `analysis.json`, refreshes `src/features/users-insert/queries/insert-users/tests/boundary-ztd-types.ts`, and creates the thin `src/features/users-insert/queries/insert-users/tests/insert-users.boundary.ztd.test.ts` Vitest entrypoint only if it is missing. Persistent case files under `src/features/users-insert/queries/insert-users/tests/cases/` stay human/AI-owned and are not overwritten. If `ztd-config` has already run, use `.ztd/generated/ztd-fixture-manifest.generated.ts` as the source for `tableDefinitions` and any fixture-shape hints when you fill the case files. The validation cases may stay at the feature boundary, but the success case must execute through the fixed app-level ZTD runner and verify the returned result. Do not put returned columns into the input fixture. Read `TEST_PLAN.md` and `analysis.json` before filling the persistent case files under `src/features/users-insert/queries/insert-users/tests/cases/`. `afterDb` is subset-based per row, rows are treated as an unordered multiset, row order is ignored, and the verifier truncates tables named in `beforeDb` with `restart identity cascade` before seeding. After the cases are ready, run `npx vitest run src/features/users-insert/queries/insert-users/tests/insert-users.boundary.ztd.test.ts` to execute the ZTD feature test.
 If the returned id is null, stop and fix the scaffold or DDL instead of weakening the test.
 Before writing the success-path assertion, inspect `insert-users.sql` and `boundary.ts`. If the scaffold does not actually return a non-null id, report that mismatch instead of inventing fixture data or schema overrides.

--- a/docs/guide/ztd-cli-describe-schema.md
+++ b/docs/guide/ztd-cli-describe-schema.md
@@ -60,8 +60,8 @@ Fields:
     "output": {
       "stdout": "Status or JSON envelope.",
       "files": [
-        "tests/generated/ztd-row-map.generated.ts",
-        "tests/generated/ztd-layout.generated.ts"
+        ".ztd/generated/ztd-row-map.generated.ts",
+        ".ztd/generated/ztd-layout.generated.ts"
       ]
     },
     "exitCodes": {

--- a/docs/guide/ztd-cli-describe-schema.md
+++ b/docs/guide/ztd-cli-describe-schema.md
@@ -61,6 +61,7 @@ Fields:
       "stdout": "Status or JSON envelope.",
       "files": [
         ".ztd/generated/ztd-row-map.generated.ts",
+        ".ztd/generated/ztd-fixture-manifest.generated.ts",
         ".ztd/generated/ztd-layout.generated.ts"
       ]
     },

--- a/docs/recipes/sql-contract.md
+++ b/docs/recipes/sql-contract.md
@@ -16,12 +16,12 @@ pnpm add -D @rawsql-ts/sql-contract
 
 - Use `createReader` (and `createWriter` when you need CUD helpers) to wrap the executor that appears in `tests/support/testkit-client.ts`.
 - Bind domain-specific `rowMapping` definitions to the reader so DTO shapes stay explicit and reusable.
-- Refer to `tests/generated/ztd-row-map.generated.ts` for authoritative row types and `src/repositories/*` for repository contracts.
+- Refer to `.ztd/generated/ztd-row-map.generated.ts` for authoritative row types and `src/features/*` or `src/libraries/*` for runtime contracts.
 
 ### Example (`tests/support/testkit-client.ts`)
 
 ```ts
-import type { SqlClient } from '../../src/db/sql-client';
+import type { SqlClient } from '../../src/libraries/sql/sql-client';
 import { createReader } from '@rawsql-ts/sql-contract/mapper';
 import { rowMapping } from '@rawsql-ts/sql-contract/mapper';
 import { getSqlClient } from '../support/sql-client-factory';

--- a/packages/ztd-cli/README.md
+++ b/packages/ztd-cli/README.md
@@ -55,9 +55,20 @@ It is a container for child query boundaries and does not expose its own `bounda
 The actual query-boundary public surfaces live under `src/features/<feature>/queries/<query>/boundary.ts`.
 
 The starter and feature scaffolds apply that rule under `src/features/<feature>/...`, so the public export surface is visible without reading prose first.
-Outside feature-owned boundaries, keep shared feature seams under `src/features/_shared/*`, driver-neutral contracts under `src/libraries/*`, driver- or sink-specific bindings under `src/adapters/<tech>/*`, shared verification seams under `tests/support/*`, and tool-managed assets under `.ztd/*`.
-Treat `src/adapters/pg/` as the adapter boundary when `<tech>` names one concrete technology. If `<tech>` names a family or plural container such as `aws` or `cloud`, treat `src/adapters/<tech>/` as a parent container and put each concrete adapter in its own child boundary such as `src/adapters/aws/s3/` or `src/adapters/aws/lambda/`.
-Reserve `db/` for DDL, migration, and schema assets; do not place runtime clients or adapters there.
+Outside feature-owned boundaries:
+
+- Keep shared feature seams under `src/features/_shared/*`.
+- Keep driver-neutral contracts under `src/libraries/*`.
+- Keep driver- or sink-specific bindings under `src/adapters/<tech>/*`.
+- Keep shared verification seams under `tests/support/*`.
+- Keep tool-managed assets under `.ztd/*`.
+
+Adapter boundary rule:
+
+- If `<tech>` is one concrete technology, treat `src/adapters/<tech>/` as the adapter boundary, for example `src/adapters/pg/`.
+- If `<tech>` is a family or plural container such as `aws` or `cloud`, treat `src/adapters/<tech>/` as a parent and create child boundaries such as `src/adapters/aws/s3/` and `src/adapters/aws/lambda/`.
+
+Reserve `db/` for DDL, migration, and schema assets only; do not place runtime clients or adapters there.
 
 PowerShell:
 
@@ -198,7 +209,7 @@ Use `ztd describe` for machine-readable discovery, and follow the linked guides 
 | `ztd init --starter` | Scaffold the starter project with smoke, DDL, compose, and local Postgres wiring. |
 | `ztd feature scaffold --table <table> --action <insert/update/delete/get-by-id/list>` | Scaffold a feature-local CRUD/SELECT slice with SQL, `boundary.ts` entrypoints, README, and a thin tests entrypoint. |
 | `ztd feature query scaffold --query-name <name> --table <table> --action <insert/update/delete/get-by-id/list>` | Add one child query boundary under an existing boundary folder without rewriting the parent boundary. Use exactly one of `--feature` or `--boundary-dir`, or omit both only when the current working directory is already the target boundary. |
-| `ztd feature tests scaffold --feature <feature-name>` | Refresh `src/features/<feature>/queries/<query>/tests/generated/TEST_PLAN.md` and `analysis.json`, create the thin `src/features/<feature>/queries/<query>/tests/<query>.boundary.ztd.test.ts` Vitest entrypoint when missing, and keep `src/features/<feature>/queries/<query>/tests/cases/` as human/AI-owned persistent cases. |
+| `ztd feature tests scaffold --feature <feature-name>` | Refresh `src/features/<feature>/queries/<query>/tests/generated/TEST_PLAN.md`, `analysis.json`, and `src/features/<feature>/queries/<query>/tests/boundary-ztd-types.ts`; create the thin `src/features/<feature>/queries/<query>/tests/<query>.boundary.ztd.test.ts` Vitest entrypoint when missing; keep `src/features/<feature>/queries/<query>/tests/cases/` as human/AI-owned persistent cases. |
 | `ztd agents init` | Add the optional Codex bootstrap files. |
 | `ztd ztd-config` | Regenerate `TestRowMap` and runtime fixture metadata from DDL without Docker. |
 | `ztd lint` | Lint SQL against a temporary Postgres. |

--- a/packages/ztd-cli/README.md
+++ b/packages/ztd-cli/README.md
@@ -55,7 +55,8 @@ It is a container for child query boundaries and does not expose its own `bounda
 The actual query-boundary public surfaces live under `src/features/<feature>/queries/<query>/boundary.ts`.
 
 The starter and feature scaffolds apply that rule under `src/features/<feature>/...`, so the public export surface is visible without reading prose first.
-Outside feature-owned boundaries, keep shared feature seams under `src/features/_shared/*`, driver-neutral contracts under `src/libraries/*`, driver or sink bindings under `src/adapters/<tech>/*`, shared verification seams under `tests/support/*`, and tool-managed assets under `.ztd/*`.
+Outside feature-owned boundaries, keep shared feature seams under `src/features/_shared/*`, driver-neutral contracts under `src/libraries/*`, driver- or sink-specific bindings under `src/adapters/<tech>/*`, shared verification seams under `tests/support/*`, and tool-managed assets under `.ztd/*`.
+Treat `src/adapters/pg/` as the adapter boundary when `<tech>` names one concrete technology. If `<tech>` names a family or plural container such as `aws` or `cloud`, treat `src/adapters/<tech>/` as a parent container and put each concrete adapter in its own child boundary such as `src/adapters/aws/s3/` or `src/adapters/aws/lambda/`.
 Reserve `db/` for DDL, migration, and schema assets; do not place runtime clients or adapters there.
 
 PowerShell:

--- a/packages/ztd-cli/README.md
+++ b/packages/ztd-cli/README.md
@@ -55,6 +55,8 @@ It is a container for child query boundaries and does not expose its own `bounda
 The actual query-boundary public surfaces live under `src/features/<feature>/queries/<query>/boundary.ts`.
 
 The starter and feature scaffolds apply that rule under `src/features/<feature>/...`, so the public export surface is visible without reading prose first.
+Outside feature-owned boundaries, keep shared feature seams under `src/features/_shared/*`, driver-neutral contracts under `src/libraries/*`, driver or sink bindings under `src/adapters/<tech>/*`, shared verification seams under `tests/support/*`, and tool-managed assets under `.ztd/*`.
+Reserve `db/` for DDL, migration, and schema assets; do not place runtime clients or adapters there.
 
 PowerShell:
 
@@ -155,7 +157,7 @@ As boundary depth grows, avoid making every import depth-sensitive by default.
 - Stabilize only shared references that are likely to break when work is split horizontally and moved into a deeper child boundary, such as `src/features/_shared/*` or `tests/support/*`.
 - One workable tactic is package `imports` or an equivalent alias that works in both TypeScript and runtime resolution, but that is a means, not the architectural goal.
 - Minimum rule: imports that cross boundaries should make the target boundary explicit and go through its `boundary.ts` entrypoint.
-- Pragmatic exception: designated shared infrastructure such as `src/features/_shared/*` and `tests/support/*` may use stabilized root-level aliases or package-style imports because they are shared support seams, not another boundary's private internals.
+- Pragmatic exception: designated shared seams such as `src/features/_shared/*` and `tests/support/*` may use stabilized root-level aliases or package-style imports because they are shared support seams, not another boundary's private internals.
 - Do not treat this issue as a reason to rewrite every scaffolded import to one style.
 
 ## Troubleshooting
@@ -195,7 +197,7 @@ Use `ztd describe` for machine-readable discovery, and follow the linked guides 
 | `ztd init --starter` | Scaffold the starter project with smoke, DDL, compose, and local Postgres wiring. |
 | `ztd feature scaffold --table <table> --action <insert/update/delete/get-by-id/list>` | Scaffold a feature-local CRUD/SELECT slice with SQL, `boundary.ts` entrypoints, README, and a thin tests entrypoint. |
 | `ztd feature query scaffold --query-name <name> --table <table> --action <insert/update/delete/get-by-id/list>` | Add one child query boundary under an existing boundary folder without rewriting the parent boundary. Use exactly one of `--feature` or `--boundary-dir`, or omit both only when the current working directory is already the target boundary. |
-| `ztd feature tests scaffold --feature <feature-name>` | Refresh `tests/generated/TEST_PLAN.md` and `analysis.json`, create the thin `<query-name>.boundary.ztd.test.ts` Vitest entrypoint when missing, and keep `tests/cases/` as human/AI-owned persistent cases. |
+| `ztd feature tests scaffold --feature <feature-name>` | Refresh `src/features/<feature>/queries/<query>/tests/generated/TEST_PLAN.md` and `analysis.json`, create the thin `src/features/<feature>/queries/<query>/tests/<query>.boundary.ztd.test.ts` Vitest entrypoint when missing, and keep `src/features/<feature>/queries/<query>/tests/cases/` as human/AI-owned persistent cases. |
 | `ztd agents init` | Add the optional Codex bootstrap files. |
 | `ztd ztd-config` | Regenerate `TestRowMap` and runtime fixture metadata from DDL without Docker. |
 | `ztd lint` | Lint SQL against a temporary Postgres. |

--- a/packages/ztd-cli/src/commands/init.ts
+++ b/packages/ztd-cli/src/commands/init.ts
@@ -141,6 +141,7 @@ type FileKey =
   | 'setupEnv'
   | 'starterPostgresTestkit'
   | 'infrastructureReadme'
+  | 'adaptersReadme'
   | 'telemetryTypes'
   | 'telemetryRepository'
   | 'telemetryConsoleRepository'
@@ -414,6 +415,7 @@ const TSCONFIG_TEMPLATE = 'tsconfig.json';
 const SQL_CLIENT_TEMPLATE = 'src/libraries/sql/sql-client.ts';
 const SQL_CLIENT_ADAPTERS_TEMPLATE = 'src/adapters/pg/sql-client.ts';
 const INFRASTRUCTURE_README_TEMPLATE = 'src/libraries/README.md';
+const ADAPTERS_README_TEMPLATE = 'src/adapters/README.md';
 const TELEMETRY_TYPES_TEMPLATE = 'src/libraries/telemetry/types.ts';
 const TELEMETRY_REPOSITORY_TEMPLATE = 'src/libraries/telemetry/repositoryTelemetry.ts';
 const TELEMETRY_CONSOLE_REPOSITORY_TEMPLATE = 'src/adapters/console/repositoryTelemetry.ts';
@@ -765,6 +767,7 @@ export async function runInitCommand(prompter: Prompter, options?: InitCommandOp
     testsSupportZtdVerifier: scaffoldLayout.testsSupportZtdVerifierPath,
     testsSupportZtdHarness: scaffoldLayout.testsSupportZtdHarnessPath,
     infrastructureReadme: scaffoldLayout.infrastructureReadmePath,
+    adaptersReadme: path.join(rootDir, 'src', 'adapters', 'README.md'),
     telemetryTypes: scaffoldLayout.telemetryTypesPath,
     telemetryRepository: scaffoldLayout.telemetryRepositoryPath,
     telemetryConsoleRepository: scaffoldLayout.telemetryConsoleRepositoryPath,
@@ -1230,6 +1233,32 @@ export async function runInitCommand(prompter: Prompter, options?: InitCommandOp
     );
     if (infrastructureReadmeSummary) {
       summaries.infrastructureReadme = infrastructureReadmeSummary;
+    }
+
+    const sqlReadmeSummary = await writeTemplateFile(
+      rootDir,
+      absolutePaths.sqlReadme,
+      relativePath('sqlReadme'),
+      SQL_README_TEMPLATE,
+      dependencies,
+      prompter,
+      overwritePolicy
+    );
+    if (sqlReadmeSummary) {
+      summaries.sqlReadme = sqlReadmeSummary;
+    }
+
+    const adaptersReadmeSummary = await writeTemplateFile(
+      rootDir,
+      absolutePaths.adaptersReadme,
+      relativePath('adaptersReadme'),
+      ADAPTERS_README_TEMPLATE,
+      dependencies,
+      prompter,
+      overwritePolicy
+    );
+    if (adaptersReadmeSummary) {
+      summaries.adaptersReadme = adaptersReadmeSummary;
     }
 
     const telemetryTypesSummary = await writeTemplateFile(
@@ -2658,6 +2687,7 @@ function buildSummaryLines(
     'setupEnv',
     'starterPostgresTestkit',
     'infrastructureReadme',
+    'adaptersReadme',
     'telemetryTypes',
     'telemetryRepository',
     'telemetryConsoleRepository',
@@ -2806,7 +2836,6 @@ export function buildInitDryRunPlan(rootDir: string, options: {
       path.join('tests', 'support', 'ztd', 'case-types.ts'),
       path.join('tests', 'support', 'ztd', 'verifier.ts'),
       path.join('tests', 'support', 'ztd', 'harness.ts'),
-      path.join('src', 'libraries', 'README.md'),
       path.join('src', 'libraries', 'telemetry', 'types.ts'),
       path.join('src', 'libraries', 'telemetry', 'repositoryTelemetry.ts'),
       path.join('src', 'adapters', 'console', 'repositoryTelemetry.ts'),
@@ -2827,9 +2856,6 @@ export function buildInitDryRunPlan(rootDir: string, options: {
   if (options.withDogfooding) {
     files.push('PROMPT_DOGFOOD.md');
   }
-
-  files.push(normalizeCliPath(path.relative(rootDir, scaffoldLayout.sqlClientPath)));
-  files.push(normalizeCliPath(path.relative(rootDir, scaffoldLayout.sqlClientAdaptersPath)));
 
   if (options.withAppInterface) {
     files.splice(0, files.length, 'AGENTS.md');

--- a/packages/ztd-cli/src/commands/init.ts
+++ b/packages/ztd-cli/src/commands/init.ts
@@ -411,13 +411,13 @@ const GLOBAL_SETUP_TEMPLATE = 'tests/support/global-setup.ts';
 const SETUP_ENV_TEMPLATE = 'tests/support/setup-env.ts';
 const VITEST_CONFIG_TEMPLATE = 'vitest.config.ts';
 const TSCONFIG_TEMPLATE = 'tsconfig.json';
-const SQL_CLIENT_TEMPLATE = 'src/db/sql-client.ts';
-const SQL_CLIENT_ADAPTERS_TEMPLATE = 'src/db/sql-client-adapters.ts';
-const INFRASTRUCTURE_README_TEMPLATE = 'src/infrastructure/README.md';
-const TELEMETRY_TYPES_TEMPLATE = 'src/infrastructure/telemetry/types.ts';
-const TELEMETRY_REPOSITORY_TEMPLATE = 'src/infrastructure/telemetry/repositoryTelemetry.ts';
-const TELEMETRY_CONSOLE_REPOSITORY_TEMPLATE = 'src/infrastructure/telemetry/consoleRepositoryTelemetry.ts';
-const SQL_README_TEMPLATE = 'src/sql/README.md';
+const SQL_CLIENT_TEMPLATE = 'src/libraries/sql/sql-client.ts';
+const SQL_CLIENT_ADAPTERS_TEMPLATE = 'src/adapters/pg/sql-client.ts';
+const INFRASTRUCTURE_README_TEMPLATE = 'src/libraries/README.md';
+const TELEMETRY_TYPES_TEMPLATE = 'src/libraries/telemetry/types.ts';
+const TELEMETRY_REPOSITORY_TEMPLATE = 'src/libraries/telemetry/repositoryTelemetry.ts';
+const TELEMETRY_CONSOLE_REPOSITORY_TEMPLATE = 'src/adapters/console/repositoryTelemetry.ts';
+const SQL_README_TEMPLATE = 'src/libraries/sql/README.md';
 const JOBS_README_TEMPLATE = 'src/jobs/README.md';
 const ZTD_README_TEMPLATE = 'ztd/README.md';
 const ZTD_DDL_DEMO_TEMPLATE = 'db/ddl/demo.sql';
@@ -566,16 +566,16 @@ function resolveInitScaffoldLayout(rootDir: string, _appShape: InitAppShape): In
     setupEnvTemplate: SETUP_ENV_TEMPLATE,
     starterPostgresTestkitPath: path.join(rootDir, supportDir, 'postgres-testkit.ts'),
     starterPostgresTestkitTemplate: 'tests/support/postgres-testkit.ts',
-    infrastructureReadmePath: path.join(rootDir, 'src', 'infrastructure', 'README.md'),
+    infrastructureReadmePath: path.join(rootDir, 'src', 'libraries', 'README.md'),
     infrastructureReadmeTemplate: INFRASTRUCTURE_README_TEMPLATE,
-    telemetryTypesPath: path.join(rootDir, 'src', 'infrastructure', 'telemetry', 'types.ts'),
+    telemetryTypesPath: path.join(rootDir, 'src', 'libraries', 'telemetry', 'types.ts'),
     telemetryTypesTemplate: TELEMETRY_TYPES_TEMPLATE,
-    telemetryRepositoryPath: path.join(rootDir, 'src', 'infrastructure', 'telemetry', 'repositoryTelemetry.ts'),
+    telemetryRepositoryPath: path.join(rootDir, 'src', 'libraries', 'telemetry', 'repositoryTelemetry.ts'),
     telemetryRepositoryTemplate: TELEMETRY_REPOSITORY_TEMPLATE,
-    telemetryConsoleRepositoryPath: path.join(rootDir, 'src', 'infrastructure', 'telemetry', 'consoleRepositoryTelemetry.ts'),
+    telemetryConsoleRepositoryPath: path.join(rootDir, 'src', 'adapters', 'console', 'repositoryTelemetry.ts'),
     telemetryConsoleRepositoryTemplate: TELEMETRY_CONSOLE_REPOSITORY_TEMPLATE,
-    sqlClientPath: path.join(rootDir, 'src', 'db', 'sql-client.ts'),
-    sqlClientAdaptersPath: path.join(rootDir, 'src', 'db', 'sql-client-adapters.ts')
+    sqlClientPath: path.join(rootDir, 'src', 'libraries', 'sql', 'sql-client.ts'),
+    sqlClientAdaptersPath: path.join(rootDir, 'src', 'adapters', 'pg', 'sql-client.ts')
   };
 }
 
@@ -777,7 +777,7 @@ export async function runInitCommand(prompter: Prompter, options?: InitCommandOp
     internalAgentsSrc: path.join(rootDir, '.ztd', 'agents', 'src.md'),
     internalAgentsTests: path.join(rootDir, '.ztd', 'agents', 'tests.md'),
     internalAgentsZtd: path.join(rootDir, '.ztd', 'agents', 'db.md'),
-    sqlReadme: path.join(rootDir, 'src', 'sql', 'README.md'),
+    sqlReadme: path.join(rootDir, 'src', 'libraries', 'sql', 'README.md'),
     sqlClient: scaffoldLayout.sqlClientPath,
     sqlClientAdapters: scaffoldLayout.sqlClientAdaptersPath,
     globalSetup: path.join(rootDir, supportDir, 'global-setup.ts'),
@@ -2775,7 +2775,11 @@ export function buildInitDryRunPlan(rootDir: string, options: {
     'README.md',
     '.env.example',
     '.gitignore',
-    'src/sql/README.md',
+    'src/libraries/README.md',
+    'src/libraries/sql/README.md',
+    'src/libraries/sql/sql-client.ts',
+    'src/adapters/README.md',
+    'src/adapters/pg/sql-client.ts',
     'vitest.config.ts',
     'tsconfig.json'
   ];
@@ -2802,10 +2806,10 @@ export function buildInitDryRunPlan(rootDir: string, options: {
       path.join('tests', 'support', 'ztd', 'case-types.ts'),
       path.join('tests', 'support', 'ztd', 'verifier.ts'),
       path.join('tests', 'support', 'ztd', 'harness.ts'),
-      path.join('src', 'infrastructure', 'README.md'),
-      path.join('src', 'infrastructure', 'telemetry', 'types.ts'),
-      path.join('src', 'infrastructure', 'telemetry', 'repositoryTelemetry.ts'),
-      path.join('src', 'infrastructure', 'telemetry', 'consoleRepositoryTelemetry.ts'),
+      path.join('src', 'libraries', 'README.md'),
+      path.join('src', 'libraries', 'telemetry', 'types.ts'),
+      path.join('src', 'libraries', 'telemetry', 'repositoryTelemetry.ts'),
+      path.join('src', 'adapters', 'console', 'repositoryTelemetry.ts'),
       path.join(resolveSupportDir(DEFAULT_ZTD_CONFIG), 'postgres-testkit.ts')
     );
   }

--- a/packages/ztd-cli/src/commands/init.ts
+++ b/packages/ztd-cli/src/commands/init.ts
@@ -2805,10 +2805,7 @@ export function buildInitDryRunPlan(rootDir: string, options: {
     'README.md',
     '.env.example',
     '.gitignore',
-    'src/libraries/README.md',
-    'src/libraries/sql/README.md',
     'src/libraries/sql/sql-client.ts',
-    'src/adapters/README.md',
     'src/adapters/pg/sql-client.ts',
     'vitest.config.ts',
     'tsconfig.json'
@@ -2816,6 +2813,9 @@ export function buildInitDryRunPlan(rootDir: string, options: {
 
   if (starter) {
     files.push(
+      path.join('src', 'libraries', 'README.md'),
+      path.join('src', 'libraries', 'sql', 'README.md'),
+      path.join('src', 'adapters', 'README.md'),
       STARTER_COMPOSE_FILE,
       path.join('src', 'features', '_shared', 'featureQueryExecutor.ts'),
       path.join('src', 'features', '_shared', 'loadSqlResource.ts'),

--- a/packages/ztd-cli/templates/AGENTS.md
+++ b/packages/ztd-cli/templates/AGENTS.md
@@ -6,7 +6,11 @@ Read `README.md` and the nearest `AGENTS.md` before editing files.
 
 - Use `src/features/<feature>` as the default change unit.
 - Keep handwritten SQL, boundary entrypoints, and tests inside the feature that owns them.
-- Treat `db/ddl` as human-owned DDL input.
+- Treat `src/features`, `src/adapters`, and `src/libraries` as the app-code roots.
+- Keep `FeatureQueryExecutor` in `src/features/_shared/`.
+- Keep the driver-neutral `SqlClient` contract in `src/libraries/sql/`.
+- Put driver or sink bindings under `src/adapters/<tech>/`.
+- Treat `db` as human-owned DDL, migration, and schema-asset input only.
 - Treat `.ztd/` as the tool-managed workspace for generated and support assets.
 - Treat `ztd.config.json`'s `testsDir` as the tool-managed test workspace root. Feature-authored boundary tests stay under `src/features/<feature>/tests/`.
 - Do not apply migrations automatically.
@@ -17,7 +21,7 @@ Read `README.md` and the nearest `AGENTS.md` before editing files.
 - For success-path insert tests, keep generated or returned columns such as `user_id` out of the input fixture. Assert returned values only after the DB-backed execution finishes.
 - If a returned id comes back `null`, treat that as a scaffold or DDL mismatch and stop. Do not paper over it by loosening the success-path schema or adding fake seed rows.
 - Before writing the success-path assertion, inspect the scaffolded SQL and query boundary contract. If the scaffold does not actually return a non-null id, report the mismatch instead of inventing fixture data or schema overrides.
-- For new feature work, run `ztd feature scaffold` first, then after SQL and DTO edits settle run `ztd feature tests scaffold --feature <feature-name>` to refresh `tests/generated/TEST_PLAN.md` and `analysis.json`, create or keep the thin `tests/<query>.boundary.ztd.test.ts` Vitest entrypoint, and keep AI-authored cases in `tests/cases/`.
+- For new feature work, run `ztd feature scaffold` first, then after SQL and DTO edits settle run `ztd feature tests scaffold --feature <feature-name>` to refresh `src/features/<feature-name>/queries/<query-name>/tests/generated/TEST_PLAN.md` and `analysis.json`, create or keep the thin `src/features/<feature-name>/queries/<query-name>/tests/<query-name>.boundary.ztd.test.ts` Vitest entrypoint, and keep AI-authored cases in `src/features/<feature-name>/queries/<query-name>/tests/cases/`.
 - If `AGENTS_ztd.md` exists in a legacy workspace, treat it as a fallback mirror only; the root `AGENTS.md` is the authoritative root guidance entrypoint.
 
 ## Safe Next Steps

--- a/packages/ztd-cli/templates/PROMPT_DOGFOOD.md
+++ b/packages/ztd-cli/templates/PROMPT_DOGFOOD.md
@@ -13,6 +13,8 @@ Start with `npx ztd feature scaffold --table <table> --action <action>`.
 Treat the project structure as Architecture as a Framework.
 Every boundary folder exposes only `boundary.ts`, and child boundaries repeat the same rule.
 Keep handwritten SQL, the feature boundary, and the query boundary inside `src/features/<feature-name>`.
+Keep shared feature seams under `src/features/_shared/*`, shared verification seams under `tests/support/*`, and tool-managed assets under `.ztd/*`.
+Keep driver-neutral contracts in `src/libraries/*` and driver or sink bindings in `src/adapters/<tech>/*`.
 Keep feature-boundary tests mock-based in `src/features/<feature-name>/tests/<feature-name>.boundary.test.ts`.
 Before you edit DTOs or write persistent query cases, run `npx ztd feature tests scaffold --feature <feature-name>`.
 That command refreshes `src/features/<feature-name>/queries/<query-name>/tests/generated/TEST_PLAN.md` and `analysis.json`, refreshes `src/features/<feature-name>/queries/<query-name>/tests/boundary-ztd-types.ts`, and creates the thin `src/features/<feature-name>/queries/<query-name>/tests/<query-name>.boundary.ztd.test.ts` Vitest entrypoint only if it is missing.
@@ -40,7 +42,7 @@ Troubleshooting reminder:
 - Compare the direct database `INSERT ... RETURNING ...` result with the ZTD result so you can separate the DB from manifest or rewrite issues.
 - Verify a dogfood workspace resolves `rawsql-ts` from the local source tree instead of a registry copy when you expect a source change to be reflected.
 - Use `ZTD_SQL_TRACE=1` only while debugging rewrite behavior so local and CI logs stay quiet by default.
-- Treat `tests/generated/*` as CLI refresh output, not an AI edit target.
+- Treat query-local `tests/generated/*` as CLI refresh output, not an AI edit target.
 
 ## Prompt 2: Fix a DDL change
 

--- a/packages/ztd-cli/templates/README.md
+++ b/packages/ztd-cli/templates/README.md
@@ -12,6 +12,8 @@ Check `package.json` to see which mode you are in. If you see `file:` dependenci
 The project is feature-first by default:
 
 - keep SQL, boundaries, and tests close to each feature
+- use `src/features`, `src/adapters`, and `src/libraries` as the app-code roots
+- keep `db/` for DDL, migration, and schema assets only
 - use `@rawsql-ts/sql-contract` for query contract metadata and catalog execution
 - keep feature-root boundary tests under `src/features/<feature>/tests/`
 - keep CLI-owned generated assets under `src/features/<feature>/queries/<query>/tests/generated`
@@ -32,7 +34,7 @@ npx vitest run src/features/**/*.test.ts
 The generated runtime manifest is the preferred input for `@rawsql-ts/testkit-postgres`; raw DDL directories remain a fallback for legacy layouts. The generated contract itself is schema metadata only (`tableDefinitions`), so test rows stay explicit.
 The starter keeps `ztdRootDir`, `ddlDir`, `defaultSchema`, and `searchPath` in `ztd.config.json`. The helper reads the project defaults from one place instead of repeating them in every DB-backed test.
 
-`src/features/<feature>/tests/` is where feature-root boundary tests live. Query-local ZTD assets live under `src/features/<feature>/queries/<query>/tests/{generated,cases}` with the thin entrypoint beside them. Starter-owned shared support lives at `tests/support/ztd/`, while `.ztd/` is the tool-managed workspace for generated metadata and support files.
+`src/features/<feature>/tests/` is where feature-root boundary tests live. Query-local ZTD assets live under `src/features/<feature>/queries/<query>/tests/{generated,cases}` with the thin entrypoint beside them. Starter-owned shared support lives at `tests/support/ztd/`, while `.ztd/` is the tool-managed workspace for generated metadata and support files. Keep `FeatureQueryExecutor` in `src/features/_shared/`, keep the driver-neutral `SqlClient` contract in `src/libraries/sql/sql-client.ts`, and put driver or sink bindings under `src/adapters/<tech>/`.
 
 ## Getting Started with AI
 
@@ -46,6 +48,9 @@ Every boundary folder exposes only `boundary.ts`, and sub-boundaries repeat the 
 Keep handwritten SQL, query boundaries, repository code, and tests inside `src/features/<feature-name>`.
 Treat the query boundary contract and its ZTD-backed test as one completion unit; do not stop at a property-only check.
 Keep feature-boundary tests mock-based in `src/features/<feature-name>/tests/<feature-name>.boundary.test.ts`.
+Keep shared feature seams in `src/features/_shared/*`, shared verification seams in `tests/support/*`, and tool-managed files in `.ztd/*`.
+Keep the driver-neutral `SqlClient` contract in `src/libraries/sql/sql-client.ts`.
+Put driver or sink bindings under `src/adapters/<tech>/` instead of under `db/`.
 Make sure the query-boundary result executes through the DB-backed ZTD path and checks mapping and validation, not just property values.
 Do not put returned columns into the input fixture; assert them only after the DB-backed result returns.
 If the returned result is `null`, stop and fix the scaffold or DDL instead of weakening the success-path schema or seeding fake rows.

--- a/packages/ztd-cli/templates/src/adapters/README.md
+++ b/packages/ztd-cli/templates/src/adapters/README.md
@@ -1,0 +1,7 @@
+# Adapters
+
+Technology-specific bindings live here.
+
+- Put driver or sink specific code under `src/adapters/<tech>/`.
+- Keep each `<tech>` folder singular until it needs child boundaries.
+- Do not place runtime clients or adapters under `db/`; reserve `db/` for DDL, migrations, and schema assets.

--- a/packages/ztd-cli/templates/src/adapters/README.md
+++ b/packages/ztd-cli/templates/src/adapters/README.md
@@ -2,6 +2,6 @@
 
 Technology-specific bindings live here.
 
-- Put driver or sink specific code under `src/adapters/<tech>/`.
+- Put driver- or sink-specific code under `src/adapters/<tech>/`.
 - Keep each `<tech>` folder singular until it needs child boundaries.
 - Do not place runtime clients or adapters under `db/`; reserve `db/` for DDL, migrations, and schema assets.

--- a/packages/ztd-cli/templates/src/adapters/console/repositoryTelemetry.ts
+++ b/packages/ztd-cli/templates/src/adapters/console/repositoryTelemetry.ts
@@ -1,0 +1,55 @@
+import type {
+  RepositoryTelemetry,
+  RepositoryTelemetryConsoleOptions,
+  RepositoryTelemetryEvent,
+} from '../../libraries/telemetry/types.js';
+
+/**
+ * Create a conservative console-backed telemetry hook for repositories.
+ *
+ * The emitted payload stays on the safe side of the boundary: it includes the
+ * runtime contract metadata, but never SQL text or bind values.
+ */
+export function createConsoleRepositoryTelemetry(
+  options: RepositoryTelemetryConsoleOptions = {},
+): RepositoryTelemetry {
+  const logger = options.logger ?? console;
+
+  return {
+    emit(event: RepositoryTelemetryEvent): void {
+      const payload = serializeEvent(event);
+      if (event.kind === 'query.execute.error') {
+        logger.error('[repository-telemetry]', payload);
+        return;
+      }
+
+      logger.info('[repository-telemetry]', payload);
+    },
+  };
+}
+
+function serializeEvent(
+  event: RepositoryTelemetryEvent,
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    kind: event.kind,
+    timestamp: event.timestamp,
+    queryId: event.queryId,
+    repositoryName: event.repositoryName,
+    methodName: event.methodName,
+    paramsShape: event.paramsShape,
+    transformations: event.transformations
+  };
+
+  if (event.kind !== 'query.execute.start') {
+    payload.durationMs = event.durationMs;
+  }
+  if (event.kind === 'query.execute.success' && event.rowCount !== undefined) {
+    payload.rowCount = event.rowCount;
+  }
+  if (event.kind === 'query.execute.error') {
+    payload.errorName = event.errorName;
+  }
+
+  return payload;
+}

--- a/packages/ztd-cli/templates/src/adapters/pg/sql-client.ts
+++ b/packages/ztd-cli/templates/src/adapters/pg/sql-client.ts
@@ -1,0 +1,34 @@
+import type { SqlClient } from '../../libraries/sql/sql-client.js';
+
+/**
+ * Adapt a `pg`-style queryable (Client or Pool) into a SqlClient.
+ *
+ * pg's `query()` returns `QueryResult<T>` with a `.rows` property.
+ * This helper unwraps the result so it satisfies the shared `SqlClient` contract.
+ *
+ * Usage:
+ *   // This runtime example uses DATABASE_URL for application code.
+ *   // ztd-cli itself does not read DATABASE_URL implicitly.
+ *   const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+ *   const client = fromPg(pool);
+ *   const users = await client.query<{ id: number }>('SELECT id ...', []);
+ */
+export function fromPg(
+  queryable: {
+    query(text: string, values?: readonly unknown[]): Promise<{ rows: Record<string, unknown>[] }>;
+  }
+): SqlClient {
+  return {
+    query<T extends Record<string, unknown> = Record<string, unknown>>(
+      text: string,
+      values?: readonly unknown[] | Record<string, unknown>
+    ): Promise<T[]> {
+      if (values != null && !Array.isArray(values)) {
+        throw new Error('fromPg adapter does not support named parameter objects; use positional parameter arrays');
+      }
+      return queryable
+        .query(text, values as readonly unknown[])
+        .then((result) => result.rows as T[]);
+    }
+  };
+}

--- a/packages/ztd-cli/templates/src/features/AGENTS.md
+++ b/packages/ztd-cli/templates/src/features/AGENTS.md
@@ -7,9 +7,12 @@
 - Prefer `queries/` as the default container folder for query boundaries, with each query folder owning exactly one `boundary.ts`.
 - Keep feature-boundary tests at `src/features/<feature>/tests/<feature>.boundary.test.ts`.
 - Keep query-boundary ZTD assets colocated with each query directory under `src/features/<feature>/queries/<query>/tests/`.
+- Keep shared feature-facing seams under `src/features/_shared/*`.
+- Put driver or sink bindings under `src/adapters/<tech>/*` and shared driver-neutral contracts under `src/libraries/*`.
+- Do not place runtime clients or adapters under `db/`.
 - Treat `smoke` as the removable starter sample when it exists.
 - `users` is the normal first feature after `smoke`.
-- `tests/generated/` is refreshable and CLI-owned; `tests/cases/` is persistent and owned by humans or AI.
-- `ztd feature tests scaffold` should refresh generated analysis, create the thin `tests/<query>.boundary.ztd.test.ts` Vitest entrypoint when missing, and not rewrite persistent case files.
+- Query-local `tests/generated/` is refreshable and CLI-owned; query-local `tests/cases/` is persistent and owned by humans or AI.
+- `ztd feature tests scaffold` should refresh query-local generated analysis, create the thin `src/features/<feature>/queries/<query>/tests/<query>.boundary.ztd.test.ts` Vitest entrypoint when missing, and not rewrite persistent case files.
 
 If a request would move code out of the feature folder, explain the tradeoff before doing it.

--- a/packages/ztd-cli/templates/src/features/README.md
+++ b/packages/ztd-cli/templates/src/features/README.md
@@ -28,6 +28,8 @@ boundary/
 - add more child boundaries as child folders when one boundary grows; each child repeats the same `boundary.ts` plus `tests/` rule
 
 `ztd.config.json` owns the tool-managed workspace under `.ztd/generated/` and `.ztd/tests/` support files. Feature-authored boundary tests stay under `src/features/<feature>/tests/`, while query-local ZTD assets stay under `src/features/<feature>/queries/<query>/tests/{generated,cases}`.
+Use `src/features/_shared/*` only for feature-facing shared seams such as `FeatureQueryExecutor`.
+Keep driver-neutral helpers in `src/libraries/*`, driver or sink bindings in `src/adapters/<tech>/*`, and keep `db/` reserved for DDL, migrations, and schema assets.
 
 Use `ztd feature tests scaffold --feature <feature-name>` after SQL and DTO edits to refresh `src/features/<feature>/queries/<query>/tests/generated/TEST_PLAN.md` and `analysis.json`, keep the thin `src/features/<feature>/queries/<query>/tests/<query>.boundary.ztd.test.ts` entrypoint in sync, and add persistent cases under `src/features/<feature>/queries/<query>/tests/cases/` with the fixed app-level ZTD runner.
 When you are on the boundary lane, treat it as query-local: `src/features/<feature>/queries/<query>/tests/<query>.boundary.ztd.test.ts`, `src/features/<feature>/queries/<query>/tests/generated/`, and `src/features/<feature>/queries/<query>/tests/cases/` move together, while the feature-root `src/features/<feature>/tests/<feature>.boundary.test.ts` stays on the mock-based lane.
@@ -41,7 +43,7 @@ Prefer stability at recursive boundary seams over one blanket import style.
 - One workable tactic is package `imports` such as `#features/*` and `#tests/*`, or an equivalent alias that works in both TypeScript and runtime resolution.
 - Minimum rule: do not let deep relative imports become the public boundary contract.
 - When a boundary depends on another boundary, make the dependency obvious by importing its compiled ESM entrypoint with `.js` specifiers, such as `./boundary.js` or `../boundary.js`, rather than walking through internal files.
-- Pragmatic exception: designated shared infrastructure such as `src/features/_shared/*` and `tests/support/*` may use stabilized root-level aliases because those files are shared support seams, not another boundary's private implementation.
+- Pragmatic exception: designated shared seams such as `src/features/_shared/*` and `tests/support/*` may use stabilized root-level aliases because those files are shared support seams, not another boundary's private implementation.
 
 ## Sample feature
 

--- a/packages/ztd-cli/templates/src/infrastructure/persistence/repositories/AGENTS.md
+++ b/packages/ztd-cli/templates/src/infrastructure/persistence/repositories/AGENTS.md
@@ -8,7 +8,7 @@
 - Repositories MUST load SQL assets from `src/sql` through shared loader infrastructure.
 - Repository CUD behavior MUST follow contract rules for `RETURNING`, rowCount handling, and explicit unsupported-driver failures.
 - Repositories MUST reference SQL by stable logical keys.
-- Constructors for repositories SHOULD accept an optional telemetry dependency from `src/infrastructure/telemetry/repositoryTelemetry.ts`.
+- Constructors for repositories SHOULD accept an optional telemetry dependency from `src/libraries/telemetry/repositoryTelemetry.ts`.
 - Tests MUST cover every public repository method.
 
 ## PROHIBITED

--- a/packages/ztd-cli/templates/src/infrastructure/telemetry/AGENTS.md
+++ b/packages/ztd-cli/templates/src/infrastructure/telemetry/AGENTS.md
@@ -1,5 +1,5 @@
 # Package Scope
-- Applies to `packages/ztd-cli/templates/src/infrastructure/telemetry`.
+- Applies to the starter telemetry template files.
 - Defines repository telemetry seams and adapters.
 
 # Policy

--- a/packages/ztd-cli/templates/src/libraries/README.md
+++ b/packages/ztd-cli/templates/src/libraries/README.md
@@ -1,0 +1,7 @@
+# Libraries
+
+Shared runtime contracts and reusable helpers live here.
+
+- Keep driver-neutral contracts under `src/libraries/sql/` and `src/libraries/telemetry/`.
+- Prefer `src/features/<feature>/` first when a helper is still owned by one feature.
+- Move code here only when it is no longer feature-owned and does not depend on a specific external technology.

--- a/packages/ztd-cli/templates/src/libraries/sql/README.md
+++ b/packages/ztd-cli/templates/src/libraries/sql/README.md
@@ -1,0 +1,7 @@
+# SQL Library
+
+Keep driver-neutral SQL contracts here.
+
+- `sql-client.ts` defines the app-to-driver contract.
+- Driver bindings belong under `src/adapters/<tech>/`, not under `db/`.
+- Keep handwritten `.sql` assets inside the feature that owns the workflow.

--- a/packages/ztd-cli/templates/src/libraries/sql/sql-client.ts
+++ b/packages/ztd-cli/templates/src/libraries/sql/sql-client.ts
@@ -1,0 +1,25 @@
+/**
+ * Promise that resolves to the array of rows produced by an SQL query.
+ * @template T Shape of each row yielded by the SQL client.
+ * @example
+ * const rows: SqlQueryRows<{ id: number; name: string }> = client.query('SELECT id, name FROM users');
+ */
+export type SqlQueryRows<T> = Promise<T[]>;
+
+/**
+ * Minimal SQL client contract shared by the app and adapter boundaries.
+ *
+ * - Production: adapt this contract to your preferred driver (pg, mysql2, etc.) and normalize the results to `T[]`.
+ * - Tests: replace the implementation with a mock, a fixture helper, or an adapter that follows this contract.
+ *
+ * Connection strategy note:
+ * - Prefer one live client per DB context or worker process for better performance.
+ * - Multiple clients can coexist in the same workflow as long as each one owns its own lifecycle.
+ * - Do not share a live client across parallel workers without proper synchronization.
+ */
+export type SqlClient = {
+  query<T extends Record<string, unknown> = Record<string, unknown>>(
+    text: string,
+    values?: readonly unknown[] | Record<string, unknown>
+  ): SqlQueryRows<T>;
+};

--- a/packages/ztd-cli/templates/src/libraries/telemetry/repositoryTelemetry.ts
+++ b/packages/ztd-cli/templates/src/libraries/telemetry/repositoryTelemetry.ts
@@ -1,0 +1,48 @@
+import type { RepositoryTelemetry } from './types.js';
+
+export type {
+  RepositoryTelemetry,
+  RepositoryTelemetryBooleanValue,
+  RepositoryTelemetryConsoleOptions,
+  RepositoryTelemetryArrayLength,
+  RepositoryTelemetryContext,
+  RepositoryTelemetryEvent,
+  RepositoryTelemetryEventKind,
+  RepositoryTelemetryNullability,
+  RepositoryTelemetryOptionalPredicatePruning,
+  RepositoryTelemetryPagingTransformation,
+  RepositoryTelemetryParameterKind,
+  RepositoryTelemetryParameterShape,
+  RepositoryTelemetryPresence,
+  RepositoryTelemetryPipelineTransformation,
+  RepositoryTelemetrySortTransformation,
+  RepositoryTelemetryTransformations,
+} from './types.js';
+
+/**
+ * Create a repository telemetry hook that intentionally does nothing.
+ *
+ * The starter scaffold keeps this as the default so applications opt in to
+ * console, pino, OpenTelemetry, or custom sinks explicitly.
+ */
+export function createNoopRepositoryTelemetry(): RepositoryTelemetry {
+  return {
+    emit(): void {
+      return;
+    }
+  };
+}
+
+export const defaultRepositoryTelemetry = createNoopRepositoryTelemetry();
+
+/**
+ * Resolve the repository telemetry hook that application code wants to use.
+ *
+ * Repository constructors can accept an optional telemetry dependency and call
+ * this helper so the default no-op hook works without extra setup.
+ */
+export function resolveRepositoryTelemetry(
+  telemetry?: RepositoryTelemetry,
+): RepositoryTelemetry {
+  return telemetry ?? defaultRepositoryTelemetry;
+}

--- a/packages/ztd-cli/templates/src/libraries/telemetry/types.ts
+++ b/packages/ztd-cli/templates/src/libraries/telemetry/types.ts
@@ -1,0 +1,164 @@
+export type RepositoryTelemetryEventKind =
+  | 'query.execute.start'
+  | 'query.execute.success'
+  | 'query.execute.error';
+
+export type RepositoryTelemetryPresence = 'present' | 'absent';
+export type RepositoryTelemetryParameterKind = 'scalar' | 'array' | 'object' | 'unknown';
+export type RepositoryTelemetryNullability = 'null' | 'non-null' | 'mixed' | 'unknown';
+export type RepositoryTelemetryArrayLength = 'empty' | 'single' | 'few' | 'many' | 'unknown';
+export type RepositoryTelemetryBooleanValue = 'true' | 'false';
+
+type RepositoryTelemetryScalarParameterShape = {
+  name: string;
+  presence: 'present';
+  kind: 'scalar';
+  isNull: false;
+  nullability: 'non-null';
+  isEmptyString?: boolean;
+  booleanValue?: RepositoryTelemetryBooleanValue;
+  arrayLength?: never;
+  isEmptyArray?: never;
+  operator?: string;
+};
+
+type RepositoryTelemetryArrayParameterShape =
+  | {
+      name: string;
+      presence: 'present';
+      kind: 'array';
+      isNull: false;
+      nullability: Exclude<RepositoryTelemetryNullability, 'null' | 'unknown'>;
+      arrayLength: RepositoryTelemetryArrayLength;
+      isEmptyArray: boolean;
+      isEmptyString?: never;
+      booleanValue?: never;
+      operator?: string;
+    }
+  | {
+      name: string;
+      presence: 'present';
+      kind: 'array';
+      isNull: true;
+      nullability: 'null';
+      arrayLength?: never;
+      isEmptyArray?: never;
+      isEmptyString?: never;
+      booleanValue?: never;
+      operator?: string;
+    };
+
+type RepositoryTelemetryNullParameterShape = {
+  name: string;
+  presence: 'present';
+  kind: 'scalar' | 'object' | 'unknown';
+  isNull: true;
+  nullability: 'null';
+  arrayLength?: never;
+  isEmptyArray?: never;
+  isEmptyString?: never;
+  booleanValue?: never;
+  operator?: string;
+};
+
+type RepositoryTelemetryUnknownParameterShape =
+  | {
+      name: string;
+      presence: 'absent';
+      kind: 'unknown';
+      isNull: false;
+      nullability: 'unknown';
+      arrayLength?: never;
+      isEmptyArray?: never;
+      isEmptyString?: never;
+      booleanValue?: never;
+      operator?: string;
+    }
+  | {
+      name: string;
+      presence: 'present';
+      kind: 'object' | 'unknown';
+      isNull: false;
+      nullability: Exclude<RepositoryTelemetryNullability, 'null'>;
+      arrayLength?: never;
+      isEmptyArray?: never;
+      isEmptyString?: never;
+      booleanValue?: never;
+      operator?: string;
+    };
+
+export type RepositoryTelemetryParameterShape =
+  | RepositoryTelemetryScalarParameterShape
+  | RepositoryTelemetryArrayParameterShape
+  | RepositoryTelemetryNullParameterShape
+  | RepositoryTelemetryUnknownParameterShape;
+
+export interface RepositoryTelemetryOptionalPredicatePruning {
+  enabled: boolean;
+  prunedPredicateCount?: number;
+}
+
+export interface RepositoryTelemetryPagingTransformation {
+  enabled: boolean;
+  hasLimit?: boolean;
+  hasOffset?: boolean;
+}
+
+export interface RepositoryTelemetrySortTransformation {
+  enabled: boolean;
+  orderByCount?: number;
+}
+
+export interface RepositoryTelemetryPipelineTransformation {
+  enabled: boolean;
+  stageCount?: number;
+}
+
+export interface RepositoryTelemetryTransformations {
+  optionalPredicatePruning?: RepositoryTelemetryOptionalPredicatePruning;
+  paging?: RepositoryTelemetryPagingTransformation;
+  sort?: RepositoryTelemetrySortTransformation;
+  pipelineDecomposition?: RepositoryTelemetryPipelineTransformation;
+}
+
+export interface RepositoryTelemetryContext {
+  queryId: string;
+  repositoryName: string;
+  methodName: string;
+  paramsShape: RepositoryTelemetryParameterShape[];
+  transformations: RepositoryTelemetryTransformations;
+}
+
+interface RepositoryTelemetryEventBase extends RepositoryTelemetryContext {
+  kind: RepositoryTelemetryEventKind;
+  timestamp: string;
+}
+
+export interface RepositoryQueryExecuteStartEvent extends RepositoryTelemetryEventBase {
+  kind: 'query.execute.start';
+}
+
+export interface RepositoryQueryExecuteSuccessEvent extends RepositoryTelemetryEventBase {
+  kind: 'query.execute.success';
+  durationMs: number;
+  rowCount?: number;
+}
+
+export interface RepositoryQueryExecuteErrorEvent extends RepositoryTelemetryEventBase {
+  kind: 'query.execute.error';
+  durationMs: number;
+  errorName: string;
+}
+
+export type RepositoryTelemetryEvent =
+  | RepositoryQueryExecuteStartEvent
+  | RepositoryQueryExecuteSuccessEvent
+  | RepositoryQueryExecuteErrorEvent;
+
+export interface RepositoryTelemetry {
+  emit(event: RepositoryTelemetryEvent): void | Promise<void>;
+}
+
+export interface RepositoryTelemetryConsoleOptions {
+  logger?: Pick<Console, 'info' | 'error'>;
+}

--- a/packages/ztd-cli/templates/src/repositories/AGENTS.md
+++ b/packages/ztd-cli/templates/src/repositories/AGENTS.md
@@ -9,7 +9,7 @@
 - Repositories MUST use catalog runtime helpers (`ensure*`, `map*`) for input/output validation.
 - Repository CUD behavior MUST follow contract rules for `RETURNING`, rowCount handling, and explicit unsupported-driver failures.
 - Repository modules MUST reference SQL by stable logical keys.
-- Repository constructors SHOULD accept an optional telemetry dependency from `src/infrastructure/telemetry/repositoryTelemetry.ts`.
+- Repository constructors SHOULD accept an optional telemetry dependency from `src/libraries/telemetry/repositoryTelemetry.ts`.
 - Public repository methods MUST be covered by tests.
 
 ## ALLOWED

--- a/packages/ztd-cli/templates/tests/AGENTS.md
+++ b/packages/ztd-cli/templates/tests/AGENTS.md
@@ -2,9 +2,9 @@
 
 - Tests under `packages/ztd-cli/templates/tests/**/*.test.ts` MUST verify rewrite execution, mapping and validation paths, and DTO-shape behavior when the feature depends on ZTD-managed SQL assets.
 - For ZTD-managed SQL assets, a passing-path test should exercise the real DB-backed ZTD execution path; a mock executor alone is not sufficient for the success case.
-- Entryspec tests are mock-based and live at `src/features/<feature>/tests/<feature>.entryspec.test.ts`.
-- Queryspec tests are the ZTD lane and live under `src/features/<feature>/<query>/tests/` with generated analysis and persistent cases colocated per query.
-- For new feature work, prefer `ztd feature tests scaffold --feature <feature-name>` to refresh `tests/generated/TEST_PLAN.md` and `analysis.json`, create the thin `tests/<query>.queryspec.ztd.test.ts` Vitest entrypoint when missing, and keep AI-authored cases under `tests/cases/`.
+- Feature-boundary tests are mock-based and live at `src/features/<feature>/tests/<feature>.boundary.test.ts`.
+- Query-boundary tests are the ZTD lane and live under `src/features/<feature>/queries/<query>/tests/` with generated analysis and persistent cases colocated per query.
+- For new feature work, prefer `ztd feature tests scaffold --feature <feature-name>` to refresh `src/features/<feature>/queries/<query>/tests/generated/TEST_PLAN.md` and `analysis.json`, create the thin `src/features/<feature>/queries/<query>/tests/<query>.boundary.ztd.test.ts` Vitest entrypoint when missing, and keep AI-authored cases under `src/features/<feature>/queries/<query>/tests/cases/`.
 - The fixed app-level ZTD runner lives in `tests/support/ztd/harness.ts`; query-local cases and the thin Vitest entrypoint should call into that runner instead of inventing per-query support helpers.
 - Keep tests close to the feature they verify when possible.
 - Regenerate DDL-derived artifacts before diagnosing missing generated modules.

--- a/packages/ztd-cli/templates/tests/support/testkit-client.webapi.ts
+++ b/packages/ztd-cli/templates/tests/support/testkit-client.webapi.ts
@@ -1,4 +1,4 @@
-import type { SqlClient } from '../../src/infrastructure/db/sql-client.js';
+import type { SqlClient } from '../../src/libraries/sql/sql-client.js';
 
 export type TestkitClient = SqlClient & {
   close(): Promise<void>;

--- a/packages/ztd-cli/templates/tests/support/ztd/README.md
+++ b/packages/ztd-cli/templates/tests/support/ztd/README.md
@@ -1,16 +1,16 @@
 # ZTD Support
 
-This folder holds the starter-owned shared support for queryspec ZTD cases.
+This folder holds the starter-owned shared support for query-boundary ZTD cases.
 
 - `harness.ts` exposes the fixed app-level runner that query-local cases call.
 - `verifier.ts` is a thin adapter that delegates ZTD execution to the testkit library mode API.
 - `case-types.ts` defines the small v1 case shape.
 
-Query-local AI work should live in `src/features/<feature>/<query>/tests/cases/`.
-Generated analysis belongs in `src/features/<feature>/<query>/tests/generated/`.
-The Vitest entrypoint `src/features/<feature>/<query>/tests/<query>.queryspec.ztd.test.ts` should stay thin and only adapt the cases to the fixed runner.
+Query-local AI work should live in `src/features/<feature>/queries/<query>/tests/cases/`.
+Generated analysis belongs in `src/features/<feature>/queries/<query>/tests/generated/`.
+The Vitest entrypoint `src/features/<feature>/queries/<query>/tests/<query>.boundary.ztd.test.ts` should stay thin and only adapt the cases to the fixed runner.
 `beforeDb` is a pure fixture skeleton with schema-qualified table keys.
-The queryspec ZTD case type only carries `beforeDb`, `input`, and `output`; use a traditional DB-state lane when you need post-state assertions.
+The query-boundary ZTD case type only carries `beforeDb`, `input`, and `output`; use a traditional DB-state lane when you need post-state assertions.
 The verifier returns machine-checkable evidence (`mode`, `rewriteApplied`, `physicalSetupUsed`) for each case.
 Enable SQL trace only when needed with `ZTD_SQL_TRACE=1` (optional `ZTD_SQL_TRACE_DIR`).
 Do not use `--force` to overwrite persistent case files.

--- a/packages/ztd-cli/templates/tests/support/ztd/harness.ts
+++ b/packages/ztd-cli/templates/tests/support/ztd/harness.ts
@@ -11,7 +11,7 @@ export type QuerySpecExecutorClient<RowShape extends Record<string, unknown>> = 
 };
 
 /**
- * Fixed runner for queryspec ZTD cases.
+ * Fixed runner for query-boundary ZTD cases.
  *
  * Keep the app-level harness stable and let query-local case files evolve.
  */

--- a/packages/ztd-cli/templates/tests/support/ztd/verifier.ts
+++ b/packages/ztd-cli/templates/tests/support/ztd/verifier.ts
@@ -61,7 +61,7 @@ export async function verifyQuerySpecZtdCase<BeforeDb extends FixtureTree, Input
 ): Promise<QuerySpecExecutionEvidence> {
   const connectionString = process.env.ZTD_DB_URL;
   if (!connectionString) {
-    throw new Error('Set ZTD_DB_URL before running queryspec ZTD cases.');
+    throw new Error('Set ZTD_DB_URL before running query-boundary ZTD cases.');
   }
 
   const tableRows = flattenFixtureTableRows(querySpecCase.beforeDb).map((tableFixture) => ({
@@ -163,7 +163,7 @@ function flattenFixtureTableRows(
     }
 
     throw new Error(
-      `Queryspec fixture entry ${nextPathSegments.join('.')} must be an object or an array of rows.`
+      `Query-boundary fixture entry ${nextPathSegments.join('.')} must be an object or an array of rows.`
     );
   }
 
@@ -175,7 +175,7 @@ function assertRecordRow(value: unknown, tableName: string): Record<string, unkn
     return value;
   }
 
-  throw new Error(`Queryspec fixture rows for ${tableName} must be objects.`);
+  throw new Error(`Query-boundary fixture rows for ${tableName} must be objects.`);
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/ztd-cli/tests/directoryFinding.docs.test.ts
+++ b/packages/ztd-cli/tests/directoryFinding.docs.test.ts
@@ -33,16 +33,19 @@ test('readmes promote the feature-first layout without tables/views taxonomy', (
   expect(packageReadme).toContain('Quickstart');
   expect(packageReadme).toContain('Create the Users Insert Feature');
   expect(packageReadme).toContain('Highlights');
-  expect(packageReadme).toContain('Commands');
+  expect(packageReadme).toContain('Command Index');
   expect(packageReadme).toContain('Glossary');
   expect(packageReadme).toContain('Further Reading');
   expect(packageReadme).toContain('ZTD here means query-boundary-local cases that execute through the fixed app-level harness against the real database engine, not a mocked executor.');
   expect(packageReadme).toContain('Use validation-only cases for boundary checks and DB-backed cases for the success path.');
   expect(packageReadme).toContain('Keep the feature-root `src/features/<feature-name>/tests/<feature-name>.boundary.test.ts` for mock-based boundary tests.');
   expect(packageReadme).toContain('Starter-owned shared support lives under `tests/support/ztd/`; `.ztd/` remains the tool-managed workspace for generated metadata and support files.');
+  expect(packageReadme).toContain('src/adapters/<tech>');
+  expect(packageReadme).toContain('src/libraries/*');
   expect(packageReadme).toContain('After you finish the SQL and DTO edits');
   expect(packageReadme).toContain('feature tests scaffold --feature <feature-name>');
   expect(packageReadme).toContain('tests/generated/TEST_PLAN.md');
+  expect(scaffoldReadme).toContain('src/features`, `src/adapters`, and `src/libraries` as the app-code roots');
   expect(scaffoldReadme).toContain('Make sure the query-boundary result executes through the DB-backed ZTD path and checks mapping and validation, not just property values.');
   expect(readNormalizedFile('docs/guide/sql-first-end-to-end-tutorial.md')).toContain('Scenario CLI at a glance');
   expect(readNormalizedFile('docs/dogfooding/ztd-migration-lifecycle.md')).toContain('Preferred CLI by scenario');
@@ -96,6 +99,8 @@ test('feature guidance centers the sample feature and recursive boundary folders
   expect(readNormalizedFile('packages/ztd-cli/templates/src/features/_shared/loadSqlResource.ts')).toContain(
     'loadSqlResource'
   );
+  expect(readNormalizedFile('packages/ztd-cli/templates/src/libraries/sql/sql-client.ts')).toContain('SqlClient');
+  expect(readNormalizedFile('packages/ztd-cli/templates/src/adapters/pg/sql-client.ts')).toContain('fromPg');
 });
 
 test('feature-first scaffold files exist in the template bundle', () => {
@@ -117,7 +122,13 @@ test('feature-first scaffold files exist in the template bundle', () => {
     'packages/ztd-cli/templates/src/features/smoke/queries/smoke/tests/generated/TEST_PLAN.md',
     'packages/ztd-cli/templates/src/features/smoke/queries/smoke/tests/generated/analysis.json',
     'packages/ztd-cli/templates/src/features/_shared/featureQueryExecutor.ts',
-    'packages/ztd-cli/templates/src/features/_shared/loadSqlResource.ts'
+    'packages/ztd-cli/templates/src/features/_shared/loadSqlResource.ts',
+    'packages/ztd-cli/templates/src/libraries/README.md',
+    'packages/ztd-cli/templates/src/libraries/sql/sql-client.ts',
+    'packages/ztd-cli/templates/src/libraries/telemetry/repositoryTelemetry.ts',
+    'packages/ztd-cli/templates/src/adapters/README.md',
+    'packages/ztd-cli/templates/src/adapters/pg/sql-client.ts',
+    'packages/ztd-cli/templates/src/adapters/console/repositoryTelemetry.ts'
   ];
 
   for (const requiredPath of requiredPaths) {

--- a/packages/ztd-cli/tests/directoryFinding.docs.test.ts
+++ b/packages/ztd-cli/tests/directoryFinding.docs.test.ts
@@ -41,6 +41,8 @@ test('readmes promote the feature-first layout without tables/views taxonomy', (
   expect(packageReadme).toContain('Keep the feature-root `src/features/<feature-name>/tests/<feature-name>.boundary.test.ts` for mock-based boundary tests.');
   expect(packageReadme).toContain('Starter-owned shared support lives under `tests/support/ztd/`; `.ztd/` remains the tool-managed workspace for generated metadata and support files.');
   expect(packageReadme).toContain('src/adapters/<tech>');
+  expect(packageReadme).toContain('src/adapters/pg/');
+  expect(packageReadme).toContain('src/adapters/aws/s3/');
   expect(packageReadme).toContain('src/libraries/*');
   expect(packageReadme).toContain('After you finish the SQL and DTO edits');
   expect(packageReadme).toContain('feature tests scaffold --feature <feature-name>');
@@ -124,6 +126,7 @@ test('feature-first scaffold files exist in the template bundle', () => {
     'packages/ztd-cli/templates/src/features/_shared/featureQueryExecutor.ts',
     'packages/ztd-cli/templates/src/features/_shared/loadSqlResource.ts',
     'packages/ztd-cli/templates/src/libraries/README.md',
+    'packages/ztd-cli/templates/src/libraries/sql/README.md',
     'packages/ztd-cli/templates/src/libraries/sql/sql-client.ts',
     'packages/ztd-cli/templates/src/libraries/telemetry/repositoryTelemetry.ts',
     'packages/ztd-cli/templates/src/adapters/README.md',

--- a/packages/ztd-cli/tests/init.command.test.ts
+++ b/packages/ztd-cli/tests/init.command.test.ts
@@ -335,6 +335,33 @@ test('init dry-run plan matches starter outputs without AGENTS files', () => {
   ]));
 });
 
+test('init dry-run plan for non-starter init excludes starter-only readmes', () => {
+  const workspace = createTempDir('cli-init-dry-run-plan-default');
+  const plan = buildInitDryRunPlan(workspace, {
+    appShape: 'default',
+    starter: false,
+    withAiGuidance: false,
+    withDogfooding: false,
+    withAppInterface: false,
+    workflow: 'empty',
+    validator: 'zod',
+    localSourceRoot: null
+  });
+
+  expect(plan.dryRun).toBe(true);
+  expect(plan.files).toEqual(expect.arrayContaining([
+    'src/libraries/sql/sql-client.ts',
+    'src/adapters/pg/sql-client.ts'
+  ]));
+  expect(plan.files).not.toEqual(expect.arrayContaining([
+    'src/libraries/README.md',
+    'src/libraries/sql/README.md',
+    'src/adapters/README.md',
+    'compose.yaml',
+    'src/features/smoke/README.md'
+  ]));
+});
+
 test('init starter keeps visible AGENTS out even when internal AI guidance is enabled', { timeout: 60_000 }, async () => {
   const workspace = createTempDir('cli-init-starter-ai-guidance');
   const prompter = new TestPrompter([]);

--- a/packages/ztd-cli/tests/init.command.test.ts
+++ b/packages/ztd-cli/tests/init.command.test.ts
@@ -90,9 +90,12 @@ test('init bootstraps a feature-first scaffold', { timeout: 60_000 }, async () =
   expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('If you see `file:` dependencies that point back to a monorepo checkout');
   expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('keep starter-owned shared support under `tests/support/ztd/`');
   expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('keep tool-managed fixture metadata under `.ztd/generated/`');
+  expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('src/features`, `src/adapters`, and `src/libraries` as the app-code roots');
   expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('this generated workspace may not contain `docs/`');
   expect(readNormalizedFile(path.join(workspace, 'README.md'))).toContain('`ztd.config.json` controls generated metadata and runtime defaults while the feature-local tests stay next to the feature they cover');
   expect(existsSync(path.join(workspace, 'src', 'features', 'README.md'))).toBe(true);
+  expect(existsSync(path.join(workspace, 'src', 'libraries', 'sql', 'sql-client.ts'))).toBe(true);
+  expect(existsSync(path.join(workspace, 'src', 'adapters', 'pg', 'sql-client.ts'))).toBe(true);
   expect(existsSync(path.join(workspace, 'src', 'features', 'smoke'))).toBe(false);
   expect(readNormalizedFile(path.join(workspace, 'vitest.config.ts'))).toContain(
     "src/features/**/*.test.ts"
@@ -235,20 +238,19 @@ test('init starter bootstraps compose, starter DDL, and smoke tests without visi
   expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'smoke', 'queries', 'smoke', 'tests', 'smoke.boundary.ztd.test.ts'))).toContain(
     "from '#tests/support/ztd/harness.js'"
   );
-  expect(existsSync(path.join(workspace, 'src', 'infrastructure', 'README.md'))).toBe(true);
-  expect(existsSync(path.join(workspace, 'src', 'infrastructure', 'telemetry', 'types.ts'))).toBe(true);
-  expect(existsSync(path.join(workspace, 'src', 'infrastructure', 'telemetry', 'repositoryTelemetry.ts'))).toBe(true);
-  expect(existsSync(path.join(workspace, 'src', 'infrastructure', 'telemetry', 'consoleRepositoryTelemetry.ts'))).toBe(true);
-  expect(readNormalizedFile(path.join(workspace, 'src', 'infrastructure', 'README.md'))).toContain('default repository telemetry seam is no-op');
-  expect(readNormalizedFile(path.join(workspace, 'src', 'infrastructure', 'README.md'))).toContain('queryId');
-  expect(readNormalizedFile(path.join(workspace, 'src', 'infrastructure', 'telemetry', 'repositoryTelemetry.ts'))).toContain('createNoopRepositoryTelemetry');
-  expect(readNormalizedFile(path.join(workspace, 'src', 'infrastructure', 'telemetry', 'repositoryTelemetry.ts'))).toContain('defaultRepositoryTelemetry');
-  expect(readNormalizedFile(path.join(workspace, 'src', 'infrastructure', 'telemetry', 'repositoryTelemetry.ts'))).not.toContain('sqlText');
-  expect(readNormalizedFile(path.join(workspace, 'src', 'infrastructure', 'telemetry', 'types.ts'))).toContain('paramsShape');
-  expect(readNormalizedFile(path.join(workspace, 'src', 'infrastructure', 'telemetry', 'types.ts'))).toContain('transformations');
-  expect(readNormalizedFile(path.join(workspace, 'src', 'infrastructure', 'telemetry', 'types.ts'))).not.toContain('parameterValues');
-  expect(readNormalizedFile(path.join(workspace, 'src', 'infrastructure', 'telemetry', 'consoleRepositoryTelemetry.ts'))).toContain('queryId');
-  expect(readNormalizedFile(path.join(workspace, 'src', 'infrastructure', 'telemetry', 'consoleRepositoryTelemetry.ts'))).not.toContain('sqlText');
+  expect(existsSync(path.join(workspace, 'src', 'libraries', 'README.md'))).toBe(true);
+  expect(existsSync(path.join(workspace, 'src', 'libraries', 'telemetry', 'types.ts'))).toBe(true);
+  expect(existsSync(path.join(workspace, 'src', 'libraries', 'telemetry', 'repositoryTelemetry.ts'))).toBe(true);
+  expect(existsSync(path.join(workspace, 'src', 'adapters', 'console', 'repositoryTelemetry.ts'))).toBe(true);
+  expect(readNormalizedFile(path.join(workspace, 'src', 'libraries', 'README.md'))).toContain('Shared runtime contracts and reusable helpers live here.');
+  expect(readNormalizedFile(path.join(workspace, 'src', 'libraries', 'telemetry', 'repositoryTelemetry.ts'))).toContain('createNoopRepositoryTelemetry');
+  expect(readNormalizedFile(path.join(workspace, 'src', 'libraries', 'telemetry', 'repositoryTelemetry.ts'))).toContain('defaultRepositoryTelemetry');
+  expect(readNormalizedFile(path.join(workspace, 'src', 'libraries', 'telemetry', 'repositoryTelemetry.ts'))).not.toContain('sqlText');
+  expect(readNormalizedFile(path.join(workspace, 'src', 'libraries', 'telemetry', 'types.ts'))).toContain('paramsShape');
+  expect(readNormalizedFile(path.join(workspace, 'src', 'libraries', 'telemetry', 'types.ts'))).toContain('transformations');
+  expect(readNormalizedFile(path.join(workspace, 'src', 'libraries', 'telemetry', 'types.ts'))).not.toContain('parameterValues');
+  expect(readNormalizedFile(path.join(workspace, 'src', 'adapters', 'console', 'repositoryTelemetry.ts'))).toContain('queryId');
+  expect(readNormalizedFile(path.join(workspace, 'src', 'adapters', 'console', 'repositoryTelemetry.ts'))).not.toContain('sqlText');
   const packageJson = JSON.parse(readNormalizedFile(path.join(workspace, 'package.json'))) as {
     type?: string;
     devDependencies: Record<string, string>;
@@ -307,7 +309,8 @@ test('init dry-run plan matches starter outputs without AGENTS files', () => {
     'tests/support/ztd/case-types.ts',
     'tests/support/ztd/verifier.ts',
     'tests/support/ztd/harness.ts',
-    'src/infrastructure/telemetry/types.ts',
+    'src/libraries/telemetry/types.ts',
+    'src/adapters/console/repositoryTelemetry.ts',
     '.ztd/support/postgres-testkit.ts'
   ]));
   expect(plan.files).not.toEqual(expect.arrayContaining([

--- a/packages/ztd-cli/tests/init.command.test.ts
+++ b/packages/ztd-cli/tests/init.command.test.ts
@@ -239,10 +239,14 @@ test('init starter bootstraps compose, starter DDL, and smoke tests without visi
     "from '#tests/support/ztd/harness.js'"
   );
   expect(existsSync(path.join(workspace, 'src', 'libraries', 'README.md'))).toBe(true);
+  expect(existsSync(path.join(workspace, 'src', 'libraries', 'sql', 'README.md'))).toBe(true);
   expect(existsSync(path.join(workspace, 'src', 'libraries', 'telemetry', 'types.ts'))).toBe(true);
   expect(existsSync(path.join(workspace, 'src', 'libraries', 'telemetry', 'repositoryTelemetry.ts'))).toBe(true);
+  expect(existsSync(path.join(workspace, 'src', 'adapters', 'README.md'))).toBe(true);
   expect(existsSync(path.join(workspace, 'src', 'adapters', 'console', 'repositoryTelemetry.ts'))).toBe(true);
   expect(readNormalizedFile(path.join(workspace, 'src', 'libraries', 'README.md'))).toContain('Shared runtime contracts and reusable helpers live here.');
+  expect(readNormalizedFile(path.join(workspace, 'src', 'libraries', 'sql', 'README.md'))).toContain('Keep driver-neutral SQL contracts here.');
+  expect(readNormalizedFile(path.join(workspace, 'src', 'adapters', 'README.md'))).toContain('Technology-specific bindings live here.');
   expect(readNormalizedFile(path.join(workspace, 'src', 'libraries', 'telemetry', 'repositoryTelemetry.ts'))).toContain('createNoopRepositoryTelemetry');
   expect(readNormalizedFile(path.join(workspace, 'src', 'libraries', 'telemetry', 'repositoryTelemetry.ts'))).toContain('defaultRepositoryTelemetry');
   expect(readNormalizedFile(path.join(workspace, 'src', 'libraries', 'telemetry', 'repositoryTelemetry.ts'))).not.toContain('sqlText');
@@ -305,6 +309,8 @@ test('init dry-run plan matches starter outputs without AGENTS files', () => {
     'src/features/smoke/boundary.ts',
     'src/features/smoke/tests/smoke.boundary.test.ts',
     'src/features/smoke/tests/smoke.test.ts',
+    'src/libraries/sql/README.md',
+    'src/adapters/README.md',
     'tests/support/ztd/README.md',
     'tests/support/ztd/case-types.ts',
     'tests/support/ztd/verifier.ts',

--- a/packages/ztd-cli/tests/sqlClientAdapterTemplate.unit.test.ts
+++ b/packages/ztd-cli/tests/sqlClientAdapterTemplate.unit.test.ts
@@ -1,0 +1,28 @@
+import { expect, test, vi } from 'vitest';
+
+import { fromPg } from '../templates/src/adapters/pg/sql-client';
+
+test('fromPg unwraps QueryResult.rows from the underlying pg queryable', async () => {
+  const queryable = {
+    query: vi.fn().mockResolvedValue({ rows: [{ id: 1 }, { id: 2 }] })
+  };
+
+  const client = fromPg(queryable);
+  const rows = await client.query<{ id: number }>('select id from users where team_id = $1', [7]);
+
+  expect(rows).toEqual([{ id: 1 }, { id: 2 }]);
+  expect(queryable.query).toHaveBeenCalledWith('select id from users where team_id = $1', [7]);
+});
+
+test('fromPg rejects named parameter objects before calling the underlying queryable', () => {
+  const queryable = {
+    query: vi.fn()
+  };
+
+  const client = fromPg(queryable);
+
+  expect(() => client.query('select id from users where id = :id', { id: 7 })).toThrowError(
+    'fromPg adapter does not support named parameter objects; use positional parameter arrays'
+  );
+  expect(queryable.query).not.toHaveBeenCalled();
+});

--- a/packages/ztd-cli/tests/sqlFirstTutorial.docs.test.ts
+++ b/packages/ztd-cli/tests/sqlFirstTutorial.docs.test.ts
@@ -69,6 +69,7 @@ test('the tutorial preserves the shortest DDL to first test path', () => {
   expect(tutorial).toContain('Read the nearest AGENTS.md files first. Then read `.codex/agents/*` and `.ztd/agents/*` if present.');
   expect(tutorial).toContain('Start with `npx ztd feature scaffold --table users --action insert`.');
   expect(tutorial).toContain('Keep `boundary.ts`, the query-local `boundary.ts`, and the query-local SQL resource inside `src/features/users-insert`.');
+  expect(tutorial).toContain('Keep shared feature seams under `src/features/_shared/*`, shared verification seams under `tests/support/*`, driver-neutral contracts under `src/libraries/*`, and driver or sink bindings under `src/adapters/<tech>/*`.');
   expect(tutorial).toContain('The feature scaffold creates the boundary files, SQL file, feature-root boundary test, and the query-local `tests/generated/` plus `tests/cases/` directories.');
   expect(tutorial).toContain('That command refreshes `src/features/users-insert/queries/insert-users/tests/generated/TEST_PLAN.md` and `analysis.json`, refreshes `src/features/users-insert/queries/insert-users/tests/boundary-ztd-types.ts`, and creates the thin `src/features/users-insert/queries/insert-users/tests/insert-users.boundary.ztd.test.ts` Vitest entrypoint only if it is missing.');
   expect(tutorial).toContain('Persistent case files under `src/features/users-insert/queries/insert-users/tests/cases/` stay human/AI-owned and are not overwritten.');


### PR DESCRIPTION
## Summary

- Resolve #776 by aligning the starter scaffold and guidance with the canonical directory taxonomy.
- Treat `src/features`, `src/adapters`, and `src/libraries` as the app-code roots; keep `db/` for schema assets, `tests/support/*` for shared verification support, and `.ztd/*` for tool-managed workspace files.
- Move the scaffolded `SqlClient` and telemetry seams into the new `libraries` / `adapters` layout and update template guidance, README text, and tutorials to describe the same ownership model.
- Add a changeset for `@rawsql-ts/ztd-cli` as a minor release.

## Verification

- `pnpm --filter @rawsql-ts/ztd-cli test -- directoryFinding.docs.test.ts sqlFirstTutorial.docs.test.ts init.command.test.ts`

## Merge Readiness

- [ ] No baseline exception requested.
- [x] Baseline exception requested and linked below.

Tracking issue: #776
Scoped checks run: `pnpm --filter @rawsql-ts/ztd-cli test -- directoryFinding.docs.test.ts sqlFirstTutorial.docs.test.ts init.command.test.ts`
Why full baseline is not required: the change scope is limited to `@rawsql-ts/ztd-cli` scaffold/templates/docs, and the targeted scaffold/docs contract tests for those surfaces passed.

## CLI Surface Migration

- [ ] No migration packet required for this CLI change.
- [x] CLI/user-facing surface change and migration packet completed.

No-migration rationale:
Upgrade note: newly scaffolded projects now place shared runtime contracts under `src/libraries/*`, technology bindings under `src/adapters/<tech>/*`, shared verification support under `tests/support/*`, and keep `db/*` reserved for DDL/migration/schema assets.
Deprecation/removal plan or issue: none beyond #776.
Docs/help/examples updated: yes; updated `README.md`, `packages/ztd-cli/README.md`, template README/AGENTS files, and the directory/telemetry/tutorial guides.
Release/changeset wording: `.changeset/green-apples-drum.md` releases `@rawsql-ts/ztd-cli` as minor for the canonical directory taxonomy alignment.

## Scaffold Contract Proof

- [ ] No scaffold contract proof required for this PR.
- [x] Scaffold contract proof completed.

No-proof rationale:
Non-edit assertion: the starter guidance now consistently reserves `db/*` for schema assets, `tests/support/*` for shared verification support, `.ztd/*` for tool-managed workspace files, and keeps feature-owned runtime seams under `src/features/*`, `src/libraries/*`, and `src/adapters/*`.
Fail-fast input-contract proof: `init.command.test.ts` verifies the emitted starter structure and guidance for the scaffolded project layout.
Generated-output viability proof: `init.command.test.ts`, `directoryFinding.docs.test.ts`, and `sqlFirstTutorial.docs.test.ts` passed with the updated paths and examples.

Closes #776

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation & Scaffolding**
  * Updated starter docs and guides to prescribe a feature-first app layout and clarify where shared seams, contracts, adapters, and DB migrations belong.
* **New Features**
  * Added library/adapter templates for a shared SQL client, telemetry contract, console telemetry sink, and a PG adapter.
* **Tests**
  * Updated scaffolding/tests conventions (renamed query type to “query-boundary”) and added unit/tests validating the new adapters and init scaffolding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->