### PR TITLE
fix(ztd-cli): align scaffold cross-root imports with root aliases

### DIFF
--- a/.changeset/ten-soft-camels-jump.md
+++ b/.changeset/ten-soft-camels-jump.md
@@ -1,0 +1,7 @@
+---
+"@rawsql-ts/ztd-cli": patch
+---
+
+Align generated project root aliases across `package.json`, `tsconfig.json`, and `vitest.config.ts` so scaffolded code can use `#features/*`, `#libraries/*`, `#adapters/*`, and `#tests/*` consistently.
+
+Starter and scaffold templates now use root aliases for imports that cross canonical roots instead of deep relative paths, which makes generated projects easier to move and reorganize without rewriting import depth.

--- a/packages/ztd-cli/README.md
+++ b/packages/ztd-cli/README.md
@@ -166,11 +166,9 @@ As boundary depth grows, avoid making every import depth-sensitive by default.
 
 - The goal is boundary-change safety, not a blanket root-alias migration.
 - Keep local, nearby references relative when they move with the same boundary.
-- Stabilize only shared references that are likely to break when work is split horizontally and moved into a deeper child boundary, such as `src/features/_shared/*` or `tests/support/*`.
-- One workable tactic is package `imports` or an equivalent alias that works in both TypeScript and runtime resolution, but that is a means, not the architectural goal.
-- Minimum rule: imports that cross boundaries should make the target boundary explicit and go through its `boundary.ts` entrypoint.
-- Pragmatic exception: designated shared seams such as `src/features/_shared/*` and `tests/support/*` may use stabilized root-level aliases or package-style imports because they are shared support seams, not another boundary's private internals.
-- Do not treat this issue as a reason to rewrite every scaffolded import to one style.
+- When an import crosses canonical roots, use the matching root alias so the target root stays explicit: `#features/*`, `#libraries/*`, `#adapters/*`, and `#tests/*`.
+- Feature-to-feature imports should still go through the target boundary's `boundary.ts` entrypoint rather than deep private files.
+- Root aliases are for cross-root references and shared seams, not a reason to rewrite every same-root local import to one style.
 
 ## Troubleshooting
 

--- a/packages/ztd-cli/src/commands/init.ts
+++ b/packages/ztd-cli/src/commands/init.ts
@@ -2076,6 +2076,14 @@ function ensurePackageJsonFormatting(
       types: './src/features/*.ts',
       default: './dist/features/*.js'
     },
+    '#libraries/*.js': {
+      types: './src/libraries/*.ts',
+      default: './dist/libraries/*.js'
+    },
+    '#adapters/*.js': {
+      types: './src/adapters/*.ts',
+      default: './dist/adapters/*.js'
+    },
     '#tests/*.js': {
       types: './tests/*.ts',
       default: './tests/*.ts'

--- a/packages/ztd-cli/templates/README.md
+++ b/packages/ztd-cli/templates/README.md
@@ -36,6 +36,15 @@ The starter keeps `ztdRootDir`, `ddlDir`, `defaultSchema`, and `searchPath` in `
 
 `src/features/<feature>/tests/` is where feature-root boundary tests live. Query-local ZTD assets live under `src/features/<feature>/queries/<query>/tests/{generated,cases}` with the thin entrypoint beside them. Starter-owned shared support lives at `tests/support/ztd/`, while `.ztd/` is the tool-managed workspace for generated metadata and support files. Keep `FeatureQueryExecutor` in `src/features/_shared/`, keep the driver-neutral `SqlClient` contract in `src/libraries/sql/sql-client.ts`, and put driver or sink bindings under `src/adapters/<tech>/`.
 
+When an import crosses one of the canonical roots, use the root alias instead of a depth-sensitive relative path:
+
+- `#features/*` for `src/features/*`
+- `#libraries/*` for `src/libraries/*`
+- `#adapters/*` for `src/adapters/*`
+- `#tests/*` for `tests/*`
+
+Keep local same-root references relative when they move with the same boundary. Use the alias when the import crosses a root boundary or points at shared support.
+
 ## Getting Started with AI
 
 Use this short prompt:

--- a/packages/ztd-cli/templates/src/adapters/console/repositoryTelemetry.ts
+++ b/packages/ztd-cli/templates/src/adapters/console/repositoryTelemetry.ts
@@ -2,7 +2,7 @@ import type {
   RepositoryTelemetry,
   RepositoryTelemetryConsoleOptions,
   RepositoryTelemetryEvent,
-} from '../../libraries/telemetry/types.js';
+} from '#libraries/telemetry/types.js';
 
 /**
  * Create a conservative console-backed telemetry hook for repositories.

--- a/packages/ztd-cli/templates/src/adapters/pg/sql-client.ts
+++ b/packages/ztd-cli/templates/src/adapters/pg/sql-client.ts
@@ -1,4 +1,4 @@
-import type { SqlClient } from '../../libraries/sql/sql-client.js';
+import type { SqlClient } from '#libraries/sql/sql-client.js';
 
 /**
  * Adapt a `pg`-style queryable (Client or Pool) into a SqlClient.

--- a/packages/ztd-cli/templates/tests/support/testkit-client.webapi.ts
+++ b/packages/ztd-cli/templates/tests/support/testkit-client.webapi.ts
@@ -1,4 +1,4 @@
-import type { SqlClient } from '../../src/libraries/sql/sql-client.js';
+import type { SqlClient } from '#libraries/sql/sql-client.js';
 
 export type TestkitClient = SqlClient & {
   close(): Promise<void>;

--- a/packages/ztd-cli/templates/tsconfig.json
+++ b/packages/ztd-cli/templates/tsconfig.json
@@ -7,6 +7,8 @@
     "baseUrl": ".",
     "paths": {
       "#features/*": ["src/features/*"],
+      "#libraries/*": ["src/libraries/*"],
+      "#adapters/*": ["src/adapters/*"],
       "#tests/*": ["tests/*"]
     },
     "strict": true,

--- a/packages/ztd-cli/templates/vitest.config.ts
+++ b/packages/ztd-cli/templates/vitest.config.ts
@@ -5,6 +5,8 @@ export default defineConfig({
   resolve: {
     alias: {
       '#features': fileURLToPath(new URL('./src/features', import.meta.url)),
+      '#libraries': fileURLToPath(new URL('./src/libraries', import.meta.url)),
+      '#adapters': fileURLToPath(new URL('./src/adapters', import.meta.url)),
       '#tests': fileURLToPath(new URL('./tests', import.meta.url)),
     },
   },

--- a/packages/ztd-cli/tests/directoryFinding.docs.test.ts
+++ b/packages/ztd-cli/tests/directoryFinding.docs.test.ts
@@ -103,6 +103,15 @@ test('feature guidance centers the sample feature and recursive boundary folders
   );
   expect(readNormalizedFile('packages/ztd-cli/templates/src/libraries/sql/sql-client.ts')).toContain('SqlClient');
   expect(readNormalizedFile('packages/ztd-cli/templates/src/adapters/pg/sql-client.ts')).toContain('fromPg');
+  expect(readNormalizedFile('packages/ztd-cli/templates/src/adapters/pg/sql-client.ts')).toContain(
+    "from '#libraries/sql/sql-client.js'"
+  );
+  expect(readNormalizedFile('packages/ztd-cli/templates/src/adapters/console/repositoryTelemetry.ts')).toContain(
+    "from '#libraries/telemetry/types.js'"
+  );
+  expect(readNormalizedFile('packages/ztd-cli/templates/tests/support/testkit-client.webapi.ts')).toContain(
+    "from '#libraries/sql/sql-client.js'"
+  );
 });
 
 test('feature-first scaffold files exist in the template bundle', () => {

--- a/packages/ztd-cli/tests/init.command.test.ts
+++ b/packages/ztd-cli/tests/init.command.test.ts
@@ -118,7 +118,14 @@ test('init bootstraps a feature-first scaffold', { timeout: 60_000 }, async () =
     ".ztd/support/setup-env.ts"
   );
   expect(readNormalizedFile(path.join(workspace, 'vitest.config.ts'))).toContain("'#features'");
+  expect(readNormalizedFile(path.join(workspace, 'vitest.config.ts'))).toContain("'#libraries'");
+  expect(readNormalizedFile(path.join(workspace, 'vitest.config.ts'))).toContain("'#adapters'");
   expect(readNormalizedFile(path.join(workspace, 'vitest.config.ts'))).toContain("'#tests'");
+  expect(readNormalizedFile(path.join(workspace, 'tsconfig.json'))).toContain('"#libraries/*"');
+  expect(readNormalizedFile(path.join(workspace, 'tsconfig.json'))).toContain('"#adapters/*"');
+  expect(readNormalizedFile(path.join(workspace, 'src', 'adapters', 'pg', 'sql-client.ts'))).toContain(
+    "from '#libraries/sql/sql-client.js'"
+  );
   expect(readNormalizedFile(path.join(workspace, '.ztd', 'support', 'setup-env.ts'))).toContain(
     'ZTD_DB_PORT'
   );
@@ -134,6 +141,14 @@ test('init bootstraps a feature-first scaffold', { timeout: 60_000 }, async () =
   expect(packageJson.imports?.['#features/*.js']).toEqual({
     types: './src/features/*.ts',
     default: './dist/features/*.js'
+  });
+  expect(packageJson.imports?.['#libraries/*.js']).toEqual({
+    types: './src/libraries/*.ts',
+    default: './dist/libraries/*.js'
+  });
+  expect(packageJson.imports?.['#adapters/*.js']).toEqual({
+    types: './src/adapters/*.ts',
+    default: './dist/adapters/*.js'
   });
   expect(packageJson.imports?.['#tests/*.js']).toEqual({
     types: './tests/*.ts',
@@ -253,6 +268,12 @@ test('init starter bootstraps compose, starter DDL, and smoke tests without visi
   expect(readNormalizedFile(path.join(workspace, 'src', 'libraries', 'telemetry', 'types.ts'))).toContain('paramsShape');
   expect(readNormalizedFile(path.join(workspace, 'src', 'libraries', 'telemetry', 'types.ts'))).toContain('transformations');
   expect(readNormalizedFile(path.join(workspace, 'src', 'libraries', 'telemetry', 'types.ts'))).not.toContain('parameterValues');
+  expect(readNormalizedFile(path.join(workspace, 'src', 'adapters', 'pg', 'sql-client.ts'))).toContain(
+    "from '#libraries/sql/sql-client.js'"
+  );
+  expect(readNormalizedFile(path.join(workspace, 'src', 'adapters', 'console', 'repositoryTelemetry.ts'))).toContain(
+    "from '#libraries/telemetry/types.js'"
+  );
   expect(readNormalizedFile(path.join(workspace, 'src', 'adapters', 'console', 'repositoryTelemetry.ts'))).toContain('queryId');
   expect(readNormalizedFile(path.join(workspace, 'src', 'adapters', 'console', 'repositoryTelemetry.ts'))).not.toContain('sqlText');
   const packageJson = JSON.parse(readNormalizedFile(path.join(workspace, 'package.json'))) as {
@@ -269,6 +290,14 @@ test('init starter bootstraps compose, starter DDL, and smoke tests without visi
   expect(packageJson.imports?.['#features/*.js']).toEqual({
     types: './src/features/*.ts',
     default: './dist/features/*.js'
+  });
+  expect(packageJson.imports?.['#libraries/*.js']).toEqual({
+    types: './src/libraries/*.ts',
+    default: './dist/libraries/*.js'
+  });
+  expect(packageJson.imports?.['#adapters/*.js']).toEqual({
+    types: './src/adapters/*.ts',
+    default: './dist/adapters/*.js'
   });
   expect(packageJson.imports?.['#tests/*.js']).toEqual({
     types: './tests/*.ts',
@@ -537,6 +566,14 @@ test('init local-source mode links rawsql-ts dependencies from the monorepo with
   );
   expect(packageJson.type).toBe('module');
   expect(packageJson.imports?.['#features/*.js']?.default).toBe('./dist/features/*.js');
+  expect(packageJson.imports?.['#libraries/*.js']).toEqual({
+    types: './src/libraries/*.ts',
+    default: './dist/libraries/*.js'
+  });
+  expect(packageJson.imports?.['#adapters/*.js']).toEqual({
+    types: './src/adapters/*.ts',
+    default: './dist/adapters/*.js'
+  });
   expect(packageJson.imports?.['#tests/*.js']).toEqual({
     types: './tests/*.ts',
     default: './tests/*.ts'
@@ -577,6 +614,14 @@ test('init starter local-source mode keeps starter rawsql-ts packages on file de
   );
   expect(packageJson.type).toBe('module');
   expect(packageJson.imports?.['#features/*.js']?.default).toBe('./dist/features/*.js');
+  expect(packageJson.imports?.['#libraries/*.js']).toEqual({
+    types: './src/libraries/*.ts',
+    default: './dist/libraries/*.js'
+  });
+  expect(packageJson.imports?.['#adapters/*.js']).toEqual({
+    types: './src/adapters/*.ts',
+    default: './dist/adapters/*.js'
+  });
   expect(packageJson.imports?.['#tests/*.js']).toEqual({
     types: './tests/*.ts',
     default: './tests/*.ts'

--- a/scripts/verify-generated-project-mode.mjs
+++ b/scripts/verify-generated-project-mode.mjs
@@ -70,6 +70,13 @@ function assertExists(filePath, description) {
   }
 }
 
+function assertFileContains(filePath, needle, description) {
+  const contents = fs.readFileSync(filePath, "utf8");
+  if (!contents.includes(needle)) {
+    throw new Error(`[generated-project verification] ${description} missing expected text ${needle}: ${filePath}`);
+  }
+}
+
 function verifyStarterScaffold(appDir) {
   const packageJson = readPackageJson(appDir);
   const ztdCliDependency = packageJson.devDependencies?.["@rawsql-ts/ztd-cli"];
@@ -82,11 +89,48 @@ function verifyStarterScaffold(appDir) {
   if (packageJson.type !== "module") {
     throw new Error(`[generated-project verification] starter scaffold package.json must set type=module, received: ${String(packageJson.type)}`);
   }
+  const requiredImports = {
+    "#features/*.js": {
+      types: "./src/features/*.ts",
+      default: "./dist/features/*.js",
+    },
+    "#libraries/*.js": {
+      types: "./src/libraries/*.ts",
+      default: "./dist/libraries/*.js",
+    },
+    "#adapters/*.js": {
+      types: "./src/adapters/*.ts",
+      default: "./dist/adapters/*.js",
+    },
+    "#tests/*.js": {
+      types: "./tests/*.ts",
+      default: "./tests/*.ts",
+    },
+  };
+  for (const [key, value] of Object.entries(requiredImports)) {
+    if (JSON.stringify(packageJson.imports?.[key]) !== JSON.stringify(value)) {
+      throw new Error(`[generated-project verification] starter scaffold package.json is missing ${key}: ${JSON.stringify(packageJson.imports?.[key])}`);
+    }
+  }
   assertExists(path.join(appDir, "README.md"), "starter README");
   assertExists(path.join(appDir, "src", "features", "smoke", "tests", "smoke.boundary.test.ts"), "starter smoke boundary test");
   assertExists(
     path.join(appDir, "src", "features", "smoke", "queries", "smoke", "tests", "smoke.boundary.ztd.test.ts"),
     "starter DB-backed smoke test"
+  );
+  assertFileContains(path.join(appDir, "tsconfig.json"), "\"#libraries/*\"", "starter tsconfig");
+  assertFileContains(path.join(appDir, "tsconfig.json"), "\"#adapters/*\"", "starter tsconfig");
+  assertFileContains(path.join(appDir, "vitest.config.ts"), "'#libraries'", "starter vitest config");
+  assertFileContains(path.join(appDir, "vitest.config.ts"), "'#adapters'", "starter vitest config");
+  assertFileContains(
+    path.join(appDir, "src", "adapters", "pg", "sql-client.ts"),
+    "from '#libraries/sql/sql-client.js'",
+    "starter pg adapter import"
+  );
+  assertFileContains(
+    path.join(appDir, "src", "adapters", "console", "repositoryTelemetry.ts"),
+    "from '#libraries/telemetry/types.js'",
+    "starter console adapter import"
   );
 }
 


### PR DESCRIPTION
## Summary

- Make generated projects define `#libraries/*` and `#adapters/*` alongside the existing `#features/*` and `#tests/*` aliases across `package.json`, `tsconfig.json`, and `vitest.config.ts`.
- Update scaffold/template files so imports that cross canonical roots use root aliases instead of deep relative paths.
- Document the root-boundary import policy and cover it with unit tests plus generated-project verification.

## Verification

- `pnpm --filter @rawsql-ts/ztd-cli test -- init.command.test.ts directoryFinding.docs.test.ts`
- `pnpm verify:generated-project-mode`

## Merge Readiness

- [ ] No baseline exception requested.
- [x] Baseline exception requested and linked below.

Tracking issue: #778
Scoped checks run: `pnpm --filter @rawsql-ts/ztd-cli test -- init.command.test.ts directoryFinding.docs.test.ts`; `pnpm verify:generated-project-mode`
Why full baseline is not required: The pre-commit full baseline (`pnpm test`) is currently failing in unchanged areas: `packages/ztd-cli/tests/agentsPolicy.unit.test.ts`, `packages/ztd-cli/tests/commandTelemetry.unit.test.ts`, and `packages/ztd-cli/tests/setupEnv.unit.test.ts`. This PR does not modify the related source or test files, and the scoped checks above cover the changed scaffold contract.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: CLI commands and flags do not change. The user-visible change is limited to generated project configuration and scaffolded import paths.
Upgrade note: Newly generated projects will expose `#libraries/*` and `#adapters/*` aliases and use them for cross-root imports.
Deprecation/removal plan or issue: none
Docs/help/examples updated: Yes. Updated `packages/ztd-cli/README.md` and `packages/ztd-cli/templates/README.md`.
Release/changeset wording: Added `.changeset/ten-soft-camels-jump.md` for `@rawsql-ts/ztd-cli` as a patch release.

## Scaffold Contract Proof

- [ ] No scaffold contract proof required for this PR.
- [x] Scaffold contract proof completed.

No-proof rationale: none
Non-edit assertion: Same-root local imports remain relative; the change only standardizes imports that cross canonical roots.
Fail-fast input-contract proof: `packages/ztd-cli/tests/init.command.test.ts` and `packages/ztd-cli/tests/directoryFinding.docs.test.ts` now assert alias definitions and generated cross-root imports for `#libraries/*` and `#adapters/*`.
Generated-output viability proof: `pnpm verify:generated-project-mode` passed after starter init, feature scaffold, and generated-project test execution with the new alias configuration.

## Issue

- #778

## Customer Value

- Generated projects now make cross-root dependencies explicit at the import site.
- Scaffolded code is less sensitive to directory depth, which reduces follow-on churn when boundaries move or get nested.

## Outcome

- `ztd init` now emits `#features/*`, `#libraries/*`, `#adapters/*`, and `#tests/*` consistently across runtime and TypeScript resolution surfaces.
- Starter/template files that crossed canonical roots were updated to use root aliases.
- Reviewer-facing docs and release metadata now describe the policy explicitly.

## Acceptance Criteria

- Generated project config defines root aliases for the canonical roots: done
- Scaffold/template files avoid deep relative imports when crossing canonical roots: done
- Starter / smoke / feature scaffold generated-project verification passes: done
- Docs state the root-boundary alias policy: done
- Existing `#features` / `#tests` behavior stays aligned with the new aliases: done

## Verification

- `pnpm --filter @rawsql-ts/ztd-cli test -- init.command.test.ts directoryFinding.docs.test.ts`
- `pnpm verify:generated-project-mode`
- `git commit` hook attempted the full baseline via `pnpm test` and exposed unrelated existing failures in unchanged files.

## Repository Evidence

- `packages/ztd-cli/src/commands/init.ts`
- `packages/ztd-cli/templates/tsconfig.json`
- `packages/ztd-cli/templates/vitest.config.ts`
- `packages/ztd-cli/templates/src/adapters/pg/sql-client.ts`
- `packages/ztd-cli/templates/src/adapters/console/repositoryTelemetry.ts`
- `packages/ztd-cli/templates/tests/support/testkit-client.webapi.ts`
- `packages/ztd-cli/tests/init.command.test.ts`
- `packages/ztd-cli/tests/directoryFinding.docs.test.ts`
- `scripts/verify-generated-project-mode.mjs`
- `.changeset/ten-soft-camels-jump.md`

## Supplementary Evidence

- The failed pre-commit full baseline output showed unrelated existing failures in unchanged tests. This is supplementary context for merge readiness, not the primary proof for the changed scaffold behavior.

## Open Questions

- none

## Merge Blockers

- none for this change
