### PR TITLE
Support DDL-derived view shadows in testkit

### DIFF
--- a/.changeset/fresh-views-shadow.md
+++ b/.changeset/fresh-views-shadow.md
@@ -1,0 +1,8 @@
+---
+"@rawsql-ts/testkit-core": minor
+"@rawsql-ts/testkit-postgres": minor
+---
+
+Add DDL-derived view support for fixture-backed SELECT rewriting.
+
+Normal `CREATE VIEW` definitions discovered from configured DDL files can now be expanded into view-name CTE shadows, allowing queries against supported views to run against the same base table fixtures used by Zero Table Dependency tests. Materialized, recursive, malformed, and cyclic view definitions fail with explicit unsupported errors.

--- a/packages/testkit-core/src/catalog/createCatalogRewriter.ts
+++ b/packages/testkit-core/src/catalog/createCatalogRewriter.ts
@@ -71,6 +71,10 @@ function toSelectRewriteContext(
     context.fixtures = executionOptions.fixtures as SelectRewriteContext['fixtures'];
   }
 
+  if (Array.isArray(executionOptions.views)) {
+    context.views = executionOptions.views as SelectRewriteContext['views'];
+  }
+
   if (isPlainObject(executionOptions.formatterOptions)) {
     context.formatterOptions =
       executionOptions.formatterOptions as SelectRewriteContext['formatterOptions'];

--- a/packages/testkit-core/src/fixtures/DdlFixtureLoader.ts
+++ b/packages/testkit-core/src/fixtures/DdlFixtureLoader.ts
@@ -13,6 +13,10 @@ import {
   type DdlLintMode,
   type DdlLintSource,
 } from './ddlLint';
+import {
+  collectDdlViewDefinitions,
+  type DdlViewDefinition,
+} from './DdlViewCatalog';
 import { DdlLintError } from '../errors';
 
 export interface DdlFixtureLoaderOptions {
@@ -27,6 +31,11 @@ export interface DdlProcessedFixture {
   rows?: FixtureRow[];
 }
 
+interface DdlLoadedDefinitions {
+  fixtures: DdlProcessedFixture[];
+  views: DdlViewDefinition[];
+}
+
 type RawFixtureDefinition = {
   columns?: Array<{ name: string; type?: string; default?: string | null }>;
   rows?: FixtureRow[];
@@ -37,12 +46,13 @@ type SqlDiagnostics = {
 };
 
 export class DdlFixtureLoader {
-  private static readonly cache = new Map<string, DdlProcessedFixture[]>();
+  private static readonly cache = new Map<string, DdlLoadedDefinitions>();
   private readonly resolvedDirectories: string[];
   private readonly extensions: string[];
   private readonly cacheKey: string;
   private fixtures: DdlProcessedFixture[] = [];
   private fixturesByName = new Map<string, DdlProcessedFixture>();
+  private views: DdlViewDefinition[] = [];
   private loaded = false;
   private readonly tableNameResolver?: TableNameResolver;
   private readonly ddlLintMode: DdlLintMode;
@@ -67,6 +77,11 @@ export class DdlFixtureLoader {
     return [...this.fixtures];
   }
 
+  public getViewDefinitions(): DdlViewDefinition[] {
+    this.ensureLoaded();
+    return [...this.views];
+  }
+
   public getFixture(tableName: string): DdlProcessedFixture | undefined {
     this.ensureLoaded();
     const normalized = normalizeTableName(tableName);
@@ -81,7 +96,7 @@ export class DdlFixtureLoader {
     // Reuse previously parsed fixtures when the same directories were processed before.
     const cached = DdlFixtureLoader.cache.get(this.cacheKey);
     if (cached) {
-      this.registerFixtures(cached);
+      this.registerLoadedDefinitions(cached);
       this.loaded = true;
       return;
     }
@@ -89,8 +104,13 @@ export class DdlFixtureLoader {
     // Load fixtures from disk and store them in the shared cache key.
     const collected = this.loadFromDirectories();
     DdlFixtureLoader.cache.set(this.cacheKey, collected);
-    this.registerFixtures(collected);
+    this.registerLoadedDefinitions(collected);
     this.loaded = true;
+  }
+
+  private registerLoadedDefinitions(definitions: DdlLoadedDefinitions): void {
+    this.registerFixtures(definitions.fixtures);
+    this.views = definitions.views;
   }
 
   private registerFixtures(fixtures: DdlProcessedFixture[]): void {
@@ -103,7 +123,7 @@ export class DdlFixtureLoader {
     }
   }
 
-  private loadFromDirectories(): DdlProcessedFixture[] {
+  private loadFromDirectories(): DdlLoadedDefinitions {
     // Verify every configured directory exists before scanning to provide fail-fast diagnostics.
     const missingDirectories = this.resolvedDirectories.filter((directory) => !existsSync(directory));
     if (missingDirectories.length) {
@@ -134,15 +154,19 @@ export class DdlFixtureLoader {
     // Run lint checks before enforcing CREATE TABLE presence so actionable diagnostics surface first.
     this.runDdlLint(sources);
 
-    if (fixtures.length === 0) {
+    const views = collectDdlViewDefinitions(sources, {
+      tableNameResolver: this.tableNameResolver,
+    });
+
+    if (fixtures.length === 0 && views.length === 0) {
       throw new Error(
         `SQL files were found under ${this.resolvedDirectories.join(
           ', '
-        )}, but no CREATE TABLE statements produced fixtures. Please verify the files contain valid DDL.`
+        )}, but no CREATE TABLE or CREATE VIEW statements produced fixtures. Please verify the files contain valid DDL.`
       );
     }
 
-    return fixtures;
+    return { fixtures, views };
   }
 
   private collectSqlFiles(

--- a/packages/testkit-core/src/fixtures/DdlViewCatalog.ts
+++ b/packages/testkit-core/src/fixtures/DdlViewCatalog.ts
@@ -1,0 +1,301 @@
+import { MultiQuerySplitter, SelectQueryParser, CTETableReferenceCollector, normalizeTableName } from 'rawsql-ts';
+import type { SelectQuery } from 'rawsql-ts';
+import { TableNameResolver } from './TableNameResolver';
+
+export interface DdlViewDefinition {
+  name: string;
+  cteName: string;
+  sql: string;
+  source?: string;
+  statementIndex?: number;
+}
+
+export interface DdlViewSource {
+  path: string;
+  sql: string;
+}
+
+export interface DdlViewCatalogOptions {
+  tableNameResolver?: TableNameResolver;
+}
+
+export interface ViewCteDefinition {
+  name: string;
+  query: SelectQuery;
+}
+
+export class DdlViewUnsupportedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DdlViewUnsupportedError';
+  }
+}
+
+interface IndexedView {
+  definition: DdlViewDefinition;
+  dependencies: string[];
+}
+
+export function collectDdlViewDefinitions(
+  sources: DdlViewSource[],
+  options: DdlViewCatalogOptions = {}
+): DdlViewDefinition[] {
+  const definitions: DdlViewDefinition[] = [];
+
+  for (const source of sources) {
+    const split = MultiQuerySplitter.split(source.sql);
+    for (const query of split.queries) {
+      if (query.isEmpty) {
+        continue;
+      }
+
+      const definition = parseCreateViewStatement(query.sql, {
+        source: source.path,
+        statementIndex: query.index,
+        tableNameResolver: options.tableNameResolver
+      });
+      if (definition) {
+        definitions.push(definition);
+      }
+    }
+  }
+
+  new DdlViewCatalog(definitions, options);
+  return definitions;
+}
+
+export class DdlViewCatalog {
+  private readonly views = new Map<string, IndexedView>();
+  private readonly leafIndex = new Map<string, string[]>();
+  private readonly resolver?: TableNameResolver;
+
+  constructor(definitions: DdlViewDefinition[] = [], options: DdlViewCatalogOptions = {}) {
+    this.resolver = options.tableNameResolver;
+    for (const definition of definitions) {
+      const key = this.resolveDefinitionKey(definition.name);
+      if (this.views.has(key)) {
+        throw new DdlViewUnsupportedError(`Duplicate CREATE VIEW definition for "${definition.name}".`);
+      }
+
+      const indexed = {
+        definition: {
+          ...definition,
+          name: key,
+          cteName: definition.cteName || extractUnqualifiedName(key)
+        },
+        dependencies: []
+      };
+      this.views.set(key, indexed);
+
+      const leaf = normalizeTableName(indexed.definition.cteName);
+      const bucket = this.leafIndex.get(leaf) ?? [];
+      bucket.push(key);
+      this.leafIndex.set(leaf, bucket);
+    }
+
+    for (const [key, indexed] of this.views.entries()) {
+      indexed.dependencies = this.collectViewDependencies(indexed.definition).filter((dependency) => dependency !== key);
+    }
+    this.assertAcyclic();
+  }
+
+  public hasView(tableName: string): boolean {
+    return this.resolveViewKey(tableName) !== undefined;
+  }
+
+  public getView(tableName: string): DdlViewDefinition | undefined {
+    const key = this.resolveViewKey(tableName);
+    return key ? this.views.get(key)?.definition : undefined;
+  }
+
+  public expandReferencedViews(tableNames: string[], existingCteNames: ReadonlySet<string> = new Set()): DdlViewDefinition[] {
+    const ordered: DdlViewDefinition[] = [];
+    const visited = new Set<string>();
+    const visiting = new Set<string>();
+
+    const visit = (key: string): void => {
+      if (visited.has(key)) {
+        return;
+      }
+      if (visiting.has(key)) {
+        throw new DdlViewUnsupportedError(`Circular CREATE VIEW dependency detected at "${this.views.get(key)?.definition.name ?? key}".`);
+      }
+
+      const view = this.views.get(key);
+      if (!view) {
+        return;
+      }
+
+      visiting.add(key);
+      for (const dependency of view.dependencies) {
+        visit(dependency);
+      }
+      visiting.delete(key);
+      visited.add(key);
+
+      if (!existingCteNames.has(normalizeTableName(view.definition.cteName))) {
+        ordered.push(view.definition);
+      }
+    };
+
+    for (const tableName of tableNames) {
+      const key = this.resolveViewKey(tableName);
+      if (key) {
+        visit(key);
+      }
+    }
+
+    return ordered;
+  }
+
+  public toCteDefinitions(definitions: DdlViewDefinition[]): ViewCteDefinition[] {
+    return definitions.map((definition) => ({
+      name: definition.cteName,
+      query: SelectQueryParser.parse(definition.sql)
+    }));
+  }
+
+  public collectReferencedTables(definitions: DdlViewDefinition[]): string[] {
+    const names = new Set<string>();
+    for (const definition of definitions) {
+      for (const tableName of collectSelectTableNames(definition.sql)) {
+        names.add(tableName);
+      }
+    }
+    return [...names];
+  }
+
+  public createAliasMap(definitions: DdlViewDefinition[]): Map<string, string> {
+    const aliasMap = new Map<string, string>();
+    for (const definition of definitions) {
+      aliasMap.set(this.resolveDefinitionKey(definition.name), definition.cteName);
+    }
+    return aliasMap;
+  }
+
+  private resolveDefinitionKey(tableName: string): string {
+    if (this.resolver) {
+      return this.resolver.resolve(tableName);
+    }
+    return normalizeTableName(tableName);
+  }
+
+  private resolveViewKey(tableName: string): string | undefined {
+    if (this.resolver) {
+      const key = this.resolver.resolve(tableName, (candidate) => this.views.has(candidate));
+      return this.views.has(key) ? key : undefined;
+    }
+
+    const normalized = normalizeTableName(tableName);
+    if (this.views.has(normalized)) {
+      return normalized;
+    }
+
+    const leaf = extractUnqualifiedName(normalized);
+    const candidates = this.leafIndex.get(leaf) ?? [];
+    if (candidates.length === 1) {
+      return candidates[0];
+    }
+    if (candidates.length > 1) {
+      throw new DdlViewUnsupportedError(`Ambiguous unqualified CREATE VIEW reference "${tableName}".`);
+    }
+    return undefined;
+  }
+
+  private collectViewDependencies(definition: DdlViewDefinition): string[] {
+    const dependencies = new Set<string>();
+    for (const tableName of collectSelectTableNames(definition.sql)) {
+      const dependency = this.resolveViewKey(tableName);
+      if (dependency) {
+        dependencies.add(dependency);
+      }
+    }
+    return [...dependencies];
+  }
+
+  private assertAcyclic(): void {
+    for (const key of this.views.keys()) {
+      this.expandReferencedViews([key]);
+    }
+  }
+}
+
+function parseCreateViewStatement(
+  sql: string,
+  options: {
+    source?: string;
+    statementIndex?: number;
+    tableNameResolver?: TableNameResolver;
+  }
+): DdlViewDefinition | undefined {
+  const trimmed = sql.trim().replace(/;+\s*$/, '');
+  if (!/^create\b/i.test(trimmed)) {
+    return undefined;
+  }
+
+  if (/^create\s+(?:or\s+replace\s+)?materialized\s+view\b/i.test(trimmed)) {
+    throw new DdlViewUnsupportedError('CREATE MATERIALIZED VIEW is not supported by ZTD view shadowing.');
+  }
+  if (/^create\s+(?:or\s+replace\s+)?recursive\s+view\b/i.test(trimmed)) {
+    throw new DdlViewUnsupportedError('CREATE RECURSIVE VIEW is not supported by ZTD view shadowing.');
+  }
+
+  const isCreateViewStatement = /^create\s+(?:or\s+replace\s+)?view\b/i.test(trimmed);
+  const match = trimmed.match(
+    /^create\s+(?:or\s+replace\s+)?view\s+(?:if\s+not\s+exists\s+)?((?:"[^"]+"|[a-zA-Z_][\w$]*)(?:\.(?:"[^"]+"|[a-zA-Z_][\w$]*))?)\s*(?:\([^)]*\))?\s+as\s+([\s\S]+)$/i
+  );
+  if (!match) {
+    if (isCreateViewStatement) {
+      throw new DdlViewUnsupportedError('CREATE VIEW uses unsupported syntax for ZTD view shadowing.');
+    }
+    return undefined;
+  }
+
+  const rawName = normalizeIdentifierPath(match[1]);
+  const body = match[2].trim();
+  if (/^with\s+recursive\b/i.test(body)) {
+    throw new DdlViewUnsupportedError(`Recursive CREATE VIEW body is not supported for "${rawName}".`);
+  }
+
+  try {
+    SelectQueryParser.parse(body);
+  } catch (error) {
+    throw new DdlViewUnsupportedError(
+      `CREATE VIEW "${rawName}" must contain a supported SELECT body: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+
+  const resolvedName = options.tableNameResolver
+    ? options.tableNameResolver.resolve(rawName)
+    : normalizeTableName(rawName);
+
+  return {
+    name: resolvedName,
+    cteName: extractUnqualifiedName(resolvedName),
+    sql: body,
+    source: options.source,
+    statementIndex: options.statementIndex
+  };
+}
+
+function collectSelectTableNames(sql: string): string[] {
+  const parsed = SelectQueryParser.parse(sql);
+  const collector = new CTETableReferenceCollector();
+  const names = new Set<string>();
+  for (const source of collector.collect(parsed)) {
+    names.add(source.getSourceName().toLowerCase());
+  }
+  return [...names];
+}
+
+function normalizeIdentifierPath(value: string): string {
+  return value
+    .split('.')
+    .map((part) => part.trim().replace(/^"/, '').replace(/"$/, ''))
+    .join('.');
+}
+
+function extractUnqualifiedName(value: string): string {
+  const parts = normalizeTableName(value).split('.');
+  return parts[parts.length - 1] ?? normalizeTableName(value);
+}

--- a/packages/testkit-core/src/index.ts
+++ b/packages/testkit-core/src/index.ts
@@ -3,6 +3,17 @@ export * from './errors';
 export { FixtureStore } from './fixtures/FixtureStore';
 export { DdlFixtureLoader } from './fixtures/DdlFixtureLoader';
 export type { DdlFixtureLoaderOptions } from './fixtures/DdlFixtureLoader';
+export {
+  DdlViewCatalog,
+  DdlViewUnsupportedError,
+  collectDdlViewDefinitions,
+} from './fixtures/DdlViewCatalog';
+export type {
+  DdlViewCatalogOptions,
+  DdlViewDefinition,
+  DdlViewSource,
+  ViewCteDefinition,
+} from './fixtures/DdlViewCatalog';
 export { DefaultFixtureProvider } from './fixtures/FixtureProvider';
 export { SelectFixtureRewriter } from './rewriter/SelectFixtureRewriter';
 export type { SelectAnalysisResult } from './rewriter/SelectAnalyzer';

--- a/packages/testkit-core/src/rewriter/ResultSelectRewriter.ts
+++ b/packages/testkit-core/src/rewriter/ResultSelectRewriter.ts
@@ -62,11 +62,14 @@ import {
   createCollisionAwareFixtureAliasMap,
   rewriteSelectFixtureReferences,
 } from './fixtureAliasing';
+import { DdlViewCatalog } from '../fixtures/DdlViewCatalog';
+import type { DdlViewDefinition, ViewCteDefinition } from '../fixtures/DdlViewCatalog';
 
 interface RewriteInputs {
   fixtureTables: ReturnType<FixtureResolver['resolve']>['fixtureTables'];
   tableDefinitions: TableDefinitionRegistry;
   fixturesApplied: string[];
+  viewDefinitions: DdlViewDefinition[];
 }
 
 interface RewriteResult {
@@ -85,7 +88,8 @@ export class ResultSelectRewriter {
     private readonly fixtures: FixtureResolver,
     private readonly missingFixtureStrategy: MissingFixtureStrategy = 'error',
     formatterOptions?: SqlFormatterOptions,
-    private readonly tableNameResolver?: TableNameResolver
+    private readonly tableNameResolver?: TableNameResolver,
+    private readonly viewDefinitions: DdlViewDefinition[] = []
   ) {
     this.formatter = new SqlFormatter({
       preset: 'postgres',
@@ -134,6 +138,7 @@ export class ResultSelectRewriter {
       fixtureTables: snapshot.fixtureTables,
       tableDefinitions: snapshot.tableDefinitions,
       fixturesApplied: snapshot.fixturesApplied,
+      viewDefinitions: this.viewDefinitions,
     };
   }
 
@@ -204,7 +209,7 @@ export class ResultSelectRewriter {
 
     if (statement instanceof SimpleSelectQuery) {
       return {
-        sql: this.injectFixtures(statement, inputs.fixtureTables),
+        sql: this.injectFixtures(statement, inputs.fixtureTables, inputs.viewDefinitions),
         sourceCommand: 'select',
         isCountWrapper: false,
       };
@@ -214,7 +219,7 @@ export class ResultSelectRewriter {
       // Normalize complex select shapes into a simple query so fixture CTEs can be prefixed consistently.
       const simple = QueryBuilder.buildSimpleQuery(statement);
       return {
-        sql: this.injectFixtures(simple, inputs.fixtureTables),
+        sql: this.injectFixtures(simple, inputs.fixtureTables, inputs.viewDefinitions),
         sourceCommand: 'select',
         isCountWrapper: false,
       };
@@ -226,7 +231,7 @@ export class ResultSelectRewriter {
         const innerSimple = statement.asSelectQuery instanceof SimpleSelectQuery
           ? statement.asSelectQuery
           : QueryBuilder.buildSimpleQuery(statement.asSelectQuery);
-        statement.asSelectQuery = this.injectFixtures(innerSimple, inputs.fixtureTables);
+        statement.asSelectQuery = this.injectFixtures(innerSimple, inputs.fixtureTables, inputs.viewDefinitions);
         return { sql: statement, sourceCommand: 'create', isCountWrapper: false };
       }
       return { sql: null, sourceCommand: null, isCountWrapper: false };
@@ -235,22 +240,37 @@ export class ResultSelectRewriter {
     return { sql: null, sourceCommand: null, isCountWrapper: false };
   }
 
-  private injectFixtures(select: SimpleSelectQuery, fixtures: FixtureTableDefinition[]): SimpleSelectQuery {
-    const targetedFixtures = this.filterFixturesForQuery(select, fixtures);
-    if (targetedFixtures.length === 0) {
+  private injectFixtures(
+    select: SimpleSelectQuery,
+    fixtures: FixtureTableDefinition[],
+    viewDefinitions: DdlViewDefinition[]
+  ): SimpleSelectQuery {
+    const viewCatalog = new DdlViewCatalog(viewDefinitions, { tableNameResolver: this.tableNameResolver });
+    const referencedNames = this.collectReferencedTableNames(select);
+    const existingCteNames = new Set((select.withClause?.tables ?? []).map((cte) => normalizeTableName(cte.aliasExpression.table.name)));
+    const viewTargets = viewCatalog.expandReferencedViews(referencedNames, existingCteNames);
+    const viewReferencedNames = viewCatalog.collectReferencedTables(viewTargets);
+    const targetedFixtures = this.filterFixturesForQuery([...referencedNames, ...viewReferencedNames], fixtures, viewCatalog);
+    if (targetedFixtures.length === 0 && viewTargets.length === 0) {
       return select;
     }
 
     const aliasMap = this.buildCollisionAwareAliasMap(select, targetedFixtures);
+    const viewAliasMap = viewCatalog.createAliasMap(viewTargets);
+    const rewriteAliasMap = new Map([...aliasMap, ...viewAliasMap]);
     const ctes = FixtureCteBuilder.buildFixtures(targetedFixtures);
     this.applyFixtureAliases(ctes, aliasMap);
-    rewriteSelectFixtureReferences(select, aliasMap, this.tableNameResolver);
+    const viewCtes = viewCatalog.toCteDefinitions(viewTargets);
+    this.rewriteViewCteReferences(viewCtes, rewriteAliasMap);
+    const viewCommonTables = viewCtes.map((cte) => new CommonTable(cte.query, cte.name, null));
+    const injectedCtes = [...ctes, ...viewCommonTables];
+    rewriteSelectFixtureReferences(select, rewriteAliasMap, this.tableNameResolver);
     if (!select.withClause) {
-      select.appendWith(ctes);
+      select.appendWith(injectedCtes);
       return select;
     }
 
-    select.withClause.tables = [...ctes, ...select.withClause.tables];
+    select.withClause.tables = [...injectedCtes, ...select.withClause.tables];
     return select;
   }
 
@@ -311,28 +331,43 @@ export class ResultSelectRewriter {
     return null;
   }
 
-  private filterFixturesForQuery(query: SelectQuery, fixtures: FixtureTableDefinition[]): FixtureTableDefinition[] {
+  private filterFixturesForQuery(
+    tableNames: string[],
+    fixtures: FixtureTableDefinition[],
+    viewCatalog: DdlViewCatalog
+  ): FixtureTableDefinition[] {
     if (fixtures.length === 0) {
       return [];
     }
 
-    const referenced = this.collectReferencedTableKeys(query);
+    const referenced = new Set<string>();
+    for (const tableName of tableNames) {
+      if (viewCatalog.hasView(tableName)) {
+        continue;
+      }
+      for (const candidate of this.getLookupCandidates(tableName)) {
+        referenced.add(candidate);
+      }
+    }
 
     return fixtures.filter((fixture) =>
       this.getLookupCandidates(fixture.tableName).some((variant) => referenced.has(variant))
     );
   }
 
-  // Capture every canonical key referenced by the query so fixtures can be matched even when schemas differ.
-  private collectReferencedTableKeys(query: SelectQuery): Set<string> {
+  private collectReferencedTableNames(query: SelectQuery): string[] {
     const collector = new TableSourceCollector(false);
     const referenced = new Set<string>();
     for (const source of collector.collect(query)) {
-      for (const candidate of this.getLookupCandidates(source.getSourceName())) {
-        referenced.add(candidate);
-      }
+      referenced.add(source.getSourceName().toLowerCase());
     }
-    return referenced;
+    return [...referenced];
+  }
+
+  private rewriteViewCteReferences(viewCtes: ViewCteDefinition[], aliasMap: Map<string, string>): void {
+    for (const cte of viewCtes) {
+      rewriteSelectFixtureReferences(cte.query, aliasMap, this.tableNameResolver);
+    }
   }
 
   // Provide all candidate keys to consult when looking up tables in maps or registries.

--- a/packages/testkit-core/src/rewriter/SelectFixtureRewriter.ts
+++ b/packages/testkit-core/src/rewriter/SelectFixtureRewriter.ts
@@ -10,6 +10,8 @@ import { FixtureStore } from '../fixtures/FixtureStore';
 import type { NormalizedFixture } from '../fixtures/FixtureStore';
 import { TableNameResolver } from '../fixtures/TableNameResolver';
 import { normalizeIdentifier } from '../fixtures/naming';
+import { DdlViewCatalog } from '../fixtures/DdlViewCatalog';
+import type { DdlViewDefinition, ViewCteDefinition } from '../fixtures/DdlViewCatalog';
 import { createLogger } from '../logger/NoopLogger';
 import type {
   AnalyzerFailureBehavior,
@@ -50,10 +52,12 @@ export class SelectFixtureRewriter {
   private readonly cteConflictBehavior: 'error' | 'override';
   private readonly analyzerFailureBehavior: AnalyzerFailureBehavior;
   private readonly tableNameResolver?: TableNameResolver;
+  private readonly viewDefinitions: DdlViewDefinition[];
 
   constructor(options: SelectRewriterOptions = {}) {
     this.tableNameResolver = options.tableNameResolver;
     this.fixtureStore = new FixtureStore(options.fixtures ?? [], options.schema, this.tableNameResolver);
+    this.viewDefinitions = options.views ?? [];
     this.logger = createLogger(options.logger);
     this.missingFixtureStrategy = options.missingFixtureStrategy ?? 'error';
     const passthrough = options.passthroughTables ?? [];
@@ -114,6 +118,10 @@ export class SelectFixtureRewriter {
   private rewriteSingleQuery(sql: string, context?: SelectRewriteContext): SelectRewriteResult {
     const fixtureMap = this.fixtureStore.withOverrides(context?.fixtures);
     const analyzerFailureBehavior = this.resolveAnalyzerFailureBehavior(context);
+    const viewCatalog = new DdlViewCatalog(
+      [...this.viewDefinitions, ...(context?.views ?? [])],
+      { tableNameResolver: this.tableNameResolver }
+    );
 
     let analysis: SelectAnalysisResult | null = null;
     let analyzerError: unknown = null;
@@ -171,6 +179,10 @@ export class SelectFixtureRewriter {
     const existingCteNames = new Set(analysis.cteNames);
     const targetTables = [...new Set(analysis.tableNames)];
     const parsedQuery = SelectQueryParser.parse(sql).toSimpleQuery();
+    const viewRoots = targetTables.filter((table) => !existingCteNames.has(normalizeIdentifier(table)));
+    const viewTargets = viewCatalog.expandReferencedViews(viewRoots, existingCteNames);
+    const viewReferencedTables = viewCatalog.collectReferencedTables(viewTargets);
+    const fixtureCandidateTables = [...new Set([...targetTables, ...viewReferencedTables])];
     const fixtureTargets: Array<{
       table: string;
       fixture: NormalizedFixture;
@@ -179,12 +191,17 @@ export class SelectFixtureRewriter {
     const exactConflictCtes: FixtureCteDefinition[] = [];
     const fixturesApplied: string[] = [];
 
-    for (const table of targetTables) {
+    for (const table of fixtureCandidateTables) {
       if (this.isPassthrough(table)) {
         continue;
       }
 
-      const fixture = fixtureMap.get(table);
+      if (viewCatalog.hasView(table)) {
+        continue;
+      }
+
+      const fixtureKey = this.resolveFixtureKey(table, fixtureMap);
+      const fixture = fixtureMap.get(fixtureKey);
       const isQueryDefinedCte = existingCteNames.has(table);
 
       if (!fixture) {
@@ -226,7 +243,9 @@ export class SelectFixtureRewriter {
     }
 
     if (fixtureTargets.length === 0) {
-      return { sql, fixturesApplied };
+      if (viewTargets.length === 0) {
+        return { sql, fixturesApplied };
+      }
     }
 
     const aliasedTargets = fixtureTargets.filter((target) => !target.exactConflict);
@@ -243,8 +262,12 @@ export class SelectFixtureRewriter {
         name: alias,
       });
     });
+    const viewAliasMap = viewCatalog.createAliasMap(viewTargets);
+    const rewriteAliasMap = new Map([...aliasMap, ...viewAliasMap]);
+    const viewCtes = viewCatalog.toCteDefinitions(viewTargets);
 
-    rewriteSelectFixtureReferences(parsedQuery, aliasMap, this.tableNameResolver);
+    rewriteSelectFixtureReferences(parsedQuery, rewriteAliasMap, this.tableNameResolver);
+    this.rewriteViewCteReferences(viewCtes, rewriteAliasMap);
     for (const target of fixtureTargets) {
       if (!target.exactConflict) {
         continue;
@@ -257,7 +280,13 @@ export class SelectFixtureRewriter {
     for (const cte of cteDefinitions) {
       parsedQuery.addCTE(cte.name, cte.query);
     }
-    this.promoteFixtureCtes(parsedQuery, cteDefinitions.map((cte) => cte.name));
+    for (const cte of viewCtes) {
+      parsedQuery.addCTE(cte.name, cte.query);
+    }
+    this.promoteFixtureCtes(parsedQuery, [
+      ...cteDefinitions.map((cte) => cte.name),
+      ...viewCtes.map((cte) => cte.name),
+    ]);
 
     const formatter = this.createFormatter(context);
     const { formattedSql } = formatter.format(parsedQuery);
@@ -428,6 +457,19 @@ export class SelectFixtureRewriter {
     query.withClause.tables = fixtureTables
       .filter((table): table is typeof query.withClause.tables[number] => Boolean(table))
       .concat(userTables);
+  }
+
+  private resolveFixtureKey(tableName: string, fixtureMap: Map<string, NormalizedFixture>): string {
+    if (!this.tableNameResolver) {
+      return normalizeIdentifier(tableName);
+    }
+    return this.tableNameResolver.resolve(tableName, (candidate) => fixtureMap.has(candidate));
+  }
+
+  private rewriteViewCteReferences(viewCtes: ViewCteDefinition[], aliasMap: Map<string, string>): void {
+    for (const cte of viewCtes) {
+      rewriteSelectFixtureReferences(cte.query, aliasMap, this.tableNameResolver);
+    }
   }
 
   private ensureTerminated(sql: string): string {

--- a/packages/testkit-core/src/types/index.ts
+++ b/packages/testkit-core/src/types/index.ts
@@ -7,6 +7,7 @@ import type {
 export type { TableDefinitionModel } from 'rawsql-ts';
 import type { TableNameResolver } from '../fixtures/TableNameResolver';
 import type { ColumnAffinity } from '../fixtures/ColumnAffinity';
+import type { DdlViewDefinition } from '../fixtures/DdlViewCatalog';
 
 /**
  * Declared column type tokens for schema metadata. Accepts raw DDL type names
@@ -60,6 +61,7 @@ export interface SelectRewriteResult {
 
 export interface SelectRewriterOptions {
   fixtures?: TableFixture[];
+  views?: DdlViewDefinition[];
   schema?: SchemaRegistry;
   missingFixtureStrategy?: MissingFixtureStrategy;
   passthroughTables?: string[];
@@ -72,6 +74,7 @@ export interface SelectRewriterOptions {
 
 export interface SelectRewriteContext {
   fixtures?: TableFixture[];
+  views?: DdlViewDefinition[];
   formatterOptions?: SqlFormatterOptions;
   analyzerFailureBehavior?: AnalyzerFailureBehavior;
 }

--- a/packages/testkit-core/tests/DdlFixtureLoader.test.ts
+++ b/packages/testkit-core/tests/DdlFixtureLoader.test.ts
@@ -3,6 +3,10 @@ import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { describe, expect, it, vi } from 'vitest';
 import { DdlFixtureLoader } from '../src/fixtures/DdlFixtureLoader';
 import { TableNameResolver } from '../src/fixtures/TableNameResolver';
+import {
+  DdlViewUnsupportedError,
+  collectDdlViewDefinitions,
+} from '../src/fixtures/DdlViewCatalog';
 
 describe('DdlFixtureLoader cache key', () => {
   it('includes resolver configuration so schema-aware clients do not share cache entries', async () => {
@@ -90,6 +94,136 @@ describe('DdlFixtureLoader ddlLint', () => {
     } finally {
       warnSpy.mockRestore();
       await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('DDL view extraction', () => {
+  it('extracts simple CREATE VIEW definitions from DDL sources', () => {
+    const resolver = new TableNameResolver({ defaultSchema: 'public', searchPath: ['public'] });
+    const views = collectDdlViewDefinitions(
+      [
+        {
+          path: 'db/ddl/views.sql',
+          sql: `
+            CREATE VIEW public.active_users AS
+            SELECT id, name
+            FROM public.users
+            WHERE role = 'admin';
+          `,
+        },
+      ],
+      { tableNameResolver: resolver }
+    );
+
+    expect(views).toEqual([
+      expect.objectContaining({
+        name: 'public.active_users',
+        cteName: 'active_users',
+        source: 'db/ddl/views.sql',
+        sql: expect.stringMatching(/^SELECT id, name/i),
+      }),
+    ]);
+  });
+
+  it('extracts CREATE OR REPLACE VIEW definitions and dependent views', () => {
+    const resolver = new TableNameResolver({ defaultSchema: 'public', searchPath: ['public'] });
+    const views = collectDdlViewDefinitions(
+      [
+        {
+          path: 'db/ddl/views.sql',
+          sql: `
+            CREATE OR REPLACE VIEW public.active_users AS
+            SELECT id, name FROM public.users WHERE role = 'admin';
+
+            CREATE VIEW public.active_user_names AS
+            SELECT name FROM public.active_users;
+          `,
+        },
+      ],
+      { tableNameResolver: resolver }
+    );
+
+    expect(views.map((view) => view.name)).toEqual([
+      'public.active_users',
+      'public.active_user_names',
+    ]);
+  });
+
+  it('rejects unsupported materialized and recursive views', () => {
+    expect(() =>
+      collectDdlViewDefinitions([
+        {
+          path: 'db/ddl/views.sql',
+          sql: 'CREATE MATERIALIZED VIEW public.active_users AS SELECT id FROM public.users;',
+        },
+      ])
+    ).toThrow(DdlViewUnsupportedError);
+
+    expect(() =>
+      collectDdlViewDefinitions([
+        {
+          path: 'db/ddl/views.sql',
+          sql: 'CREATE VIEW public.active_users AS WITH RECURSIVE u AS (SELECT 1) SELECT * FROM u;',
+        },
+      ])
+    ).toThrow(DdlViewUnsupportedError);
+
+    expect(() =>
+      collectDdlViewDefinitions([
+        {
+          path: 'db/ddl/views.sql',
+          sql: 'CREATE VIEW public.active_users WITH (security_barrier) AS SELECT id FROM public.users;',
+        },
+      ])
+    ).toThrow(DdlViewUnsupportedError);
+  });
+
+  it('rejects cyclic view dependencies', () => {
+    expect(() =>
+      collectDdlViewDefinitions([
+        {
+          path: 'db/ddl/views.sql',
+          sql: `
+            CREATE VIEW public.a AS SELECT id FROM public.b;
+            CREATE VIEW public.b AS SELECT id FROM public.a;
+          `,
+        },
+      ], {
+        tableNameResolver: new TableNameResolver({ defaultSchema: 'public', searchPath: ['public'] }),
+      })
+    ).toThrow(/Circular CREATE VIEW dependency/);
+  });
+
+  it('exposes DDL-derived view definitions from DdlFixtureLoader', async () => {
+    const ddlRoot = path.join('tmp', 'ddl-view-loader');
+    const ddlFile = path.join(ddlRoot, 'views.sql');
+    await mkdir(ddlRoot, { recursive: true });
+
+    try {
+      await writeFile(
+        ddlFile,
+        `
+          CREATE TABLE public.users (id int, name text, role text);
+          CREATE VIEW public.active_users AS
+          SELECT id, name FROM public.users WHERE role = 'admin';
+        `
+      );
+
+      const loader = new DdlFixtureLoader({
+        directories: [ddlRoot],
+        tableNameResolver: new TableNameResolver({ defaultSchema: 'public', searchPath: ['public'] }),
+      });
+
+      expect(loader.getFixtures()).toHaveLength(1);
+      expect(loader.getViewDefinitions()).toEqual([
+        expect.objectContaining({
+          name: 'public.active_users',
+          cteName: 'active_users',
+        }),
+      ]);
+    } finally {
+      await rm(ddlRoot, { recursive: true, force: true });
     }
   });
 });

--- a/packages/testkit-core/tests/ResultSelectRewriter.test.ts
+++ b/packages/testkit-core/tests/ResultSelectRewriter.test.ts
@@ -117,4 +117,48 @@ describe('ResultSelectRewriter', () => {
     expect(result.sql).toContain('from "public_users"');
     expect(result.fixturesApplied).toEqual(['public.users']);
   });
+
+  it('injects DDL-derived view CTE shadows for result SELECT rewrites', () => {
+    const resolver = new TableNameResolver({ defaultSchema: 'public' });
+    const fixtures = new DefaultFixtureProvider(
+      [
+        {
+          name: 'public.users',
+          columns: [
+            { name: 'id', typeName: 'INTEGER' },
+            { name: 'name', typeName: 'TEXT' },
+            { name: 'role', typeName: 'TEXT' },
+          ],
+        },
+      ],
+      [
+        {
+          tableName: 'public.users',
+          rows: [{ id: 1, name: 'Alice', role: 'admin' }],
+        },
+      ],
+      resolver
+    );
+    const rewriter = new ResultSelectRewriter(
+      fixtures,
+      'error',
+      undefined,
+      resolver,
+      [
+        {
+          name: 'public.active_users',
+          cteName: 'active_users',
+          sql: "SELECT id, name FROM public.users WHERE role = 'admin'",
+        },
+      ]
+    );
+
+    const result = rewriter.rewrite('select id, name from public.active_users');
+    const normalized = result.sql.toLowerCase();
+
+    expect(normalized).toContain('with "public_users" as');
+    expect(normalized).toContain('"active_users" as');
+    expect(normalized).toContain('from "public_users"');
+    expect(normalized).toContain('from "active_users"');
+  });
 });

--- a/packages/testkit-core/tests/SelectFixtureRewriter.test.ts
+++ b/packages/testkit-core/tests/SelectFixtureRewriter.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { SelectFixtureRewriter } from '../src/rewriter/SelectFixtureRewriter';
 import { SelectAnalyzer } from '../src/rewriter/SelectAnalyzer';
+import { TableNameResolver } from '../src/fixtures/TableNameResolver';
 import type { SchemaRegistry, TableSchemaDefinition } from '../src/types';
 
 const schema: Record<string, TableSchemaDefinition> = {
@@ -349,6 +350,75 @@ SELECT id, name FROM users -- trailing`;
     const result = rewriter.rewrite(sql, { analyzerFailureBehavior: 'skip' });
     expect(result.sql).toBe(sql);
     expect(result.fixturesApplied).toEqual([]);
+  });
+
+  it('injects DDL-derived view CTE shadows over fixture-backed base tables', () => {
+    const resolver = new TableNameResolver({ defaultSchema: 'public', searchPath: ['public'] });
+    const rewriter = new SelectFixtureRewriter({
+      tableNameResolver: resolver,
+      fixtures: [
+        {
+          tableName: 'public.users',
+          rows: [
+            { id: 1, name: 'Alice', role: 'admin' },
+            { id: 2, name: 'Bob', role: 'user' },
+          ],
+          schema: schema.users,
+        },
+      ],
+      views: [
+        {
+          name: 'public.active_users',
+          cteName: 'active_users',
+          sql: "SELECT id, name FROM public.users WHERE role = 'admin'",
+        },
+      ],
+    });
+
+    const result = rewriter.rewrite('SELECT id, name FROM public.active_users');
+    const normalized = result.sql.toLowerCase();
+
+    expect(normalized).toContain('with "public_users" as');
+    expect(normalized).toContain('"active_users" as');
+    expect(normalized).toContain('from "public_users"');
+    expect(normalized).toContain('select "id", "name" from "active_users"');
+    expect(result.fixturesApplied).toEqual(['public.users']);
+    expect(result.sql.indexOf('"public_users" as')).toBeLessThan(result.sql.indexOf('"active_users" as'));
+  });
+
+  it('rewrites multi-level DDL view dependencies in dependency order', () => {
+    const resolver = new TableNameResolver({ defaultSchema: 'public', searchPath: ['public'] });
+    const rewriter = new SelectFixtureRewriter({
+      tableNameResolver: resolver,
+      fixtures: [
+        {
+          tableName: 'public.users',
+          rows: [{ id: 1, name: 'Alice', role: 'admin' }],
+          schema: schema.users,
+        },
+      ],
+      views: [
+        {
+          name: 'public.active_users',
+          cteName: 'active_users',
+          sql: "SELECT id, name FROM public.users WHERE role = 'admin'",
+        },
+        {
+          name: 'public.active_user_names',
+          cteName: 'active_user_names',
+          sql: 'SELECT name FROM public.active_users',
+        },
+      ],
+    });
+
+    const result = rewriter.rewrite('SELECT name FROM public.active_user_names');
+    const normalized = result.sql.toLowerCase();
+
+    expect(normalized).toContain('"active_users" as');
+    expect(normalized).toContain('"active_user_names" as');
+    expect(normalized).toContain('from "active_users"');
+    expect(normalized).toContain('select "name" from "active_user_names"');
+    expect(result.sql.indexOf('"active_users" as')).toBeLessThan(result.sql.indexOf('"active_user_names" as'));
   });
 
   it('injects all fixtures via regex when analyzer failure behavior is inject', () => {

--- a/packages/testkit-postgres/src/client/PostgresTestkitClient.ts
+++ b/packages/testkit-postgres/src/client/PostgresTestkitClient.ts
@@ -68,7 +68,8 @@ export class PostgresTestkitClient<RowType extends Row = Row> {
       this.fixtureStore,
       options.missingFixtureStrategy ?? 'error',
       options.formatterOptions,
-      this.tableNameResolver
+      this.tableNameResolver,
+      fixturesState.viewDefinitions
     );
     this.scopedRows = scopedRows;
     this.context = context ?? {

--- a/packages/testkit-postgres/src/utils/fixtureState.ts
+++ b/packages/testkit-postgres/src/utils/fixtureState.ts
@@ -1,4 +1,4 @@
-import type { DdlFixtureLoaderOptions, DdlProcessedFixture, TableRowsFixture } from '@rawsql-ts/testkit-core';
+import type { DdlFixtureLoaderOptions, DdlProcessedFixture, DdlViewDefinition, TableRowsFixture } from '@rawsql-ts/testkit-core';
 import { DdlFixtureLoader } from '@rawsql-ts/testkit-core';
 import type { TableDefinitionModel } from 'rawsql-ts';
 import type { TableNameResolver } from '@rawsql-ts/testkit-core';
@@ -13,6 +13,7 @@ export interface FixtureResolutionOptions {
 
 export interface ResolvedFixtureState {
   ddlFixtures: DdlProcessedFixture[];
+  viewDefinitions: DdlViewDefinition[];
   tableDefinitions: TableDefinitionModel[];
   tableRows: TableRowsFixture[];
 }
@@ -33,6 +34,7 @@ export function resolveFixtureState(
       })
     : undefined;
   const ddlFixtures = loader?.getFixtures() ?? [];
+  const viewDefinitions = loader?.getViewDefinitions() ?? [];
 
   // Combine generated definitions with any explicit metadata the caller provided.
   const tableDefinitions = [
@@ -53,6 +55,7 @@ export function resolveFixtureState(
 
   return {
     ddlFixtures,
+    viewDefinitions,
     tableDefinitions,
     tableRows,
   };


### PR DESCRIPTION
## Summary

- Add DDL-derived `CREATE VIEW` extraction for ZTD/testkit fixture rewriting.
- Inject view-name CTE shadows so queries against supported views expand onto fixture-backed base tables.
- Wire view definitions through catalog and pg-testkit rewrite paths.

## Verification

- `pnpm --filter @rawsql-ts/testkit-core test -- SelectFixtureRewriter.test.ts DdlFixtureLoader.test.ts ResultSelectRewriter.test.ts`
- `pnpm --filter @rawsql-ts/testkit-core build`
- `pnpm --filter @rawsql-ts/testkit-postgres build`
- `pnpm --filter @rawsql-ts/ztd-cli test -- queryExecute.unit.test.ts queryStructure.unit.test.ts queryPlanner.unit.test.ts`
- `pnpm --filter @rawsql-ts/ztd-cli build`

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: #629
Scoped checks run: Focused testkit-core, testkit-postgres, and ztd-cli checks listed above.
Why full baseline is not required: Scoped package behavior change; focused tests cover DDL view extraction, fixture/view CTE rewriting, pg-testkit wiring, and existing ztd-cli query pipeline regression checks.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: The committed PR diff does not change ztd-cli commands, flags, help text, or CLI-facing docs.
Upgrade note: No CLI upgrade action required.
Deprecation/removal plan or issue: None.
Docs/help/examples updated: Not applicable; no CLI docs, help, or examples changed.
Release/changeset wording: `.changeset/fresh-views-shadow.md` covers testkit DDL view shadowing behavior.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: The committed PR diff does not change ztd scaffold commands, templates, generated output contracts, or scaffold tests.
Non-edit assertion: No scaffold files are edited.
Fail-fast input-contract proof: Not applicable to this non-scaffold change.
Generated-output viability proof: Not applicable to this non-scaffold change.
