### PR TITLE
Fix ZTD feature test scaffold readiness

### DIFF
--- a/.changeset/ztd-case-readiness.md
+++ b/.changeset/ztd-case-readiness.md
@@ -1,0 +1,7 @@
+---
+"@rawsql-ts/ztd-cli": patch
+---
+
+Make `ztd feature tests scaffold` generate query-local ZTD case scaffolds as explicit TODO placeholders.
+
+The generated ZTD Vitest entrypoint now starts skipped until the case values are filled, and the placeholder case includes CLI-discovered table, input, and output hints so users and AI agents can see what still needs to be completed before enabling the test.

--- a/packages/ztd-cli/src/commands/featureTests.ts
+++ b/packages/ztd-cli/src/commands/featureTests.ts
@@ -105,7 +105,7 @@ export function registerFeatureTestsScaffoldCommand(featureCommand: Command): vo
         `- src/features/${result.featureName}/queries/${result.queryName}/tests/generated/${result.testKind === 'ztd' ? 'analysis.json' : 'analysis.traditional.json'}`,
         '',
         'AI-authored files:',
-        `- src/features/${result.featureName}/queries/${result.queryName}/tests/cases/`
+        `- src/features/${result.featureName}/queries/${result.queryName}/tests/cases/ (${result.testKind === 'ztd' ? 'TODO-based cases; fill them before enabling the generated test' : 'TODO-based cases for the future traditional runner'})`
       ];
       process.stdout.write(`${lines.join('\n')}\n`);
     });
@@ -177,7 +177,9 @@ export async function runFeatureTestsScaffoldCommand(options: FeatureTestsComman
 
   emitDiagnostic({
     code: 'feature-tests-scaffold.ai-follow-up',
-    message: `CLI refreshed generated analysis under src/features/${featureName}/queries/${queryLayout.queryName}/tests/generated/ for test-kind=${testKind}, refreshed boundary-${testKind}-types.ts, created the thin Vitest entrypoint only if it was missing, and left AI-authored cases under src/features/${featureName}/queries/${queryLayout.queryName}/tests/cases/ untouched.`
+    message: testKind === 'ztd'
+      ? `CLI refreshed generated analysis under src/features/${featureName}/queries/${queryLayout.queryName}/tests/generated/ for test-kind=${testKind}, refreshed boundary-${testKind}-types.ts, created the skipped Vitest entrypoint only if it was missing, and left TODO-based AI-authored cases under src/features/${featureName}/queries/${queryLayout.queryName}/tests/cases/ untouched. Fill the case values, then enable the generated test.`
+      : `CLI refreshed generated analysis under src/features/${featureName}/queries/${queryLayout.queryName}/tests/generated/ for test-kind=${testKind}, refreshed boundary-${testKind}-types.ts, created the skipped Vitest entrypoint only if it was missing, and left TODO-based AI-authored cases under src/features/${featureName}/queries/${queryLayout.queryName}/tests/cases/ untouched. Keep this lane skipped until the traditional runner is wired.`
   });
 
   return {
@@ -246,11 +248,14 @@ function renderFeatureTestScaffoldFiles(params: {
   const dbHintsLine = params.planDetails.dbScenarioHints.length > 0
     ? params.planDetails.dbScenarioHints.map((field) => `- ${field}`).join('\n')
     : '- TODO: inspect the scaffolded query boundary and SQL for DB-backed hints.';
+  const caseReadinessLine = isZtdLane
+    ? '- Generated ZTD cases are intentionally placeholders. Fill `beforeDb`, `input`, and `output`, then change the generated Vitest entrypoint from `test.skip` to `test`.'
+    : '- Generated traditional cases are intentionally placeholders until the traditional runner is wired.';
 
   const testPlanFile = [
     `# ${params.featureName} / ${params.queryName} boundary test plan`,
     '',
-    'This file snapshots the current scaffold contract before AI adds case files.',
+    'This file snapshots the current scaffold contract before AI completes the TODO-based case files.',
     '',
     '## Contract Snapshot',
     '',
@@ -287,6 +292,10 @@ function renderFeatureTestScaffoldFiles(params: {
     '',
     dbHintsLine,
     '',
+    '## Case Readiness',
+    '',
+    caseReadinessLine,
+    '',
     '## After DB Semantics',
     '',
     ...(isZtdLane
@@ -306,7 +315,7 @@ function renderFeatureTestScaffoldFiles(params: {
     '## Ownership',
     '',
     `- Generated files live under ${params.planDetails.generatedDirPath}.`,
-    `- AI-authored case files live under ${params.planDetails.casesDirPath}.`,
+    `- AI-authored TODO case files live under ${params.planDetails.casesDirPath}.`,
     '- Do not edit generated files by hand unless you are intentionally repairing them with --force.',
     ''
   ].join('\n');
@@ -342,6 +351,18 @@ function renderFeatureTestScaffoldFiles(params: {
   const beforeDbValueLiteral = buildQueryFixtureValueLiteral(params.planDetails.fixtureCandidateTables);
   const queryInputTypeLiteral = buildRecordShapeTypeLiteral(params.planDetails.queryInputFields);
   const queryOutputTypeLiteral = buildRecordShapeTypeLiteral(params.planDetails.queryOutputFields);
+  const beforeDbTodoLines = renderTodoCommentLines(
+    'TODO: Fill fixture rows for the tables the CLI could identify. Remove rows that are not needed for this case.',
+    params.planDetails.fixtureCandidateTables
+  );
+  const inputTodoLines = renderTodoCommentLines(
+    'TODO: Replace the placeholder input with concrete query parameters before enabling the generated test.',
+    params.planDetails.queryInputFields
+  );
+  const outputTodoLines = renderTodoCommentLines(
+    'TODO: Replace the placeholder output with the exact result expected from the query boundary.',
+    params.planDetails.queryOutputFields
+  );
   const vitestEntrypointFile = isZtdLane
     ? [
       `import { expect, test } from 'vitest';`,
@@ -351,7 +372,8 @@ function renderFeatureTestScaffoldFiles(params: {
       `import cases from '${casesImportPath}';`,
       `import type { ${queryCaseTypeName} } from '${queryTypesImportPath}';`,
       '',
-      `test('${params.featureName}/${params.queryName} boundary ZTD cases run through the fixed app-level harness', async () => {`,
+      `test.skip('${params.featureName}/${params.queryName} boundary ZTD case scaffold placeholder', async () => {`,
+      '  // TODO: Fill tests/cases/basic.case.ts, then change this to test(...).',
       '  expect(cases.length).toBeGreaterThan(0);',
       `  const evidence = await runQuerySpecZtdCases(cases, ${executorName});`,
       "  expect(evidence.every((entry) => entry.mode === 'ztd')).toBe(true);",
@@ -380,8 +402,11 @@ function renderFeatureTestScaffoldFiles(params: {
     `const cases: readonly ${queryCaseTypeName}[] = [`,
     '  {',
     "    name: 'basic-success',",
+    ...beforeDbTodoLines,
     `    beforeDb: ${beforeDbValueLiteral} as ${queryTypePrefix}BeforeDb,`,
+    ...inputTodoLines,
     `    input: {} as ${queryTypePrefix}Input,`,
+    ...outputTodoLines,
     `    output: {} as ${queryTypePrefix}Output,`,
     '  }',
     '];',
@@ -585,6 +610,18 @@ function buildRecordShapeTypeLiteral(fieldNames: string[]): string {
   }
 
   return `{ ${normalized.map((field) => `${field}: unknown`).join('; ')} }`;
+}
+
+function renderTodoCommentLines(message: string, hints: string[]): string[] {
+  const lines = [`    // ${message}`];
+  const normalized = dedupeStrings(hints);
+  if (normalized.length === 0) {
+    lines.push('    // CLI hints: none discovered; inspect boundary.ts, SQL, DDL, and TEST_PLAN.md.');
+    return lines;
+  }
+
+  lines.push(`    // CLI hints: ${normalized.join(', ')}.`);
+  return lines;
 }
 
 function buildQueryFixtureValueLiteral(tableNames: string[]): string {

--- a/packages/ztd-cli/src/commands/featureTests.ts
+++ b/packages/ztd-cli/src/commands/featureTests.ts
@@ -684,7 +684,7 @@ function extractSqlInsertColumns(sqlSource: string): string[] {
 }
 
 function extractSqlReturningColumns(sqlSource: string): string[] {
-  const match = sqlSource.match(/\breturning\s+([^;]+)$/i);
+  const match = sqlSource.match(/\breturning\s+([^;]+)\s*;?\s*$/i);
   if (!match || !match[1]) {
     return [];
   }

--- a/packages/ztd-cli/tests/featureTestsScaffold.unit.test.ts
+++ b/packages/ztd-cli/tests/featureTestsScaffold.unit.test.ts
@@ -134,10 +134,26 @@ test('runFeatureTestsScaffoldCommand writes query-local ZTD scaffolds from the c
   expect(vitestEntrypointFile).toContain("import { executeBoundaryQuerySpec } from '../boundary.js';");
   expect(vitestEntrypointFile).toContain("import cases from './cases/basic.case.js';");
   expect(vitestEntrypointFile).toContain("import type { InsertUsersQueryBoundaryZtdCase } from './boundary-ztd-types.js';");
+  expect(vitestEntrypointFile).toContain("test.skip('users-insert/insert-users boundary ZTD case scaffold placeholder'");
+  expect(vitestEntrypointFile).toContain('TODO: Fill tests/cases/basic.case.ts, then change this to test(...).');
+  expect(vitestEntrypointFile).not.toContain("test('users-insert/insert-users boundary ZTD cases run through the fixed app-level harness'");
   expect(vitestEntrypointFile).toContain('expect(cases.length).toBeGreaterThan(0);');
   expect(vitestEntrypointFile).toContain('const evidence = await runQuerySpecZtdCases(cases, executeBoundaryQuerySpec);');
   expect(vitestEntrypointFile).toContain("expect(evidence.every((entry) => entry.mode === 'ztd')).toBe(true);");
   expect(vitestEntrypointFile).toContain('expect(evidence.every((entry) => entry.physicalSetupUsed === false)).toBe(true);');
+
+  const basicCaseFile = readFileSync(
+    path.join(featureDir, 'queries', 'insert-users', 'tests', 'cases', 'basic.case.ts'),
+    'utf8'
+  );
+  expect(basicCaseFile).toContain('TODO: Fill fixture rows for the tables the CLI could identify.');
+  expect(basicCaseFile).toContain('CLI hints: public.users.');
+  expect(basicCaseFile).toContain('beforeDb: { public: { users: [] } } as InsertUsersBeforeDb,');
+  expect(basicCaseFile).toContain('TODO: Replace the placeholder input with concrete query parameters before enabling the generated test.');
+  expect(basicCaseFile).toContain('CLI hints: email.');
+  expect(basicCaseFile).toContain('input: {} as InsertUsersInput,');
+  expect(basicCaseFile).toContain('TODO: Replace the placeholder output with the exact result expected from the query boundary.');
+  expect(basicCaseFile).toContain('output: {} as InsertUsersOutput,');
 
   const queryTypesFile = readFileSync(
     path.join(featureDir, 'queries', 'insert-users', 'tests', 'boundary-ztd-types.ts'),
@@ -172,6 +188,9 @@ test('runFeatureTestsScaffoldCommand writes query-local ZTD scaffolds from the c
   expect(testPlanFile).toContain('Write Tables');
   expect(testPlanFile).toContain('Validation Scenario Hints');
   expect(testPlanFile).toContain('DB Scenario Hints');
+  expect(testPlanFile).toContain('Case Readiness');
+  expect(testPlanFile).toContain('Generated ZTD cases are intentionally placeholders.');
+  expect(testPlanFile).toContain('change the generated Vitest entrypoint from `test.skip` to `test`');
   expect(testPlanFile).toContain('After DB Semantics');
   expect(testPlanFile).toContain('machine-checkable evidence');
   expect(testPlanFile).toContain('physicalSetupUsed=false');

--- a/packages/ztd-cli/tests/featureTestsScaffold.unit.test.ts
+++ b/packages/ztd-cli/tests/featureTestsScaffold.unit.test.ts
@@ -153,15 +153,16 @@ test('runFeatureTestsScaffoldCommand writes query-local ZTD scaffolds from the c
   expect(basicCaseFile).toContain('CLI hints: email.');
   expect(basicCaseFile).toContain('input: {} as InsertUsersInput,');
   expect(basicCaseFile).toContain('TODO: Replace the placeholder output with the exact result expected from the query boundary.');
+  expect(basicCaseFile).toContain('CLI hints: user_id.');
   expect(basicCaseFile).toContain('output: {} as InsertUsersOutput,');
 
   const queryTypesFile = readFileSync(
     path.join(featureDir, 'queries', 'insert-users', 'tests', 'boundary-ztd-types.ts'),
     'utf8'
   );
-  expect(queryTypesFile).toContain('export type InsertUsersBeforeDb = { public: { users: readonly { email?: unknown }[] } };');
+  expect(queryTypesFile).toContain('export type InsertUsersBeforeDb = { public: { users: readonly { email?: unknown; user_id?: unknown }[] } };');
   expect(queryTypesFile).toContain('export type InsertUsersInput = { email: unknown };');
-  expect(queryTypesFile).toContain('export type InsertUsersOutput = Record<string, unknown>;');
+  expect(queryTypesFile).toContain('export type InsertUsersOutput = { user_id: unknown };');
   expect(queryTypesFile).toContain("import type { QuerySpecZtdCase } from '../../../../../../tests/support/ztd/case-types.js';");
   expect(queryTypesFile).not.toContain('AfterDb');
   expect(queryTypesFile).not.toContain('InsertUsersBeforeDb = Record<string, unknown>');


### PR DESCRIPTION
## Summary

- Closes #785.
- Makes generated query-local ZTD feature test entrypoints start as explicit `test.skip(...)` placeholders until the generated case is filled.
- Adds TODO comments and CLI-discovered table/input/output hints to `basic.case.ts` so the generated code shows what the CLI knows and what a human or AI still needs to complete.
- Adds a patch changeset for `@rawsql-ts/ztd-cli`.

Issue: `ztd feature tests scaffold` generated an active ZTD Vitest entrypoint while `basic.case.ts` still contained placeholder casts, causing immediate validation failures that looked like a broken scaffold.
Customer Value: Fresh scaffold users get an honest readiness contract: generated placeholders do not fail immediately, and the code explains how to complete and enable the case.
Outcome: The CLI now separates generated hints from human/AI-owned values and keeps generated ZTD tests skipped until the case is made executable.
Acceptance Criteria: Generated ZTD entrypoint is skipped, placeholder case includes actionable TODO/hints, persistent cases/entrypoints are still not overwritten, and the ztd-cli essential test lane stays green.
Verification: See scoped checks below.
Repository Evidence: `packages/ztd-cli/src/commands/featureTests.ts`, `packages/ztd-cli/tests/featureTestsScaffold.unit.test.ts`, `.changeset/ztd-case-readiness.md`.
Supplementary Evidence: None required; repository tests cover the contract.
Open Questions: None.
Merge Blockers: None known.

## Verification

- `pnpm --filter @rawsql-ts/ztd-cli test -- tests/featureTestsScaffold.unit.test.ts` passed: 7 tests.
- `pnpm --filter @rawsql-ts/ztd-cli test:essential` passed: 107 tests.
- Pre-commit also passed ztd-cli typecheck, `test:essential`, build, and lint.
- `git diff --check` passed before commit; only line-ending warnings were reported.

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: #785
Scoped checks run: `pnpm --filter @rawsql-ts/ztd-cli test -- tests/featureTestsScaffold.unit.test.ts`; `pnpm --filter @rawsql-ts/ztd-cli test:essential`; pre-commit ztd-cli typecheck/build/lint/test gates
Why full baseline is not required: Change is scoped to ztd-cli feature test scaffold rendering plus its focused unit coverage and changeset.

## CLI Surface Migration

- [ ] No migration packet required for this CLI change.
- [x] CLI/user-facing surface change and migration packet completed.

No-migration rationale: Behavior changes only for newly generated scaffold files; existing user-owned case and entrypoint files remain persistent and are not overwritten.
Upgrade note: New `ztd feature tests scaffold` ZTD cases start skipped until `beforeDb`, `input`, and `output` are filled, then users enable the generated test.
Deprecation/removal plan or issue: None.
Docs/help/examples updated: CLI output, generated `TEST_PLAN.md`, generated case comments, and changeset wording were updated.
Release/changeset wording: `.changeset/ztd-case-readiness.md`

## Scaffold Contract Proof

- [ ] No scaffold contract proof required for this PR.
- [x] Scaffold contract proof completed.

No-proof rationale: N/A
Non-edit assertion: Existing `writeFileIfMissing` behavior remains covered by `runFeatureTestsScaffoldCommand refreshes generated analysis without overwriting persistent cases`.
Fail-fast input-contract proof: Existing missing support and partial alias tests remain in `featureTestsScaffold.unit.test.ts` and pass.
Generated-output viability proof: `featureTestsScaffold.unit.test.ts` asserts the generated ZTD entrypoint uses `test.skip(...)`, the generated case includes TODO/hints, and `TEST_PLAN.md` documents case readiness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * ZTD feature test cases now generate as TODO placeholders requiring completion before tests run
  * Generated test suites skip by default until case values are filled in
  * Placeholder scaffolds include CLI-discovered metadata hints for tables, inputs, and outputs
  * Updated test plan documentation with case readiness guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->