### PR TITLE
Add returning CTE pipeline materialization

### DIFF
--- a/packages/ztd-cli/src/query/analysis.ts
+++ b/packages/ztd-cli/src/query/analysis.ts
@@ -85,12 +85,48 @@ export function buildDependencyMap(
   const cteNameSet = new Set(cteNames);
   return new Map(
     ctes.map((cte) => {
-      const references = collector.collect(cte.query).map((source) => source.table.name);
+      const references = collectCteQueryReferenceNames(cte.query, collector);
       const dependencies = Array.from(
         new Set(references.filter((reference) => cteNameSet.has(reference) && reference !== cte.aliasExpression.table.name))
       );
       return [cte.aliasExpression.table.name, dependencies];
     })
+  );
+}
+
+function collectCteQueryReferenceNames(
+  query: ReturnType<CTECollector['collect']>[number]['query'],
+  collector: CTETableReferenceCollector
+): string[] {
+  if (query instanceof InsertQuery) {
+    return query.selectQuery ? collectNamesFromComponents(collector, [query.selectQuery]) : [];
+  }
+
+  if (query instanceof UpdateQuery) {
+    return collectNamesFromComponents(collector, [
+      query.updateClause.source,
+      query.fromClause,
+      query.whereClause
+    ]);
+  }
+
+  if (query instanceof DeleteQuery) {
+    return collectNamesFromComponents(collector, [
+      query.deleteClause.source,
+      query.usingClause,
+      query.whereClause
+    ]);
+  }
+
+  return collector.collect(query).map((source) => source.table.name);
+}
+
+function collectNamesFromComponents(
+  collector: CTETableReferenceCollector,
+  components: Array<Parameters<CTETableReferenceCollector['collect']>[0] | null | undefined>
+): string[] {
+  return uniquePreservingOrder(
+    components.flatMap((component) => component ? collector.collect(component).map((source) => source.table.name) : [])
   );
 }
 

--- a/packages/ztd-cli/src/query/execute.ts
+++ b/packages/ztd-cli/src/query/execute.ts
@@ -63,7 +63,7 @@ export interface ExecuteQueryPipelineOptions {
 }
 
 export interface QueryPipelineExecutionStepResult {
-  kind: 'materialize' | 'scalar-filter-bind' | 'final-query';
+  kind: 'materialize' | 'materialize-returning' | 'scalar-filter-bind' | 'final-query';
   target: string;
   sql: string;
   params?: unknown[] | Record<string, unknown>;
@@ -140,7 +140,7 @@ export async function executeQueryPipeline(
 
   try {
     for (const step of plan.steps) {
-      if (step.kind === 'materialize') {
+      if (step.kind === 'materialize' || step.kind === 'materialize-returning') {
         const stage = await buildPipelineStageQuery(source, session, {
           cte: step.target,
           runtimeParams: options.params,
@@ -242,14 +242,18 @@ async function buildTargetStageQuery(
   );
   const scalarSteps = await bindScalarFilterPredicatesInCtes(includedCtes, bindingContext, session);
   const formatter = createPipelineFormatter(options.runtimeParams);
-  const targetQuery = assertSelectQuery(targetCte.query);
-  const withComponent = dependencyCtes.length > 0 ? new WithClause(getWithClause(parsed)?.recursive ?? false, dependencyCtes) : null;
+  const isReturningCte = isReturningDmlQuery(targetCte.query);
+  const withCtes = isReturningCte ? [...dependencyCtes, targetCte] : dependencyCtes;
+  const targetQuery = isReturningCte ? buildSelectFromTargetQuery(targetName, options.limit) : assertSelectQuery(targetCte.query);
+  const withComponent = withCtes.length > 0 ? new WithClause(getWithClause(parsed)?.recursive ?? false, withCtes) : null;
   const withResult = withComponent
     ? formatter.format(withComponent)
     : { formattedSql: '', params: emptyFormatterParams(options.runtimeParams) };
 
   let mainResult: { formattedSql: string; params: unknown[] | Record<string, unknown> };
-  if (options.limit !== undefined) {
+  if (isReturningCte) {
+    mainResult = formatter.format(targetQuery);
+  } else if (options.limit !== undefined) {
     if (targetQuery instanceof SimpleSelectQuery) {
       targetQuery.limitClause = new LimitClause(new LiteralValue(options.limit));
       mainResult = formatter.format(targetQuery);
@@ -361,7 +365,10 @@ async function bindScalarFilterPredicatesInCtes(
 ): Promise<QueryPipelineExecutionStepResult[]> {
   const steps: QueryPipelineExecutionStepResult[] = [];
   for (const cte of ctes) {
-    steps.push(...await bindScalarFilterPredicates(assertSelectQuery(cte.query), context, session));
+    if (!isSelectQuery(cte.query)) {
+      continue;
+    }
+    steps.push(...await bindScalarFilterPredicates(cte.query, context, session));
   }
   return steps;
 }
@@ -1097,6 +1104,24 @@ function assertSelectQuery(statement: unknown): SimpleSelectQuery | BinarySelect
   }
 
   throw new Error('Expected a SELECT-compatible statement for query execution.');
+}
+
+function isSelectQuery(statement: unknown): statement is SimpleSelectQuery | BinarySelectQuery | ValuesQuery {
+  return (
+    statement instanceof SimpleSelectQuery ||
+    statement instanceof BinarySelectQuery ||
+    statement instanceof ValuesQuery
+  );
+}
+
+function isReturningDmlQuery(statement: unknown): statement is InsertQuery | UpdateQuery | DeleteQuery {
+  if (statement instanceof InsertQuery || statement instanceof UpdateQuery || statement instanceof DeleteQuery) {
+    if (!statement.returningClause) {
+      throw new Error('DML CTE materialization requires a RETURNING clause.');
+    }
+    return true;
+  }
+  return false;
 }
 
 function getSelectWithClause(statement: SimpleSelectQuery | BinarySelectQuery | ValuesQuery): WithClause | null {

--- a/packages/ztd-cli/src/query/planner.ts
+++ b/packages/ztd-cli/src/query/planner.ts
@@ -1,7 +1,11 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { DeleteQuery, InsertQuery, SqlParser, UpdateQuery } from 'rawsql-ts';
+import { analyzeStatement, assertSupportedStatement } from './analysis';
 import { buildQueryStructureReport, type QueryStructureReport } from './structure';
 
 export type QueryPipelinePlanFormat = 'text' | 'json';
-export type QueryPipelineStepKind = 'materialize' | 'final-query';
+export type QueryPipelineStepKind = 'materialize' | 'materialize-returning' | 'final-query';
 
 export interface QueryPipelineMetadata {
   material?: string[];
@@ -43,10 +47,11 @@ export function buildQueryPipelinePlan(
   const orderedCtes = topologicallySortCtes(report);
   const plannedCtes = orderedCtes.filter((name) => material.includes(name));
   const cteMap = new Map(report.ctes.map((cte) => [cte.name, cte]));
+  const returningCteNames = collectReturningCteNames(sqlFile);
 
   const steps: QueryPipelineStep[] = plannedCtes.map((name, index) => ({
     step: index + 1,
-    kind: 'materialize',
+    kind: returningCteNames.has(name) ? 'materialize-returning' : 'materialize',
     target: name,
     depends_on: [...(cteMap.get(name)?.depends_on ?? [])]
   }));
@@ -101,10 +106,32 @@ function describeStep(step: QueryPipelineStep): string {
   switch (step.kind) {
     case 'materialize':
       return `materialize ${step.target}`;
+    case 'materialize-returning':
+      return `materialize returning ${step.target}`;
     case 'final-query':
     default:
       return 'run final query';
   }
+}
+
+function collectReturningCteNames(sqlFile: string): Set<string> {
+  const absolutePath = path.resolve(sqlFile);
+  const sql = readFileSync(absolutePath, 'utf8');
+  const statement = assertSupportedStatement(SqlParser.parse(sql), 'ztd query plan');
+  const analysis = analyzeStatement(statement);
+  const names = new Set<string>();
+
+  for (const cte of analysis.ctes) {
+    const query = cte.query;
+    if (
+      (query instanceof InsertQuery || query instanceof UpdateQuery || query instanceof DeleteQuery) &&
+      query.returningClause
+    ) {
+      names.add(cte.aliasExpression.table.name);
+    }
+  }
+
+  return names;
 }
 
 function validateKnownCtes(names: string[], cteNameSet: Set<string>, label: 'material'): void {

--- a/packages/ztd-cli/tests/queryExecute.unit.test.ts
+++ b/packages/ztd-cli/tests/queryExecute.unit.test.ts
@@ -129,6 +129,41 @@ function writeMixedPipelineSql(sqlFile: string): void {
   );
 }
 
+function writeReturningCtePipelineSql(sqlFile: string): void {
+  writeFileSync(
+    sqlFile,
+    [
+      'with source_rows as (',
+      '  select id from pending_events',
+      '),',
+      'inserted_rows as (',
+      '  insert into audit_log (id)',
+      '  select id from source_rows',
+      '  returning id',
+      '),',
+      'fanout_rows as (',
+      '  select id from inserted_rows',
+      ')',
+      'select * from fanout_rows'
+    ].join('\n'),
+    'utf8'
+  );
+}
+
+function writeDmlCteWithoutReturningSql(sqlFile: string): void {
+  writeFileSync(
+    sqlFile,
+    [
+      'with inserted_rows as (',
+      '  insert into audit_log (id)',
+      '  select id from pending_events',
+      ')',
+      'select 1'
+    ].join('\n'),
+    'utf8'
+  );
+}
+
 function writeInvalidStaticScalarSql(sqlFile: string): void {
   writeFileSync(
     sqlFile,
@@ -302,6 +337,64 @@ test('executeQueryPipeline materializes root ctes without self-shadowing the tem
   expect(stageSql).not.toContain('with base_sales as (');
   expect(finalSql).toContain('from "base_sales"');
   expect(normalizeSql(query.mock.calls[2]?.[0] as string)).toBe('drop table if exists "base_sales"');
+  expect(release).toHaveBeenCalledTimes(1);
+});
+
+test('executeQueryPipeline materializes RETURNING CTE output before downstream fanout', async () => {
+  const workspace = createSqlWorkspace('query-pipeline-returning-cte');
+  writeReturningCtePipelineSql(workspace.sqlFile);
+
+  const query = vi.fn()
+    .mockResolvedValueOnce({ rows: [], rowCount: 2 })
+    .mockResolvedValueOnce({ rows: [{ id: 1 }, { id: 2 }], rowCount: 2 })
+    .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+  const release = vi.fn();
+  const openSession = vi.fn(async () => ({ query, release }));
+
+  const result = await executeQueryPipeline(
+    { openSession },
+    {
+      sqlFile: workspace.sqlFile,
+      metadata: {
+        material: ['inserted_rows']
+      }
+    }
+  );
+
+  expect(result.steps.map((step) => step.kind)).toEqual(['materialize-returning', 'final-query']);
+  const materializeSql = normalizeSql(query.mock.calls[0]?.[0] as string);
+  const finalSql = normalizeSql(query.mock.calls[1]?.[0] as string);
+
+  expect(materializeSql).toContain('create temp table "inserted_rows" as with');
+  expect(materializeSql).toContain('"inserted_rows" as (insert into "audit_log"("id") select "id" from "source_rows" returning "id")');
+  expect(materializeSql).toContain('select * from "inserted_rows"');
+  expect(finalSql).not.toContain('insert into "audit_log"');
+  expect(finalSql).toContain('from "inserted_rows"');
+  expect(normalizeSql(query.mock.calls[2]?.[0] as string)).toBe('drop table if exists "inserted_rows"');
+  expect(release).toHaveBeenCalledTimes(1);
+});
+
+test('executeQueryPipeline rejects DML CTE materialization without RETURNING', async () => {
+  const workspace = createSqlWorkspace('query-pipeline-dml-no-returning');
+  writeDmlCteWithoutReturningSql(workspace.sqlFile);
+
+  const query = vi.fn();
+  const release = vi.fn();
+  const openSession = vi.fn(async () => ({ query, release }));
+
+  await expect(() =>
+    executeQueryPipeline(
+      { openSession },
+      {
+        sqlFile: workspace.sqlFile,
+        metadata: {
+          material: ['inserted_rows']
+        }
+      }
+    )
+  ).rejects.toThrow('DML CTE materialization requires a RETURNING clause.');
+
+  expect(query).not.toHaveBeenCalled();
   expect(release).toHaveBeenCalledTimes(1);
 });
 

--- a/packages/ztd-cli/tests/queryPlanner.unit.test.ts
+++ b/packages/ztd-cli/tests/queryPlanner.unit.test.ts
@@ -87,6 +87,74 @@ test('buildQueryPipelinePlan emits deterministic ordered steps from metadata', (
   ]);
 });
 
+test('buildQueryPipelinePlan marks RETURNING CTE materialization steps explicitly', () => {
+  const workspace = createSqlWorkspace('query-pipeline-returning-plan');
+  writeFileSync(
+    workspace.sqlFile,
+    `
+      with source_rows as (
+        select id
+        from pending_events
+      ),
+      inserted_rows as (
+        insert into audit_log (id)
+        select id
+        from source_rows
+        returning id
+      )
+      select *
+      from inserted_rows
+    `,
+    'utf8'
+  );
+
+  const plan = buildQueryPipelinePlan(workspace.sqlFile, {
+    material: ['inserted_rows']
+  });
+
+  expect(plan.steps).toEqual([
+    {
+      step: 1,
+      kind: 'materialize-returning',
+      target: 'inserted_rows',
+      depends_on: ['source_rows']
+    },
+    {
+      step: 2,
+      kind: 'final-query',
+      target: 'FINAL_QUERY',
+      depends_on: ['inserted_rows']
+    }
+  ]);
+
+  expect(formatQueryPipelinePlan(plan, 'text')).toContain('1. materialize returning inserted_rows');
+});
+
+test('buildQueryPipelinePlan keeps non-returning DML CTEs as normal materialize steps for execution fail-fast', () => {
+  const workspace = createSqlWorkspace('query-pipeline-dml-no-returning-plan');
+  writeFileSync(
+    workspace.sqlFile,
+    `
+      with inserted_rows as (
+        insert into audit_log (id)
+        select id
+        from pending_events
+      )
+      select 1
+    `,
+    'utf8'
+  );
+
+  const plan = buildQueryPipelinePlan(workspace.sqlFile, {
+    material: ['inserted_rows']
+  });
+
+  expect(plan.steps[0]).toMatchObject({
+    kind: 'materialize',
+    target: 'inserted_rows'
+  });
+});
+
 test('formatQueryPipelinePlan renders json for agents and text for humans', () => {
   const workspace = createSqlWorkspace('query-pipeline-format');
   writeFileSync(


### PR DESCRIPTION
## Summary

- Fixes #703 by adding a ztd query pipeline step kind for materializing DML CTEs with RETURNING output.
- Executes RETURNING CTE materialization as a temp table so downstream CTEs and the final query reuse the returned rows instead of re-running the DML.
- Keeps non-RETURNING DML CTE materialization fail-fast.

## Verification

- pnpm --filter @rawsql-ts/ztd-cli test -- queryPlanner.unit.test.ts queryExecute.unit.test.ts
- pnpm --filter @rawsql-ts/ztd-cli build
- pnpm --filter @rawsql-ts/ztd-cli lint
- pre-commit ztd-cli gates during commit: typecheck, test:essential, build, lint

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: not needed; no baseline exception requested.
Scoped checks run: not needed; no baseline exception requested.
Why full baseline is not required: full baseline exception path not used for this PR.

## Self Review

Self-review workflow: Codex self-review skill, two-cycle review before PR creation.
Self-review result: No merge blockers found; unrelated local changes were excluded from the commit and PR.

## CLI Surface Migration

- [ ] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: not selected for this PR.
Upgrade note: not selected for this PR.
Deprecation/removal plan or issue: not selected for this PR.
Docs/help/examples updated: not selected for this PR.
Release/changeset wording: not selected for this PR.

## Scaffold Contract Proof

- [ ] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: not selected for this PR.
Non-edit assertion: not selected for this PR.
Fail-fast input-contract proof: not selected for this PR.
Generated-output viability proof: not selected for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced query pipeline to properly handle materialization of DML operations (INSERT, UPDATE, DELETE) with RETURNING clauses in complex query scenarios.
  * Improved CTE dependency analysis with query-type-specific reference resolution.

* **Tests**
  * Added comprehensive unit test coverage for DML operation materialization with RETURNING clauses in query planning and execution pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
