### PR TITLE
Add RFBA boundary inspection command

### DIFF
--- a/.changeset/rfba-boundary-inspect.md
+++ b/.changeset/rfba-boundary-inspect.md
@@ -1,0 +1,7 @@
+---
+"@rawsql-ts/ztd-cli": minor
+---
+
+Add `ztd rfba inspect` as a read-only RFBA boundary inspection command.
+
+The command reports starter root boundaries, feature boundaries, query sub-boundaries, likely public surface files, SQL assets, generated artifacts, local verification files, and structural warnings in text or deterministic JSON output.

--- a/packages/ztd-cli/README.md
+++ b/packages/ztd-cli/README.md
@@ -72,6 +72,18 @@ src/features/<feature>/
 
 The starter and feature scaffolds apply that convention under `src/features/<feature>/...`, so the feature-local public surface stays easy to discover.
 
+### Inspect RFBA Boundaries
+
+Reviewers and agents can inspect the current RFBA boundary map before editing:
+
+```bash
+npx ztd rfba inspect
+npx ztd rfba inspect --format json
+```
+
+The command is read-only. It reports concrete starter root boundaries, feature-boundaries, query sub-boundaries, likely public surface files, SQL assets, generated artifacts, local verification files, and structural warnings.
+The JSON output is deterministic and omits timestamps so it can be consumed by agents and review checks.
+
 Important repo areas outside the concrete root-boundary list:
 
 - Keep shared feature seams under `src/features/_shared/*`.

--- a/packages/ztd-cli/src/commands/describe.ts
+++ b/packages/ztd-cli/src/commands/describe.ts
@@ -406,6 +406,25 @@ const COMMANDS: CommandDescriptor[] = [
     ]
   },
   {
+    name: 'rfba inspect',
+    summary: 'Inspect RFBA root, feature, and query sub-boundaries without writing files.',
+    writesFiles: false,
+    supportsDryRun: false,
+    supportsJsonPayload: true,
+    output: {
+      stdout: 'Text boundary map or deterministic JSON report.'
+    },
+    exitCodes: {
+      '0': 'Boundary report emitted.',
+      '1': 'Validation or filesystem error.'
+    },
+    flags: [
+      { name: '--format <format>', description: 'Output format (text|json).' },
+      { name: '--root <path>', description: 'Project root to inspect.' },
+      { name: '--json', description: 'Pass inspect options as a JSON object.' }
+    ]
+  },
+  {
     name: 'evidence',
     summary: 'Generate deterministic specification evidence artifacts.',
     writesFiles: true,

--- a/packages/ztd-cli/src/commands/rfba.ts
+++ b/packages/ztd-cli/src/commands/rfba.ts
@@ -1,0 +1,467 @@
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { Command } from 'commander';
+import { getAgentOutputFormat, parseJsonPayload, writeCommandEnvelope } from '../utils/agentCli';
+
+export type RfbaBoundaryKind = 'root-boundary' | 'feature-boundary' | 'child-boundary-container' | 'sub-boundary';
+export type RfbaInspectFormat = 'text' | 'json';
+
+export interface RfbaBoundaryReviewQuestions {
+  responsibilityBoundary: string;
+  dependencyFlow: string;
+  publicSurface: string;
+  verification: string;
+}
+
+export interface RfbaBoundaryAssets {
+  publicSurfaceFiles: string[];
+  sqlAssets: string[];
+  generatedArtifacts: string[];
+  localVerificationFiles: string[];
+}
+
+export interface RfbaBoundaryReport extends RfbaBoundaryAssets {
+  id: string;
+  kind: RfbaBoundaryKind;
+  name: string;
+  path: string;
+  parentBoundaryId: string | null;
+  childBoundaryIds: string[];
+  publicBoundary: boolean;
+  reviewQuestions: RfbaBoundaryReviewQuestions;
+  notes: string[];
+  warnings: string[];
+}
+
+export interface RfbaInspectionReport {
+  schemaVersion: 1;
+  projectRoot: string;
+  expectedRootBoundaryPaths: string[];
+  summary: {
+    rootBoundaries: number;
+    featureBoundaries: number;
+    childBoundaryContainers: number;
+    subBoundaries: number;
+    warnings: number;
+  };
+  boundaries: RfbaBoundaryReport[];
+}
+
+interface RfbaInspectOptions {
+  format?: string;
+  root?: string;
+  json?: string;
+}
+
+interface BoundaryDraft {
+  id: string;
+  kind: RfbaBoundaryKind;
+  name: string;
+  absolutePath: string;
+  relativePath: string;
+  parentBoundaryId: string | null;
+  childBoundaryIds: string[];
+  publicBoundary: boolean;
+  reviewQuestions: RfbaBoundaryReviewQuestions;
+  notes: string[];
+  warnings: string[];
+  excludeChildPaths: string[];
+}
+
+const STARTER_ROOT_BOUNDARIES = [
+  { name: 'features', relativePath: 'src/features' },
+  { name: 'adapters', relativePath: 'src/adapters' },
+  { name: 'libraries', relativePath: 'src/libraries' },
+] as const;
+
+const PUBLIC_SURFACE_FILENAMES = new Set(['boundary.ts', 'index.ts', 'index.js', 'README.md']);
+const VERIFICATION_FILE_PATTERNS = [
+  /\.test\.[cm]?[jt]sx?$/i,
+  /\.spec\.[cm]?[jt]sx?$/i,
+  /\.case\.[cm]?[jt]sx?$/i,
+  /TEST_PLAN\.md$/i,
+];
+
+export function registerRfbaCommand(program: Command): void {
+  const rfba = program.command('rfba').description('Review-first boundary inspection for RFBA projects');
+
+  rfba
+    .command('inspect')
+    .description('Inspect RFBA root, feature, and query sub-boundaries without writing files')
+    .option('--format <format>', 'Output format (text|json)')
+    .option('--root <path>', 'Project root to inspect', '.')
+    .option('--json <payload>', 'Pass command options as a JSON object')
+    .action((options: RfbaInspectOptions) => {
+      const merged = options.json ? { ...options, ...parseJsonPayload<Record<string, unknown>>(options.json, '--json') } : options;
+      const root = normalizeStringOption(merged.root) ?? '.';
+      const format = resolveRfbaInspectFormat(merged.format);
+      const report = inspectRfbaBoundaries(path.resolve(process.cwd(), root));
+
+      if (getAgentOutputFormat() === 'json' && !merged.format) {
+        writeCommandEnvelope('rfba inspect', report);
+        return;
+      }
+
+      process.stdout.write(formatRfbaInspectionReport(report, format));
+    });
+}
+
+export function inspectRfbaBoundaries(projectRoot: string): RfbaInspectionReport {
+  const absoluteRoot = path.resolve(projectRoot);
+  const drafts: BoundaryDraft[] = [];
+
+  for (const rootBoundary of STARTER_ROOT_BOUNDARIES) {
+    const absolutePath = path.join(absoluteRoot, ...rootBoundary.relativePath.split('/'));
+    if (!isDirectory(absolutePath)) {
+      continue;
+    }
+
+    drafts.push(createBoundaryDraft({
+      kind: 'root-boundary',
+      name: rootBoundary.name,
+      absolutePath,
+      relativePath: rootBoundary.relativePath,
+      parentBoundaryId: null,
+      publicBoundary: true,
+      reviewQuestions: rootBoundaryReviewQuestions(rootBoundary.relativePath),
+      notes: [`Concrete starter root boundary: ${rootBoundary.relativePath}.`],
+    }));
+  }
+
+  const featuresRoot = path.join(absoluteRoot, 'src', 'features');
+  if (isDirectory(featuresRoot)) {
+    const featureRootDraft = drafts.find((draft) => draft.relativePath === 'src/features');
+    for (const featureName of listChildDirectoryNames(featuresRoot)) {
+      if (featureName.startsWith('_')) {
+        continue;
+      }
+
+      const featurePath = path.join(featuresRoot, featureName);
+      const featureRelativePath = toPosixPath(path.relative(absoluteRoot, featurePath));
+      const featureDraft = createBoundaryDraft({
+        kind: 'feature-boundary',
+        name: featureName,
+        absolutePath: featurePath,
+        relativePath: featureRelativePath,
+        parentBoundaryId: featureRootDraft?.id ?? null,
+        publicBoundary: true,
+        reviewQuestions: featureBoundaryReviewQuestions(featureRelativePath),
+        notes: ['Feature-owned boundary for orchestration, SQL ownership, and feature-local verification.'],
+      });
+      if (!existsSync(path.join(featurePath, 'boundary.ts'))) {
+        featureDraft.warnings.push('Feature boundary does not expose the starter public surface file boundary.ts.');
+      }
+      drafts.push(featureDraft);
+      if (featureRootDraft) {
+        featureRootDraft.childBoundaryIds.push(featureDraft.id);
+        featureRootDraft.excludeChildPaths.push(featurePath);
+      }
+
+      const queriesPath = path.join(featurePath, 'queries');
+      if (!isDirectory(queriesPath)) {
+        continue;
+      }
+
+      const queriesRelativePath = toPosixPath(path.relative(absoluteRoot, queriesPath));
+      const queriesDraft = createBoundaryDraft({
+        kind: 'child-boundary-container',
+        name: 'queries',
+        absolutePath: queriesPath,
+        relativePath: queriesRelativePath,
+        parentBoundaryId: featureDraft.id,
+        publicBoundary: false,
+        reviewQuestions: queriesContainerReviewQuestions(queriesRelativePath),
+        notes: ['Container for query sub-boundaries; not a public RFBA boundary by itself.'],
+      });
+      const directFiles = listDirectFiles(queriesPath);
+      if (directFiles.length > 0) {
+        queriesDraft.warnings.push('queries/ contains direct files; query assets should usually live under queries/<query>/ sub-boundaries.');
+      }
+      drafts.push(queriesDraft);
+      featureDraft.childBoundaryIds.push(queriesDraft.id);
+      featureDraft.excludeChildPaths.push(queriesPath);
+
+      for (const queryName of listChildDirectoryNames(queriesPath)) {
+        const queryPath = path.join(queriesPath, queryName);
+        const queryRelativePath = toPosixPath(path.relative(absoluteRoot, queryPath));
+        const queryDraft = createBoundaryDraft({
+          kind: 'sub-boundary',
+          name: queryName,
+          absolutePath: queryPath,
+          relativePath: queryRelativePath,
+          parentBoundaryId: queriesDraft.id,
+          publicBoundary: true,
+          reviewQuestions: querySubBoundaryReviewQuestions(queryRelativePath),
+          notes: ['Feature-local query sub-boundary for SQL, generated evidence, and query-local verification.'],
+        });
+        if (!existsSync(path.join(queryPath, 'boundary.ts'))) {
+          queryDraft.warnings.push('Query sub-boundary does not expose boundary.ts.');
+        }
+        if (collectOwnedFiles(queryPath, []).filter((file) => file.endsWith('.sql')).length === 0) {
+          queryDraft.warnings.push('Query sub-boundary does not contain a SQL asset.');
+        }
+        drafts.push(queryDraft);
+        queriesDraft.childBoundaryIds.push(queryDraft.id);
+        queriesDraft.excludeChildPaths.push(queryPath);
+      }
+    }
+  }
+
+  const boundaries = drafts
+    .sort((left, right) => left.relativePath.localeCompare(right.relativePath))
+    .map((draft) => {
+      const assets = classifyBoundaryAssets(absoluteRoot, draft.absolutePath, draft.excludeChildPaths);
+      return {
+        id: draft.id,
+        kind: draft.kind,
+        name: draft.name,
+        path: draft.relativePath,
+        parentBoundaryId: draft.parentBoundaryId,
+        childBoundaryIds: draft.childBoundaryIds.sort(),
+        publicBoundary: draft.publicBoundary,
+        reviewQuestions: draft.reviewQuestions,
+        ...assets,
+        notes: draft.notes.sort(),
+        warnings: draft.warnings.sort(),
+      };
+    });
+
+  const warningCount = boundaries.reduce((sum, boundary) => sum + boundary.warnings.length, 0);
+
+  return {
+    schemaVersion: 1,
+    projectRoot: absoluteRoot,
+    expectedRootBoundaryPaths: STARTER_ROOT_BOUNDARIES.map((boundary) => boundary.relativePath),
+    summary: {
+      rootBoundaries: boundaries.filter((boundary) => boundary.kind === 'root-boundary').length,
+      featureBoundaries: boundaries.filter((boundary) => boundary.kind === 'feature-boundary').length,
+      childBoundaryContainers: boundaries.filter((boundary) => boundary.kind === 'child-boundary-container').length,
+      subBoundaries: boundaries.filter((boundary) => boundary.kind === 'sub-boundary').length,
+      warnings: warningCount,
+    },
+    boundaries,
+  };
+}
+
+export function formatRfbaInspectionReport(report: RfbaInspectionReport, format: RfbaInspectFormat): string {
+  if (format === 'json') {
+    return `${JSON.stringify(report, null, 2)}\n`;
+  }
+
+  const lines = [
+    'RFBA boundary inspection',
+    `Project root: ${report.projectRoot}`,
+    `Expected starter root boundaries: ${report.expectedRootBoundaryPaths.join(', ')}`,
+    `Root boundaries: ${report.summary.rootBoundaries}`,
+    `Feature boundaries: ${report.summary.featureBoundaries}`,
+    `Query containers: ${report.summary.childBoundaryContainers}`,
+    `Query sub-boundaries: ${report.summary.subBoundaries}`,
+    `Warnings: ${report.summary.warnings}`,
+    '',
+    'Boundaries:',
+  ];
+
+  for (const boundary of report.boundaries) {
+    lines.push(`- ${boundary.path} [${boundary.kind}]${boundary.publicBoundary ? '' : ' (not public boundary)'}`);
+    lines.push(`  responsibility: ${boundary.reviewQuestions.responsibilityBoundary}`);
+    lines.push(`  dependency flow: ${boundary.reviewQuestions.dependencyFlow}`);
+    lines.push(`  public surface: ${formatAssetList(boundary.publicSurfaceFiles)}`);
+    lines.push(`  sql assets: ${formatAssetList(boundary.sqlAssets)}`);
+    lines.push(`  generated artifacts: ${formatAssetList(boundary.generatedArtifacts)}`);
+    lines.push(`  verification: ${formatAssetList(boundary.localVerificationFiles)}`);
+    for (const warning of boundary.warnings) {
+      lines.push(`  warning: ${warning}`);
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+function createBoundaryDraft(input: {
+  kind: RfbaBoundaryKind;
+  name: string;
+  absolutePath: string;
+  relativePath: string;
+  parentBoundaryId: string | null;
+  publicBoundary: boolean;
+  reviewQuestions: RfbaBoundaryReviewQuestions;
+  notes: string[];
+}): BoundaryDraft {
+  return {
+    id: `${input.kind}:${input.relativePath}`,
+    kind: input.kind,
+    name: input.name,
+    absolutePath: input.absolutePath,
+    relativePath: input.relativePath,
+    parentBoundaryId: input.parentBoundaryId,
+    childBoundaryIds: [],
+    publicBoundary: input.publicBoundary,
+    reviewQuestions: input.reviewQuestions,
+    notes: input.notes,
+    warnings: [],
+    excludeChildPaths: [],
+  };
+}
+
+function classifyBoundaryAssets(projectRoot: string, boundaryPath: string, excludeChildPaths: string[]): RfbaBoundaryAssets {
+  const files = collectOwnedFiles(boundaryPath, excludeChildPaths);
+  const publicSurfaceFiles: string[] = [];
+  const sqlAssets: string[] = [];
+  const generatedArtifacts: string[] = [];
+  const localVerificationFiles: string[] = [];
+
+  for (const file of files) {
+    const relativePath = toPosixPath(path.relative(projectRoot, file));
+    const basename = path.basename(file);
+    if (PUBLIC_SURFACE_FILENAMES.has(basename)) {
+      if (basename !== 'README.md' || path.dirname(file) === boundaryPath) {
+        publicSurfaceFiles.push(relativePath);
+      }
+    }
+    if (basename.toLowerCase().endsWith('.sql')) {
+      sqlAssets.push(relativePath);
+    }
+    if (isGeneratedArtifact(relativePath, basename)) {
+      generatedArtifacts.push(relativePath);
+    }
+    if (isVerificationFile(relativePath, basename)) {
+      localVerificationFiles.push(relativePath);
+    }
+  }
+
+  return {
+    publicSurfaceFiles: sortUnique(publicSurfaceFiles),
+    sqlAssets: sortUnique(sqlAssets),
+    generatedArtifacts: sortUnique(generatedArtifacts),
+    localVerificationFiles: sortUnique(localVerificationFiles),
+  };
+}
+
+function collectOwnedFiles(root: string, excludedRoots: string[]): string[] {
+  if (!isDirectory(root)) {
+    return [];
+  }
+
+  const normalizedExcludedRoots = excludedRoots.map((excludedRoot) => path.resolve(excludedRoot));
+  const results: string[] = [];
+  const visit = (current: string) => {
+    const resolvedCurrent = path.resolve(current);
+    if (normalizedExcludedRoots.some((excludedRoot) => resolvedCurrent === excludedRoot || resolvedCurrent.startsWith(`${excludedRoot}${path.sep}`))) {
+      return;
+    }
+
+    for (const entry of readdirSync(current, { withFileTypes: true }).sort((left, right) => left.name.localeCompare(right.name))) {
+      const entryPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        visit(entryPath);
+      } else if (entry.isFile()) {
+        results.push(entryPath);
+      }
+    }
+  };
+
+  visit(root);
+  return results.sort((left, right) => left.localeCompare(right));
+}
+
+function listChildDirectoryNames(root: string): string[] {
+  return readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function listDirectFiles(root: string): string[] {
+  return readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function isDirectory(value: string): boolean {
+  try {
+    return statSync(value).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function isGeneratedArtifact(relativePath: string, basename: string): boolean {
+  return relativePath.split('/').includes('generated') || basename.includes('.generated.') || basename === 'analysis.json';
+}
+
+function isVerificationFile(relativePath: string, basename: string): boolean {
+  return relativePath.split('/').includes('tests') || VERIFICATION_FILE_PATTERNS.some((pattern) => pattern.test(basename));
+}
+
+function resolveRfbaInspectFormat(value: unknown): RfbaInspectFormat {
+  const explicit = normalizeStringOption(value);
+  if (!explicit) {
+    return getAgentOutputFormat();
+  }
+
+  const normalized = explicit.trim().toLowerCase();
+  if (normalized === 'text' || normalized === 'json') {
+    return normalized;
+  }
+
+  throw new Error(`Unsupported RFBA inspection format: ${explicit}`);
+}
+
+function normalizeStringOption(value: unknown): string | undefined {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+  if (typeof value !== 'string') {
+    throw new Error(`Expected a string option but received ${typeof value}.`);
+  }
+  return value;
+}
+
+function sortUnique(values: string[]): string[] {
+  return Array.from(new Set(values)).sort((left, right) => left.localeCompare(right));
+}
+
+function toPosixPath(value: string): string {
+  return value.split(path.sep).join('/');
+}
+
+function formatAssetList(values: string[]): string {
+  return values.length === 0 ? '(none)' : values.join(', ');
+}
+
+function rootBoundaryReviewQuestions(relativePath: string): RfbaBoundaryReviewQuestions {
+  return {
+    responsibilityBoundary: `${relativePath} is a starter root boundary for a top-level application responsibility area.`,
+    dependencyFlow: 'Root boundaries should depend inward on stable contracts and avoid depending on sibling implementation details.',
+    publicSurface: 'Review README.md, index files, and boundary files that define how this root area is entered.',
+    verification: 'Review tests and generated evidence inside this root area before changing its contracts.',
+  };
+}
+
+function featureBoundaryReviewQuestions(relativePath: string): RfbaBoundaryReviewQuestions {
+  return {
+    responsibilityBoundary: `${relativePath} owns one feature boundary and its feature-local orchestration.`,
+    dependencyFlow: 'Feature code may call its query sub-boundaries and stable shared helpers; external callers should enter through the feature public surface.',
+    publicSurface: 'boundary.ts and README.md are the likely reviewer entry points for the feature.',
+    verification: 'Feature-local tests under tests/ verify orchestration and boundary behavior.',
+  };
+}
+
+function queriesContainerReviewQuestions(relativePath: string): RfbaBoundaryReviewQuestions {
+  return {
+    responsibilityBoundary: `${relativePath} groups query sub-boundaries for one feature.`,
+    dependencyFlow: 'The container should not be treated as a callable public surface; dependencies flow into concrete queries/<query>/ sub-boundaries.',
+    publicSurface: 'No public boundary is expected directly on queries/.',
+    verification: 'Verification belongs to each concrete query sub-boundary.',
+  };
+}
+
+function querySubBoundaryReviewQuestions(relativePath: string): RfbaBoundaryReviewQuestions {
+  return {
+    responsibilityBoundary: `${relativePath} owns one query-level SQL boundary.`,
+    dependencyFlow: 'The parent feature boundary calls into this query sub-boundary; query code should keep SQL, mapping, and generated evidence local.',
+    publicSurface: 'boundary.ts is the likely callable query surface; SQL files are review assets, not external entry points.',
+    verification: 'Query-local tests, cases, generated analysis, and TEST_PLAN.md belong with this sub-boundary.',
+  };
+}

--- a/packages/ztd-cli/src/index.ts
+++ b/packages/ztd-cli/src/index.ts
@@ -11,6 +11,7 @@ import { registerLintCommand } from './commands/lint';
 import { registerModelGenCommand } from './commands/modelGen';
 import { registerPerfCommands } from './commands/perf';
 import { registerQueryCommands } from './commands/query';
+import { registerRfbaCommand } from './commands/rfba';
 import { TestEvidenceRuntimeError, registerTestEvidenceCommand } from './commands/testEvidence';
 import { registerZtdConfigCommand } from './commands/ztdConfigCommand';
 import { setAgentOutputFormat } from './utils/agentCli';
@@ -94,6 +95,7 @@ export function buildProgram(): Command {
   registerTestEvidenceCommand(program);
   registerZtdConfigCommand(program);
   registerDdlCommands(program);
+  registerRfbaCommand(program);
   registerDescribeCommand(program);
 
   program.addHelpText('after', `
@@ -112,6 +114,7 @@ Getting started:
   $ ztd --telemetry --telemetry-export file --telemetry-file tmp/telemetry/perf-run.jsonl perf run --query src/sql/report.sql --dry-run
   $ ztd query uses table public.users
   $ ztd query uses column public.users.email --format json
+  $ ztd rfba inspect --format json
   $ ztd --telemetry --telemetry-export debug query uses table public.users
 
 Common workflow:

--- a/packages/ztd-cli/tests/__snapshots__/describe.cli.test.ts.snap
+++ b/packages/ztd-cli/tests/__snapshots__/describe.cli.test.ts.snap
@@ -382,6 +382,14 @@ exports[`describe command snapshots the top-level command catalog and every deta
         "writesFiles": false,
       },
       {
+        "name": "rfba inspect",
+        "summary": "Inspect RFBA root, feature, and query sub-boundaries without writing files.",
+        "supportsDescribeOutput": false,
+        "supportsDryRun": false,
+        "supportsJsonPayload": true,
+        "writesFiles": false,
+      },
+      {
         "name": "evidence",
         "summary": "Generate deterministic specification evidence artifacts.",
         "supportsDescribeOutput": false,
@@ -989,6 +997,45 @@ exports[`describe command snapshots the top-level command catalog and every deta
       "supportsDryRun": false,
       "supportsJsonPayload": true,
       "writesFiles": true,
+    },
+    "schemaVersion": 1,
+  },
+  "ok": true,
+  "schemaVersion": 1,
+}
+`;
+
+exports[`describe command snapshots the top-level command catalog and every detailed descriptor > rfba inspect 1`] = `
+{
+  "command": "describe command",
+  "data": {
+    "command": {
+      "exitCodes": {
+        "0": "Boundary report emitted.",
+        "1": "Validation or filesystem error.",
+      },
+      "flags": [
+        {
+          "description": "Output format (text|json).",
+          "name": "--format <format>",
+        },
+        {
+          "description": "Project root to inspect.",
+          "name": "--root <path>",
+        },
+        {
+          "description": "Pass inspect options as a JSON object.",
+          "name": "--json",
+        },
+      ],
+      "name": "rfba inspect",
+      "output": {
+        "stdout": "Text boundary map or deterministic JSON report.",
+      },
+      "summary": "Inspect RFBA root, feature, and query sub-boundaries without writing files.",
+      "supportsDryRun": false,
+      "supportsJsonPayload": true,
+      "writesFiles": false,
     },
     "schemaVersion": 1,
   },

--- a/packages/ztd-cli/tests/rfba.unit.test.ts
+++ b/packages/ztd-cli/tests/rfba.unit.test.ts
@@ -1,0 +1,162 @@
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { Command } from 'commander';
+import { afterEach, expect, test } from 'vitest';
+import {
+  formatRfbaInspectionReport,
+  inspectRfbaBoundaries,
+  registerRfbaCommand,
+} from '../src/commands/rfba';
+import { setAgentOutputFormat } from '../src/utils/agentCli';
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+const tmpRoot = path.join(repoRoot, 'tmp');
+const originalFormat = process.env.ZTD_CLI_OUTPUT_FORMAT;
+
+afterEach(() => {
+  process.env.ZTD_CLI_OUTPUT_FORMAT = originalFormat;
+});
+
+function createTempDir(prefix: string): string {
+  if (!existsSync(tmpRoot)) {
+    mkdirSync(tmpRoot, { recursive: true });
+  }
+  return mkdtempSync(path.join(tmpRoot, `${prefix}-`));
+}
+
+function writeWorkspaceFile(root: string, relativePath: string, contents = ''): void {
+  const filePath = path.join(root, ...relativePath.split('/'));
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, contents, 'utf8');
+}
+
+test('RFBA inspection discovers starter root, feature, query container, and query sub-boundaries', () => {
+  const workspace = createTempDir('rfba-starter');
+  writeWorkspaceFile(workspace, 'src/features/README.md', '# Features\n');
+  writeWorkspaceFile(workspace, 'src/adapters/README.md', '# Adapters\n');
+  writeWorkspaceFile(workspace, 'src/libraries/README.md', '# Libraries\n');
+  writeWorkspaceFile(workspace, 'src/features/_shared/loadSqlResource.ts', 'export {};\n');
+  writeWorkspaceFile(workspace, 'src/features/orders-list/README.md', '# Orders list\n');
+  writeWorkspaceFile(workspace, 'src/features/orders-list/boundary.ts', 'export {};\n');
+  writeWorkspaceFile(workspace, 'src/features/orders-list/tests/orders-list.boundary.test.ts', 'test.todo("feature");\n');
+  writeWorkspaceFile(workspace, 'src/features/orders-list/queries/list-orders/boundary.ts', 'export {};\n');
+  writeWorkspaceFile(workspace, 'src/features/orders-list/queries/list-orders/list-orders.sql', 'select 1;\n');
+  writeWorkspaceFile(workspace, 'src/features/orders-list/queries/list-orders/tests/list-orders.boundary.ztd.test.ts', 'test.todo("query");\n');
+  writeWorkspaceFile(workspace, 'src/features/orders-list/queries/list-orders/tests/generated/analysis.json', '{}\n');
+  writeWorkspaceFile(workspace, 'src/features/orders-list/queries/list-orders/tests/generated/TEST_PLAN.md', '# Plan\n');
+
+  const report = inspectRfbaBoundaries(workspace);
+
+  expect(report.schemaVersion).toBe(1);
+  expect(report.expectedRootBoundaryPaths).toEqual(['src/features', 'src/adapters', 'src/libraries']);
+  expect(report.summary).toMatchObject({
+    rootBoundaries: 3,
+    featureBoundaries: 1,
+    childBoundaryContainers: 1,
+    subBoundaries: 1,
+    warnings: 0,
+  });
+  expect(report.boundaries.map((boundary) => boundary.path)).toEqual([
+    'src/adapters',
+    'src/features',
+    'src/features/orders-list',
+    'src/features/orders-list/queries',
+    'src/features/orders-list/queries/list-orders',
+    'src/libraries',
+  ]);
+
+  const queriesContainer = report.boundaries.find((boundary) => boundary.path === 'src/features/orders-list/queries');
+  expect(queriesContainer).toMatchObject({
+    kind: 'child-boundary-container',
+    publicBoundary: false,
+    publicSurfaceFiles: [],
+  });
+
+  const featureBoundary = report.boundaries.find((boundary) => boundary.path === 'src/features/orders-list');
+  expect(featureBoundary).toMatchObject({
+    kind: 'feature-boundary',
+    publicSurfaceFiles: ['src/features/orders-list/boundary.ts', 'src/features/orders-list/README.md'],
+    localVerificationFiles: ['src/features/orders-list/tests/orders-list.boundary.test.ts'],
+  });
+  expect(featureBoundary?.sqlAssets).toEqual([]);
+  expect(featureBoundary?.generatedArtifacts).toEqual([]);
+
+  const queryBoundary = report.boundaries.find((boundary) => boundary.path === 'src/features/orders-list/queries/list-orders');
+  expect(queryBoundary).toMatchObject({
+    kind: 'sub-boundary',
+    publicSurfaceFiles: ['src/features/orders-list/queries/list-orders/boundary.ts'],
+    sqlAssets: ['src/features/orders-list/queries/list-orders/list-orders.sql'],
+    generatedArtifacts: [
+      'src/features/orders-list/queries/list-orders/tests/generated/analysis.json',
+      'src/features/orders-list/queries/list-orders/tests/generated/TEST_PLAN.md',
+    ],
+    localVerificationFiles: [
+      'src/features/orders-list/queries/list-orders/tests/generated/analysis.json',
+      'src/features/orders-list/queries/list-orders/tests/generated/TEST_PLAN.md',
+      'src/features/orders-list/queries/list-orders/tests/list-orders.boundary.ztd.test.ts',
+    ],
+  });
+});
+
+test('RFBA inspection reports malformed boundary evidence without failing the read-only command', () => {
+  const workspace = createTempDir('rfba-malformed');
+  writeWorkspaceFile(workspace, 'src/features/billing-export/README.md', '# Billing\n');
+  writeWorkspaceFile(workspace, 'src/features/billing-export/queries/orphan.sql', 'select 1;\n');
+  mkdirSync(path.join(workspace, 'src', 'features', 'billing-export', 'queries', 'missing-contract'), { recursive: true });
+
+  const report = inspectRfbaBoundaries(workspace);
+
+  expect(report.summary).toMatchObject({
+    rootBoundaries: 1,
+    featureBoundaries: 1,
+    childBoundaryContainers: 1,
+    subBoundaries: 1,
+    warnings: 4,
+  });
+  expect(report.boundaries.find((boundary) => boundary.path === 'src/features/billing-export')?.warnings).toEqual([
+    'Feature boundary does not expose the starter public surface file boundary.ts.',
+  ]);
+  expect(report.boundaries.find((boundary) => boundary.path === 'src/features/billing-export/queries')?.warnings).toEqual([
+    'queries/ contains direct files; query assets should usually live under queries/<query>/ sub-boundaries.',
+  ]);
+  expect(report.boundaries.find((boundary) => boundary.path === 'src/features/billing-export/queries/missing-contract')?.warnings).toEqual([
+    'Query sub-boundary does not contain a SQL asset.',
+    'Query sub-boundary does not expose boundary.ts.',
+  ]);
+});
+
+test('RFBA JSON output is deterministic and text output identifies queries as a non-public container', () => {
+  const workspace = createTempDir('rfba-json');
+  writeWorkspaceFile(workspace, 'src/features/orders-list/boundary.ts', 'export {};\n');
+  writeWorkspaceFile(workspace, 'src/features/orders-list/queries/list-orders/boundary.ts', 'export {};\n');
+  writeWorkspaceFile(workspace, 'src/features/orders-list/queries/list-orders/list-orders.sql', 'select 1;\n');
+
+  const first = formatRfbaInspectionReport(inspectRfbaBoundaries(workspace), 'json');
+  const second = formatRfbaInspectionReport(inspectRfbaBoundaries(workspace), 'json');
+  expect(second).toBe(first);
+
+  const text = formatRfbaInspectionReport(inspectRfbaBoundaries(workspace), 'text');
+  expect(text).toContain('src/features/orders-list/queries [child-boundary-container] (not public boundary)');
+  expect(text).toContain('src/features/orders-list/queries/list-orders/list-orders.sql');
+});
+
+test('rfba inspect help exposes the read-only inspection surface', async () => {
+  setAgentOutputFormat('text');
+  const capture = { stdout: [] as string[], stderr: [] as string[] };
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({
+    writeOut: (str) => capture.stdout.push(str),
+    writeErr: (str) => capture.stderr.push(str),
+  });
+  registerRfbaCommand(program);
+
+  await expect(program.parseAsync(['rfba', 'inspect', '--help'], { from: 'user' })).rejects.toMatchObject({
+    code: 'commander.helpDisplayed',
+  });
+  const stdout = capture.stdout.join('');
+  expect(stdout).toContain('Inspect RFBA root, feature, and query sub-boundaries without writing files');
+  expect(stdout).toContain('--format <format>');
+  expect(stdout).toContain('--root <path>');
+  expect(stdout).toContain('--json <payload>');
+});


### PR DESCRIPTION
## Issue

Closes #788.

## Customer Value

Reviewers and agents can inspect an RFBA starter project's boundary map before editing. This reduces guesswork about responsibility boundaries, dependency direction, public surfaces, SQL ownership, generated evidence, and local verification files.

## Outcome

- Added `ztd rfba inspect` as a read-only CLI command.
- Added text and deterministic JSON output for RFBA boundary inspection.
- Reports starter root boundaries, feature boundaries, `queries/` child-boundary containers, and query sub-boundaries.
- Lists likely public surface files, SQL assets, generated artifacts, local verification files, notes, and structural warnings.
- Exposes the command through CLI help and `ztd describe`.
- Documented reviewer usage in the ztd-cli README.
- Added a changeset for `@rawsql-ts/ztd-cli`.

## Acceptance Criteria

- [x] Add a read-only CLI surface for RFBA inspection with text and JSON output.
- [x] Identify starter root boundaries: `src/features`, `src/adapters`, and `src/libraries`.
- [x] Identify feature boundaries under `src/features/<feature>/`.
- [x] Identify query sub-boundaries under `src/features/<feature>/queries/<query>/`.
- [x] Treat `queries/` as a child-boundary container, not a public boundary.
- [x] Report likely public surface files, SQL assets, generated artifacts, and local verification files.
- [x] Keep JSON output deterministic for agents and follow-up checks.
- [x] Add representative tests and help/discoverability coverage.
- [x] Update reviewer-facing docs.

## Verification

- `pnpm --filter @rawsql-ts/ztd-cli test -- tests/rfba.unit.test.ts tests/describe.cli.test.ts`
- `pnpm --filter @rawsql-ts/ztd-cli build`
- `pnpm --filter @rawsql-ts/ztd-cli lint`
- `node packages\ztd-cli\dist\index.js rfba inspect --format json --root packages\ztd-cli\templates`
- `node packages\ztd-cli\dist\index.js --output json describe command "rfba inspect"`
- `node packages\ztd-cli\dist\index.js rfba inspect --help`
- `node packages\ztd-cli\dist\index.js --help`

## Repository Evidence

- `packages/ztd-cli/src/commands/rfba.ts`
- `packages/ztd-cli/src/index.ts`
- `packages/ztd-cli/src/commands/describe.ts`
- `packages/ztd-cli/tests/rfba.unit.test.ts`
- `packages/ztd-cli/tests/__snapshots__/describe.cli.test.ts.snap`
- `packages/ztd-cli/README.md`
- `.changeset/rfba-boundary-inspect.md`

## Supplementary Evidence

Manual built-CLI checks confirmed that top-level help, `rfba --help`, `rfba inspect --help`, and `describe command "rfba inspect"` expose the new command.

## Open Questions

None.

## Merge Blockers

None known.

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

## CLI Surface Migration

- [ ] No migration packet required for this CLI change.
- [x] CLI/user-facing surface change and migration packet completed.

Upgrade note: `ztd rfba inspect` is a new read-only command. Existing commands and flags are unchanged.

Deprecation/removal plan or issue: No deprecations or removals are included in this PR.

Docs/help/examples updated: The command is exposed through top-level help, `ztd rfba --help`, `ztd rfba inspect --help`, `ztd describe command "rfba inspect"`, and the ztd-cli README.

Release/changeset wording: `.changeset/rfba-boundary-inspect.md` describes the new RFBA inspection command and deterministic text/JSON output.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: This PR updates ztd-cli README guidance but does not modify scaffold generation code, templates, generated project layout, or scaffold output contracts.
