### PR TITLE
Add RFBA review-data command

### DIFF
--- a/.changeset/rfba-review-data.md
+++ b/.changeset/rfba-review-data.md
@@ -1,0 +1,5 @@
+---
+"@rawsql-ts/ztd-cli": minor
+---
+
+Add `ztd rfba review-data` to generate deterministic RFBA review packet JSON from Git diffs. The command classifies changed files, maps changes to RFBA boundaries, summarizes supported DDL and SQL changes, groups verification evidence, and writes CI-friendly JSON with review hints and warnings.

--- a/packages/ztd-cli/README.md
+++ b/packages/ztd-cli/README.md
@@ -84,6 +84,28 @@ npx ztd rfba inspect --format json
 The command is read-only. It reports concrete starter root boundaries, feature-boundaries, query sub-boundaries, likely public surface files, SQL assets, generated artifacts, local verification files, and structural warnings.
 The JSON output is deterministic and omits timestamps so it can be consumed by agents and review checks.
 
+### Generate RFBA Review Data
+
+Use `rfba review-data` in merge PR checks when an agent or reviewer needs RFBA-aware review packet data instead of raw diff text:
+
+```bash
+npx ztd rfba review-data --base origin/main --head HEAD --out .ztd/review/rfba-review-data.json
+```
+
+The output is deterministic JSON and is suitable for a CI artifact. It classifies changed files, maps changes to RFBA boundaries, summarizes supported DDL and SQL changes, groups verification evidence, and emits warnings for review gaps that need human or AI attention.
+The command does not write the final PR review narrative and does not judge business correctness.
+
+Example AI prompt for PR summary generation:
+
+```text
+Read .ztd/review/rfba-review-data.json and write an RFBA Review Summary for the PR.
+Do not repeat raw git diff.
+Summarize the meaning of DDL, SQL, boundary, adapter, and verification changes.
+Separate confirmed facts from review questions.
+Use warnings as high-priority review notes.
+Do not claim business correctness when the JSON only provides structural evidence.
+```
+
 Important repo areas outside the concrete root-boundary list:
 
 - Keep shared feature seams under `src/features/_shared/*`.
@@ -249,6 +271,7 @@ Use `ztd describe` for machine-readable discovery, and follow the linked guides 
 | `ztd query match-observed` | Rank likely source SQL assets from observed SELECT text. |
 | `ztd query sssql list` / `scaffold` / `remove` / `refresh` | Inspect, author, undo, and re-anchor SQL-first optional filter branches. See [ztd-cli SSSQL Reference](../../docs/guide/ztd-cli-sssql-reference.md). |
 | `ztd ddl pull` / `ztd ddl diff` | Inspect a target and prepare migration SQL. |
+| `ztd rfba inspect` / `review-data` | Inspect RFBA boundaries and generate deterministic merge PR review packet JSON. |
 | `ztd perf init` / `ztd perf run` | Run the tuning loop for index or pipeline investigation. |
 | `ztd describe` | Inspect commands in machine-readable form. |
 

--- a/packages/ztd-cli/src/commands/rfba.ts
+++ b/packages/ztd-cli/src/commands/rfba.ts
@@ -2,6 +2,7 @@ import { existsSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { Command } from 'commander';
 import { getAgentOutputFormat, parseJsonPayload, writeCommandEnvelope } from '../utils/agentCli';
+import { runRfbaReviewData } from './rfbaReviewData';
 
 export type RfbaBoundaryKind = 'root-boundary' | 'feature-boundary' | 'child-boundary-container' | 'sub-boundary';
 export type RfbaInspectFormat = 'text' | 'json';
@@ -49,6 +50,17 @@ export interface RfbaInspectionReport {
 
 interface RfbaInspectOptions {
   format?: string;
+  root?: string;
+  json?: string;
+}
+
+interface RfbaReviewDataOptions {
+  base?: string;
+  head?: string;
+  out?: string;
+  format?: string;
+  scope?: string;
+  includeRawDiff?: boolean;
   root?: string;
   json?: string;
 }
@@ -103,6 +115,35 @@ export function registerRfbaCommand(program: Command): void {
       }
 
       process.stdout.write(formatRfbaInspectionReport(report, format));
+    });
+
+  rfba
+    .command('review-data')
+    .description('Generate deterministic RFBA review packet data from a Git diff')
+    .option('--base <ref>', 'Compare base ref', 'origin/main')
+    .option('--head <ref>', 'Compare head ref', 'HEAD')
+    .option('--out <file>', 'Write JSON output to file')
+    .option('--format <format>', 'Output format (json)', 'json')
+    .option('--scope <path>', 'Limit review data collection to a path')
+    .option('--include-raw-diff', 'Include raw file diff snippets', false)
+    .option('--root <path>', 'Project root to inspect and compare', '.')
+    .option('--json <payload>', 'Pass command options as a JSON object')
+    .action((options: RfbaReviewDataOptions) => {
+      const merged = options.json ? { ...options, ...parseJsonPayload<Record<string, unknown>>(options.json, '--json') } : options;
+      const root = normalizeStringOption(merged.root) ?? '.';
+      const projectRoot = path.resolve(process.cwd(), root);
+      const report = runRfbaReviewData({
+        base: normalizeStringOption(merged.base),
+        head: normalizeStringOption(merged.head),
+        out: normalizeStringOption(merged.out),
+        format: normalizeStringOption(merged.format),
+        scope: normalizeStringOption(merged.scope),
+        includeRawDiff: Boolean(merged.includeRawDiff),
+        projectRoot,
+        inspectReport: inspectRfbaBoundaries(projectRoot),
+      });
+
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
     });
 }
 

--- a/packages/ztd-cli/src/commands/rfbaReviewData.ts
+++ b/packages/ztd-cli/src/commands/rfbaReviewData.ts
@@ -35,9 +35,13 @@ export interface RfbaChangedFile {
   oldPath?: string;
   status: GitChangeStatus;
   kind: RfbaChangedFileKind;
+  oldKind?: RfbaChangedFileKind;
   boundary: string | null;
+  oldBoundary?: string | null;
   parentFeatureBoundary: string | null;
+  oldParentFeatureBoundary?: string | null;
   reviewWeight: RfbaReviewWeight;
+  oldReviewWeight?: RfbaReviewWeight;
   rawDiff?: string;
 }
 
@@ -283,7 +287,7 @@ export function buildRfbaReviewData(params: {
   const reviewHints = buildReviewHints(changedFiles, ddlChanges, sqlChanges, boundaryChanges);
 
   addVerificationWarnings(changedFiles, verificationChanges, warnings);
-  addGeneratedOnlyWarnings(changedFiles, generatedChanges, warnings);
+  addGeneratedOnlyWarnings(changedFiles, warnings);
   warnings.sort(compareWarnings);
 
   return {
@@ -356,14 +360,20 @@ export function parseGitNameStatus(output: string): GitNameStatusEntry[] {
 export function classifyRfbaChangedFile(entry: GitNameStatusEntry): RfbaChangedFile {
   const pathValue = normalizePath(entry.path);
   const kind = classifyKind(pathValue);
+  const oldPath = entry.oldPath ? normalizePath(entry.oldPath) : undefined;
+  const oldKind = oldPath ? classifyKind(oldPath) : undefined;
   return {
     path: pathValue,
-    oldPath: entry.oldPath ? normalizePath(entry.oldPath) : undefined,
+    oldPath,
     status: entry.status,
     kind,
+    oldKind,
     boundary: deriveBoundary(pathValue, kind),
+    oldBoundary: oldPath && oldKind ? deriveBoundary(oldPath, oldKind) : undefined,
     parentFeatureBoundary: deriveParentFeatureBoundary(pathValue),
+    oldParentFeatureBoundary: oldPath ? deriveParentFeatureBoundary(oldPath) : undefined,
     reviewWeight: reviewWeightForKind(kind),
+    oldReviewWeight: oldKind ? reviewWeightForKind(oldKind) : undefined,
   };
 }
 
@@ -378,26 +388,29 @@ export function buildChangedBoundarySummary(
       : null;
     return [boundary.path, parentPath] as const;
   }));
-  const grouped = new Map<string, RfbaChangedFile[]>();
+  const grouped = new Map<string, { path: string; parentFeatureBoundary: string | null; reviewWeight: RfbaReviewWeight }[]>();
 
   for (const file of changedFiles) {
-    if (!file.boundary) {
-      continue;
+    for (const boundaryRef of changedBoundaryRefs(file)) {
+      const list = grouped.get(boundaryRef.boundary) ?? [];
+      list.push({
+        path: boundaryRef.path,
+        parentFeatureBoundary: boundaryRef.parentFeatureBoundary,
+        reviewWeight: boundaryRef.reviewWeight,
+      });
+      grouped.set(boundaryRef.boundary, list);
     }
-    const list = grouped.get(file.boundary) ?? [];
-    list.push(file);
-    grouped.set(file.boundary, list);
   }
 
   return Array.from(grouped.entries())
-    .map(([boundaryPath, files]): RfbaChangedBoundary => {
+    .map(([boundaryPath, refs]): RfbaChangedBoundary => {
       const boundary = boundaryByPath.get(boundaryPath);
       return {
         boundary: boundaryPath,
         kind: boundary?.kind ?? 'unknown',
-        parentBoundary: parentByPath.get(boundaryPath) ?? files[0]?.parentFeatureBoundary ?? null,
-        changedFiles: sortUnique(files.map((file) => file.path)),
-        reviewWeight: maxReviewWeight(files.map((file) => file.reviewWeight)),
+        parentBoundary: parentByPath.get(boundaryPath) ?? refs.find((ref) => ref.parentFeatureBoundary)?.parentFeatureBoundary ?? null,
+        changedFiles: sortUnique(refs.map((ref) => ref.path)),
+        reviewWeight: maxReviewWeight(refs.map((ref) => ref.reviewWeight)),
       };
     })
     .sort((left, right) => left.boundary.localeCompare(right.boundary));
@@ -511,25 +524,30 @@ export function buildVerificationSummary(changedFiles: RfbaChangedFile[]): Verif
   };
 
   for (const file of changedFiles) {
-    const boundary = file.boundary ?? file.parentFeatureBoundary ?? 'global';
-    if (!isVerificationKind(file.kind)) {
-      continue;
-    }
-    const item = ensure(boundary);
-    if (file.kind === 'query-case') {
-      item.changedCases.push(file.path);
-    } else if (file.kind === 'generated-evidence') {
-      item.changedGeneratedEvidence.push(file.path);
-    } else if (file.kind === 'feature-verification') {
-      item.changedFeatureTests.push(file.path);
-    } else if (file.kind === 'test-support') {
-      item.changedTestSupport.push(file.path);
-    } else {
-      item.changedEntrypoints.push(file.path);
+    for (const ref of changedFileKindRefs(file)) {
+      const boundary = ref.boundary ?? ref.parentFeatureBoundary ?? 'global';
+      if (!isVerificationKind(ref.kind)) {
+        continue;
+      }
+      const item = ensure(boundary);
+      if (ref.kind === 'query-case') {
+        item.changedCases.push(ref.path);
+      } else if (ref.kind === 'generated-evidence') {
+        item.changedGeneratedEvidence.push(ref.path);
+      } else if (ref.kind === 'feature-verification') {
+        item.changedFeatureTests.push(ref.path);
+      } else if (ref.kind === 'test-support') {
+        item.changedTestSupport.push(ref.path);
+      } else {
+        item.changedEntrypoints.push(ref.path);
+      }
     }
   }
 
-  const sqlBoundaries = sortUnique(changedFiles.filter((file) => file.kind === 'query-sql' && file.boundary).map((file) => file.boundary as string));
+  const sqlBoundaries = sortUnique(changedFiles
+    .flatMap((file) => changedFileKindRefs(file))
+    .filter((ref) => ref.kind === 'query-sql' && ref.boundary)
+    .map((ref) => ref.boundary as string));
   for (const boundary of sqlBoundaries) {
     const item = ensure(boundary);
     if (item.changedCases.length === 0 && item.changedGeneratedEvidence.length === 0) {
@@ -726,8 +744,8 @@ function addVerificationWarnings(
   verificationChanges: VerificationSummaryItem[],
   warnings: RfbaReviewWarning[]
 ): void {
-  const changedDdl = changedFiles.some((file) => file.kind === 'ddl');
-  if (changedDdl && !changedFiles.some((file) => file.kind === 'query-case' || file.kind === 'generated-evidence' || file.kind === 'feature-verification' || file.kind === 'query-verification')) {
+  const changedDdl = changedFiles.some((file) => hasChangedFileKind(file, 'ddl'));
+  if (changedDdl && !changedFiles.some((file) => hasAnyChangedFileKind(file, ['query-case', 'generated-evidence', 'feature-verification', 'query-verification']))) {
     warnings.push({
       code: 'verification.possibly-missing',
       message: 'DDL changed but no obvious RFBA verification or generated evidence changed.',
@@ -746,46 +764,160 @@ function addVerificationWarnings(
 
 function addGeneratedOnlyWarnings(
   changedFiles: RfbaChangedFile[],
-  generatedChanges: RfbaChangedFile[],
   warnings: RfbaReviewWarning[]
 ): void {
-  if (generatedChanges.length === 0) {
+  const generatedPaths = sortUnique(changedFiles
+    .flatMap((file) => changedFileKindRefs(file))
+    .filter((ref) => ref.kind === 'generated-evidence')
+    .map((ref) => ref.path));
+  if (generatedPaths.length === 0) {
     return;
   }
   const sourceKinds: RfbaChangedFileKind[] = ['ddl', 'query-sql', 'feature-boundary', 'query-boundary', 'query-case'];
-  const hasSourceChange = changedFiles.some((file) => sourceKinds.includes(file.kind));
+  const hasSourceChange = changedFiles.some((file) => hasAnyChangedFileKind(file, sourceKinds));
   if (!hasSourceChange) {
     warnings.push({
       code: 'generated-without-source',
-      paths: generatedChanges.map((file) => file.path).sort(),
+      paths: generatedPaths,
       message: 'Generated evidence changed without an obvious DDL, SQL, boundary, or case change.',
     });
   }
 }
 
+function changedBoundaryRefs(file: RfbaChangedFile): {
+  boundary: string;
+  path: string;
+  parentFeatureBoundary: string | null;
+  reviewWeight: RfbaReviewWeight;
+}[] {
+  const refs: {
+    boundary: string;
+    path: string;
+    parentFeatureBoundary: string | null;
+    reviewWeight: RfbaReviewWeight;
+  }[] = [];
+  if (file.boundary) {
+    refs.push({
+      boundary: file.boundary,
+      path: file.path,
+      parentFeatureBoundary: file.parentFeatureBoundary,
+      reviewWeight: file.reviewWeight,
+    });
+  }
+  if (file.oldPath && file.oldBoundary) {
+    refs.push({
+      boundary: file.oldBoundary,
+      path: file.oldPath,
+      parentFeatureBoundary: file.oldParentFeatureBoundary ?? null,
+      reviewWeight: file.oldReviewWeight ?? file.reviewWeight,
+    });
+  }
+  return refs;
+}
+
+function changedFileKindRefs(file: RfbaChangedFile): {
+  path: string;
+  kind: RfbaChangedFileKind;
+  boundary: string | null;
+  parentFeatureBoundary: string | null;
+}[] {
+  const refs = [{
+    path: file.path,
+    kind: file.kind,
+    boundary: file.boundary,
+    parentFeatureBoundary: file.parentFeatureBoundary,
+  }];
+  if (file.oldPath && file.oldKind) {
+    refs.push({
+      path: file.oldPath,
+      kind: file.oldKind,
+      boundary: file.oldBoundary ?? null,
+      parentFeatureBoundary: file.oldParentFeatureBoundary ?? null,
+    });
+  }
+  return refs;
+}
+
+function hasChangedFileKind(file: RfbaChangedFile, kind: RfbaChangedFileKind): boolean {
+  return file.kind === kind || file.oldKind === kind;
+}
+
+function hasAnyChangedFileKind(file: RfbaChangedFile, kinds: RfbaChangedFileKind[]): boolean {
+  return kinds.some((kind) => hasChangedFileKind(file, kind));
+}
+
+function getFeaturePathInfo(parts: string[]): { startIndex: number; endIndex: number } | null {
+  const srcIndex = parts.indexOf('src');
+  if (srcIndex < 0 || parts[srcIndex + 1] !== 'features') {
+    return null;
+  }
+  const startIndex = srcIndex + 2;
+  const stopIndex = findFirstSegmentIndex(parts, startIndex, ['queries', 'tests', 'generated-evidence', 'boundary.ts']);
+  const endIndex = (stopIndex < 0 ? parts.length : stopIndex) - 1;
+  if (endIndex < startIndex) {
+    return null;
+  }
+  const featureSegments = parts.slice(startIndex, endIndex + 1).filter((segment) => !segment.startsWith('_'));
+  if (featureSegments.length === 0) {
+    return null;
+  }
+  return { startIndex, endIndex };
+}
+
+function getQueryPathInfo(parts: string[], featureStartIndex: number): { queriesIndex: number; queryNameIndex: number } | null {
+  const queriesIndex = parts.indexOf('queries', featureStartIndex);
+  const queryNameIndex = queriesIndex + 1;
+  if (queriesIndex < 0 || !parts[queryNameIndex]) {
+    return null;
+  }
+  return { queriesIndex, queryNameIndex };
+}
+
+function buildFeatureBoundaryPath(parts: string[], featureInfo: { startIndex: number; endIndex: number }): string {
+  const featureSegments = parts
+    .slice(featureInfo.startIndex, featureInfo.endIndex + 1)
+    .filter((segment) => !segment.startsWith('_'));
+  return [...parts.slice(0, featureInfo.startIndex), ...featureSegments].join('/');
+}
+
+function findFirstSegmentIndex(parts: string[], startIndex: number, segments: string[]): number {
+  const indices = segments
+    .map((segment) => parts.indexOf(segment, startIndex))
+    .filter((index) => index >= 0);
+  return indices.length > 0 ? Math.min(...indices) : -1;
+}
+
 function classifyKind(filePath: string): RfbaChangedFileKind {
+  const parts = filePath.split('/');
+  const featureInfo = getFeaturePathInfo(parts);
+  const queryInfo = featureInfo ? getQueryPathInfo(parts, featureInfo.startIndex) : null;
   if (/^db\/ddl\/.+\.sql$/i.test(filePath)) {
     return 'ddl';
   }
-  if (/^src\/features\/[^/]+\/boundary\.ts$/i.test(filePath)) {
+  if (queryInfo) {
+    const afterQuery = parts.slice(queryInfo.queryNameIndex + 1);
+    const testsIndex = afterQuery.indexOf('tests');
+    if (testsIndex >= 0) {
+      const testsKind = afterQuery[testsIndex + 1];
+      if (testsKind === 'cases') {
+        return 'query-case';
+      }
+      if (testsKind === 'generated') {
+        return 'generated-evidence';
+      }
+      return 'query-verification';
+    }
+    if (afterQuery.length === 1 && afterQuery[0] === 'boundary.ts') {
+      return 'query-boundary';
+    }
+    if (/\.sql$/i.test(parts[parts.length - 1] ?? '')) {
+      return 'query-sql';
+    }
+  }
+  if (featureInfo && parts[parts.length - 1] === 'boundary.ts') {
     return 'feature-boundary';
   }
-  if (/^src\/features\/[^/]+\/queries\/[^/]+\/boundary\.ts$/i.test(filePath)) {
-    return 'query-boundary';
-  }
-  if (/^src\/features\/[^/]+\/queries\/[^/]+\/.+\.sql$/i.test(filePath)) {
-    return 'query-sql';
-  }
-  if (/^src\/features\/[^/]+\/queries\/[^/]+\/tests\/cases\//i.test(filePath)) {
-    return 'query-case';
-  }
-  if (/^src\/features\/[^/]+\/queries\/[^/]+\/tests\/generated\//i.test(filePath)) {
-    return 'generated-evidence';
-  }
-  if (/^src\/features\/[^/]+\/queries\/[^/]+\/tests\//i.test(filePath)) {
-    return 'query-verification';
-  }
-  if (/^src\/features\/[^/]+\/tests\//i.test(filePath)) {
+  if (featureInfo && parts.indexOf('tests', featureInfo.startIndex) >= 0) {
     return 'feature-verification';
   }
   if (/^src\/adapters\//i.test(filePath)) {
@@ -805,11 +937,13 @@ function classifyKind(filePath: string): RfbaChangedFileKind {
 
 function deriveBoundary(filePath: string, kind: RfbaChangedFileKind): string | null {
   const parts = filePath.split('/');
+  const featureInfo = getFeaturePathInfo(parts);
+  const queryInfo = featureInfo ? getQueryPathInfo(parts, featureInfo.startIndex) : null;
   if (kind === 'feature-boundary' || kind === 'feature-verification') {
-    return parts.length >= 3 ? parts.slice(0, 3).join('/') : null;
+    return featureInfo ? buildFeatureBoundaryPath(parts, featureInfo) : null;
   }
   if (kind === 'query-boundary' || kind === 'query-sql' || kind === 'query-case' || kind === 'query-verification' || kind === 'generated-evidence') {
-    return parts.length >= 5 ? parts.slice(0, 5).join('/') : null;
+    return queryInfo ? parts.slice(0, queryInfo.queryNameIndex + 1).join('/') : null;
   }
   if (kind === 'adapter') {
     return parts.length >= 3 ? parts.slice(0, 3).join('/') : 'src/adapters';
@@ -822,10 +956,8 @@ function deriveBoundary(filePath: string, kind: RfbaChangedFileKind): string | n
 
 function deriveParentFeatureBoundary(filePath: string): string | null {
   const parts = filePath.split('/');
-  if (parts[0] === 'src' && parts[1] === 'features' && parts[2] && !parts[2].startsWith('_')) {
-    return parts.slice(0, 3).join('/');
-  }
-  return null;
+  const featureInfo = getFeaturePathInfo(parts);
+  return featureInfo ? buildFeatureBoundaryPath(parts, featureInfo) : null;
 }
 
 function reviewWeightForKind(kind: RfbaChangedFileKind): RfbaReviewWeight {

--- a/packages/ztd-cli/src/commands/rfbaReviewData.ts
+++ b/packages/ztd-cli/src/commands/rfbaReviewData.ts
@@ -1,0 +1,1383 @@
+import { spawnSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { SqlParser } from 'rawsql-ts';
+import { ensureDirectory } from '../utils/fs';
+import type { RfbaBoundaryKind, RfbaInspectionReport } from './rfba';
+
+export type RfbaReviewDataFormat = 'json';
+export type GitChangeStatus = 'added' | 'modified' | 'deleted' | 'renamed' | 'copied';
+export type RfbaChangedFileKind =
+  | 'ddl'
+  | 'feature-boundary'
+  | 'query-boundary'
+  | 'query-sql'
+  | 'query-case'
+  | 'generated-evidence'
+  | 'query-verification'
+  | 'feature-verification'
+  | 'adapter'
+  | 'library'
+  | 'test-support'
+  | 'tool-managed'
+  | 'unknown';
+export type RfbaReviewWeight = 'high' | 'medium' | 'low';
+
+export interface GitNameStatusEntry {
+  status: GitChangeStatus;
+  path: string;
+  oldPath?: string;
+  score?: number;
+}
+
+export interface RfbaChangedFile {
+  path: string;
+  oldPath?: string;
+  status: GitChangeStatus;
+  kind: RfbaChangedFileKind;
+  boundary: string | null;
+  parentFeatureBoundary: string | null;
+  reviewWeight: RfbaReviewWeight;
+  rawDiff?: string;
+}
+
+export interface RfbaReviewHint {
+  target: string;
+  priority: RfbaReviewWeight;
+  hint: string;
+}
+
+export interface RfbaReviewWarning {
+  code: string;
+  message: string;
+  path?: string;
+  paths?: string[];
+  boundary?: string;
+}
+
+export interface RfbaChangedBoundary {
+  boundary: string;
+  kind: RfbaBoundaryKind | 'unknown';
+  parentBoundary: string | null;
+  changedFiles: string[];
+  reviewWeight: RfbaReviewWeight;
+}
+
+export interface DdlColumnView {
+  name: string;
+  type: string | null;
+  notNull: boolean;
+  default: string | null;
+  primaryKey: boolean;
+  unique: boolean;
+}
+
+export interface DdlTableView {
+  table: string;
+  columnsAfter: DdlColumnView[];
+}
+
+export interface DdlChangeDetail {
+  kind:
+    | 'add-table'
+    | 'drop-table'
+    | 'add-column'
+    | 'drop-column'
+    | 'modify-column-type'
+    | 'modify-column-nullability'
+    | 'modify-column-default'
+    | 'add-primary-key'
+    | 'drop-primary-key'
+    | 'add-unique'
+    | 'drop-unique'
+    | 'add-index'
+    | 'drop-index';
+  column?: string;
+  index?: string;
+  before: unknown;
+  after: unknown;
+  explanationSql: string;
+  reviewHints: string[];
+}
+
+export interface DdlChangeItem {
+  path: string;
+  objectKind: 'table' | 'index';
+  object: string;
+  explanationSqlPurpose: 'human-readable explanation only; not an auto-apply migration';
+  changes: DdlChangeDetail[];
+  tableViewAfter?: DdlTableView;
+}
+
+export interface SqlChangeItem {
+  path: string;
+  boundary: string | null;
+  statementKindBefore: string | null;
+  statementKindAfter: string | null;
+  readTablesBefore: string[];
+  readTablesAfter: string[];
+  writeTablesBefore: string[];
+  writeTablesAfter: string[];
+  returningColumnsBefore: string[];
+  returningColumnsAfter: string[];
+  selectedColumnsBefore: string[];
+  selectedColumnsAfter: string[];
+  whereColumnsBefore: string[];
+  whereColumnsAfter: string[];
+  joinTablesBefore: string[];
+  joinTablesAfter: string[];
+  reviewHints: string[];
+}
+
+export interface BoundaryChangeItem {
+  path: string;
+  boundary: string | null;
+  kind: RfbaChangedFileKind;
+  exportedNamesBefore: string[];
+  exportedNamesAfter: string[];
+  zodSchemaNamesBefore: string[];
+  zodSchemaNamesAfter: string[];
+  addedExports: string[];
+  removedExports: string[];
+  reviewWeight: RfbaReviewWeight;
+  reviewHints: string[];
+}
+
+export interface VerificationSummaryItem {
+  boundary: string;
+  changedCases: string[];
+  changedGeneratedEvidence: string[];
+  changedEntrypoints: string[];
+  changedFeatureTests: string[];
+  changedTestSupport: string[];
+  missingLikelyEvidence: string[];
+}
+
+export interface RfbaReviewDataReport {
+  schemaVersion: 1;
+  command: 'rfba review-data';
+  base: string;
+  head: string;
+  summary: {
+    changedFiles: number;
+    changedBoundaries: number;
+    ddlChanges: number;
+    sqlChanges: number;
+    boundaryChanges: number;
+    adapterChanges: number;
+    verificationChanges: number;
+    generatedChanges: number;
+    warnings: number;
+  };
+  changedFiles: RfbaChangedFile[];
+  changedBoundaries: RfbaChangedBoundary[];
+  ddlChanges: DdlChangeItem[];
+  sqlChanges: SqlChangeItem[];
+  boundaryChanges: BoundaryChangeItem[];
+  adapterChanges: RfbaChangedFile[];
+  verificationChanges: VerificationSummaryItem[];
+  generatedChanges: RfbaChangedFile[];
+  reviewHints: RfbaReviewHint[];
+  warnings: RfbaReviewWarning[];
+}
+
+export interface RfbaReviewDataOptions {
+  base?: string;
+  head?: string;
+  out?: string;
+  format?: string;
+  scope?: string;
+  includeRawDiff?: boolean;
+  projectRoot?: string;
+  inspectReport: RfbaInspectionReport;
+}
+
+interface GitClient {
+  nameStatus(base: string, head: string): string;
+  show(ref: string, filePath: string): string | null;
+  diff(base: string, head: string, filePath: string): string | null;
+}
+
+interface DdlTableModel {
+  name: string;
+  columns: Map<string, DdlColumnView>;
+  primaryKeyColumns: string[];
+  uniqueColumns: string[][];
+}
+
+interface DdlIndexModel {
+  name: string;
+  table: string;
+  unique: boolean;
+  columns: string[];
+}
+
+interface SqlSummary {
+  statementKind: string | null;
+  readTables: string[];
+  writeTables: string[];
+  returningColumns: string[];
+  selectedColumns: string[];
+  whereColumns: string[];
+  joinTables: string[];
+  parseWarning: boolean;
+}
+
+const EXPLANATION_SQL_PURPOSE = 'human-readable explanation only; not an auto-apply migration' as const;
+
+export function runRfbaReviewData(options: RfbaReviewDataOptions): RfbaReviewDataReport {
+  const projectRoot = path.resolve(options.projectRoot ?? process.cwd());
+  const base = normalizeOption(options.base) ?? 'origin/main';
+  const head = normalizeOption(options.head) ?? 'HEAD';
+  const format = resolveRfbaReviewDataFormat(options.format);
+  const scope = normalizeScope(options.scope);
+  const git = createGitClient(projectRoot);
+  const report = buildRfbaReviewData({
+    base,
+    head,
+    scope,
+    includeRawDiff: Boolean(options.includeRawDiff),
+    inspectReport: options.inspectReport,
+    git,
+  });
+
+  if (format !== 'json') {
+    throw new Error(`Unsupported RFBA review-data format: ${options.format}`);
+  }
+
+  if (options.out) {
+    const outPath = path.resolve(projectRoot, options.out);
+    ensureDirectory(path.dirname(outPath));
+    writeFileSync(outPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  }
+
+  return report;
+}
+
+export function buildRfbaReviewData(params: {
+  base: string;
+  head: string;
+  scope?: string;
+  includeRawDiff: boolean;
+  inspectReport: RfbaInspectionReport;
+  git: GitClient;
+}): RfbaReviewDataReport {
+  const entries = parseGitNameStatus(params.git.nameStatus(params.base, params.head))
+    .filter((entry) => !params.scope || isInScope(entry.path, params.scope) || (entry.oldPath ? isInScope(entry.oldPath, params.scope) : false));
+  const warnings: RfbaReviewWarning[] = [];
+  const changedFiles = entries.map((entry) => {
+    const file = classifyRfbaChangedFile(entry);
+    if (params.includeRawDiff) {
+      file.rawDiff = params.git.diff(params.base, params.head, file.path) ?? undefined;
+    }
+    return file;
+  });
+
+  const changedBoundaries = buildChangedBoundarySummary(changedFiles, params.inspectReport);
+  const ddlChanges = buildDdlChanges(changedFiles, params.base, params.head, params.git, warnings);
+  const sqlChanges = buildSqlChanges(changedFiles, params.base, params.head, params.git, warnings);
+  const boundaryChanges = buildBoundaryChanges(changedFiles, params.base, params.head, params.git);
+  const verificationChanges = buildVerificationSummary(changedFiles);
+  const generatedChanges = changedFiles.filter((file) => file.kind === 'generated-evidence');
+  const adapterChanges = changedFiles.filter((file) => file.kind === 'adapter');
+  const reviewHints = buildReviewHints(changedFiles, ddlChanges, sqlChanges, boundaryChanges);
+
+  addVerificationWarnings(changedFiles, verificationChanges, warnings);
+  addGeneratedOnlyWarnings(changedFiles, generatedChanges, warnings);
+  warnings.sort(compareWarnings);
+
+  return {
+    schemaVersion: 1,
+    command: 'rfba review-data',
+    base: params.base,
+    head: params.head,
+    summary: {
+      changedFiles: changedFiles.length,
+      changedBoundaries: changedBoundaries.length,
+      ddlChanges: ddlChanges.reduce((sum, item) => sum + item.changes.length, 0),
+      sqlChanges: sqlChanges.length,
+      boundaryChanges: boundaryChanges.length,
+      adapterChanges: adapterChanges.length,
+      verificationChanges: verificationChanges.length,
+      generatedChanges: generatedChanges.length,
+      warnings: warnings.length,
+    },
+    changedFiles: changedFiles.sort(compareByPath),
+    changedBoundaries,
+    ddlChanges,
+    sqlChanges,
+    boundaryChanges,
+    adapterChanges: adapterChanges.sort(compareByPath),
+    verificationChanges,
+    generatedChanges: generatedChanges.sort(compareByPath),
+    reviewHints: reviewHints.sort((left, right) => left.target.localeCompare(right.target) || left.hint.localeCompare(right.hint)),
+    warnings,
+  };
+}
+
+export function parseGitNameStatus(output: string): GitNameStatusEntry[] {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const parts = line.split('\t');
+      const rawStatus = parts[0] ?? '';
+      const statusCode = rawStatus.charAt(0);
+      const score = rawStatus.length > 1 ? Number(rawStatus.slice(1)) : undefined;
+      if (statusCode === 'R' || statusCode === 'C') {
+        if (parts.length < 3) {
+          throw new Error(`Invalid git name-status rename/copy entry: ${line}`);
+        }
+        return {
+          status: statusCode === 'R' ? 'renamed' : 'copied',
+          oldPath: normalizePath(parts[1]),
+          path: normalizePath(parts[2]),
+          score: Number.isFinite(score) ? score : undefined,
+        };
+      }
+      const pathValue = parts[1] ?? parts[0]?.slice(1).trim();
+      if (!pathValue) {
+        throw new Error(`Invalid git name-status entry: ${line}`);
+      }
+      switch (statusCode) {
+        case 'A':
+          return { status: 'added', path: normalizePath(pathValue) };
+        case 'M':
+          return { status: 'modified', path: normalizePath(pathValue) };
+        case 'D':
+          return { status: 'deleted', path: normalizePath(pathValue) };
+        default:
+          return { status: 'modified', path: normalizePath(pathValue) };
+      }
+    });
+}
+
+export function classifyRfbaChangedFile(entry: GitNameStatusEntry): RfbaChangedFile {
+  const pathValue = normalizePath(entry.path);
+  const kind = classifyKind(pathValue);
+  return {
+    path: pathValue,
+    oldPath: entry.oldPath ? normalizePath(entry.oldPath) : undefined,
+    status: entry.status,
+    kind,
+    boundary: deriveBoundary(pathValue, kind),
+    parentFeatureBoundary: deriveParentFeatureBoundary(pathValue),
+    reviewWeight: reviewWeightForKind(kind),
+  };
+}
+
+export function buildChangedBoundarySummary(
+  changedFiles: RfbaChangedFile[],
+  inspectReport: RfbaInspectionReport
+): RfbaChangedBoundary[] {
+  const boundaryByPath = new Map(inspectReport.boundaries.map((boundary) => [boundary.path, boundary]));
+  const parentByPath = new Map(inspectReport.boundaries.map((boundary) => {
+    const parentPath = boundary.parentBoundaryId
+      ? inspectReport.boundaries.find((candidate) => candidate.id === boundary.parentBoundaryId)?.path ?? null
+      : null;
+    return [boundary.path, parentPath] as const;
+  }));
+  const grouped = new Map<string, RfbaChangedFile[]>();
+
+  for (const file of changedFiles) {
+    if (!file.boundary) {
+      continue;
+    }
+    const list = grouped.get(file.boundary) ?? [];
+    list.push(file);
+    grouped.set(file.boundary, list);
+  }
+
+  return Array.from(grouped.entries())
+    .map(([boundaryPath, files]): RfbaChangedBoundary => {
+      const boundary = boundaryByPath.get(boundaryPath);
+      return {
+        boundary: boundaryPath,
+        kind: boundary?.kind ?? 'unknown',
+        parentBoundary: parentByPath.get(boundaryPath) ?? files[0]?.parentFeatureBoundary ?? null,
+        changedFiles: sortUnique(files.map((file) => file.path)),
+        reviewWeight: maxReviewWeight(files.map((file) => file.reviewWeight)),
+      };
+    })
+    .sort((left, right) => left.boundary.localeCompare(right.boundary));
+}
+
+export function diffDdlTables(beforeSql: string | null, afterSql: string | null, filePath = 'db/ddl/schema.sql'): DdlChangeItem[] {
+  const before = parseDdlTables(beforeSql ?? '');
+  const after = parseDdlTables(afterSql ?? '');
+  const beforeIndexes = parseDdlIndexes(beforeSql ?? '');
+  const afterIndexes = parseDdlIndexes(afterSql ?? '');
+  const items: DdlChangeItem[] = [];
+  const tableNames = sortUnique([...before.keys(), ...after.keys()]);
+
+  for (const tableName of tableNames) {
+    const beforeTable = before.get(tableName);
+    const afterTable = after.get(tableName);
+    const changes: DdlChangeDetail[] = [];
+    if (!beforeTable && afterTable) {
+      changes.push({
+        kind: 'add-table',
+        before: null,
+        after: tableView(afterTable),
+        explanationSql: `CREATE TABLE ${tableName} (...);`,
+        reviewHints: ['Review the new table ownership, constraints, and migration rollout semantics.'],
+      });
+    } else if (beforeTable && !afterTable) {
+      changes.push({
+        kind: 'drop-table',
+        before: tableView(beforeTable),
+        after: null,
+        explanationSql: `DROP TABLE ${tableName};`,
+        reviewHints: ['Confirm whether dropping this table is intended and whether data migration is required.'],
+      });
+    } else if (beforeTable && afterTable) {
+      changes.push(...diffColumns(tableName, beforeTable, afterTable));
+      changes.push(...diffPrimaryKey(tableName, beforeTable, afterTable));
+      changes.push(...diffUnique(tableName, beforeTable, afterTable));
+    }
+
+    if (changes.length > 0) {
+      items.push({
+        path: filePath,
+        objectKind: 'table',
+        object: tableName,
+        explanationSqlPurpose: EXPLANATION_SQL_PURPOSE,
+        changes,
+        tableViewAfter: afterTable ? tableView(afterTable) : undefined,
+      });
+    }
+  }
+
+  items.push(...diffDdlIndexes(beforeIndexes, afterIndexes, filePath));
+
+  return items.sort((left, right) => left.object.localeCompare(right.object));
+}
+
+export function summarizeSqlChange(beforeSql: string | null, afterSql: string | null, filePath = 'query.sql', boundary: string | null = null): SqlChangeItem {
+  const before = summarizeSql(beforeSql ?? '');
+  const after = summarizeSql(afterSql ?? '');
+  const reviewHints: string[] = [];
+  if (before.statementKind !== after.statementKind) {
+    reviewHints.push('Confirm whether the query boundary contract changed with the SQL statement kind.');
+  }
+  if (before.returningColumns.join('\0') !== after.returningColumns.join('\0')) {
+    reviewHints.push('Confirm whether the returned result shape change is reflected in the query boundary.');
+    reviewHints.push('Confirm whether query-local cases assert the returned columns.');
+  }
+  if (before.writeTables.join('\0') !== after.writeTables.join('\0')) {
+    reviewHints.push('Confirm write table changes against DDL ownership and transaction semantics.');
+  }
+
+  return {
+    path: filePath,
+    boundary,
+    statementKindBefore: before.statementKind,
+    statementKindAfter: after.statementKind,
+    readTablesBefore: before.readTables,
+    readTablesAfter: after.readTables,
+    writeTablesBefore: before.writeTables,
+    writeTablesAfter: after.writeTables,
+    returningColumnsBefore: before.returningColumns,
+    returningColumnsAfter: after.returningColumns,
+    selectedColumnsBefore: before.selectedColumns,
+    selectedColumnsAfter: after.selectedColumns,
+    whereColumnsBefore: before.whereColumns,
+    whereColumnsAfter: after.whereColumns,
+    joinTablesBefore: before.joinTables,
+    joinTablesAfter: after.joinTables,
+    reviewHints: sortUnique(reviewHints),
+  };
+}
+
+export function buildVerificationSummary(changedFiles: RfbaChangedFile[]): VerificationSummaryItem[] {
+  const grouped = new Map<string, VerificationSummaryItem>();
+  const ensure = (boundary: string) => {
+    const existing = grouped.get(boundary);
+    if (existing) {
+      return existing;
+    }
+    const created: VerificationSummaryItem = {
+      boundary,
+      changedCases: [],
+      changedGeneratedEvidence: [],
+      changedEntrypoints: [],
+      changedFeatureTests: [],
+      changedTestSupport: [],
+      missingLikelyEvidence: [],
+    };
+    grouped.set(boundary, created);
+    return created;
+  };
+
+  for (const file of changedFiles) {
+    const boundary = file.boundary ?? file.parentFeatureBoundary ?? 'global';
+    if (!isVerificationKind(file.kind)) {
+      continue;
+    }
+    const item = ensure(boundary);
+    if (file.kind === 'query-case') {
+      item.changedCases.push(file.path);
+    } else if (file.kind === 'generated-evidence') {
+      item.changedGeneratedEvidence.push(file.path);
+    } else if (file.kind === 'feature-verification') {
+      item.changedFeatureTests.push(file.path);
+    } else if (file.kind === 'test-support') {
+      item.changedTestSupport.push(file.path);
+    } else {
+      item.changedEntrypoints.push(file.path);
+    }
+  }
+
+  const sqlBoundaries = sortUnique(changedFiles.filter((file) => file.kind === 'query-sql' && file.boundary).map((file) => file.boundary as string));
+  for (const boundary of sqlBoundaries) {
+    const item = ensure(boundary);
+    if (item.changedCases.length === 0 && item.changedGeneratedEvidence.length === 0) {
+      item.missingLikelyEvidence.push('SQL changed but no query-local cases or generated evidence changed.');
+    }
+  }
+
+  return Array.from(grouped.values())
+    .map((item) => ({
+      ...item,
+      changedCases: sortUnique(item.changedCases),
+      changedGeneratedEvidence: sortUnique(item.changedGeneratedEvidence),
+      changedEntrypoints: sortUnique(item.changedEntrypoints),
+      changedFeatureTests: sortUnique(item.changedFeatureTests),
+      changedTestSupport: sortUnique(item.changedTestSupport),
+      missingLikelyEvidence: sortUnique(item.missingLikelyEvidence),
+    }))
+    .sort((left, right) => left.boundary.localeCompare(right.boundary));
+}
+
+function createGitClient(projectRoot: string): GitClient {
+  return {
+    nameStatus(base, head) {
+      return runGit(projectRoot, ['diff', '--name-status', `${base}...${head}`]);
+    },
+    show(ref, filePath) {
+      const result = runGitMaybe(projectRoot, ['show', `${ref}:${filePath}`]);
+      return result.status === 0 ? result.stdout : null;
+    },
+    diff(base, head, filePath) {
+      const result = runGitMaybe(projectRoot, ['diff', `${base}...${head}`, '--', filePath]);
+      return result.status === 0 ? result.stdout : null;
+    },
+  };
+}
+
+function runGit(cwd: string, args: string[]): string {
+  const result = runGitMaybe(cwd, args);
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || result.stdout.trim() || `git ${args.join(' ')} failed`);
+  }
+  return result.stdout;
+}
+
+function runGitMaybe(cwd: string, args: string[]): { status: number | null; stdout: string; stderr: string; error?: Error } {
+  const result = spawnSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    error: result.error,
+  };
+}
+
+function buildDdlChanges(
+  changedFiles: RfbaChangedFile[],
+  base: string,
+  head: string,
+  git: GitClient,
+  warnings: RfbaReviewWarning[]
+): DdlChangeItem[] {
+  const result: DdlChangeItem[] = [];
+  for (const file of changedFiles.filter((candidate) => candidate.kind === 'ddl')) {
+    const before = file.status === 'added' ? null : git.show(base, file.oldPath ?? file.path);
+    const after = file.status === 'deleted' ? null : git.show(head, file.path);
+    const changes = diffDdlTables(before, after, file.path);
+    if ((before || after) && changes.length === 0 && containsSupportedDdl(before ?? after ?? '')) {
+      warnings.push({
+        code: 'ddl-analysis.partial',
+        path: file.path,
+        message: 'DDL analysis produced no supported structural changes. AI should inspect the DDL file directly.',
+      });
+    }
+    if ((before || after) && !containsSupportedDdl(before ?? '') && !containsSupportedDdl(after ?? '')) {
+      warnings.push({
+        code: 'ddl-analysis.partial',
+        path: file.path,
+        message: 'DDL analysis only supports CREATE TABLE and CREATE INDEX statements in the MVP. AI should inspect this DDL file directly.',
+      });
+    }
+    result.push(...changes);
+  }
+  return result.sort((left, right) => left.path.localeCompare(right.path) || left.object.localeCompare(right.object));
+}
+
+function buildSqlChanges(
+  changedFiles: RfbaChangedFile[],
+  base: string,
+  head: string,
+  git: GitClient,
+  warnings: RfbaReviewWarning[]
+): SqlChangeItem[] {
+  const result: SqlChangeItem[] = [];
+  for (const file of changedFiles.filter((candidate) => candidate.kind === 'query-sql')) {
+    const before = file.status === 'added' ? null : git.show(base, file.oldPath ?? file.path);
+    const after = file.status === 'deleted' ? null : git.show(head, file.path);
+    const beforeSummary = summarizeSql(before ?? '');
+    const afterSummary = summarizeSql(after ?? '');
+    if ((before && beforeSummary.parseWarning) || (after && afterSummary.parseWarning)) {
+      warnings.push({
+        code: 'sql-analysis.partial',
+        path: file.path,
+        message: 'SQL analysis was partial. AI should inspect the SQL file directly.',
+      });
+    }
+    result.push(summarizeSqlChange(before, after, file.path, file.boundary));
+  }
+  return result.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function buildBoundaryChanges(
+  changedFiles: RfbaChangedFile[],
+  base: string,
+  head: string,
+  git: GitClient
+): BoundaryChangeItem[] {
+  return changedFiles
+    .filter((file) => file.kind === 'feature-boundary' || file.kind === 'query-boundary')
+    .map((file) => {
+      const before = file.status === 'added' ? '' : git.show(base, file.oldPath ?? file.path) ?? '';
+      const after = file.status === 'deleted' ? '' : git.show(head, file.path) ?? '';
+      const beforeExports = extractExportedNames(before);
+      const afterExports = extractExportedNames(after);
+      return {
+        path: file.path,
+        boundary: file.boundary,
+        kind: file.kind,
+        exportedNamesBefore: beforeExports,
+        exportedNamesAfter: afterExports,
+        zodSchemaNamesBefore: extractZodSchemaNames(before),
+        zodSchemaNamesAfter: extractZodSchemaNames(after),
+        addedExports: afterExports.filter((name) => !beforeExports.includes(name)).sort(),
+        removedExports: beforeExports.filter((name) => !afterExports.includes(name)).sort(),
+        reviewWeight: file.reviewWeight,
+        reviewHints: [
+          'Inspect public request and response shape changes manually.',
+          'Confirm orchestration still calls query boundaries through public surfaces.',
+        ],
+      };
+    })
+    .sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function buildReviewHints(
+  changedFiles: RfbaChangedFile[],
+  ddlChanges: DdlChangeItem[],
+  sqlChanges: SqlChangeItem[],
+  boundaryChanges: BoundaryChangeItem[]
+): RfbaReviewHint[] {
+  const hints: RfbaReviewHint[] = [];
+  for (const file of changedFiles) {
+    if (file.kind === 'ddl') {
+      hints.push({
+        target: file.path,
+        priority: 'high',
+        hint: 'DDL changed. Human should review table, column, constraint, and migration risk semantics.',
+      });
+    } else if (file.kind === 'query-sql') {
+      hints.push({
+        target: file.path,
+        priority: 'high',
+        hint: 'SQL changed. Human should review query behavior, table usage, and returned shape.',
+      });
+    } else if (file.kind === 'generated-evidence') {
+      hints.push({
+        target: file.path,
+        priority: 'low',
+        hint: 'Generated evidence changed. Confirm the source SQL, DDL, or cases explain the generated update.',
+      });
+    }
+  }
+  for (const item of ddlChanges) {
+    for (const change of item.changes) {
+      hints.push(...change.reviewHints.map((hint) => ({ target: item.object, priority: 'high' as const, hint })));
+    }
+  }
+  for (const item of sqlChanges) {
+    hints.push(...item.reviewHints.map((hint) => ({ target: item.path, priority: 'high' as const, hint })));
+  }
+  for (const item of boundaryChanges) {
+    hints.push(...item.reviewHints.map((hint) => ({ target: item.path, priority: item.reviewWeight, hint })));
+  }
+  return uniqueHints(hints);
+}
+
+function addVerificationWarnings(
+  changedFiles: RfbaChangedFile[],
+  verificationChanges: VerificationSummaryItem[],
+  warnings: RfbaReviewWarning[]
+): void {
+  const changedDdl = changedFiles.some((file) => file.kind === 'ddl');
+  if (changedDdl && !changedFiles.some((file) => file.kind === 'query-case' || file.kind === 'generated-evidence' || file.kind === 'feature-verification' || file.kind === 'query-verification')) {
+    warnings.push({
+      code: 'verification.possibly-missing',
+      message: 'DDL changed but no obvious RFBA verification or generated evidence changed.',
+    });
+  }
+  for (const item of verificationChanges) {
+    for (const missing of item.missingLikelyEvidence) {
+      warnings.push({
+        code: 'verification.possibly-missing',
+        boundary: item.boundary,
+        message: missing,
+      });
+    }
+  }
+}
+
+function addGeneratedOnlyWarnings(
+  changedFiles: RfbaChangedFile[],
+  generatedChanges: RfbaChangedFile[],
+  warnings: RfbaReviewWarning[]
+): void {
+  if (generatedChanges.length === 0) {
+    return;
+  }
+  const sourceKinds: RfbaChangedFileKind[] = ['ddl', 'query-sql', 'feature-boundary', 'query-boundary', 'query-case'];
+  const hasSourceChange = changedFiles.some((file) => sourceKinds.includes(file.kind));
+  if (!hasSourceChange) {
+    warnings.push({
+      code: 'generated-without-source',
+      paths: generatedChanges.map((file) => file.path).sort(),
+      message: 'Generated evidence changed without an obvious DDL, SQL, boundary, or case change.',
+    });
+  }
+}
+
+function classifyKind(filePath: string): RfbaChangedFileKind {
+  if (/^db\/ddl\/.+\.sql$/i.test(filePath)) {
+    return 'ddl';
+  }
+  if (/^src\/features\/[^/]+\/boundary\.ts$/i.test(filePath)) {
+    return 'feature-boundary';
+  }
+  if (/^src\/features\/[^/]+\/queries\/[^/]+\/boundary\.ts$/i.test(filePath)) {
+    return 'query-boundary';
+  }
+  if (/^src\/features\/[^/]+\/queries\/[^/]+\/.+\.sql$/i.test(filePath)) {
+    return 'query-sql';
+  }
+  if (/^src\/features\/[^/]+\/queries\/[^/]+\/tests\/cases\//i.test(filePath)) {
+    return 'query-case';
+  }
+  if (/^src\/features\/[^/]+\/queries\/[^/]+\/tests\/generated\//i.test(filePath)) {
+    return 'generated-evidence';
+  }
+  if (/^src\/features\/[^/]+\/queries\/[^/]+\/tests\//i.test(filePath)) {
+    return 'query-verification';
+  }
+  if (/^src\/features\/[^/]+\/tests\//i.test(filePath)) {
+    return 'feature-verification';
+  }
+  if (/^src\/adapters\//i.test(filePath)) {
+    return 'adapter';
+  }
+  if (/^src\/libraries\//i.test(filePath)) {
+    return 'library';
+  }
+  if (/^tests\/support\//i.test(filePath)) {
+    return 'test-support';
+  }
+  if (/^\.ztd\//i.test(filePath)) {
+    return 'tool-managed';
+  }
+  return 'unknown';
+}
+
+function deriveBoundary(filePath: string, kind: RfbaChangedFileKind): string | null {
+  const parts = filePath.split('/');
+  if (kind === 'feature-boundary' || kind === 'feature-verification') {
+    return parts.length >= 3 ? parts.slice(0, 3).join('/') : null;
+  }
+  if (kind === 'query-boundary' || kind === 'query-sql' || kind === 'query-case' || kind === 'query-verification' || kind === 'generated-evidence') {
+    return parts.length >= 5 ? parts.slice(0, 5).join('/') : null;
+  }
+  if (kind === 'adapter') {
+    return parts.length >= 3 ? parts.slice(0, 3).join('/') : 'src/adapters';
+  }
+  if (kind === 'library') {
+    return parts.length >= 3 ? parts.slice(0, 3).join('/') : 'src/libraries';
+  }
+  return null;
+}
+
+function deriveParentFeatureBoundary(filePath: string): string | null {
+  const parts = filePath.split('/');
+  if (parts[0] === 'src' && parts[1] === 'features' && parts[2] && !parts[2].startsWith('_')) {
+    return parts.slice(0, 3).join('/');
+  }
+  return null;
+}
+
+function reviewWeightForKind(kind: RfbaChangedFileKind): RfbaReviewWeight {
+  switch (kind) {
+    case 'ddl':
+    case 'query-sql':
+    case 'feature-boundary':
+    case 'query-boundary':
+    case 'adapter':
+      return 'high';
+    case 'generated-evidence':
+    case 'tool-managed':
+      return 'low';
+    default:
+      return 'medium';
+  }
+}
+
+function parseDdlTables(sql: string): Map<string, DdlTableModel> {
+  const result = new Map<string, DdlTableModel>();
+  for (const match of sql.matchAll(/create\s+(?:unlogged\s+|temporary\s+|temp\s+)?table\s+(?:if\s+not\s+exists\s+)?([^\s(]+)\s*\(([\s\S]*?)\)\s*;/gi)) {
+    const tableName = normalizeIdentifier(match[1]);
+    const body = match[2] ?? '';
+    const columns = new Map<string, DdlColumnView>();
+    const primaryKeyColumns: string[] = [];
+    const uniqueColumns: string[][] = [];
+    for (const part of splitTopLevelComma(body)) {
+      const trimmed = part.trim();
+      if (!trimmed) {
+        continue;
+      }
+      const tablePrimary = trimmed.match(/^(?:constraint\s+\S+\s+)?primary\s+key\s*\(([^)]+)\)/i);
+      if (tablePrimary) {
+        primaryKeyColumns.push(...splitIdentifierList(tablePrimary[1]));
+        continue;
+      }
+      const tableUnique = trimmed.match(/^(?:constraint\s+\S+\s+)?unique\s*\(([^)]+)\)/i);
+      if (tableUnique) {
+        uniqueColumns.push(splitIdentifierList(tableUnique[1]));
+        continue;
+      }
+      if (/^(constraint|foreign|check|exclude)\b/i.test(trimmed)) {
+        continue;
+      }
+      const column = parseDdlColumn(trimmed);
+      if (column) {
+        columns.set(column.name, column);
+        if (column.primaryKey) {
+          primaryKeyColumns.push(column.name);
+        }
+        if (column.unique) {
+          uniqueColumns.push([column.name]);
+        }
+      }
+    }
+    for (const column of columns.values()) {
+      column.primaryKey = primaryKeyColumns.includes(column.name);
+      column.unique = uniqueColumns.some((group) => group.length === 1 && group[0] === column.name);
+      if (column.primaryKey) {
+        column.notNull = true;
+      }
+    }
+    result.set(tableName, { name: tableName, columns, primaryKeyColumns: sortUnique(primaryKeyColumns), uniqueColumns });
+  }
+  return result;
+}
+
+function parseDdlIndexes(sql: string): Map<string, DdlIndexModel> {
+  const result = new Map<string, DdlIndexModel>();
+  for (const match of sql.matchAll(/create\s+(unique\s+)?index\s+(?:concurrently\s+)?(?:if\s+not\s+exists\s+)?([^\s]+)\s+on\s+([^\s(]+)\s*\(([^)]+)\)\s*;/gi)) {
+    const name = normalizeIdentifier(match[2]);
+    result.set(name, {
+      name,
+      table: normalizeTableRef(match[3]),
+      unique: Boolean(match[1]),
+      columns: splitIdentifierList(match[4]),
+    });
+  }
+  return result;
+}
+
+function parseDdlColumn(definition: string): DdlColumnView | null {
+  const match = definition.match(/^("[^"]+"|[a-zA-Z_][\w$]*)\s+(.+)$/);
+  if (!match) {
+    return null;
+  }
+  const name = normalizeIdentifier(match[1]);
+  const rest = match[2].trim();
+  const keywordIndex = findFirstConstraintKeywordIndex(rest);
+  const type = (keywordIndex === -1 ? rest : rest.slice(0, keywordIndex)).trim() || null;
+  const constraintText = keywordIndex === -1 ? '' : rest.slice(keywordIndex);
+  return {
+    name,
+    type,
+    notNull: /\bnot\s+null\b/i.test(constraintText),
+    default: extractDefaultValue(constraintText),
+    primaryKey: /\bprimary\s+key\b/i.test(constraintText),
+    unique: /\bunique\b/i.test(constraintText),
+  };
+}
+
+function diffColumns(tableName: string, before: DdlTableModel, after: DdlTableModel): DdlChangeDetail[] {
+  const changes: DdlChangeDetail[] = [];
+  const columnNames = sortUnique([...before.columns.keys(), ...after.columns.keys()]);
+  for (const columnName of columnNames) {
+    const beforeColumn = before.columns.get(columnName);
+    const afterColumn = after.columns.get(columnName);
+    if (!beforeColumn && afterColumn) {
+      changes.push({
+        kind: 'add-column',
+        column: columnName,
+        before: null,
+        after: afterColumn,
+        explanationSql: `ALTER TABLE ${tableName} ADD COLUMN ${columnName} ${afterColumn.type ?? ''}${afterColumn.notNull ? ' NOT NULL' : ''}${afterColumn.default ? ` DEFAULT ${afterColumn.default}` : ''};`,
+        reviewHints: [
+          'Confirm whether the default value is correct for business semantics.',
+          'Confirm whether this column should have an enum or check constraint.',
+        ],
+      });
+    } else if (beforeColumn && !afterColumn) {
+      changes.push({
+        kind: 'drop-column',
+        column: columnName,
+        before: beforeColumn,
+        after: null,
+        explanationSql: `ALTER TABLE ${tableName} DROP COLUMN ${columnName};`,
+        reviewHints: ['Confirm whether dropping this column is intended and whether existing data must be migrated.'],
+      });
+    } else if (beforeColumn && afterColumn) {
+      if ((beforeColumn.type ?? '').toLowerCase() !== (afterColumn.type ?? '').toLowerCase()) {
+        changes.push({
+          kind: 'modify-column-type',
+          column: columnName,
+          before: beforeColumn.type,
+          after: afterColumn.type,
+          explanationSql: `ALTER TABLE ${tableName} ALTER COLUMN ${columnName} TYPE ${afterColumn.type ?? 'unknown'};`,
+          reviewHints: ['Confirm type conversion safety and whether a USING clause is required.'],
+        });
+      }
+      if (beforeColumn.notNull !== afterColumn.notNull) {
+        changes.push({
+          kind: 'modify-column-nullability',
+          column: columnName,
+          before: { notNull: beforeColumn.notNull },
+          after: { notNull: afterColumn.notNull },
+          explanationSql: `ALTER TABLE ${tableName} ALTER COLUMN ${columnName} ${afterColumn.notNull ? 'SET NOT NULL' : 'DROP NOT NULL'};`,
+          reviewHints: ['Confirm nullability changes against existing rows and request validation.'],
+        });
+      }
+      if ((beforeColumn.default ?? '') !== (afterColumn.default ?? '')) {
+        changes.push({
+          kind: 'modify-column-default',
+          column: columnName,
+          before: beforeColumn.default,
+          after: afterColumn.default,
+          explanationSql: afterColumn.default
+            ? `ALTER TABLE ${tableName} ALTER COLUMN ${columnName} SET DEFAULT ${afterColumn.default};`
+            : `ALTER TABLE ${tableName} ALTER COLUMN ${columnName} DROP DEFAULT;`,
+          reviewHints: ['Confirm whether the default value is correct for business semantics.'],
+        });
+      }
+    }
+  }
+  return changes;
+}
+
+function diffPrimaryKey(tableName: string, before: DdlTableModel, after: DdlTableModel): DdlChangeDetail[] {
+  const beforeKey = before.primaryKeyColumns.join(',');
+  const afterKey = after.primaryKeyColumns.join(',');
+  if (beforeKey === afterKey) {
+    return [];
+  }
+  return [{
+    kind: beforeKey ? 'drop-primary-key' : 'add-primary-key',
+    before: before.primaryKeyColumns,
+    after: after.primaryKeyColumns,
+    explanationSql: afterKey
+      ? `ALTER TABLE ${tableName} ADD PRIMARY KEY (${after.primaryKeyColumns.join(', ')});`
+      : `ALTER TABLE ${tableName} DROP CONSTRAINT <primary-key-constraint>;`,
+    reviewHints: ['Confirm primary key changes against references and application identity semantics.'],
+  }];
+}
+
+function diffUnique(tableName: string, before: DdlTableModel, after: DdlTableModel): DdlChangeDetail[] {
+  const beforeKeys = before.uniqueColumns.map((columns) => columns.join(',')).sort();
+  const afterKeys = after.uniqueColumns.map((columns) => columns.join(',')).sort();
+  const changes: DdlChangeDetail[] = [];
+  for (const key of beforeKeys.filter((candidate) => !afterKeys.includes(candidate))) {
+    changes.push({
+      kind: 'drop-unique',
+      before: key.split(','),
+      after: null,
+      explanationSql: `ALTER TABLE ${tableName} DROP CONSTRAINT <unique-constraint>;`,
+      reviewHints: ['Confirm whether removing uniqueness is intended for business semantics.'],
+    });
+  }
+  for (const key of afterKeys.filter((candidate) => !beforeKeys.includes(candidate))) {
+    changes.push({
+      kind: 'add-unique',
+      before: null,
+      after: key.split(','),
+      explanationSql: `ALTER TABLE ${tableName} ADD UNIQUE (${key.split(',').join(', ')});`,
+      reviewHints: ['Confirm whether existing rows satisfy the new uniqueness rule.'],
+    });
+  }
+  return changes;
+}
+
+function diffDdlIndexes(
+  before: Map<string, DdlIndexModel>,
+  after: Map<string, DdlIndexModel>,
+  filePath: string
+): DdlChangeItem[] {
+  const items: DdlChangeItem[] = [];
+  const indexNames = sortUnique([...before.keys(), ...after.keys()]);
+  for (const indexName of indexNames) {
+    const beforeIndex = before.get(indexName);
+    const afterIndex = after.get(indexName);
+    if (!beforeIndex && afterIndex) {
+      items.push({
+        path: filePath,
+        objectKind: 'index',
+        object: indexName,
+        explanationSqlPurpose: EXPLANATION_SQL_PURPOSE,
+        changes: [{
+          kind: 'add-index',
+          index: indexName,
+          before: null,
+          after: afterIndex,
+          explanationSql: `CREATE ${afterIndex.unique ? 'UNIQUE ' : ''}INDEX ${indexName} ON ${afterIndex.table} (${afterIndex.columns.join(', ')});`,
+          reviewHints: ['Confirm whether the new index supports the changed query path and whether build cost is acceptable.'],
+        }],
+      });
+    } else if (beforeIndex && !afterIndex) {
+      items.push({
+        path: filePath,
+        objectKind: 'index',
+        object: indexName,
+        explanationSqlPurpose: EXPLANATION_SQL_PURPOSE,
+        changes: [{
+          kind: 'drop-index',
+          index: indexName,
+          before: beforeIndex,
+          after: null,
+          explanationSql: `DROP INDEX ${indexName};`,
+          reviewHints: ['Confirm whether removing this index is safe for existing read paths.'],
+        }],
+      });
+    }
+  }
+  return items;
+}
+
+function summarizeSql(sql: string): SqlSummary {
+  const stripped = stripSqlComments(sql).trim();
+  if (!stripped) {
+    return emptySqlSummary();
+  }
+  let parseWarning = false;
+  try {
+    SqlParser.parse(stripped);
+  } catch {
+    parseWarning = true;
+  }
+  const statementKind = stripped.match(/^(?:with\b[\s\S]+?\)\s*)?(select|insert|update|delete|merge)\b/i)?.[1]?.toLowerCase() ?? null;
+  return {
+    statementKind,
+    readTables: extractReadTables(stripped, statementKind),
+    writeTables: extractWriteTables(stripped, statementKind),
+    returningColumns: extractReturningColumns(stripped),
+    selectedColumns: extractSelectedColumns(stripped, statementKind),
+    whereColumns: extractWhereColumns(stripped),
+    joinTables: extractJoinTables(stripped),
+    parseWarning,
+  };
+}
+
+function emptySqlSummary(): SqlSummary {
+  return {
+    statementKind: null,
+    readTables: [],
+    writeTables: [],
+    returningColumns: [],
+    selectedColumns: [],
+    whereColumns: [],
+    joinTables: [],
+    parseWarning: false,
+  };
+}
+
+function extractReadTables(sql: string, statementKind: string | null): string[] {
+  const tables: string[] = [];
+  for (const match of sql.matchAll(/\bfrom\s+("[^"]+"|[a-zA-Z_][\w$]*(?:\s*\.\s*"?[\w$]+"?)?)/gi)) {
+    tables.push(normalizeTableRef(match[1]));
+  }
+  for (const match of sql.matchAll(/\bjoin\s+("[^"]+"|[a-zA-Z_][\w$]*(?:\s*\.\s*"?[\w$]+"?)?)/gi)) {
+    tables.push(normalizeTableRef(match[1]));
+  }
+  if (statementKind === 'delete') {
+    const writeTables = extractWriteTables(sql, statementKind);
+    return sortUnique(tables.filter((table) => !writeTables.includes(table)));
+  }
+  return sortUnique(tables);
+}
+
+function extractWriteTables(sql: string, statementKind: string | null): string[] {
+  const patterns: RegExp[] = [];
+  if (statementKind === 'insert') {
+    patterns.push(/\binsert\s+into\s+("[^"]+"|[a-zA-Z_][\w$]*(?:\s*\.\s*"?[\w$]+"?)?)/i);
+  } else if (statementKind === 'update') {
+    patterns.push(/\bupdate\s+("[^"]+"|[a-zA-Z_][\w$]*(?:\s*\.\s*"?[\w$]+"?)?)/i);
+  } else if (statementKind === 'delete') {
+    patterns.push(/\bdelete\s+from\s+("[^"]+"|[a-zA-Z_][\w$]*(?:\s*\.\s*"?[\w$]+"?)?)/i);
+  }
+  return sortUnique(patterns.map((pattern) => sql.match(pattern)?.[1]).filter((value): value is string => Boolean(value)).map(normalizeTableRef));
+}
+
+function extractReturningColumns(sql: string): string[] {
+  const returning = sql.match(/\breturning\s+([\s\S]+?)(?:;|$)/i)?.[1];
+  if (!returning) {
+    return [];
+  }
+  return splitTopLevelComma(returning).map(cleanSqlExpressionName).filter(Boolean).sort();
+}
+
+function extractSelectedColumns(sql: string, statementKind: string | null): string[] {
+  if (statementKind !== 'select') {
+    return [];
+  }
+  const selected = sql.match(/\bselect\s+([\s\S]+?)\s+\bfrom\b/i)?.[1];
+  if (!selected) {
+    return [];
+  }
+  return splitTopLevelComma(selected).map(cleanSqlExpressionName).filter(Boolean).sort();
+}
+
+function extractWhereColumns(sql: string): string[] {
+  const where = sql.match(/\bwhere\s+([\s\S]+?)(?:\bgroup\s+by\b|\border\s+by\b|\blimit\b|\breturning\b|;|$)/i)?.[1];
+  if (!where) {
+    return [];
+  }
+  return sortUnique(Array.from(where.matchAll(/(?<!['"])(?:[a-zA-Z_][\w$]*\.)?([a-zA-Z_][\w$]*)\s*(?:=|<>|!=|<|>|<=|>=|\bis\b|\bin\b|\blike\b)/gi))
+    .map((match) => normalizeIdentifier(match[1]))
+    .filter((name) => !SQL_KEYWORDS.has(name.toLowerCase())));
+}
+
+function extractJoinTables(sql: string): string[] {
+  return sortUnique(Array.from(sql.matchAll(/\bjoin\s+("[^"]+"|[a-zA-Z_][\w$]*(?:\s*\.\s*"?[\w$]+"?)?)/gi))
+    .map((match) => normalizeTableRef(match[1])));
+}
+
+function extractExportedNames(source: string): string[] {
+  const names = new Set<string>();
+  for (const match of source.matchAll(/\bexport\s+(?:async\s+)?(?:const|let|var|function|class|interface|type|enum)\s+([A-Za-z_$][\w$]*)/g)) {
+    names.add(match[1]);
+  }
+  for (const match of source.matchAll(/\bexport\s*\{([^}]+)\}/g)) {
+    for (const part of match[1].split(',')) {
+      const name = part.trim().split(/\s+as\s+/i)[1] ?? part.trim().split(/\s+as\s+/i)[0];
+      if (/^[A-Za-z_$][\w$]*$/.test(name)) {
+        names.add(name);
+      }
+    }
+  }
+  return Array.from(names).sort();
+}
+
+function extractZodSchemaNames(source: string): string[] {
+  const names = new Set<string>();
+  for (const match of source.matchAll(/\b(?:const|let|var)\s+([A-Za-z_$][\w$]*(?:Schema|Input|Output|Request|Response))\s*=\s*z\./g)) {
+    names.add(match[1]);
+  }
+  return Array.from(names).sort();
+}
+
+function splitTopLevelComma(value: string): string[] {
+  const parts: string[] = [];
+  let current = '';
+  let depth = 0;
+  let quote: string | null = null;
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    const previous = value[index - 1];
+    if (quote) {
+      current += char;
+      if (char === quote && previous !== '\\') {
+        quote = null;
+      }
+      continue;
+    }
+    if (char === '\'' || char === '"') {
+      quote = char;
+      current += char;
+      continue;
+    }
+    if (char === '(') {
+      depth += 1;
+    } else if (char === ')' && depth > 0) {
+      depth -= 1;
+    }
+    if (char === ',' && depth === 0) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+  if (current.trim()) {
+    parts.push(current);
+  }
+  return parts;
+}
+
+function splitIdentifierList(value: string): string[] {
+  return splitTopLevelComma(value).map((part) => normalizeIdentifier(part.trim())).filter(Boolean).sort();
+}
+
+function findFirstConstraintKeywordIndex(value: string): number {
+  const match = value.search(/\s(?:constraint|not\s+null|null|default|primary\s+key|unique|references|check|generated)\b/i);
+  return match === -1 ? -1 : match + 1;
+}
+
+function extractDefaultValue(value: string): string | null {
+  const match = value.match(/\bdefault\s+(.+?)(?:\s+(?:constraint|not\s+null|null|primary\s+key|unique|references|check|generated)\b|$)/i);
+  return match?.[1]?.trim() ?? null;
+}
+
+function tableView(table: DdlTableModel): DdlTableView {
+  return {
+    table: table.name,
+    columnsAfter: Array.from(table.columns.values()).sort((left, right) => left.name.localeCompare(right.name)),
+  };
+}
+
+function containsCreateTable(sql: string): boolean {
+  return /\bcreate\s+(?:unlogged\s+|temporary\s+|temp\s+)?table\b/i.test(sql);
+}
+
+function containsSupportedDdl(sql: string): boolean {
+  return containsCreateTable(sql) || /\bcreate\s+(?:unique\s+)?index\b/i.test(sql);
+}
+
+function cleanSqlExpressionName(value: string): string {
+  const trimmed = value.trim();
+  const alias = trimmed.match(/\bas\s+("[^"]+"|[a-zA-Z_][\w$]*)$/i)?.[1]
+    ?? trimmed.match(/\s+("[^"]+"|[a-zA-Z_][\w$]*)$/)?.[1];
+  if (alias && !/[()*/+-]/.test(alias)) {
+    return normalizeIdentifier(alias);
+  }
+  const column = trimmed.match(/(?:^|\.)("[^"]+"|[a-zA-Z_][\w$]*)$/)?.[1];
+  return column ? normalizeIdentifier(column) : trimmed.replace(/\s+/g, ' ');
+}
+
+function normalizeTableRef(value: string): string {
+  return value.split('.').map((part) => normalizeIdentifier(part.trim())).join('.');
+}
+
+function normalizeIdentifier(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed.slice(1, -1).replace(/""/g, '"');
+  }
+  return trimmed.replace(/"/g, '');
+}
+
+function stripSqlComments(value: string): string {
+  return value.replace(/--.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+function normalizePath(value: string): string {
+  return value.replace(/\\/g, '/').replace(/^\.\//, '');
+}
+
+function normalizeScope(value: string | undefined): string | undefined {
+  const normalized = normalizeOption(value);
+  return normalized ? normalizePath(normalized).replace(/\/$/, '') : undefined;
+}
+
+function normalizeOption(value: string | undefined): string | undefined {
+  if (value === undefined || value === '') {
+    return undefined;
+  }
+  return value;
+}
+
+function resolveRfbaReviewDataFormat(value: string | undefined): RfbaReviewDataFormat {
+  const normalized = (value ?? 'json').trim().toLowerCase();
+  if (normalized === 'json') {
+    return 'json';
+  }
+  throw new Error(`Unsupported RFBA review-data format: ${value}`);
+}
+
+function isInScope(filePath: string, scope: string): boolean {
+  return filePath === scope || filePath.startsWith(`${scope}/`);
+}
+
+function isVerificationKind(kind: RfbaChangedFileKind): boolean {
+  return kind === 'query-case'
+    || kind === 'generated-evidence'
+    || kind === 'query-verification'
+    || kind === 'feature-verification'
+    || kind === 'test-support';
+}
+
+function maxReviewWeight(values: RfbaReviewWeight[]): RfbaReviewWeight {
+  if (values.includes('high')) {
+    return 'high';
+  }
+  if (values.includes('medium')) {
+    return 'medium';
+  }
+  return 'low';
+}
+
+function sortUnique(values: string[]): string[] {
+  return Array.from(new Set(values)).sort((left, right) => left.localeCompare(right));
+}
+
+function compareByPath(left: { path: string }, right: { path: string }): number {
+  return left.path.localeCompare(right.path);
+}
+
+function compareWarnings(left: RfbaReviewWarning, right: RfbaReviewWarning): number {
+  return left.code.localeCompare(right.code)
+    || (left.path ?? left.boundary ?? left.paths?.join(',') ?? '').localeCompare(right.path ?? right.boundary ?? right.paths?.join(',') ?? '')
+    || left.message.localeCompare(right.message);
+}
+
+function uniqueHints(hints: RfbaReviewHint[]): RfbaReviewHint[] {
+  const seen = new Set<string>();
+  const result: RfbaReviewHint[] = [];
+  for (const hint of hints) {
+    const key = `${hint.target}\0${hint.priority}\0${hint.hint}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(hint);
+    }
+  }
+  return result;
+}
+
+const SQL_KEYWORDS = new Set([
+  'and',
+  'or',
+  'not',
+  'null',
+  'true',
+  'false',
+  'is',
+  'in',
+  'like',
+  'between',
+  'exists',
+]);

--- a/packages/ztd-cli/tests/rfbaReviewData.unit.test.ts
+++ b/packages/ztd-cli/tests/rfbaReviewData.unit.test.ts
@@ -1,0 +1,327 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { Command } from 'commander';
+import { expect, test } from 'vitest';
+import { inspectRfbaBoundaries, registerRfbaCommand } from '../src/commands/rfba';
+import {
+  buildChangedBoundarySummary,
+  buildVerificationSummary,
+  classifyRfbaChangedFile,
+  diffDdlTables,
+  parseGitNameStatus,
+  summarizeSqlChange,
+} from '../src/commands/rfbaReviewData';
+import { setAgentOutputFormat } from '../src/utils/agentCli';
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+const tmpRoot = path.join(repoRoot, 'tmp');
+
+function createTempDir(prefix: string): string {
+  if (!existsSync(tmpRoot)) {
+    mkdirSync(tmpRoot, { recursive: true });
+  }
+  return mkdtempSync(path.join(tmpRoot, `${prefix}-`));
+}
+
+function writeWorkspaceFile(root: string, relativePath: string, contents = ''): void {
+  const filePath = path.join(root, ...relativePath.split('/'));
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, contents, 'utf8');
+}
+
+function runGit(cwd: string, args: string[]): void {
+  const result = spawnSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+  });
+  expect(result.status, result.stderr || result.stdout).toBe(0);
+}
+
+test('parseGitNameStatus supports added, modified, deleted, renamed, and copied entries', () => {
+  expect(parseGitNameStatus([
+    'A\tsrc/features/users/boundary.ts',
+    'M\tdb/ddl/public.sql',
+    'D\tsrc/features/users/tests/users.test.ts',
+    'R091\told.sql\tnew.sql',
+    'C100\ta.sql\tb.sql',
+  ].join('\n'))).toEqual([
+    { status: 'added', path: 'src/features/users/boundary.ts' },
+    { status: 'modified', path: 'db/ddl/public.sql' },
+    { status: 'deleted', path: 'src/features/users/tests/users.test.ts' },
+    { status: 'renamed', oldPath: 'old.sql', path: 'new.sql', score: 91 },
+    { status: 'copied', oldPath: 'a.sql', path: 'b.sql', score: 100 },
+  ]);
+});
+
+test('classifyRfbaChangedFile maps RFBA review kinds and weights deterministically', () => {
+  expect(classifyRfbaChangedFile({ status: 'modified', path: 'db/ddl/public.sql' })).toMatchObject({
+    kind: 'ddl',
+    boundary: null,
+    reviewWeight: 'high',
+  });
+  expect(classifyRfbaChangedFile({ status: 'modified', path: 'src/features/users-insert/queries/insert-users/insert-users.sql' })).toMatchObject({
+    kind: 'query-sql',
+    boundary: 'src/features/users-insert/queries/insert-users',
+    parentFeatureBoundary: 'src/features/users-insert',
+    reviewWeight: 'high',
+  });
+  expect(classifyRfbaChangedFile({ status: 'modified', path: 'src/features/users-insert/queries/insert-users/tests/generated/analysis.json' })).toMatchObject({
+    kind: 'generated-evidence',
+    reviewWeight: 'low',
+  });
+  expect(classifyRfbaChangedFile({ status: 'modified', path: 'docs/notes.md' })).toMatchObject({
+    kind: 'unknown',
+    reviewWeight: 'medium',
+  });
+});
+
+test('buildChangedBoundarySummary reuses RFBA inspection boundaries', () => {
+  const workspace = createTempDir('rfba-review-boundaries');
+  writeWorkspaceFile(workspace, 'src/features/users-insert/boundary.ts', 'export {};\n');
+  writeWorkspaceFile(workspace, 'src/features/users-insert/queries/insert-users/boundary.ts', 'export {};\n');
+  writeWorkspaceFile(workspace, 'src/features/users-insert/queries/insert-users/insert-users.sql', 'select 1;\n');
+  const changedFiles = [
+    classifyRfbaChangedFile({ status: 'modified', path: 'src/features/users-insert/queries/insert-users/insert-users.sql' }),
+    classifyRfbaChangedFile({ status: 'modified', path: 'src/features/users-insert/queries/insert-users/boundary.ts' }),
+  ];
+
+  expect(buildChangedBoundarySummary(changedFiles, inspectRfbaBoundaries(workspace))).toEqual([
+    {
+      boundary: 'src/features/users-insert/queries/insert-users',
+      kind: 'sub-boundary',
+      parentBoundary: 'src/features/users-insert/queries',
+      changedFiles: [
+        'src/features/users-insert/queries/insert-users/boundary.ts',
+        'src/features/users-insert/queries/insert-users/insert-users.sql',
+      ],
+      reviewWeight: 'high',
+    },
+  ]);
+});
+
+test('diffDdlTables reports add column, type, nullability, default, and explanation-only SQL', () => {
+  const before = `
+    CREATE TABLE public.users (
+      id integer PRIMARY KEY,
+      email text NOT NULL
+    );
+  `;
+  const after = `
+    CREATE TABLE public.users (
+      id integer PRIMARY KEY,
+      email varchar(320),
+      status text NOT NULL DEFAULT 'active'
+    );
+  `;
+
+  const changes = diffDdlTables(before, after, 'db/ddl/public.sql');
+
+  expect(changes).toHaveLength(1);
+  expect(changes[0]).toMatchObject({
+    object: 'public.users',
+    explanationSqlPurpose: 'human-readable explanation only; not an auto-apply migration',
+  });
+  expect(changes[0].changes.map((change) => change.kind)).toEqual([
+    'modify-column-type',
+    'modify-column-nullability',
+    'add-column',
+  ]);
+  expect(changes[0].tableViewAfter?.columnsAfter.map((column) => column.name)).toEqual(['email', 'id', 'status']);
+});
+
+test('diffDdlTables reports add-index and drop-index changes', () => {
+  const before = `
+    CREATE TABLE public.users (
+      id integer PRIMARY KEY,
+      email text NOT NULL
+    );
+    CREATE INDEX users_email_idx ON public.users (email);
+  `;
+  const after = `
+    CREATE TABLE public.users (
+      id integer PRIMARY KEY,
+      email text NOT NULL
+    );
+    CREATE UNIQUE INDEX users_email_unique_idx ON public.users (email);
+  `;
+
+  expect(diffDdlTables(before, after, 'db/ddl/public.sql')).toEqual(expect.arrayContaining([
+    expect.objectContaining({
+      objectKind: 'index',
+      object: 'users_email_idx',
+      changes: [expect.objectContaining({ kind: 'drop-index' })],
+    }),
+    expect.objectContaining({
+      objectKind: 'index',
+      object: 'users_email_unique_idx',
+      changes: [expect.objectContaining({ kind: 'add-index' })],
+    }),
+  ]));
+});
+
+test('summarizeSqlChange reports INSERT RETURNING and table usage changes', () => {
+  const before = `INSERT INTO public.users (email) VALUES ($1) RETURNING id, email;`;
+  const after = `INSERT INTO public.users (email, status) VALUES ($1, $2) RETURNING id, email, status;`;
+
+  expect(summarizeSqlChange(before, after, 'src/features/users-insert/queries/insert-users/insert-users.sql', 'src/features/users-insert/queries/insert-users')).toMatchObject({
+    statementKindBefore: 'insert',
+    statementKindAfter: 'insert',
+    writeTablesBefore: ['public.users'],
+    writeTablesAfter: ['public.users'],
+    returningColumnsBefore: ['email', 'id'],
+    returningColumnsAfter: ['email', 'id', 'status'],
+    reviewHints: expect.arrayContaining([
+      'Confirm whether the returned result shape change is reflected in the query boundary.',
+      'Confirm whether query-local cases assert the returned columns.',
+    ]),
+  });
+
+  expect(summarizeSqlChange(
+    `SELECT id, email FROM public.users WHERE email = $1;`,
+    `SELECT id, email FROM public.users JOIN public.accounts ON accounts.user_id = users.id WHERE email = $1;`
+  )).toMatchObject({
+    readTablesAfter: ['public.accounts', 'public.users'],
+    joinTablesAfter: ['public.accounts'],
+    selectedColumnsAfter: ['email', 'id'],
+    whereColumnsAfter: ['email'],
+  });
+
+  expect(summarizeSqlChange(
+    `UPDATE public.users SET email = $1 WHERE id = $2 RETURNING id;`,
+    `UPDATE public.user_profiles SET email = $1 WHERE id = $2 RETURNING id;`
+  )).toMatchObject({
+    writeTablesBefore: ['public.users'],
+    writeTablesAfter: ['public.user_profiles'],
+  });
+});
+
+test('buildVerificationSummary groups query evidence and flags likely missing evidence', () => {
+  const files = [
+    classifyRfbaChangedFile({ status: 'modified', path: 'src/features/users-insert/queries/insert-users/insert-users.sql' }),
+    classifyRfbaChangedFile({ status: 'modified', path: 'src/features/users-insert/queries/insert-users/tests/generated/analysis.json' }),
+    classifyRfbaChangedFile({ status: 'modified', path: 'src/features/users-insert/queries/insert-users/tests/cases/basic.case.ts' }),
+    classifyRfbaChangedFile({ status: 'modified', path: 'tests/support/ztd/runner.ts' }),
+  ];
+
+  expect(buildVerificationSummary(files)).toEqual([
+    {
+      boundary: 'global',
+      changedCases: [],
+      changedGeneratedEvidence: [],
+      changedEntrypoints: [],
+      changedFeatureTests: [],
+      changedTestSupport: ['tests/support/ztd/runner.ts'],
+      missingLikelyEvidence: [],
+    },
+    {
+      boundary: 'src/features/users-insert/queries/insert-users',
+      changedCases: ['src/features/users-insert/queries/insert-users/tests/cases/basic.case.ts'],
+      changedGeneratedEvidence: ['src/features/users-insert/queries/insert-users/tests/generated/analysis.json'],
+      changedEntrypoints: [],
+      changedFeatureTests: [],
+      changedTestSupport: [],
+      missingLikelyEvidence: [],
+    },
+  ]);
+
+  expect(buildVerificationSummary([
+    classifyRfbaChangedFile({ status: 'modified', path: 'src/features/users-insert/queries/insert-users/insert-users.sql' }),
+  ])[0].missingLikelyEvidence).toEqual(['SQL changed but no query-local cases or generated evidence changed.']);
+});
+
+test('rfba review-data command emits stdout JSON and writes --out in a Git workspace', async () => {
+  setAgentOutputFormat('text');
+  const workspace = createTempDir('rfba-review-cli');
+  runGit(workspace, ['init']);
+  runGit(workspace, ['config', 'user.email', 'test@example.com']);
+  runGit(workspace, ['config', 'user.name', 'Test User']);
+  writeWorkspaceFile(workspace, 'db/ddl/public.sql', `
+    CREATE TABLE public.users (
+      id integer PRIMARY KEY,
+      email text NOT NULL
+    );
+  `);
+  writeWorkspaceFile(workspace, 'src/features/users-insert/boundary.ts', 'export const createUser = () => undefined;\n');
+  writeWorkspaceFile(workspace, 'src/features/users-insert/queries/insert-users/boundary.ts', 'export const insertUsers = () => undefined;\n');
+  writeWorkspaceFile(workspace, 'src/features/users-insert/queries/insert-users/insert-users.sql', 'INSERT INTO public.users (email) VALUES ($1) RETURNING id, email;\n');
+  runGit(workspace, ['add', '.']);
+  runGit(workspace, ['commit', '-m', 'base']);
+  runGit(workspace, ['branch', 'base']);
+
+  writeWorkspaceFile(workspace, 'db/ddl/public.sql', `
+    CREATE TABLE public.users (
+      id integer PRIMARY KEY,
+      email text NOT NULL,
+      status text NOT NULL DEFAULT 'active'
+    );
+  `);
+  writeWorkspaceFile(workspace, 'src/features/users-insert/queries/insert-users/insert-users.sql', 'INSERT INTO public.users (email, status) VALUES ($1, $2) RETURNING id, email, status;\n');
+  runGit(workspace, ['add', '.']);
+  runGit(workspace, ['commit', '-m', 'head']);
+
+  const capture = { stdout: [] as string[], stderr: [] as string[] };
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({
+    writeOut: (str) => capture.stdout.push(str),
+    writeErr: (str) => capture.stderr.push(str),
+  });
+  registerRfbaCommand(program);
+  const outFile = '.ztd/review/rfba-review-data.json';
+
+  const originalWrite = process.stdout.write;
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    capture.stdout.push(String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    await program.parseAsync(['rfba', 'review-data', '--root', workspace, '--base', 'base', '--head', 'HEAD', '--out', outFile], { from: 'user' });
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+
+  const stdoutJson = JSON.parse(capture.stdout.join(''));
+  const fileJson = JSON.parse(readFileSync(path.join(workspace, outFile), 'utf8'));
+  expect(stdoutJson).toEqual(fileJson);
+  expect(stdoutJson).toMatchObject({
+    schemaVersion: 1,
+    command: 'rfba review-data',
+    base: 'base',
+    head: 'HEAD',
+    summary: {
+      changedFiles: 2,
+      changedBoundaries: 1,
+      ddlChanges: 1,
+      sqlChanges: 1,
+    },
+  });
+  expect(stdoutJson.changedFiles.map((file: { kind: string }) => file.kind).sort()).toEqual(['ddl', 'query-sql']);
+  expect(stdoutJson.warnings).toEqual(expect.arrayContaining([
+    expect.objectContaining({ code: 'verification.possibly-missing' }),
+  ]));
+});
+
+test('rfba review-data help exposes review packet options', async () => {
+  setAgentOutputFormat('text');
+  const capture = { stdout: [] as string[], stderr: [] as string[] };
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({
+    writeOut: (str) => capture.stdout.push(str),
+    writeErr: (str) => capture.stderr.push(str),
+  });
+  registerRfbaCommand(program);
+
+  await expect(program.parseAsync(['rfba', 'review-data', '--help'], { from: 'user' })).rejects.toMatchObject({
+    code: 'commander.helpDisplayed',
+  });
+  const stdout = capture.stdout.join('');
+  expect(stdout).toContain('Generate deterministic RFBA review packet data from a Git diff');
+  expect(stdout).toContain('--base <ref>');
+  expect(stdout).toContain('--head <ref>');
+  expect(stdout).toContain('--out <file>');
+  expect(stdout).toContain('--scope <path>');
+  expect(stdout).toContain('--include-raw-diff');
+});

--- a/packages/ztd-cli/tests/rfbaReviewData.unit.test.ts
+++ b/packages/ztd-cli/tests/rfbaReviewData.unit.test.ts
@@ -77,6 +77,50 @@ test('classifyRfbaChangedFile maps RFBA review kinds and weights deterministical
   });
 });
 
+test('classifyRfbaChangedFile preserves old-side RFBA classification for renames', () => {
+  expect(classifyRfbaChangedFile({
+    status: 'renamed',
+    oldPath: 'src/features/accounts/queries/list-accounts/list-accounts.sql',
+    path: 'src/features/customers/queries/list-customers/list-customers.sql',
+  })).toMatchObject({
+    kind: 'query-sql',
+    oldKind: 'query-sql',
+    boundary: 'src/features/customers/queries/list-customers',
+    oldBoundary: 'src/features/accounts/queries/list-accounts',
+    parentFeatureBoundary: 'src/features/customers',
+    oldParentFeatureBoundary: 'src/features/accounts',
+    reviewWeight: 'high',
+    oldReviewWeight: 'high',
+  });
+});
+
+test('classifyRfbaChangedFile supports nested feature query and test layouts', () => {
+  expect(classifyRfbaChangedFile({
+    status: 'modified',
+    path: 'src/features/billing/accounts/queries/read-balance/read-balance.sql',
+  })).toMatchObject({
+    kind: 'query-sql',
+    boundary: 'src/features/billing/accounts/queries/read-balance',
+    parentFeatureBoundary: 'src/features/billing/accounts',
+  });
+  expect(classifyRfbaChangedFile({
+    status: 'modified',
+    path: 'src/features/billing/accounts/queries/read-balance/tests/cases/basic.case.ts',
+  })).toMatchObject({
+    kind: 'query-case',
+    boundary: 'src/features/billing/accounts/queries/read-balance',
+    parentFeatureBoundary: 'src/features/billing/accounts',
+  });
+  expect(classifyRfbaChangedFile({
+    status: 'modified',
+    path: 'src/features/billing/accounts/tests/read-balance.test.ts',
+  })).toMatchObject({
+    kind: 'feature-verification',
+    boundary: 'src/features/billing/accounts',
+    parentFeatureBoundary: 'src/features/billing/accounts',
+  });
+});
+
 test('buildChangedBoundarySummary reuses RFBA inspection boundaries', () => {
   const workspace = createTempDir('rfba-review-boundaries');
   writeWorkspaceFile(workspace, 'src/features/users-insert/boundary.ts', 'export {};\n');
@@ -98,6 +142,32 @@ test('buildChangedBoundarySummary reuses RFBA inspection boundaries', () => {
       ],
       reviewWeight: 'high',
     },
+  ]);
+});
+
+test('buildChangedBoundarySummary includes both old and new boundaries for renamed files', () => {
+  const workspace = createTempDir('rfba-review-rename-boundaries');
+  writeWorkspaceFile(workspace, 'src/features/accounts/boundary.ts', 'export {};\n');
+  writeWorkspaceFile(workspace, 'src/features/accounts/queries/list-accounts/boundary.ts', 'export {};\n');
+  writeWorkspaceFile(workspace, 'src/features/customers/boundary.ts', 'export {};\n');
+  writeWorkspaceFile(workspace, 'src/features/customers/queries/list-customers/boundary.ts', 'export {};\n');
+  const changedFiles = [
+    classifyRfbaChangedFile({
+      status: 'renamed',
+      oldPath: 'src/features/accounts/queries/list-accounts/list-accounts.sql',
+      path: 'src/features/customers/queries/list-customers/list-customers.sql',
+    }),
+  ];
+
+  expect(buildChangedBoundarySummary(changedFiles, inspectRfbaBoundaries(workspace))).toEqual([
+    expect.objectContaining({
+      boundary: 'src/features/accounts/queries/list-accounts',
+      changedFiles: ['src/features/accounts/queries/list-accounts/list-accounts.sql'],
+    }),
+    expect.objectContaining({
+      boundary: 'src/features/customers/queries/list-customers',
+      changedFiles: ['src/features/customers/queries/list-customers/list-customers.sql'],
+    }),
   ]);
 });
 
@@ -229,6 +299,25 @@ test('buildVerificationSummary groups query evidence and flags likely missing ev
   expect(buildVerificationSummary([
     classifyRfbaChangedFile({ status: 'modified', path: 'src/features/users-insert/queries/insert-users/insert-users.sql' }),
   ])[0].missingLikelyEvidence).toEqual(['SQL changed but no query-local cases or generated evidence changed.']);
+});
+
+test('buildVerificationSummary includes old query boundaries for renamed SQL files', () => {
+  expect(buildVerificationSummary([
+    classifyRfbaChangedFile({
+      status: 'renamed',
+      oldPath: 'src/features/accounts/queries/list-accounts/list-accounts.sql',
+      path: 'src/features/customers/queries/list-customers/list-customers.sql',
+    }),
+  ])).toEqual([
+    expect.objectContaining({
+      boundary: 'src/features/accounts/queries/list-accounts',
+      missingLikelyEvidence: ['SQL changed but no query-local cases or generated evidence changed.'],
+    }),
+    expect.objectContaining({
+      boundary: 'src/features/customers/queries/list-customers',
+      missingLikelyEvidence: ['SQL changed but no query-local cases or generated evidence changed.'],
+    }),
+  ]);
 });
 
 test('rfba review-data command emits stdout JSON and writes --out in a Git workspace', async () => {


### PR DESCRIPTION
## Summary

- Adds `ztd rfba review-data` for deterministic RFBA review packet JSON from Git diffs.
- Classifies changed files, maps changed RFBA boundaries, summarizes supported DDL and SQL changes, groups verification evidence, and emits review hints/warnings.
- Documents CI artifact usage and adds a Changeset for `@rawsql-ts/ztd-cli`.

## Verification

- `pnpm --filter @rawsql-ts/ztd-cli test -- rfbaReviewData.unit.test.ts rfba.unit.test.ts`
- `pnpm --filter @rawsql-ts/ztd-cli build`
- `pnpm --filter @rawsql-ts/ztd-cli test -- cliCommands.test.ts rfba.unit.test.ts rfbaReviewData.unit.test.ts --testTimeout 30000 --hookTimeout 30000`
- Commit hook: ztd-cli typecheck, `test:essential`, build, and lint passed.
- Note: `cliCommands.test.ts` skipped DB-dependent cases because `pg_dump` is not on PATH in this local environment.

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: #796
Scoped checks run: ztd-cli focused RFBA tests, ztd-cli build, ztd-cli CLI command suite, pre-commit ztd-cli gates
Why full baseline is not required: The change is scoped to ztd-cli RFBA review-data command behavior, docs, tests, and a changeset; the focused ztd-cli gates cover the affected package surface.

## Self Review

Self-review workflow: repo-local developer-self-review skill plus generic self-review skill, two cycles.
Self-review result: No blockers remain. Cycle 1 found missing changeset/index DDL coverage, both resolved before commit. Cycle 2 confirmed PR readiness fields, CLI migration packet, scaffold no-proof rationale, and verification evidence are visible.

## CLI Surface Migration

- [ ] No migration packet required for this CLI change.
- [x] CLI/user-facing surface change and migration packet completed.

No-migration rationale: New optional command; existing command behavior remains compatible.
Upgrade note: Users can now run `ztd rfba review-data --base origin/main --head HEAD --out .ztd/review/rfba-review-data.json` to create CI-friendly RFBA review packet JSON.
Deprecation/removal plan or issue: None. This is an additive command with no deprecations or removals.
Docs/help/examples updated: README documents the command, CI artifact usage, and AI PR summary prompt; command help exposes the new options; tests cover help and command output.
Release/changeset wording: `.changeset/rfba-review-data.md` adds a minor Changeset for `@rawsql-ts/ztd-cli`.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: This PR does not change scaffold commands, templates, or generated scaffold output. The README change is RFBA review-data documentation only.
Non-edit assertion: Not applicable.
Fail-fast input-contract proof: Not applicable.
Generated-output viability proof: Not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `ztd rfba review-data` command that generates deterministic review packets from Git diffs.
  * Automatically classifies and analyzes database schema and SQL query changes.
  * Detects potential gaps in test coverage and verification evidence.
  * Produces structured JSON output optimized for CI integration.

* **Documentation**
  * Added comprehensive documentation for the new command with usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->