### PR TITLE
Align contract and evidence discovery with RFBA feature-local QuerySpecs

### DIFF
--- a/.agents/skills/pr-readiness/SKILL.md
+++ b/.agents/skills/pr-readiness/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: developer-pr-readiness
+description: Prepare rawsql-ts pull requests with the repository PR template and local readiness gate so required merge, CLI migration, and scaffold proof sections are not missed.
+---
+
+# PR Readiness
+
+Use this skill before creating or editing a rawsql-ts pull request.
+
+## Use It For
+- Creating a PR body.
+- Editing an existing PR body after CI or reviewer feedback.
+- Any PR that changes CLI-facing files, scaffold behavior, release readiness, or documentation used by those gates.
+
+## Workflow
+1. Read `.github/pull_request_template.md`.
+2. Preserve every template section unless a repository script explicitly says it is optional.
+3. Read `scripts/check-pr-readiness.js` when it exists.
+4. Classify the changed files with the script rules, not memory.
+5. Fill exactly one checkbox in each required choice group:
+   - `Merge Readiness`
+   - `CLI Surface Migration` when CLI-facing files changed
+   - `Scaffold Contract Proof` when scaffold-related files changed
+6. Fill required same-line fields exactly as labels appear in the template.
+7. Before or immediately after `gh pr create` / `gh pr edit`, run the readiness script against the PR body.
+8. Do not present the PR as ready while the readiness script fails.
+
+## Local Validation
+When validating a PR body locally, create a temporary event payload containing the PR body, then run:
+
+```bash
+node scripts/check-pr-readiness.js --base-sha <base-sha> --head-sha <head-sha> --event-path <temp-event-json>
+```
+
+Use the actual base and head SHAs from the PR or from `git merge-base` / `git rev-parse HEAD`.
+
+## Failure Handling
+- If CI reports a PR readiness failure, fix the PR body first.
+- If the failure is caused by missing template sections, treat it as an authoring process defect, not a product-code defect.
+- If the current task caused the miss, add or update a repo-local skill or AGENTS rule before claiming the prevention is durable.
+
+## Output Shape
+- Template sections preserved
+- Required gates selected
+- Required fields filled
+- Local readiness command
+- Readiness result
+- Remaining blockers
+
+## Constraints
+- Do not replace the repository template with a free-form PR body.
+- Do not rely on memory for required section names or checkbox labels.
+- Do not mark a PR `ready` based only on focused tests when `check-pr-readiness.js` is failing.

--- a/.agents/skills/pr-readiness/SKILL.md
+++ b/.agents/skills/pr-readiness/SKILL.md
@@ -22,8 +22,9 @@ Use this skill before creating or editing a rawsql-ts pull request.
    - `CLI Surface Migration` when CLI-facing files changed
    - `Scaffold Contract Proof` when scaffold-related files changed
 6. Fill required same-line fields exactly as labels appear in the template.
-7. Before or immediately after `gh pr create` / `gh pr edit`, run the readiness script against the PR body.
-8. Do not present the PR as ready while the readiness script fails.
+7. After implementation verification, run the repo self-review workflow as the finishing review pass before PR authoring.
+8. Before `gh pr create` / `gh pr edit`, validate the prepared PR body by running the readiness script locally.
+9. Do not present the PR as ready while self-review has unresolved blockers or the readiness script fails.
 
 ## Local Validation
 When validating a PR body locally, create a temporary event payload containing the PR body, then run:
@@ -38,11 +39,13 @@ Use the actual base and head SHAs from the PR or from `git merge-base` / `git re
 - If CI reports a PR readiness failure, fix the PR body first.
 - If the failure is caused by missing template sections, treat it as an authoring process defect, not a product-code defect.
 - If the current task caused the miss, add or update a repo-local skill or AGENTS rule before claiming the prevention is durable.
+- If a reviewer finds a correctness issue after the PR is opened, treat that as evidence that the finishing self-review pass was missing or too weak; update this skill or the relevant review checklist when the miss is reusable.
 
 ## Output Shape
 - Template sections preserved
 - Required gates selected
 - Required fields filled
+- Self-review blockers resolved or explicitly surfaced
 - Local readiness command
 - Readiness result
 - Remaining blockers

--- a/.changeset/scope-contract-evidence-discovery.md
+++ b/.changeset/scope-contract-evidence-discovery.md
@@ -1,0 +1,5 @@
+---
+"@rawsql-ts/ztd-cli": minor
+---
+
+Align `ztd check contract` and `ztd evidence` with RFBA feature-local QuerySpec discovery. Both commands now scan project QuerySpec-like assets by default, support `--scope-dir` for feature or subtree reviews, and keep `--specs-dir` as the legacy fixed catalog-spec override.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,8 @@ Deeper `AGENTS.md` files take precedence when they add stricter or narrower rule
 ## Review Minimums
 
 - Final PR text and final implementation reports must pass self-review before human review.
+- Before creating or editing a PR, read `.github/pull_request_template.md` and use `.agents/skills/pr-readiness/SKILL.md` when present.
+- Before claiming a PR is ready, run the repository PR readiness script locally when `scripts/check-pr-readiness.js` exists, or explicitly state why it could not be run.
 - Blockers must be resolved or explicitly called out before human review.
 - Before creating or presenting a PR, review `tmp/RETRO.md` and either resolve every PR-blocking retro item or explicitly surface the remaining item and why it is safe to defer.
 - A retro item with `PR gate status: open` blocks PR readiness.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,8 @@ Deeper `AGENTS.md` files take precedence when they add stricter or narrower rule
 
 ## Review Minimums
 
+- Development has two completion stages: first prove the feature and regression tests, then run a separate finishing review pass before PR handoff.
+- The finishing review pass must use the available self-review workflow or repo-local review skill, and it must look for cross-mode regressions such as direct command versus PR/worktree command behavior.
 - Final PR text and final implementation reports must pass self-review before human review.
 - Before creating or editing a PR, read `.github/pull_request_template.md` and use `.agents/skills/pr-readiness/SKILL.md` when present.
 - Before claiming a PR is ready, run the repository PR readiness script locally when `scripts/check-pr-readiness.js` exists, or explicitly state why it could not be run.

--- a/docs/dogfooding/test-documentation.md
+++ b/docs/dogfooding/test-documentation.md
@@ -40,10 +40,10 @@ This regression surface keeps the shortest export loop in git so future changes 
 
 ### 1. Prepare a minimal workspace
 
-The workspace needs at least one side of the evidence model:
+The workspace must include at least one of the following:
 
-- Feature-local QuerySpec-like files under `src/features/**`, or legacy `src/catalog/specs/*.spec.json`, for SQL catalog metadata
-- `tests/specs/index.*` for function and SQL catalog case exports
+- Option A, feature-side: Feature-local QuerySpec-like files under `src/features/**`, or legacy `src/catalog/specs/*.spec.json`, for SQL catalog metadata.
+- Option B, test-side: `tests/specs/index.*` for function and SQL catalog case exports.
 
 ### 2. Export the documentation
 

--- a/docs/dogfooding/test-documentation.md
+++ b/docs/dogfooding/test-documentation.md
@@ -32,7 +32,7 @@ This regression surface keeps the shortest export loop in git so future changes 
 
 ## Shortest happy path
 
-1. Prepare a workspace with SQL specs plus `tests/specs/index` exports.
+1. Prepare a workspace with feature-local QuerySpecs or legacy SQL specs plus `tests/specs/index` exports.
 2. Run `ztd evidence test-doc --out artifacts/test-evidence/test-documentation.md`.
 3. Inspect the Markdown for catalog summaries, case lists, fixture notes, and expected results.
 
@@ -40,9 +40,9 @@ This regression surface keeps the shortest export loop in git so future changes 
 
 ### 1. Prepare a minimal workspace
 
-The workspace needs both sides of the evidence model:
+The workspace needs at least one side of the evidence model:
 
-- `src/catalog/specs/*.spec.json` for SQL catalog metadata
+- Feature-local QuerySpec-like files under `src/features/**`, or legacy `src/catalog/specs/*.spec.json`, for SQL catalog metadata
 - `tests/specs/index.*` for function and SQL catalog case exports
 
 ### 2. Export the documentation

--- a/docs/dogfooding/test-documentation.md
+++ b/docs/dogfooding/test-documentation.md
@@ -32,7 +32,7 @@ This regression surface keeps the shortest export loop in git so future changes 
 
 ## Shortest happy path
 
-1. Prepare a workspace with feature-local QuerySpecs or legacy SQL specs plus `tests/specs/index` exports.
+1. Prepare a workspace with either feature-local QuerySpecs, legacy SQL specs, or `tests/specs/index.*` exports.
 2. Run `ztd evidence test-doc --out artifacts/test-evidence/test-documentation.md`.
 3. Inspect the Markdown for catalog summaries, case lists, fixture notes, and expected results.
 

--- a/docs/guide/feature-index.md
+++ b/docs/guide/feature-index.md
@@ -45,7 +45,8 @@ An at-a-glance index of easy-to-miss but important capabilities across the rawsq
 | Repository telemetry contract | `src/libraries/telemetry/repositoryTelemetry.ts` | Keep the shared telemetry seam driver-neutral |
 | Repository telemetry console sink | `src/adapters/console/repositoryTelemetry.ts` | Emit safe local logs without widening the shared contract |
 | Runtime coercions | `src/catalog/runtime/_coercions.ts` | Driver-type normalization before validation |
-| Spec files | `src/catalog/specs/` | Define catalog contracts with validators |
+| QuerySpec files | Feature-local query boundaries under `src/features/**` | Define SQL contracts near the boundary under review |
+| Legacy spec files | `src/catalog/specs/` | Maintain fixed catalog contracts in older projects |
 | Global test setup | `tests/support/global-setup.ts` | Test-runner initialization hooks |
 
 ## Documentation

--- a/docs/guide/spec-change-scenarios.md
+++ b/docs/guide/spec-change-scenarios.md
@@ -82,7 +82,7 @@ Condensed scenarios covering common specification and schema changes, what steps
 
 **What changed:** Project migrated from one validator to another.
 
-**Steps:** Update spec files in `src/catalog/specs/` → update runtime files → update `package.json` dependencies → re-run tests.
+**Steps:** Update feature-local QuerySpec files, or legacy spec files in `src/catalog/specs/` when the project still uses that layout → update runtime files → update `package.json` dependencies → re-run tests.
 
 **Takeaway:** Validator-agnostic design means the switch is limited to spec/runtime files. The SQL layer and `rowMapping` are unaffected.
 

--- a/docs/guide/ztd-cli-agent-interface.md
+++ b/docs/guide/ztd-cli-agent-interface.md
@@ -67,9 +67,12 @@ Examples:
 ```bash
 ztd ztd-config --json '{"ddlDir":"ztd/ddl","extensions":".sql,.ddl","dryRun":true}'
 ztd check contract --json '{"format":"json","strict":true}'
+ztd check contract --json '{"format":"json","scopeDir":"src/features/users"}'
 ztd query uses column --json '{"target":"public.users.email","format":"json","summaryOnly":true}'
 ztd lint --json '{"path":"src/sql/**/*.sql"}'
 ```
+
+`ztd check contract` and `ztd evidence` discover QuerySpec-like assets project-wide by default, including RFBA feature-local query boundaries. Use `--scope-dir` or `scopeDir` only when a review should focus on one feature or subtree. `--specs-dir` remains available for legacy fixed catalog-spec directories.
 
 ## Write Safety
 

--- a/docs/guide/ztd-cli-agent-interface.md
+++ b/docs/guide/ztd-cli-agent-interface.md
@@ -74,6 +74,8 @@ ztd lint --json '{"path":"src/sql/**/*.sql"}'
 
 `ztd check contract` and `ztd evidence` discover QuerySpec-like assets project-wide by default, including RFBA feature-local query boundaries. Use `--scope-dir` or `scopeDir` only when a review should focus on one feature or subtree. `--specs-dir` remains available for legacy fixed catalog-spec directories.
 
+`--scope-dir`/`scopeDir` and `--specs-dir` are mutually exclusive. Passing both is a runtime error. Omit both to scan project-wide, pass only `--scope-dir src/features/users` for a feature subtree, or pass only `--specs-dir src/catalog/specs` for a legacy fixed catalog-spec directory.
+
 ## Write Safety
 
 These commands support `--dry-run`:

--- a/packages/ztd-cli/src/commands/checkContract.ts
+++ b/packages/ztd-cli/src/commands/checkContract.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { Command } from 'commander';
 import { BinarySelectQuery, ColumnReference, DeleteQuery, MultiQuerySplitter, SimpleSelectQuery, SqlParser, UpdateQuery } from 'rawsql-ts';
 import {
+  discoverProjectSqlCatalogSpecFiles,
   isPlainObject,
   loadSqlCatalogSpecsFromFile,
   walkSqlCatalogSpecFiles,
@@ -66,6 +67,7 @@ interface CheckCommandOptions {
   format?: string;
   out?: string;
   strict?: boolean;
+  scopeDir?: string;
   specsDir?: string;
   json?: string;
 }
@@ -80,7 +82,8 @@ export function registerCheckContractCommand(program: Command): void {
     .option('--format <format>', 'Output format (human|json)')
     .option('--out <path>', 'Write output to file')
     .option('--strict', 'Treat safety warnings as violations')
-    .option('--specs-dir <path>', 'Override specs directory (default: src/catalog/specs)')
+    .option('--scope-dir <path>', 'Limit QuerySpec discovery to one feature, boundary, or subtree')
+    .option('--specs-dir <path>', 'Legacy override for a fixed SQL catalog specs directory')
     .option('--json <payload>', 'Pass command options as a JSON object')
     .action(async (options: CheckCommandOptions) => {
       try {
@@ -89,6 +92,7 @@ export function registerCheckContractCommand(program: Command): void {
         const result = runCheckContract({
           strict: normalizeBooleanOption(merged.strict),
           rootDir: process.env.ZTD_PROJECT_ROOT,
+          scopeDir: normalizeStringOption(merged.scopeDir),
           specsDir: normalizeStringOption(merged.specsDir)
         });
         const text = formatOutput(result, format);
@@ -154,16 +158,17 @@ function normalizeBooleanOption(value: unknown): boolean {
  * Run deterministic contract checks for catalog specs under a project root.
  * @param options.strict Treat safety checks as errors when true, warnings otherwise.
  * @param options.rootDir Optional project root override.
- * @param options.specsDir Optional specs directory override (relative to rootDir).
+ * @param options.scopeDir Optional feature/boundary subtree override (relative to rootDir).
+ * @param options.specsDir Optional legacy specs directory override (relative to rootDir).
  */
-export function runCheckContract(options: { strict: boolean; rootDir?: string; specsDir?: string }): CheckContractResult {
+export function runCheckContract(options: {
+  strict: boolean;
+  rootDir?: string;
+  scopeDir?: string;
+  specsDir?: string;
+}): CheckContractResult {
   const root = path.resolve(options.rootDir ?? process.cwd());
-  const specsDir = options.specsDir ? path.resolve(root, options.specsDir) : path.resolve(root, 'src', 'catalog', 'specs');
-  if (!existsSync(specsDir)) {
-    throw new CheckContractRuntimeError(`Spec directory not found: ${specsDir}`);
-  }
-
-  const specFiles = walkSqlCatalogSpecFiles(specsDir, { excludeTestFiles: true });
+  const specFiles = resolveCheckContractSpecFiles(root, options);
   const loadedSpecs = specFiles.flatMap((filePath) =>
     loadSqlCatalogSpecsFromFile(filePath, (message) => new CheckContractRuntimeError(message))
   );
@@ -290,6 +295,33 @@ export function runCheckContract(options: { strict: boolean; rootDir?: string; s
     filesChecked: specFiles.length,
     specsChecked: loadedSpecs.length
   };
+}
+
+function resolveCheckContractSpecFiles(
+  root: string,
+  options: { scopeDir?: string; specsDir?: string }
+): string[] {
+  if (options.scopeDir && options.specsDir) {
+    throw new CheckContractRuntimeError('Use either --scope-dir or --specs-dir, not both.');
+  }
+
+  if (options.specsDir) {
+    const specsDir = path.resolve(root, options.specsDir);
+    if (!existsSync(specsDir)) {
+      throw new CheckContractRuntimeError(`Spec directory not found: ${specsDir}`);
+    }
+    return walkSqlCatalogSpecFiles(specsDir, { excludeTestFiles: true });
+  }
+
+  if (options.scopeDir) {
+    const scopeDir = path.resolve(root, options.scopeDir);
+    if (!existsSync(scopeDir)) {
+      throw new CheckContractRuntimeError(`Scope directory not found: ${scopeDir}`);
+    }
+    return discoverProjectSqlCatalogSpecFiles(scopeDir, { excludeTestFiles: true });
+  }
+
+  return discoverProjectSqlCatalogSpecFiles(root, { excludeTestFiles: true });
 }
 
 function applySafetyChecks(

--- a/packages/ztd-cli/src/commands/checkContract.ts
+++ b/packages/ztd-cli/src/commands/checkContract.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { Command } from 'commander';
 import { BinarySelectQuery, ColumnReference, DeleteQuery, MultiQuerySplitter, SimpleSelectQuery, SqlParser, UpdateQuery } from 'rawsql-ts';
@@ -173,7 +173,9 @@ export function runCheckContract(options: {
     loadSqlCatalogSpecsFromFile(filePath, (message) => new CheckContractRuntimeError(message))
   );
   const violations: ContractViolation[] = [];
-  const sqlDir = path.resolve(root, 'src', 'sql');
+  const sqlDir = options.scopeDir
+    ? resolveDirectoryOption(root, options.scopeDir, 'Scope directory')
+    : path.resolve(root, 'src', 'sql');
   const sqlFiles = existsSync(sqlDir) ? walkSqlFiles(sqlDir) : [];
 
   const coveredSqlFiles = new Set<string>();
@@ -306,22 +308,31 @@ function resolveCheckContractSpecFiles(
   }
 
   if (options.specsDir) {
-    const specsDir = path.resolve(root, options.specsDir);
-    if (!existsSync(specsDir)) {
-      throw new CheckContractRuntimeError(`Spec directory not found: ${specsDir}`);
-    }
+    const specsDir = resolveDirectoryOption(root, options.specsDir, 'Spec directory');
     return walkSqlCatalogSpecFiles(specsDir, { excludeTestFiles: true });
   }
 
   if (options.scopeDir) {
-    const scopeDir = path.resolve(root, options.scopeDir);
-    if (!existsSync(scopeDir)) {
-      throw new CheckContractRuntimeError(`Scope directory not found: ${scopeDir}`);
-    }
+    const scopeDir = resolveDirectoryOption(root, options.scopeDir, 'Scope directory');
     return discoverProjectSqlCatalogSpecFiles(scopeDir, { excludeTestFiles: true });
   }
 
   return discoverProjectSqlCatalogSpecFiles(root, { excludeTestFiles: true });
+}
+
+function resolveDirectoryOption(root: string, value: string, label: string): string {
+  const resolved = path.resolve(root, value);
+  const relative = path.relative(root, resolved);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new CheckContractRuntimeError(`${label} must be inside the project root: ${resolved}`);
+  }
+  if (!existsSync(resolved)) {
+    throw new CheckContractRuntimeError(`${label} not found: ${resolved}`);
+  }
+  if (!statSync(resolved).isDirectory()) {
+    throw new CheckContractRuntimeError(`${label} is not a directory: ${resolved}`);
+  }
+  return resolved;
 }
 
 function applySafetyChecks(

--- a/packages/ztd-cli/src/commands/describe.ts
+++ b/packages/ztd-cli/src/commands/describe.ts
@@ -228,7 +228,7 @@ const COMMANDS: CommandDescriptor[] = [
   },
   {
     name: 'check contract',
-    summary: 'Validate SQL contract specs and emit deterministic findings.',
+    summary: 'Validate project QuerySpec-backed SQL contracts and emit deterministic findings.',
     writesFiles: true,
     supportsDryRun: false,
     supportsJsonPayload: true,
@@ -242,6 +242,8 @@ const COMMANDS: CommandDescriptor[] = [
     },
     flags: [
       { name: '--format json', description: 'Emit the report as deterministic JSON.' },
+      { name: '--scope-dir', description: 'Limit QuerySpec discovery to one feature, boundary, or subtree.' },
+      { name: '--specs-dir', description: 'Legacy fixed catalog specs directory override.' },
       { name: '--json', description: 'Pass check options as a JSON object.' }
     ]
   },
@@ -407,7 +409,7 @@ const COMMANDS: CommandDescriptor[] = [
   },
   {
     name: 'evidence',
-    summary: 'Generate deterministic specification evidence artifacts.',
+    summary: 'Generate deterministic specification evidence artifacts from project QuerySpec and test assets.',
     writesFiles: true,
     supportsDryRun: false,
     supportsJsonPayload: true,
@@ -420,6 +422,8 @@ const COMMANDS: CommandDescriptor[] = [
       '2': 'Runtime or config error.'
     },
     flags: [
+      { name: '--scope-dir', description: 'Limit QuerySpec discovery to one feature, boundary, or subtree.' },
+      { name: '--specs-dir', description: 'Legacy fixed catalog specs directory override.' },
       { name: '--json', description: 'Pass evidence options as a JSON object.' }
     ]
   }

--- a/packages/ztd-cli/src/commands/testEvidence.ts
+++ b/packages/ztd-cli/src/commands/testEvidence.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
@@ -484,16 +484,31 @@ function resolveTestEvidenceSpecFiles(
   }
 
   if (options.specsDir) {
-    const specsDir = path.resolve(root, options.specsDir);
-    return existsSync(specsDir) ? walkSqlCatalogSpecFiles(specsDir) : [];
+    const specsDir = resolveDirectoryOption(root, options.specsDir, 'Spec directory');
+    return walkSqlCatalogSpecFiles(specsDir);
   }
 
   if (options.scopeDir) {
-    const scopeDir = path.resolve(root, options.scopeDir);
-    return existsSync(scopeDir) ? discoverProjectSqlCatalogSpecFiles(scopeDir) : [];
+    const scopeDir = resolveDirectoryOption(root, options.scopeDir, 'Scope directory');
+    return discoverProjectSqlCatalogSpecFiles(scopeDir);
   }
 
   return discoverProjectSqlCatalogSpecFiles(root);
+}
+
+function resolveDirectoryOption(root: string, value: string, label: string): string {
+  const resolved = path.resolve(root, value);
+  const relative = path.relative(root, resolved);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new TestEvidenceRuntimeError(`${label} must be inside the project root: ${resolved}`);
+  }
+  if (!existsSync(resolved)) {
+    throw new TestEvidenceRuntimeError(`${label} not found: ${resolved}`);
+  }
+  if (!statSync(resolved).isDirectory()) {
+    throw new TestEvidenceRuntimeError(`${label} is not a directory: ${resolved}`);
+  }
+  return resolved;
 }
 
 function describeSpecDiscoveryScope(root: string, options: { scopeDir?: string; specsDir?: string }): string {

--- a/packages/ztd-cli/src/commands/testEvidence.ts
+++ b/packages/ztd-cli/src/commands/testEvidence.ts
@@ -20,6 +20,7 @@ import {
   type RemovedDetailLevel
 } from '@rawsql-ts/test-evidence-renderer-md';
 import {
+  discoverProjectSqlCatalogSpecFiles,
   isPlainObject,
   loadSqlCatalogSpecsFromFile,
   walkSqlCatalogSpecFiles,
@@ -164,6 +165,7 @@ interface TestEvidenceCommandOptions {
   mode: string;
   format: string;
   outDir: string;
+  scopeDir?: string;
   specsDir?: string;
   testsDir?: string;
   specModule?: string;
@@ -179,6 +181,7 @@ interface TestEvidencePrCommandOptions {
   allowEmptyBase?: boolean;
   removedDetail?: string;
   outDir?: string;
+  scopeDir?: string;
   specsDir?: string;
   testsDir?: string;
   specModule?: string;
@@ -189,6 +192,7 @@ interface TestEvidencePrCommandOptions {
 
 interface TestDocCommandOptions {
   out?: string;
+  scopeDir?: string;
   specsDir?: string;
   testsDir?: string;
   specModule?: string;
@@ -260,7 +264,8 @@ export function registerTestEvidenceCommand(program: Command): void {
     .option('--mode <mode>', 'Evidence mode (specification)', 'specification')
     .option('--format <format>', 'Output format (json|markdown|both)', 'both')
     .option('--out-dir <path>', 'Output directory', '.ztd/test-evidence')
-    .option('--specs-dir <path>', 'Override SQL catalog specs directory (default: src/catalog/specs)')
+    .option('--scope-dir <path>', 'Limit QuerySpec discovery to one feature, boundary, or subtree')
+    .option('--specs-dir <path>', 'Legacy override for a fixed SQL catalog specs directory')
     .option('--tests-dir <path>', 'Override tests directory (default: tests)')
     .option('--spec-module <path>', 'Explicit evidence module path (default: tests/specs/index)')
     .option('--json <payload>', 'Pass evidence options as a JSON object')
@@ -275,6 +280,7 @@ export function registerTestEvidenceCommand(program: Command): void {
           runTestEvidenceSpecification({
           mode,
           rootDir: process.env.ZTD_PROJECT_ROOT,
+          scopeDir: merged.scopeDir as string | undefined,
           specsDir: merged.specsDir as string | undefined,
           testsDir: merged.testsDir as string | undefined,
           specModule: merged.specModule as string | undefined
@@ -301,7 +307,8 @@ export function registerTestEvidenceCommand(program: Command): void {
     .command('test-doc')
     .description('Generate human-readable Markdown test documentation from ZTD test assets')
     .option('--out <path>', 'Output markdown path', '.ztd/test-evidence/test-documentation.md')
-    .option('--specs-dir <path>', 'Override SQL catalog specs directory (default: src/catalog/specs)')
+    .option('--scope-dir <path>', 'Limit QuerySpec discovery to one feature, boundary, or subtree')
+    .option('--specs-dir <path>', 'Legacy override for a fixed SQL catalog specs directory')
     .option('--tests-dir <path>', 'Override tests directory (default: tests)')
     .option('--spec-module <path>', 'Explicit evidence module path (default: tests/specs/index)')
     .option('--json <payload>', 'Pass test-doc options as a JSON object')
@@ -311,6 +318,7 @@ export function registerTestEvidenceCommand(program: Command): void {
         const report = runTestEvidenceSpecification({
           mode: 'specification',
           rootDir: process.env.ZTD_PROJECT_ROOT,
+          scopeDir: merged.scopeDir as string | undefined,
           specsDir: merged.specsDir as string | undefined,
           testsDir: merged.testsDir as string | undefined,
           specModule: merged.specModule as string | undefined
@@ -337,7 +345,8 @@ export function registerTestEvidenceCommand(program: Command): void {
     .option('--allow-empty-base', 'Allow empty base evidence when head has catalogs')
     .option('--removed-detail <level>', 'Removed case detail level (none|input|full)', 'input')
     .option('--out-dir <path>', 'Output directory', 'artifacts/test-evidence')
-    .option('--specs-dir <path>', 'Override SQL catalog specs directory (default: src/catalog/specs)')
+    .option('--scope-dir <path>', 'Limit QuerySpec discovery to one feature, boundary, or subtree')
+    .option('--specs-dir <path>', 'Legacy override for a fixed SQL catalog specs directory')
     .option('--tests-dir <path>', 'Override tests directory (default: tests)')
     .option('--spec-module <path>', 'Explicit evidence module path (default: tests/specs/index)')
     .option('--json <payload>', 'Pass PR evidence options as a JSON object')
@@ -354,6 +363,7 @@ export function registerTestEvidenceCommand(program: Command): void {
           removedDetail: normalizeRemovedDetail(String(merged.removedDetail ?? 'input')),
           outDir: String(merged.outDir ?? 'artifacts/test-evidence'),
           rootDir: process.env.ZTD_PROJECT_ROOT,
+          scopeDir: merged.scopeDir as string | undefined,
           specsDir: merged.specsDir as string | undefined,
           testsDir: merged.testsDir as string | undefined,
           specModule: merged.specModule as string | undefined,
@@ -406,15 +416,15 @@ function normalizeRemovedDetail(level: string): RemovedDetailLevel {
 export function runTestEvidenceSpecification(options: {
   mode: TestEvidenceMode;
   rootDir?: string;
+  scopeDir?: string;
   specsDir?: string;
   testsDir?: string;
   specModule?: string;
 }): TestSpecificationEvidence {
   const root = path.resolve(options.rootDir ?? process.cwd());
-  const specsDir = options.specsDir ? path.resolve(root, options.specsDir) : path.resolve(root, 'src', 'catalog', 'specs');
   const testsDir = options.testsDir ? path.resolve(root, options.testsDir) : path.resolve(root, 'tests');
 
-  const sqlSpecFiles = existsSync(specsDir) ? walkSqlCatalogSpecFiles(specsDir) : [];
+  const sqlSpecFiles = resolveTestEvidenceSpecFiles(root, options);
   const evidenceModule = loadEvidenceModule(root, testsDir, options.specModule);
   const testCaseCatalogFiles = existsSync(testsDir) ? walkFiles(testsDir, isTestCaseCatalogFile) : [];
   const legacyTestCases = evidenceModule ? [] : testCaseCatalogFiles.flatMap((filePath) => loadTestCaseCatalogEvidence(root, filePath));
@@ -431,7 +441,7 @@ export function runTestEvidenceSpecification(options: {
   const sqlCaseCatalogsFromModule = evidenceModule ? readSqlCaseCatalogsFromModule(evidenceModule) : [];
   if (sqlSpecFiles.length === 0 && testCasesFromModule.length === 0 && legacyTestCases.length === 0 && sqlCaseCatalogsFromModule.length === 0) {
     throw new TestEvidenceRuntimeError(
-      `No catalog specs or test-case evidence exports were found. Checked specsDir=${specsDir}, testsDir=${testsDir}`,
+      `No catalog specs or test-case evidence exports were found. Checked scope=${describeSpecDiscoveryScope(root, options)}, testsDir=${testsDir}`,
       { code: 'NO_SPECS_FOUND' }
     );
   }
@@ -463,6 +473,37 @@ export function runTestEvidenceSpecification(options: {
     testCaseCatalogs,
     testCases
   };
+}
+
+function resolveTestEvidenceSpecFiles(
+  root: string,
+  options: { scopeDir?: string; specsDir?: string }
+): string[] {
+  if (options.scopeDir && options.specsDir) {
+    throw new TestEvidenceRuntimeError('Use either --scope-dir or --specs-dir, not both.');
+  }
+
+  if (options.specsDir) {
+    const specsDir = path.resolve(root, options.specsDir);
+    return existsSync(specsDir) ? walkSqlCatalogSpecFiles(specsDir) : [];
+  }
+
+  if (options.scopeDir) {
+    const scopeDir = path.resolve(root, options.scopeDir);
+    return existsSync(scopeDir) ? discoverProjectSqlCatalogSpecFiles(scopeDir) : [];
+  }
+
+  return discoverProjectSqlCatalogSpecFiles(root);
+}
+
+function describeSpecDiscoveryScope(root: string, options: { scopeDir?: string; specsDir?: string }): string {
+  if (options.scopeDir) {
+    return path.resolve(root, options.scopeDir);
+  }
+  if (options.specsDir) {
+    return path.resolve(root, options.specsDir);
+  }
+  return root;
 }
 
 /**
@@ -582,6 +623,7 @@ export function runTestEvidencePr(options: {
   removedDetail?: RemovedDetailLevel;
   outDir: string;
   rootDir?: string;
+  scopeDir?: string;
   specsDir?: string;
   testsDir?: string;
   specModule?: string;
@@ -614,6 +656,7 @@ export function runTestEvidencePr(options: {
       specsDir: options.specsDir,
       testsDir: options.testsDir,
       specModule: options.specModule,
+      scopeDir: options.scopeDir,
       summaryOnly: options.summaryOnly,
       limit: options.limit
     });
@@ -627,6 +670,7 @@ export function runTestEvidencePr(options: {
       specsDir: options.specsDir,
       testsDir: options.testsDir,
       specModule: options.specModule,
+      scopeDir: options.scopeDir,
       summaryOnly: options.summaryOnly,
       limit: options.limit
     });
@@ -942,6 +986,7 @@ function materializeEvidenceForRef(args: {
   allowCurrentWorkspace: boolean;
   tempRoot: string;
   createdWorktrees: string[];
+  scopeDir?: string;
   specsDir?: string;
   testsDir?: string;
   specModule?: string;
@@ -954,6 +999,7 @@ function materializeEvidenceForRef(args: {
         runTestEvidenceSpecification({
           mode: 'specification',
           rootDir,
+          scopeDir: args.scopeDir,
           specsDir: args.specsDir,
           testsDir: args.testsDir,
           specModule: args.specModule

--- a/packages/ztd-cli/src/commands/testEvidence.ts
+++ b/packages/ztd-cli/src/commands/testEvidence.ts
@@ -659,6 +659,8 @@ export function runTestEvidencePr(options: {
       ? resolveGitMergeBase(root, options.baseRef, options.headRef)
       : resolveGitSha(root, options.baseRef);
   const currentHeadSha = resolveGitSha(root, 'HEAD');
+  const normalizedScopeDir = normalizeDiscoveryDirForWorktree(root, options.scopeDir, 'Scope directory');
+  const normalizedSpecsDir = normalizeDiscoveryDirForWorktree(root, options.specsDir, 'Spec directory');
 
   try {
     const headMaterialized = materializeEvidenceForRef({
@@ -668,10 +670,10 @@ export function runTestEvidencePr(options: {
       allowCurrentWorkspace: resolvedHeadSha === currentHeadSha,
       tempRoot,
       createdWorktrees,
-      specsDir: options.specsDir,
+      specsDir: normalizedSpecsDir,
       testsDir: options.testsDir,
       specModule: options.specModule,
-      scopeDir: options.scopeDir,
+      scopeDir: normalizedScopeDir,
       summaryOnly: options.summaryOnly,
       limit: options.limit
     });
@@ -682,10 +684,10 @@ export function runTestEvidencePr(options: {
       allowCurrentWorkspace: resolvedBaseSha === currentHeadSha,
       tempRoot,
       createdWorktrees,
-      specsDir: options.specsDir,
+      specsDir: normalizedSpecsDir,
       testsDir: options.testsDir,
       specModule: options.specModule,
-      scopeDir: options.scopeDir,
+      scopeDir: normalizedScopeDir,
       summaryOnly: options.summaryOnly,
       limit: options.limit
     });
@@ -728,6 +730,14 @@ export function runTestEvidencePr(options: {
   } finally {
     cleanupWorktrees(root, createdWorktrees);
   }
+}
+
+function normalizeDiscoveryDirForWorktree(root: string, value: string | undefined, label: string): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const resolved = resolveDirectoryOption(root, value, label);
+  return path.relative(root, resolved) || '.';
 }
 
 function writeArtifacts(args: {

--- a/packages/ztd-cli/tests/__snapshots__/describe.cli.test.ts.snap
+++ b/packages/ztd-cli/tests/__snapshots__/describe.cli.test.ts.snap
@@ -63,6 +63,14 @@ exports[`describe command snapshots the top-level command catalog and every deta
           "name": "--format json",
         },
         {
+          "description": "Limit QuerySpec discovery to one feature, boundary, or subtree.",
+          "name": "--scope-dir",
+        },
+        {
+          "description": "Legacy fixed catalog specs directory override.",
+          "name": "--specs-dir",
+        },
+        {
           "description": "Pass check options as a JSON object.",
           "name": "--json",
         },
@@ -71,7 +79,7 @@ exports[`describe command snapshots the top-level command catalog and every deta
       "output": {
         "stdout": "Human report or deterministic JSON report.",
       },
-      "summary": "Validate SQL contract specs and emit deterministic findings.",
+      "summary": "Validate project QuerySpec-backed SQL contracts and emit deterministic findings.",
       "supportsDryRun": false,
       "supportsJsonPayload": true,
       "writesFiles": true,
@@ -311,7 +319,7 @@ exports[`describe command snapshots the top-level command catalog and every deta
       },
       {
         "name": "check contract",
-        "summary": "Validate SQL contract specs and emit deterministic findings.",
+        "summary": "Validate project QuerySpec-backed SQL contracts and emit deterministic findings.",
         "supportsDescribeOutput": false,
         "supportsDryRun": false,
         "supportsJsonPayload": true,
@@ -383,7 +391,7 @@ exports[`describe command snapshots the top-level command catalog and every deta
       },
       {
         "name": "evidence",
-        "summary": "Generate deterministic specification evidence artifacts.",
+        "summary": "Generate deterministic specification evidence artifacts from project QuerySpec and test assets.",
         "supportsDescribeOutput": false,
         "supportsDryRun": false,
         "supportsJsonPayload": true,
@@ -409,6 +417,14 @@ exports[`describe command snapshots the top-level command catalog and every deta
       },
       "flags": [
         {
+          "description": "Limit QuerySpec discovery to one feature, boundary, or subtree.",
+          "name": "--scope-dir",
+        },
+        {
+          "description": "Legacy fixed catalog specs directory override.",
+          "name": "--specs-dir",
+        },
+        {
           "description": "Pass evidence options as a JSON object.",
           "name": "--json",
         },
@@ -420,7 +436,7 @@ exports[`describe command snapshots the top-level command catalog and every deta
           "<out-dir>/test-specification.md",
         ],
       },
-      "summary": "Generate deterministic specification evidence artifacts.",
+      "summary": "Generate deterministic specification evidence artifacts from project QuerySpec and test assets.",
       "supportsDryRun": false,
       "supportsJsonPayload": true,
       "writesFiles": true,

--- a/packages/ztd-cli/tests/checkContract.cli.test.ts
+++ b/packages/ztd-cli/tests/checkContract.cli.test.ts
@@ -31,6 +31,22 @@ function createProgram(capture: { stdout: string[]; stderr: string[] }): Command
   return program;
 }
 
+test('CLI: check contract help documents RFBA scope discovery and legacy specsDir', async () => {
+  const capture = { stdout: [] as string[], stderr: [] as string[] };
+  const program = createProgram(capture);
+
+  await expect(program.parseAsync(['check', 'contract', '--help'], { from: 'user' })).rejects.toMatchObject({
+    code: 'commander.helpDisplayed'
+  });
+
+  const help = capture.stdout.join('');
+  expect(help).toContain('--scope-dir <path>');
+  expect(help).toContain('Limit QuerySpec discovery to one feature, boundary, or');
+  expect(help).toContain('subtree');
+  expect(help).toContain('--specs-dir <path>');
+  expect(help).toContain('Legacy override for a fixed SQL catalog specs directory');
+});
+
 test('CLI: check contract writes json output and sets exitCode=0 on success', async () => {
   const workspace = createWorkspace('check-contract-cli-pass');
   writeFileSync(
@@ -115,7 +131,7 @@ test('CLI: check contract sets exitCode=2 for runtime/config errors', async () =
   const capture = { stdout: [] as string[], stderr: [] as string[] };
   const program = createProgram(capture);
 
-  await program.parseAsync(['check', 'contract'], { from: 'user' });
+  await program.parseAsync(['check', 'contract', '--scope-dir', 'missing-feature'], { from: 'user' });
 
   expect(process.exitCode).toBe(2);
 });
@@ -152,4 +168,43 @@ test('CLI: check contract accepts --json payload options', async () => {
   expect(output).toMatchObject({ ok: true, filesChecked: 1, specsChecked: 1, violations: [] });
   expect(capture.stdout.join('')).toBe('');
   expect(capture.stderr.join('')).toBe('');
+});
+
+test('CLI: check contract accepts scopeDir from --json payload', async () => {
+  const workspace = createWorkspace('check-contract-cli-scope-json');
+  const queryDir = path.join(workspace, 'src', 'features', 'users', 'queries', 'list-users');
+  mkdirSync(queryDir, { recursive: true });
+  writeFileSync(path.join(queryDir, 'list-users.sql'), 'SELECT id FROM users WHERE active = :active', 'utf8');
+  writeFileSync(
+    path.join(queryDir, 'queryspec.ts'),
+    [
+      "const listUsersSql = loadSqlResource(__dirname, 'list-users.sql');",
+      "export const listUsersQuerySpec = { label: 'features.users.list-users', sql: listUsersSql };",
+      ''
+    ].join('\n'),
+    'utf8'
+  );
+
+  process.env.ZTD_PROJECT_ROOT = workspace;
+  const capture = { stdout: [] as string[], stderr: [] as string[] };
+  const program = createProgram(capture);
+  const outPath = path.join(workspace, 'artifacts', 'contract-check.json');
+
+  await program.parseAsync(
+    [
+      'check',
+      'contract',
+      '--json',
+      JSON.stringify({
+        format: 'json',
+        out: outPath,
+        scopeDir: path.join('src', 'features', 'users')
+      })
+    ],
+    { from: 'user' }
+  );
+
+  expect(process.exitCode).toBe(0);
+  const output = JSON.parse(readFileSync(outPath, 'utf8'));
+  expect(output).toMatchObject({ ok: true, filesChecked: 1, specsChecked: 1, violations: [] });
 });

--- a/packages/ztd-cli/tests/checkContract.unit.test.ts
+++ b/packages/ztd-cli/tests/checkContract.unit.test.ts
@@ -11,6 +11,27 @@ function createWorkspace(): string {
   return dir;
 }
 
+function writeFeatureLocalQuerySpec(root: string, featureName: string, sql: string): void {
+  const queryDir = path.join(root, 'src', 'features', featureName, 'queries', 'list-users');
+  mkdirSync(queryDir, { recursive: true });
+  writeFileSync(path.join(queryDir, 'list-users.sql'), sql, 'utf8');
+  writeFileSync(
+    path.join(queryDir, 'queryspec.ts'),
+    [
+      "import { loadSqlResource } from '../../../_shared/loadSqlResource';",
+      '',
+      "const listUsersSql = loadSqlResource(__dirname, 'list-users.sql');",
+      '',
+      'export const listUsersQuerySpec = {',
+      `  label: 'features.${featureName}.list-users',`,
+      '  sql: listUsersSql',
+      '};',
+      ''
+    ].join('\n'),
+    'utf8'
+  );
+}
+
 describe('runCheckContract', () => {
   test('detects duplicate spec ids', () => {
     const root = createWorkspace();
@@ -28,6 +49,40 @@ describe('runCheckContract', () => {
 
     const result = runCheckContract({ strict: true, rootDir: root });
     expect(result.violations).toEqual(expect.arrayContaining([expect.objectContaining({ rule: 'unresolved-sql-file', specId: 'a' })]));
+  });
+
+  test('discovers feature-local QuerySpec assets project-wide by default', () => {
+    const root = createWorkspace();
+    writeFeatureLocalQuerySpec(root, 'users', 'SELECT id FROM users WHERE active = :active');
+
+    const result = runCheckContract({ strict: true, rootDir: root });
+
+    expect(result).toMatchObject({
+      ok: true,
+      filesChecked: 1,
+      specsChecked: 1
+    });
+    expect(result.violations).toEqual([]);
+  });
+
+  test('limits project discovery with scopeDir and preserves legacy specsDir', () => {
+    const root = createWorkspace();
+    writeFeatureLocalQuerySpec(root, 'users', 'SELECT id FROM users WHERE active = :active');
+    writeFeatureLocalQuerySpec(root, 'orders', 'SELECT * FROM orders');
+    writeFileSync(path.join(root, 'src', 'sql', 'legacy.sql'), 'SELECT 1', 'utf8');
+    writeFileSync(
+      path.join(root, 'src', 'catalog', 'specs', 'legacy.json'),
+      JSON.stringify({ id: 'legacy', sqlFile: '../../sql/legacy.sql', params: { shape: 'positional', example: [] } }),
+      'utf8'
+    );
+
+    const scoped = runCheckContract({ strict: true, rootDir: root, scopeDir: path.join('src', 'features', 'users') });
+    expect(scoped).toMatchObject({ filesChecked: 1, specsChecked: 1 });
+    expect(scoped.violations.some((v) => v.specId === 'features.orders.list-users')).toBe(false);
+
+    const legacy = runCheckContract({ strict: true, rootDir: root, specsDir: path.join('src', 'catalog', 'specs') });
+    expect(legacy).toMatchObject({ filesChecked: 1, specsChecked: 1 });
+    expect(legacy.violations.some((v) => v.specId === 'features.users.list-users')).toBe(false);
   });
 
   test('detects params shape mismatches', () => {

--- a/packages/ztd-cli/tests/checkContract.unit.test.ts
+++ b/packages/ztd-cli/tests/checkContract.unit.test.ts
@@ -85,6 +85,34 @@ describe('runCheckContract', () => {
     expect(legacy.violations.some((v) => v.specId === 'features.users.list-users')).toBe(false);
   });
 
+  test('limits uncovered SQL detection to scopeDir', () => {
+    const root = createWorkspace();
+    writeFeatureLocalQuerySpec(root, 'users', 'SELECT id FROM users WHERE active = :active');
+    writeFileSync(path.join(root, 'src', 'sql', 'outside-scope.sql'), 'SELECT 1', 'utf8');
+
+    const result = runCheckContract({
+      strict: true,
+      rootDir: root,
+      scopeDir: path.join('src', 'features', 'users')
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.violations).toEqual([]);
+  });
+
+  test('rejects non-directory scopeDir and specsDir options', () => {
+    const root = createWorkspace();
+    writeFileSync(path.join(root, 'src', 'features-file'), 'not a directory', 'utf8');
+    writeFileSync(path.join(root, 'src', 'catalog', 'specs-file'), 'not a directory', 'utf8');
+
+    expect(() =>
+      runCheckContract({ strict: true, rootDir: root, scopeDir: path.join('src', 'features-file') })
+    ).toThrow(/Scope directory is not a directory/);
+    expect(() =>
+      runCheckContract({ strict: true, rootDir: root, specsDir: path.join('src', 'catalog', 'specs-file') })
+    ).toThrow(/Spec directory is not a directory/);
+  });
+
   test('detects params shape mismatches', () => {
     const root = createWorkspace();
     writeFileSync(path.join(root, 'src', 'sql', 'a.sql'), 'SELECT 1', 'utf8');

--- a/packages/ztd-cli/tests/describe.cli.test.ts
+++ b/packages/ztd-cli/tests/describe.cli.test.ts
@@ -37,6 +37,23 @@ test('describe command emits JSON envelope when global output is json', async ()
   expect(capture.stderr).toEqual([]);
 });
 
+test('describe metadata documents RFBA scope discovery options for contract and evidence commands', () => {
+  const descriptors = getDescribeCommandDescriptors();
+  const checkContract = descriptors.find((descriptor) => descriptor.name === 'check contract');
+  const evidence = descriptors.find((descriptor) => descriptor.name === 'evidence');
+
+  expect(checkContract?.flags).toEqual(expect.arrayContaining([
+    expect.objectContaining({ name: '--scope-dir' }),
+    expect.objectContaining({ name: '--specs-dir', description: expect.stringContaining('Legacy') })
+  ]));
+  expect(checkContract?.summary).toContain('QuerySpec-backed');
+  expect(evidence?.flags).toEqual(expect.arrayContaining([
+    expect.objectContaining({ name: '--scope-dir' }),
+    expect.objectContaining({ name: '--specs-dir', description: expect.stringContaining('Legacy') })
+  ]));
+  expect(evidence?.summary).toContain('project QuerySpec');
+});
+
 test('describe command snapshots the top-level command catalog and every detailed descriptor', async () => {
   setAgentOutputFormat('json');
   const rootCapture = { stdout: [] as string[], stderr: [] as string[] };

--- a/packages/ztd-cli/tests/testEvidence.cli.test.ts
+++ b/packages/ztd-cli/tests/testEvidence.cli.test.ts
@@ -69,6 +69,17 @@ function createProgram(): Command {
   return program;
 }
 
+function createCapturingProgram(capture: { stdout: string[]; stderr: string[] }): Command {
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({
+    writeOut: (str) => capture.stdout.push(str),
+    writeErr: (str) => capture.stderr.push(str)
+  });
+  registerTestEvidenceCommand(program);
+  return program;
+}
+
 function escapeRegex(input: string): string {
   return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
@@ -163,6 +174,70 @@ test('CLI: evidence writes json and markdown artifacts', async () => {
   expect(markdown).toContain('"active": 1');
   expect(markdown).toContain('```json');
   expect(markdown).not.toContain('select order_id from orders where active = @active');
+});
+
+test('CLI: evidence help documents scopeDir and legacy specsDir across evidence commands', async () => {
+  for (const args of [
+    ['evidence', '--help'],
+    ['evidence', 'test-doc', '--help'],
+    ['evidence', 'pr', '--help']
+  ]) {
+    const capture = { stdout: [] as string[], stderr: [] as string[] };
+    const program = createCapturingProgram(capture);
+
+    await expect(program.parseAsync(args, { from: 'user' })).rejects.toMatchObject({
+      code: 'commander.helpDisplayed'
+    });
+
+    const help = capture.stdout.join('');
+    expect(help).toContain('--scope-dir <path>');
+    expect(help).toContain('Limit QuerySpec discovery to one feature, boundary');
+    expect(help).toContain('subtree');
+    expect(help).toContain('--specs-dir <path>');
+    expect(help).toContain('Legacy override for a fixed SQL catalog specs');
+    expect(help).toContain('directory');
+  }
+});
+
+test('CLI: evidence accepts scopeDir from --json payload', async () => {
+  const root = createWorkspace('evidence-cli-scope-json');
+  const queryDir = path.join(root, 'src', 'features', 'users', 'queries', 'list-users');
+  mkdirSync(queryDir, { recursive: true });
+  writeFileSync(path.join(queryDir, 'list-users.sql'), 'SELECT id FROM users WHERE active = :active', 'utf8');
+  writeFileSync(
+    path.join(queryDir, 'queryspec.ts'),
+    [
+      "const listUsersSql = loadSqlResource(__dirname, 'list-users.sql');",
+      "export const listUsersQuerySpec = { label: 'features.users.list-users', sql: listUsersSql };",
+      ''
+    ].join('\n'),
+    'utf8'
+  );
+
+  process.env.ZTD_PROJECT_ROOT = root;
+  const outDir = path.join(root, 'artifacts-scope');
+  const program = createProgram();
+  await program.parseAsync(
+    [
+      'evidence',
+      '--json',
+      JSON.stringify({
+        mode: 'specification',
+        format: 'json',
+        outDir,
+        scopeDir: path.join('src', 'features', 'users')
+      })
+    ],
+    { from: 'user' }
+  );
+
+  expect(process.exitCode).toBe(0);
+  const parsedJson = JSON.parse(readFileSync(path.join(outDir, 'test-specification.json'), 'utf8'));
+  expect(parsedJson.summary).toMatchObject({ sqlCatalogCount: 1, specFilesScanned: 1 });
+  expect(parsedJson.sqlCatalogs[0]).toMatchObject({
+    id: 'features.users.list-users',
+    specFile: 'src/features/users/queries/list-users/queryspec.ts'
+  });
 });
 
 test('CLI: evidence summary-only writes compact artifacts', async () => {

--- a/packages/ztd-cli/tests/testEvidence.unit.test.ts
+++ b/packages/ztd-cli/tests/testEvidence.unit.test.ts
@@ -18,6 +18,27 @@ function createWorkspace(prefix: string): string {
   return root;
 }
 
+function writeFeatureLocalQuerySpec(root: string, featureName: string): void {
+  const queryDir = path.join(root, 'src', 'features', featureName, 'queries', 'list-users');
+  mkdirSync(queryDir, { recursive: true });
+  writeFileSync(path.join(queryDir, 'list-users.sql'), 'SELECT id FROM users WHERE active = :active', 'utf8');
+  writeFileSync(
+    path.join(queryDir, 'queryspec.ts'),
+    [
+      "import { loadSqlResource } from '../../../_shared/loadSqlResource';",
+      '',
+      "const listUsersSql = loadSqlResource(__dirname, 'list-users.sql');",
+      '',
+      'export const listUsersQuerySpec = {',
+      `  label: 'features.${featureName}.list-users',`,
+      '  sql: listUsersSql',
+      '};',
+      ''
+    ].join('\n'),
+    'utf8'
+  );
+}
+
 function writeSpecModule(root: string, options?: { testCaseIds?: string[]; includeSqlCase?: boolean }): void {
   const testCaseIds = options?.testCaseIds ?? ['returns-active-users', 'skipped-case'];
   const sqlCaseBlock = options?.includeSqlCase === false
@@ -134,6 +155,52 @@ test('runTestEvidenceSpecification extracts SQL catalogs, SQL case catalogs, and
 test('runTestEvidenceSpecification throws when neither specs nor evidence module exports exist', () => {
   const root = mkdtempSync(path.join(os.tmpdir(), 'evidence-empty-'));
   expect(() => runTestEvidenceSpecification({ mode: 'specification', rootDir: root })).toThrowError(TestEvidenceRuntimeError);
+});
+
+test('runTestEvidenceSpecification discovers feature-local QuerySpecs project-wide by default', () => {
+  const root = createWorkspace('evidence-feature-local');
+  writeFeatureLocalQuerySpec(root, 'users');
+
+  const report = runTestEvidenceSpecification({ mode: 'specification', rootDir: root });
+
+  expect(report.summary).toMatchObject({
+    sqlCatalogCount: 1,
+    specFilesScanned: 1
+  });
+  expect(report.sqlCatalogs).toEqual([
+    expect.objectContaining({
+      id: 'features.users.list-users',
+      specFile: 'src/features/users/queries/list-users/queryspec.ts',
+      sqlFile: './list-users.sql',
+      sqlFileResolved: true
+    })
+  ]);
+});
+
+test('runTestEvidenceSpecification supports scopeDir and legacy specsDir discovery', () => {
+  const root = createWorkspace('evidence-scope-dir');
+  writeFeatureLocalQuerySpec(root, 'users');
+  writeFeatureLocalQuerySpec(root, 'orders');
+  writeFileSync(path.join(root, 'src', 'sql', 'legacy.sql'), 'select 1', 'utf8');
+  writeFileSync(
+    path.join(root, 'src', 'catalog', 'specs', 'legacy.spec.json'),
+    JSON.stringify({ id: 'legacy', sqlFile: '../../sql/legacy.sql', params: { shape: 'named' } }, null, 2),
+    'utf8'
+  );
+
+  const scoped = runTestEvidenceSpecification({
+    mode: 'specification',
+    rootDir: root,
+    scopeDir: path.join('src', 'features', 'users')
+  });
+  expect(scoped.sqlCatalogs.map((item) => item.id)).toEqual(['features.users.list-users']);
+
+  const legacy = runTestEvidenceSpecification({
+    mode: 'specification',
+    rootDir: root,
+    specsDir: path.join('src', 'catalog', 'specs')
+  });
+  expect(legacy.sqlCatalogs.map((item) => item.id)).toEqual(['legacy']);
 });
 
 test('formatTestEvidenceOutput emits deterministic markdown and json text', () => {

--- a/packages/ztd-cli/tests/testEvidence.unit.test.ts
+++ b/packages/ztd-cli/tests/testEvidence.unit.test.ts
@@ -203,6 +203,40 @@ test('runTestEvidenceSpecification supports scopeDir and legacy specsDir discove
   expect(legacy.sqlCatalogs.map((item) => item.id)).toEqual(['legacy']);
 });
 
+test('runTestEvidenceSpecification rejects ambiguous scopeDir and specsDir discovery', () => {
+  const root = createWorkspace('evidence-conflicting-discovery');
+
+  expect(() =>
+    runTestEvidenceSpecification({
+      mode: 'specification',
+      rootDir: root,
+      scopeDir: path.join('src', 'features', 'users'),
+      specsDir: path.join('src', 'catalog', 'specs')
+    })
+  ).toThrowError(TestEvidenceRuntimeError);
+});
+
+test('runTestEvidenceSpecification rejects non-directory or external discovery roots', () => {
+  const root = createWorkspace('evidence-invalid-discovery');
+  const outsideRoot = mkdtempSync(path.join(os.tmpdir(), 'evidence-outside-'));
+  writeFileSync(path.join(root, 'src', 'features-file'), 'not a directory', 'utf8');
+
+  expect(() =>
+    runTestEvidenceSpecification({
+      mode: 'specification',
+      rootDir: root,
+      scopeDir: path.join('src', 'features-file')
+    })
+  ).toThrow(/Scope directory is not a directory/);
+  expect(() =>
+    runTestEvidenceSpecification({
+      mode: 'specification',
+      rootDir: root,
+      specsDir: outsideRoot
+    })
+  ).toThrow(/Spec directory must be inside the project root/);
+});
+
 test('formatTestEvidenceOutput emits deterministic markdown and json text', () => {
   const root = createWorkspace('evidence-format');
   writeFileSync(

--- a/packages/ztd-cli/tests/testEvidence.unit.test.ts
+++ b/packages/ztd-cli/tests/testEvidence.unit.test.ts
@@ -1,4 +1,5 @@
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import os from 'node:os';
 import path from 'node:path';
 import { expect, test } from 'vitest';
@@ -6,6 +7,7 @@ import {
   applyEvidenceOutputControls,
   formatTestDocumentationOutput,
   formatTestEvidenceOutput,
+  runTestEvidencePr,
   runTestEvidenceSpecification,
   TestEvidenceRuntimeError
 } from '../src/commands/testEvidence';
@@ -102,6 +104,22 @@ function withoutGitHubEnv<T>(fn: () => T): T {
       }
     });
   }
+}
+
+function git(root: string, args: string[]): string {
+  const { GIT_DIR: _gitDir, GIT_WORK_TREE: _gitWorkTree, ...env } = process.env;
+  return execFileSync('git', args, {
+    cwd: root,
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    encoding: 'utf8'
+  }).trim();
+}
+
+function initGitRepository(root: string): void {
+  git(root, ['init']);
+  git(root, ['config', 'user.email', 'test@example.com']);
+  git(root, ['config', 'user.name', 'Test User']);
 }
 
 test('runTestEvidenceSpecification extracts SQL catalogs, SQL case catalogs, and test-case catalogs deterministically', () => {
@@ -235,6 +253,53 @@ test('runTestEvidenceSpecification rejects non-directory or external discovery r
       specsDir: outsideRoot
     })
   ).toThrow(/Spec directory must be inside the project root/);
+});
+
+test('runTestEvidencePr normalizes absolute discovery roots before materializing worktrees', () => {
+  const root = createWorkspace('evidence-pr-absolute-specs');
+  initGitRepository(root);
+  writeFeatureLocalQuerySpec(root, 'users');
+  writeFileSync(
+    path.join(root, 'src', 'catalog', 'specs', 'users.spec.json'),
+    JSON.stringify({ id: 'legacy.users', sqlFile: '../../sql/users.sql', params: { shape: 'named' } }, null, 2),
+    'utf8'
+  );
+  writeFileSync(path.join(root, 'src', 'sql', 'users.sql'), 'select id from users', 'utf8');
+  writeSpecModule(root, { testCaseIds: ['works'], includeSqlCase: false });
+  git(root, ['add', '.']);
+  git(root, ['commit', '-m', 'base']);
+  const baseSha = git(root, ['rev-parse', 'HEAD']);
+
+  writeFileSync(path.join(root, 'src', 'sql', 'users.sql'), 'select id, name from users', 'utf8');
+  git(root, ['add', '.']);
+  git(root, ['commit', '-m', 'head']);
+  const headSha = git(root, ['rev-parse', 'HEAD']);
+
+  const result = runTestEvidencePr({
+    baseRef: baseSha,
+    headRef: headSha,
+    baseMode: 'ref',
+    outDir: 'artifacts/test-evidence',
+    rootDir: root,
+    specsDir: path.join(root, 'src', 'catalog', 'specs'),
+    summaryOnly: true
+  });
+
+  expect(result.baseReport.summary.sqlCatalogCount).toBe(1);
+  expect(result.headReport.summary.sqlCatalogCount).toBe(1);
+
+  const scopedResult = runTestEvidencePr({
+    baseRef: baseSha,
+    headRef: headSha,
+    baseMode: 'ref',
+    outDir: 'artifacts/test-evidence-scoped',
+    rootDir: root,
+    scopeDir: path.join(root, 'src', 'features', 'users'),
+    summaryOnly: true
+  });
+
+  expect(scopedResult.baseReport.summary.sqlCatalogCount).toBe(1);
+  expect(scopedResult.headReport.summary.sqlCatalogCount).toBe(1);
 });
 
 test('formatTestEvidenceOutput emits deterministic markdown and json text', () => {


### PR DESCRIPTION
## Summary

- Align `ztd check contract` and `ztd evidence` with RFBA feature-local QuerySpec discovery.
- Add `--scope-dir` for feature/subtree narrowing while keeping legacy `--specs-dir` compatibility.
- Update help/describe metadata, docs, tests, snapshots, and a changeset.

## Issue

Closes #787.

## Customer Value

Users can validate and summarize SQL contracts from feature-local RFBA projects without maintaining a parallel catalog-spec directory or remembering command-specific discovery exceptions.

## Outcome

- `ztd check contract` now uses project-wide QuerySpec-like discovery by default.
- `ztd evidence`, `ztd evidence test-doc`, and `ztd evidence pr` use the same RFBA-compatible discovery path.
- `--scope-dir` is available consistently for feature/subtree review scope.
- `--specs-dir` remains available as the legacy fixed catalog-spec override.

## Acceptance Criteria

- Project-wide feature-local discovery: done.
- Feature-local `loadSqlResource(...)` QuerySpec assets: done.
- Evidence commands share the RFBA-compatible discovery path: done.
- Boundary-scoped narrowing via `--scope-dir`: done.
- Legacy `--specs-dir` compatibility: done.
- Help/describe/docs no longer imply `src/catalog/specs` is the only normal layout: done.

## Verification

- `pnpm --filter @rawsql-ts/ztd-cli test -- checkContract.unit.test.ts checkContract.cli.test.ts testEvidence.unit.test.ts testEvidence.cli.test.ts describe.cli.test.ts sqlCatalogDiscovery.unit.test.ts`
  - Passed: 6 files, 46 tests.
- `pnpm --filter @rawsql-ts/ztd-cli build`
  - Passed.
- `git diff --check`
  - Passed with only Windows LF-to-CRLF warnings.

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: not requested
Scoped checks run: focused ztd-cli discovery tests, ztd-cli build, git diff --check
Why full baseline is not required: not requested

## CLI Surface Migration

- [ ] No migration packet required for this CLI change.
- [x] CLI/user-facing surface change and migration packet completed.

No-migration rationale: not applicable
Upgrade note: `ztd check contract` and `ztd evidence` now discover QuerySpec-like assets project-wide by default. Use `--scope-dir` to narrow review to one feature or subtree. Existing `--specs-dir` usage remains supported for legacy fixed catalog-spec layouts.
Deprecation/removal plan or issue: no removal in this PR; `--specs-dir` remains as the documented legacy compatibility path.
Docs/help/examples updated: command help, describe metadata, docs/guide/ztd-cli-agent-interface.md, docs/guide/feature-index.md, docs/dogfooding/test-documentation.md, and docs/guide/spec-change-scenarios.md were updated.
Release/changeset wording: .changeset/scope-contract-evidence-discovery.md describes the RFBA discovery alignment, `--scope-dir`, and `--specs-dir` compatibility.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: this PR changes CLI discovery, help, documentation, and tests only; it does not change scaffold generation behavior or generated scaffold layout.
Non-edit assertion: not applicable
Fail-fast input-contract proof: not applicable
Generated-output viability proof: not applicable

## Repository Evidence

- Discovery implementation: `packages/ztd-cli/src/commands/checkContract.ts`, `packages/ztd-cli/src/commands/testEvidence.ts`.
- Help/describe metadata: `packages/ztd-cli/src/commands/describe.ts`, `packages/ztd-cli/tests/__snapshots__/describe.cli.test.ts.snap`.
- Focused tests: `packages/ztd-cli/tests/checkContract.unit.test.ts`, `packages/ztd-cli/tests/checkContract.cli.test.ts`, `packages/ztd-cli/tests/testEvidence.unit.test.ts`, `packages/ztd-cli/tests/testEvidence.cli.test.ts`, `packages/ztd-cli/tests/describe.cli.test.ts`.
- Docs and release note: `docs/guide/ztd-cli-agent-interface.md`, `docs/guide/feature-index.md`, `docs/dogfooding/test-documentation.md`, `.changeset/scope-contract-evidence-discovery.md`.

## Supplementary Evidence

None required beyond repository checks.

## Open Questions

None.

## Local Full-Suite Note

The local pre-commit hook ran the full workspace test suite and failed outside this change area:

- `packages/testkit-core/tests/SelectFixtureRewriter.test.ts`: `afterEach is not defined`.
- `packages/ztd-cli/tests/commandTelemetry.unit.test.ts`: perf telemetry tests fail with `[SqlParser] No SQL statements found in input`.
- `packages/ztd-cli/tests/setupEnv.unit.test.ts`: cannot resolve `dotenv` from template setup-env import.

Those failures are not part of the focused evidence for this PR and are called out here for visibility.

## Reviewer Focus

- Confirm the new default discovery behavior is acceptable for empty projects: default project-wide scans may return zero specs instead of treating missing `src/catalog/specs` as a config error.
- Confirm `--scope-dir` and legacy `--specs-dir` conflict handling is the intended migration shape.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--scope-dir` option to contract and evidence commands for focused subtree-based reviews.
  * Feature-local QuerySpec discovery now enabled project-wide by default; legacy `--specs-dir` mechanism retained for backward compatibility.
  * Note: `--scope-dir` and `--specs-dir` are mutually exclusive; using both will raise an error.

* **Documentation**
  * Updated guidance on workspace setup and QuerySpec asset location.
  * Clarified CLI flag behavior and usage patterns for contract and evidence validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->