### PR TITLE
Add transfer destination definition feature

### DIFF
--- a/packages/transfer/.editorconfig
+++ b/packages/transfer/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+tab_width = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.sql]
+indent_size = 2

--- a/packages/transfer/.env.example
+++ b/packages/transfer/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to .env and adjust ZTD_DB_PORT if 5432 is already in use.
+# The generated Vitest setup derives ZTD_DB_URL from ZTD_DB_PORT.
+ZTD_DB_PORT=5432

--- a/packages/transfer/.gitignore
+++ b/packages/transfer/.gitignore
@@ -1,0 +1,11 @@
+node_modules/
+dist/
+coverage/
+*.log
+
+
+.ztd/generated/**
+
+.env
+.env.*
+!.env.example

--- a/packages/transfer/.prettierignore
+++ b/packages/transfer/.prettierignore
@@ -1,0 +1,1 @@
+.ztd/generated/**

--- a/packages/transfer/.prettierrc
+++ b/packages/transfer/.prettierrc
@@ -1,0 +1,24 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "printWidth": 100,
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "plugins": ["prettier-plugin-sql"],
+  "overrides": [
+    {
+      "files": "*.sql",
+      "options": {
+        "parser": "sql"
+      }
+    },
+    {
+      "files": "*.md",
+      "options": {
+        "parser": "markdown"
+      }
+    }
+  ]
+}

--- a/packages/transfer/.prettierrc
+++ b/packages/transfer/.prettierrc
@@ -9,13 +9,13 @@
   "plugins": ["prettier-plugin-sql"],
   "overrides": [
     {
-      "files": "*.sql",
+      "files": "**/*.sql",
       "options": {
         "parser": "sql"
       }
     },
     {
-      "files": "*.md",
+      "files": "**/*.md",
       "options": {
         "parser": "markdown"
       }

--- a/packages/transfer/.ztd/support/global-setup.ts
+++ b/packages/transfer/.ztd/support/global-setup.ts
@@ -1,0 +1,25 @@
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { config } from 'dotenv';
+
+export default async function globalSetup() {
+  config();
+
+  if (process.env.ZTD_DB_URL) {
+    return () => undefined;
+  }
+
+  const container = await startPostgresContainer();
+  process.env.ZTD_DB_URL = container.getConnectionUri();
+
+  return async () => {
+    await container.stop();
+  };
+}
+
+async function startPostgresContainer(): Promise<StartedPostgreSqlContainer> {
+  return new PostgreSqlContainer('postgres:18')
+    .withDatabase('ztd')
+    .withUsername('ztd')
+    .withPassword('ztd')
+    .start();
+}

--- a/packages/transfer/.ztd/support/setup-env.ts
+++ b/packages/transfer/.ztd/support/setup-env.ts
@@ -1,0 +1,8 @@
+import { config } from 'dotenv';
+
+config();
+
+if (!process.env.ZTD_DB_URL) {
+  const port = process.env.ZTD_DB_PORT?.trim() || '5432';
+  process.env.ZTD_DB_URL = `postgres://ztd:ztd@localhost:${port}/ztd`;
+}

--- a/packages/transfer/README.md
+++ b/packages/transfer/README.md
@@ -1,0 +1,43 @@
+# @rawsql-ts/transfer
+
+`@rawsql-ts/transfer` contains transfer-definition features for rawsql-ts workflows.
+
+The first feature is `create-transfer-destination-definition`. It registers one `transfer_destination_definition` row for a PostgreSQL destination table definition.
+
+## Transfer Destination Definition
+
+The `transfer_destination_definition` table stores:
+
+- the destination table name
+- destination column metadata
+- destination key metadata
+- optional sequence-expression metadata
+- update and delete transfer policies
+- optional red-transfer and diff-comparison column metadata
+
+DDL lives in `db/ddl/transfer_destination_definition.sql`.
+
+## Policy Values
+
+### update_transfer_policy
+
+| Value | Meaning |
+| --- | --- |
+| `overwrite` | Overwrite an existing transferred destination row on update. |
+| `immutable` | Add a red-transfer row for the old black row, then add a new black row on update. |
+
+### delete_transfer_policy
+
+| Value | Meaning |
+| --- | --- |
+| `physical_delete` | Physically delete the destination row on delete. |
+| `immutable` | Add a red-transfer row from the original black row on delete. |
+| `ignore` | Do nothing when a delete request is received. |
+
+## Feature Boundary
+
+`src/features/create-transfer-destination-definition/` owns the create use case.
+
+The feature accepts `CreateTransferDestinationDefinitionInput` from `boundary.ts`, validates the request, maps it to the query boundary, and returns the inserted row using camelCase names.
+
+Feature-specific validation stays inside this feature. Do not move this validation into `src/libraries/` unless it becomes independent enough to extract as a reusable external package.

--- a/packages/transfer/db/ddl/transfer_destination_definition.sql
+++ b/packages/transfer/db/ddl/transfer_destination_definition.sql
@@ -1,0 +1,112 @@
+create table transfer_destination_definition (
+  transfer_destination_definition_id bigserial primary key
+
+  , transfer_destination_definition_name text not null unique
+  , description text null
+
+  , destination_table_name text not null
+  , destination_columns jsonb not null
+  , destination_key_definition jsonb not null
+  , sequence_expression_definition jsonb null
+
+  , update_transfer_policy text not null
+  , delete_transfer_policy text not null
+
+  , sign_inversion_columns jsonb null
+  , red_transfer_source_columns jsonb null
+  , diff_compare_excluded_columns jsonb null
+
+  , created_at timestamptz not null default current_timestamp
+  , updated_at timestamptz not null default current_timestamp
+  , note text null
+
+  , constraint chk_transfer_destination_definition_name_not_blank
+    check (btrim(transfer_destination_definition_name) <> '')
+
+  , constraint chk_transfer_destination_table_name_not_blank
+    check (btrim(destination_table_name) <> '')
+
+  , constraint chk_transfer_destination_update_policy
+    check (update_transfer_policy in ('overwrite', 'immutable'))
+
+  , constraint chk_transfer_destination_delete_policy
+    check (delete_transfer_policy in ('physical_delete', 'immutable', 'ignore'))
+
+  , constraint chk_transfer_destination_columns_object
+    check (jsonb_typeof(destination_columns) = 'object')
+
+  , constraint chk_transfer_destination_key_definition_object
+    check (jsonb_typeof(destination_key_definition) = 'object')
+
+  , constraint chk_transfer_sequence_expression_definition_object
+    check (
+      sequence_expression_definition is null
+      or jsonb_typeof(sequence_expression_definition) = 'object'
+    )
+
+  , constraint chk_transfer_sign_inversion_columns_object
+    check (
+      sign_inversion_columns is null
+      or jsonb_typeof(sign_inversion_columns) = 'object'
+    )
+
+  , constraint chk_transfer_red_transfer_source_columns_object
+    check (
+      red_transfer_source_columns is null
+      or jsonb_typeof(red_transfer_source_columns) = 'object'
+    )
+
+  , constraint chk_transfer_diff_compare_excluded_columns_object
+    check (
+      diff_compare_excluded_columns is null
+      or jsonb_typeof(diff_compare_excluded_columns) = 'object'
+    )
+);
+
+comment on table transfer_destination_definition is
+  '転送先定義。転送先テーブル、列、主キー、採番式、変更方針、削除方針、赤伝生成に必要な列情報を管理する。';
+
+comment on column transfer_destination_definition.transfer_destination_definition_id is
+  '転送先定義ID。サロゲートキー。';
+
+comment on column transfer_destination_definition.transfer_destination_definition_name is
+  '転送先定義名。アプリケーションや他の転送定義から名前で参照するため一意にする。例: journal, account_balance。';
+
+comment on column transfer_destination_definition.description is
+  '説明。転送先定義の目的や業務上の意味を記録する。';
+
+comment on column transfer_destination_definition.destination_table_name is
+  '転送先テーブル名。実際に転送先として書き込むテーブル名。例: journal, account_balance。';
+
+comment on column transfer_destination_definition.destination_columns is
+  '転送先列定義。転送先テーブルへ書き込む列の一覧、型、役割などをJSONBで保持する。例: {"columns":[{"name":"amount","type":"numeric","role":"amount"}]}。';
+
+comment on column transfer_destination_definition.destination_key_definition is
+  '転送先キー定義。転送先行を一意に特定する主キーまたは一意キーの列定義をJSONBで保持する。赤伝生成時に元黒行を参照するためにも使用する。例: {"keys":["journal_id"]}。';
+
+comment on column transfer_destination_definition.sequence_expression_definition is
+  '採番式定義。採番列と採番式をJSONBで保持する。例: {"journal_id": "nextval(''journal_seq'')" }。';
+
+comment on column transfer_destination_definition.update_transfer_policy is
+  '変更転送方針。更新時の扱いを表す。許可値は overwrite, immutable。overwrite は既存の転送先行を上書きする方針。immutable は旧黒を赤伝化して新黒を追加する方針。';
+
+comment on column transfer_destination_definition.delete_transfer_policy is
+  '削除転送方針。削除時の扱いを表す。許可値は physical_delete, immutable, ignore。physical_delete は転送先行を物理削除する方針。immutable は元黒から赤伝を追加する方針。ignore は削除依頼時に何もしない方針。';
+
+comment on column transfer_destination_definition.sign_inversion_columns is
+  '符号反転列定義。赤伝生成時に符号を反転する列をJSONBで保持する。例: {"columns": ["amount"]}。';
+
+comment on column transfer_destination_definition.red_transfer_source_columns is
+  '赤伝生成対象列定義。元黒行から赤伝へコピーする対象列をJSONBで保持する。採番列は通常含めない。例: {"columns":["journal_date","amount","remarks"]}。';
+
+comment on column transfer_destination_definition.diff_compare_excluded_columns is
+  '差分比較除外列定義。更新判定時に比較対象から除外する転送先列をJSONBで保持する。例: {"columns":["journal_id","created_at"]}。';
+
+comment on column transfer_destination_definition.created_at is
+  '作成日時。レコード作成時刻。';
+
+comment on column transfer_destination_definition.updated_at is
+  '更新日時。レコード更新時刻。CreateのみのIssueでは初期値として作成日時と同じになる。';
+
+comment on column transfer_destination_definition.note is
+  '備考。実装・運用上の補足を記録する。';

--- a/packages/transfer/package.json
+++ b/packages/transfer/package.json
@@ -41,7 +41,7 @@
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,json,md,sql}": [
-      "pnpm format"
+      "prettier --write"
     ]
   },
   "simple-git-hooks": {

--- a/packages/transfer/package.json
+++ b/packages/transfer/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@rawsql-ts/transfer",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "imports": {
+    "#features/*.js": {
+      "types": "./src/features/*.ts",
+      "default": "./dist/features/*.js"
+    },
+    "#libraries/*.js": {
+      "types": "./src/libraries/*.ts",
+      "default": "./dist/libraries/*.js"
+    },
+    "#adapters/*.js": {
+      "types": "./src/adapters/*.ts",
+      "default": "./dist/adapters/*.js"
+    },
+    "#tests/*.js": {
+      "types": "./tests/*.ts",
+      "default": "./tests/*.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "node ./scripts/local-source-guard.mjs test --passWithNoTests",
+    "typecheck": "node ./scripts/local-source-guard.mjs typecheck",
+    "format": "prettier . --write",
+    "lint": "node ./scripts/check-sql-leading-commas.mjs && eslint src tests --ext .ts",
+    "lint:sql": "node ./scripts/check-sql-leading-commas.mjs",
+    "lint:fix": "eslint . --fix",
+    "ztd": "node ./scripts/local-source-guard.mjs ztd"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,jsx,json,md,sql}": [
+      "pnpm format"
+    ]
+  },
+  "simple-git-hooks": {
+    "pre-commit": "pnpm lint-staged"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "eslint": "^9.22.0",
+    "lint-staged": "^16.2.7",
+    "prettier": "^3.7.4",
+    "prettier-plugin-sql": "^0.19.2",
+    "simple-git-hooks": "^2.13.1",
+    "dotenv": "^16.6.1",
+    "vitest": "^4.0.7",
+    "typescript": "^5.8.2",
+    "@types/node": "22.18.7",
+    "@testcontainers/postgresql": "^11.14.0",
+    "@rawsql-ts/sql-contract": "workspace:*",
+    "@rawsql-ts/testkit-core": "workspace:*",
+    "@rawsql-ts/testkit-postgres": "workspace:*",
+    "@rawsql-ts/ztd-cli": "workspace:*",
+    "pg": "^8.11.1"
+  }
+}

--- a/packages/transfer/scripts/check-sql-leading-commas.mjs
+++ b/packages/transfer/scripts/check-sql-leading-commas.mjs
@@ -1,0 +1,49 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+
+const rootDir = path.resolve(import.meta.dirname, '..');
+const sqlFiles = collectSqlFiles([
+  path.join(rootDir, 'db'),
+  path.join(rootDir, 'src')
+]);
+
+const violations = [];
+
+for (const filePath of sqlFiles) {
+  const lines = readFileSync(filePath, 'utf8').split(/\r?\n/);
+  lines.forEach((line, index) => {
+    if (line.trimEnd().endsWith(',')) {
+      violations.push(`${toProjectPath(filePath)}:${index + 1}: use leading commas in multiline SQL lists`);
+    }
+  });
+}
+
+if (violations.length > 0) {
+  console.error(violations.join('\n'));
+  process.exit(1);
+}
+
+function collectSqlFiles(directories) {
+  const results = [];
+  for (const directory of directories) {
+    visit(directory, results);
+  }
+  return results.sort();
+}
+
+function visit(directory, results) {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      visit(entryPath, results);
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith('.sql')) {
+      results.push(entryPath);
+    }
+  }
+}
+
+function toProjectPath(filePath) {
+  return path.relative(rootDir, filePath).replace(/\\/g, '/');
+}

--- a/packages/transfer/scripts/local-source-guard.mjs
+++ b/packages/transfer/scripts/local-source-guard.mjs
@@ -1,0 +1,190 @@
+import { createRequire } from 'node:module';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const projectRoot = process.cwd();
+const command = process.argv[2];
+
+if (command !== 'test' && command !== 'typecheck' && command !== 'ztd') {
+  console.error('local-source guard expects "test", "typecheck", or "ztd".');
+  process.exit(1);
+}
+
+if (command === 'ztd') {
+  const cliEntry = path.resolve(projectRoot, '../ztd-cli/dist/index.js');
+  const requestedSubcommand = process.argv.slice(3).join(' ').trim() || '(none)';
+  if (!existsSync(cliEntry)) {
+    console.error(
+      [
+        '[local-source guard] ztd cannot run against the local source checkout yet.',
+        '',
+        `What happened:`,
+        `- Requested subcommand: ${requestedSubcommand}`,
+        `- Project root: ${normalizePath(projectRoot)}`,
+        `- The local CLI entry was not found at ${normalizePath(cliEntry)}.`,
+        '',
+        'Next steps:',
+        '1. Build the local CLI package (for example: pnpm --filter @rawsql-ts/ztd-cli build)',
+        '2. Confirm this scaffold still points at the intended rawsql-ts monorepo root',
+        '3. Re-run pnpm ztd <subcommand>'
+      ].join('\n')
+    );
+    process.exit(1);
+  }
+
+  const cliArgs = process.argv.slice(3);
+  const result = spawnSync(process.execPath, [cliEntry, ...cliArgs], {
+    cwd: projectRoot,
+    stdio: 'inherit',
+    shell: false
+  });
+
+  // Surface execution failures explicitly so local-source dogfooding does not
+  // collapse permission, spawn, and signal problems into the same exit code.
+  if (result.error) {
+    console.error('[local-source guard] Failed to launch the local ztd CLI entry.');
+    console.error(`- Message: ${result.error.message}`);
+    if (result.error.stack) {
+      console.error(result.error.stack);
+    }
+    process.exit(1);
+  }
+
+  if (result.signal) {
+    console.error('[local-source guard] The local ztd CLI entry was terminated by signal.');
+    console.error(`- Signal: ${result.signal}`);
+    process.exit(1);
+  }
+
+  process.exit(result.status ?? 1);
+}
+
+const workspaceRoot = findAncestorPnpmWorkspaceRoot(projectRoot);
+const installCommand = workspaceRoot ? 'pnpm install --ignore-workspace' : 'pnpm install';
+const rerunCommand = command === 'test' ? 'pnpm test' : 'pnpm typecheck';
+const fallbackCommand = command === 'test' ? 'npx vitest run' : 'npx tsc --noEmit';
+const binaryName = process.platform === 'win32'
+  ? command === 'test'
+    ? 'vitest.cmd'
+    : 'tsc.cmd'
+  : command === 'test'
+  ? 'vitest'
+  : 'tsc';
+const forwardedArgs = process.argv.slice(3);
+const binaryArgs = command === 'test' ? ['run', ...forwardedArgs] : ['--noEmit', ...forwardedArgs];
+const binaryPath = path.join(projectRoot, 'node_modules', '.bin', binaryName);
+const packageChecks = command === 'test'
+  ? ['vitest/package.json', 'zod/package.json', '@rawsql-ts/sql-contract/package.json']
+  : ['typescript/package.json', 'zod/package.json', '@rawsql-ts/sql-contract/package.json'];
+
+const resolutionIssues = inspectResolution(packageChecks);
+if (!existsSync(binaryPath) || resolutionIssues.length > 0) {
+  printGuidance({
+    command,
+    installCommand,
+    rerunCommand,
+    fallbackCommand,
+    workspaceRoot,
+    binaryPath,
+    resolutionIssues
+  });
+  process.exit(1);
+}
+
+const result = spawnSync(binaryPath, binaryArgs, {
+  cwd: projectRoot,
+  stdio: 'inherit',
+  shell: process.platform === 'win32'
+});
+process.exit(result.status ?? 1);
+
+function inspectResolution(specifiers) {
+  const projectRequire = createRequire(path.join(projectRoot, 'package.json'));
+  const issues = [];
+
+  for (const specifier of specifiers) {
+    try {
+      const resolvedPath = specifier.endsWith('/package.json')
+        ? resolveInstalledPackageManifest(specifier)
+        : projectRequire.resolve(specifier);
+      if (!isInsideProject(resolvedPath)) {
+        issues.push(`${specifier} resolved outside this scaffold: ${normalizePath(resolvedPath)}`);
+      }
+    } catch {
+      issues.push(`${specifier} is not installed in this scaffold`);
+    }
+  }
+
+  return issues;
+}
+
+function resolveInstalledPackageManifest(specifier) {
+  const manifestRelativePath = path.join('node_modules', ...specifier.split('/'));
+  const manifestPath = path.join(projectRoot, manifestRelativePath);
+  if (!existsSync(manifestPath)) {
+    throw new Error(`${specifier} manifest is missing`);
+  }
+  return manifestPath;
+}
+
+function isInsideProject(filePath) {
+  const relativePath = path.relative(projectRoot, filePath);
+  return relativePath.length === 0 || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
+}
+
+function normalizePath(filePath) {
+  return filePath.replace(/\\/g, '/');
+}
+
+function findAncestorPnpmWorkspaceRoot(rootDir) {
+  let cursor = path.resolve(rootDir);
+  while (true) {
+    const parentDir = path.dirname(cursor);
+    if (parentDir === cursor) {
+      return null;
+    }
+    cursor = parentDir;
+    if (existsSync(path.join(cursor, 'pnpm-workspace.yaml'))) {
+      return cursor;
+    }
+  }
+}
+
+function printGuidance({
+  command,
+  installCommand,
+  rerunCommand,
+  fallbackCommand,
+  workspaceRoot,
+  binaryPath,
+  resolutionIssues
+}) {
+  const commandLabel = command === 'test' ? 'pnpm test' : 'pnpm typecheck';
+  const lines = [
+    `[local-source guard] ${commandLabel} cannot run against this scaffold yet.`,
+    '',
+    'What happened:',
+    `- The local binary was not found at ${normalizePath(binaryPath)} or required packages resolved outside this project.`,
+  ];
+
+  if (workspaceRoot) {
+    lines.push(`- This project sits under pnpm workspace ${normalizePath(workspaceRoot)}, so pnpm may still be using the parent workspace context.`);
+  }
+
+  if (resolutionIssues.length > 0) {
+    lines.push('- Resolution details:');
+    for (const issue of resolutionIssues) {
+      lines.push(`  - ${issue}`);
+    }
+  }
+
+  lines.push(
+    '',
+    'Next steps:',
+    `1. Run ${installCommand}`,
+    `2. Re-run ${rerunCommand}`,
+    `3. If pnpm still looks absorbed by the parent workspace, try ${fallbackCommand}`
+  );
+  console.error(lines.join('\n'));
+}

--- a/packages/transfer/src/adapters/pg/sql-client.ts
+++ b/packages/transfer/src/adapters/pg/sql-client.ts
@@ -1,0 +1,34 @@
+import type { SqlClient } from '#libraries/sql/sql-client.js';
+
+/**
+ * Adapt a `pg`-style queryable (Client or Pool) into a SqlClient.
+ *
+ * pg's `query()` returns `QueryResult<T>` with a `.rows` property.
+ * This helper unwraps the result so it satisfies the shared `SqlClient` contract.
+ *
+ * Usage:
+ *   // This runtime example uses DATABASE_URL for application code.
+ *   // ztd-cli itself does not read DATABASE_URL implicitly.
+ *   const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+ *   const client = fromPg(pool);
+ *   const users = await client.query<{ id: number }>('SELECT id ...', []);
+ */
+export function fromPg(
+  queryable: {
+    query(text: string, values?: readonly unknown[]): Promise<{ rows: Record<string, unknown>[] }>;
+  }
+): SqlClient {
+  return {
+    query<T extends Record<string, unknown> = Record<string, unknown>>(
+      text: string,
+      values?: readonly unknown[] | Record<string, unknown>
+    ): Promise<T[]> {
+      if (values != null && !Array.isArray(values)) {
+        throw new Error('fromPg adapter does not support named parameter objects; use positional parameter arrays');
+      }
+      return queryable
+        .query(text, values as readonly unknown[])
+        .then((result) => result.rows as T[]);
+    }
+  };
+}

--- a/packages/transfer/src/adapters/pg/sql-client.ts
+++ b/packages/transfer/src/adapters/pg/sql-client.ts
@@ -21,14 +21,9 @@ export function fromPg(
   return {
     query<T extends Record<string, unknown> = Record<string, unknown>>(
       text: string,
-      values?: readonly unknown[] | Record<string, unknown>
+      values?: readonly unknown[]
     ): Promise<T[]> {
-      if (values != null && !Array.isArray(values)) {
-        throw new Error('fromPg adapter does not support named parameter objects; use positional parameter arrays');
-      }
-      return queryable
-        .query(text, values as readonly unknown[])
-        .then((result) => result.rows as T[]);
+      return queryable.query(text, values).then((result) => result.rows as T[]);
     }
   };
 }

--- a/packages/transfer/src/features/README.md
+++ b/packages/transfer/src/features/README.md
@@ -1,0 +1,52 @@
+# Feature-First Layout
+
+This scaffold organizes application work under `src/features/<feature>/`.
+
+## Architecture as a Framework
+
+The feature layout treats architecture as a framework contract, not a naming convention:
+
+```text
+boundary/
+  boundary.ts
+  child-boundary/
+  tests/
+```
+
+- A folder is a boundary.
+- `boundary.ts` is that boundary's public surface.
+- Child boundaries are child folders that repeat the same rule.
+- `tests/` is the verification group owned by that boundary.
+- Cross-boundary tests should go through `boundary.ts`, not internal helper files.
+
+## Default shape
+
+- `boundary.ts`: the single feature boundary public surface for request parsing, normalization, and response shaping
+- `queries/<query>/boundary.ts`: the single query boundary public surface for DB-facing SQL execution and row/result mapping
+- `tests`: the feature-local verification group, including a thin `tests/<feature>.boundary.test.ts` Vitest entrypoint for the mock-based lane
+- `queries/<query>/tests`: the query-local verification group, including a thin `queries/<query>/tests/<query>.boundary.ztd.test.ts` Vitest entrypoint for the ZTD lane
+- add more child boundaries as child folders when one boundary grows; each child repeats the same `boundary.ts` plus `tests/` rule
+
+`ztd.config.json` owns the tool-managed workspace under `.ztd/generated/` and `.ztd/tests/` support files. Feature-authored boundary tests stay under `src/features/<feature>/tests/`, while query-local ZTD assets stay under `src/features/<feature>/queries/<query>/tests/{generated,cases}`.
+Use `src/features/_shared/*` only for feature-facing shared seams such as `FeatureQueryExecutor`.
+Keep driver-neutral helpers in `src/libraries/*`, driver or sink bindings in `src/adapters/<tech>/*`, and keep `db/` reserved for DDL, migrations, and schema assets.
+
+Use `ztd feature tests scaffold --feature <feature-name>` after SQL and DTO edits to refresh `src/features/<feature>/queries/<query>/tests/generated/TEST_PLAN.md` and `analysis.json`, keep the thin `src/features/<feature>/queries/<query>/tests/<query>.boundary.ztd.test.ts` entrypoint in sync, and add persistent cases under `src/features/<feature>/queries/<query>/tests/cases/` with the fixed app-level ZTD runner.
+When you are on the boundary lane, treat it as query-local: `src/features/<feature>/queries/<query>/tests/<query>.boundary.ztd.test.ts`, `src/features/<feature>/queries/<query>/tests/generated/`, and `src/features/<feature>/queries/<query>/tests/cases/` move together, while the feature-root `src/features/<feature>/tests/<feature>.boundary.test.ts` stays on the mock-based lane.
+
+## Import Paths
+
+Prefer stability at recursive boundary seams over one blanket import style.
+
+- Keep local, nearby references relative when they naturally move with the same boundary.
+- Stabilize only shared references that are likely to break when a boundary is split and moved deeper, such as `src/features/_shared/*` or `tests/support/*`.
+- One workable tactic is package `imports` such as `#features/*` and `#tests/*`, or an equivalent alias that works in both TypeScript and runtime resolution.
+- Minimum rule: do not let deep relative imports become the public boundary contract.
+- When a boundary depends on another boundary, make the dependency obvious by importing its compiled ESM entrypoint with `.js` specifiers, such as `./boundary.js` or `../boundary.js`, rather than walking through internal files.
+- Pragmatic exception: designated shared seams such as `src/features/_shared/*` and `tests/support/*` may use stabilized root-level aliases because those files are shared support seams, not another boundary's private implementation.
+
+## Sample feature
+
+If you enabled the starter flow, `smoke` is the removable teaching feature.
+Copy its shape for the first real feature, then delete it once the project has a real slice of its own.
+In the starter flow, `smoke` also shows the DB-backed path through `@rawsql-ts/testkit-postgres` and the preferred named-parameter SQL style through its feature-local SQL sample.

--- a/packages/transfer/src/features/_shared/featureQueryExecutor.ts
+++ b/packages/transfer/src/features/_shared/featureQueryExecutor.ts
@@ -1,0 +1,5 @@
+// Shared runtime contract for scaffolded features.
+// Inject your DB execution implementation at this seam from the application runtime.
+export interface FeatureQueryExecutor {
+  query<T = unknown>(sql: string, params: Record<string, unknown>): Promise<T[]>;
+}

--- a/packages/transfer/src/features/_shared/loadSqlResource.ts
+++ b/packages/transfer/src/features/_shared/loadSqlResource.ts
@@ -1,0 +1,6 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+export function loadSqlResource(currentDir: string, relativePath: string): string {
+  return readFileSync(path.join(currentDir, relativePath), 'utf8');
+}

--- a/packages/transfer/src/features/create-transfer-destination-definition/README.md
+++ b/packages/transfer/src/features/create-transfer-destination-definition/README.md
@@ -1,0 +1,46 @@
+# create-transfer-destination-definition
+
+Creates one `transfer_destination_definition` row.
+
+This feature is intentionally scoped to the create use case. Do not rename or reshape it into a table-level `transfer-destination-definitions` CRUD feature.
+
+## Input
+
+The public feature boundary accepts `CreateTransferDestinationDefinitionInput` with camelCase fields:
+
+- `name`
+- `description`
+- `destinationTableName`
+- `destinationColumns`
+- `destinationKeyDefinition`
+- `sequenceExpressionDefinition`
+- `updateTransferPolicy`
+- `deleteTransferPolicy`
+- `signInversionColumns`
+- `redTransferSourceColumns`
+- `diffCompareExcludedColumns`
+- `note`
+
+## Validation
+
+The feature boundary validates the minimum create rules before calling the query boundary:
+
+- non-blank `name`
+- non-blank `destinationTableName`
+- at least one `destinationColumns.columns` entry
+- unique `destinationColumns.columns[].name`
+- at least one `destinationKeyDefinition.keys` entry
+- referenced key, sequence, sign inversion, red-transfer source, and diff-excluded columns exist in `destinationColumns.columns`
+- allowed `updateTransferPolicy` and `deleteTransferPolicy` values
+
+Duplicate `transfer_destination_definition_name` values are not preflighted in the feature SQL. The database unique constraint owns that fail-fast behavior.
+
+## SQL
+
+The query boundary lives under `queries/insert-transfer-destination-definition/`.
+
+`insert-transfer-destination-definition.sql` explicitly lists caller-supplied columns, casts JSONB values, omits `created_at` and `updated_at` so the DB defaults apply, and returns the inserted row.
+
+## RFBA Note
+
+Feature-specific validation remains local to this feature. `src/libraries/` is reserved for logic that can stand on its own as a reusable package-level library.

--- a/packages/transfer/src/features/create-transfer-destination-definition/boundary.ts
+++ b/packages/transfer/src/features/create-transfer-destination-definition/boundary.ts
@@ -1,0 +1,198 @@
+import { z } from 'zod';
+import type { FeatureQueryExecutor } from '../_shared/featureQueryExecutor.js';
+
+import {
+  executeInsertTransferDestinationDefinitionQuerySpec,
+  type InsertTransferDestinationDefinitionQueryParams,
+  type InsertTransferDestinationDefinitionQueryResult
+} from './queries/insert-transfer-destination-definition/boundary.js';
+
+const UPDATE_TRANSFER_POLICIES = ['overwrite', 'immutable'] as const;
+const DELETE_TRANSFER_POLICIES = ['physical_delete', 'immutable', 'ignore'] as const;
+
+const DestinationColumnSchema = z.object({
+  name: z.string().trim().min(1),
+  type: z.string().trim().min(1),
+  role: z.string().trim().min(1).optional()
+}).strict();
+
+const DestinationColumnsSchema = z.object({
+  columns: z.array(DestinationColumnSchema)
+}).strict();
+
+const DestinationKeyDefinitionSchema = z.object({
+  keys: z.array(z.string().trim().min(1))
+}).strict();
+
+const ColumnListSchema = z.object({
+  columns: z.array(z.string().trim().min(1))
+}).strict();
+
+const RequestSchema = z.object({
+  name: z.string().trim().min(1),
+  description: z.string().trim().min(1).optional(),
+  destinationTableName: z.string().trim().min(1),
+  destinationColumns: DestinationColumnsSchema,
+  destinationKeyDefinition: DestinationKeyDefinitionSchema,
+  sequenceExpressionDefinition: z.record(z.string(), z.string().trim().min(1)).optional(),
+  updateTransferPolicy: z.enum(UPDATE_TRANSFER_POLICIES),
+  deleteTransferPolicy: z.enum(DELETE_TRANSFER_POLICIES),
+  signInversionColumns: ColumnListSchema.optional(),
+  redTransferSourceColumns: ColumnListSchema.optional(),
+  diffCompareExcludedColumns: ColumnListSchema.optional(),
+  note: z.string().trim().min(1).optional()
+}).strict();
+
+export type CreateTransferDestinationDefinitionInput = z.infer<typeof RequestSchema>;
+
+const ResponseSchema = z.object({
+  transferDestinationDefinitionId: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  destinationTableName: z.string(),
+  destinationColumns: DestinationColumnsSchema,
+  destinationKeyDefinition: DestinationKeyDefinitionSchema,
+  sequenceExpressionDefinition: z.record(z.string(), z.string()).nullable(),
+  updateTransferPolicy: z.enum(UPDATE_TRANSFER_POLICIES),
+  deleteTransferPolicy: z.enum(DELETE_TRANSFER_POLICIES),
+  signInversionColumns: ColumnListSchema.nullable(),
+  redTransferSourceColumns: ColumnListSchema.nullable(),
+  diffCompareExcludedColumns: ColumnListSchema.nullable(),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+  note: z.string().nullable()
+}).strict();
+
+export type CreateTransferDestinationDefinitionResult = z.infer<typeof ResponseSchema>;
+
+function parseRequest(raw: unknown): CreateTransferDestinationDefinitionInput {
+  return RequestSchema.parse(raw);
+}
+
+function normalizeRequest(request: CreateTransferDestinationDefinitionInput): CreateTransferDestinationDefinitionInput {
+  return {
+    ...request,
+    destinationColumns: {
+      columns: request.destinationColumns.columns.map((column) => ({
+        ...column,
+        role: column.role === undefined ? undefined : column.role
+      }))
+    },
+    destinationKeyDefinition: {
+      keys: request.destinationKeyDefinition.keys
+    },
+    sequenceExpressionDefinition: request.sequenceExpressionDefinition === undefined
+      ? undefined
+      : { ...request.sequenceExpressionDefinition },
+    signInversionColumns: request.signInversionColumns === undefined
+      ? undefined
+      : { columns: request.signInversionColumns.columns },
+    redTransferSourceColumns: request.redTransferSourceColumns === undefined
+      ? undefined
+      : { columns: request.redTransferSourceColumns.columns },
+    diffCompareExcludedColumns: request.diffCompareExcludedColumns === undefined
+      ? undefined
+      : { columns: request.diffCompareExcludedColumns.columns }
+  };
+}
+
+function rejectRequest(request: CreateTransferDestinationDefinitionInput): void {
+  const destinationColumnNames = request.destinationColumns.columns.map((column) => column.name);
+  const destinationColumnNameSet = new Set(destinationColumnNames);
+
+  if (destinationColumnNames.length === 0) {
+    throw new Error('destinationColumns.columns must contain at least one column.');
+  }
+  if (destinationColumnNameSet.size !== destinationColumnNames.length) {
+    throw new Error('destinationColumns.columns[].name must be unique.');
+  }
+  if (request.destinationKeyDefinition.keys.length === 0) {
+    throw new Error('destinationKeyDefinition.keys must contain at least one key.');
+  }
+
+  rejectUnknownColumnReferences(
+    'destinationKeyDefinition.keys',
+    request.destinationKeyDefinition.keys,
+    destinationColumnNameSet
+  );
+  rejectUnknownColumnReferences(
+    'sequenceExpressionDefinition',
+    Object.keys(request.sequenceExpressionDefinition ?? {}),
+    destinationColumnNameSet
+  );
+  rejectUnknownColumnReferences(
+    'signInversionColumns.columns',
+    request.signInversionColumns?.columns ?? [],
+    destinationColumnNameSet
+  );
+  rejectUnknownColumnReferences(
+    'redTransferSourceColumns.columns',
+    request.redTransferSourceColumns?.columns ?? [],
+    destinationColumnNameSet
+  );
+  rejectUnknownColumnReferences(
+    'diffCompareExcludedColumns.columns',
+    request.diffCompareExcludedColumns?.columns ?? [],
+    destinationColumnNameSet
+  );
+}
+
+function rejectUnknownColumnReferences(
+  fieldName: string,
+  referencedColumns: string[],
+  destinationColumnNameSet: ReadonlySet<string>
+): void {
+  const unknownColumns = referencedColumns.filter((columnName) => !destinationColumnNameSet.has(columnName));
+  if (unknownColumns.length > 0) {
+    throw new Error(`${fieldName} references unknown destination columns: ${unknownColumns.join(', ')}.`);
+  }
+}
+
+function toQueryParams(request: CreateTransferDestinationDefinitionInput): InsertTransferDestinationDefinitionQueryParams {
+  return {
+    transfer_destination_definition_name: request.name,
+    description: request.description ?? null,
+    destination_table_name: request.destinationTableName,
+    destination_columns: request.destinationColumns,
+    destination_key_definition: request.destinationKeyDefinition,
+    sequence_expression_definition: request.sequenceExpressionDefinition ?? null,
+    update_transfer_policy: request.updateTransferPolicy,
+    delete_transfer_policy: request.deleteTransferPolicy,
+    sign_inversion_columns: request.signInversionColumns ?? null,
+    red_transfer_source_columns: request.redTransferSourceColumns ?? null,
+    diff_compare_excluded_columns: request.diffCompareExcludedColumns ?? null,
+    note: request.note ?? null
+  };
+}
+
+function fromQueryResult(
+  result: InsertTransferDestinationDefinitionQueryResult
+): CreateTransferDestinationDefinitionResult {
+  return ResponseSchema.parse({
+    transferDestinationDefinitionId: result.transfer_destination_definition_id,
+    name: result.transfer_destination_definition_name,
+    description: result.description,
+    destinationTableName: result.destination_table_name,
+    destinationColumns: result.destination_columns,
+    destinationKeyDefinition: result.destination_key_definition,
+    sequenceExpressionDefinition: result.sequence_expression_definition,
+    updateTransferPolicy: result.update_transfer_policy,
+    deleteTransferPolicy: result.delete_transfer_policy,
+    signInversionColumns: result.sign_inversion_columns,
+    redTransferSourceColumns: result.red_transfer_source_columns,
+    diffCompareExcludedColumns: result.diff_compare_excluded_columns,
+    createdAt: result.created_at,
+    updatedAt: result.updated_at,
+    note: result.note
+  });
+}
+
+export async function executeCreateTransferDestinationDefinitionEntrySpec(
+  executor: FeatureQueryExecutor,
+  rawRequest: unknown
+): Promise<CreateTransferDestinationDefinitionResult> {
+  const request = normalizeRequest(parseRequest(rawRequest));
+  rejectRequest(request);
+  const result = await executeInsertTransferDestinationDefinitionQuerySpec(executor, toQueryParams(request));
+  return fromQueryResult(result);
+}

--- a/packages/transfer/src/features/create-transfer-destination-definition/queries/insert-transfer-destination-definition/boundary.ts
+++ b/packages/transfer/src/features/create-transfer-destination-definition/queries/insert-transfer-destination-definition/boundary.ts
@@ -1,0 +1,90 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { z } from 'zod';
+
+import type { FeatureQueryExecutor } from '#features/_shared/featureQueryExecutor.js';
+import { loadSqlResource } from '#features/_shared/loadSqlResource.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const insertTransferDestinationDefinitionSqlResource = loadSqlResource(
+  __dirname,
+  'insert-transfer-destination-definition.sql'
+);
+
+const JsonObjectSchema = z.record(z.string(), z.unknown());
+
+const QueryParamsSchema = z.object({
+  transfer_destination_definition_name: z.string().min(1),
+  description: z.string().min(1).nullable(),
+  destination_table_name: z.string().min(1),
+  destination_columns: JsonObjectSchema,
+  destination_key_definition: JsonObjectSchema,
+  sequence_expression_definition: JsonObjectSchema.nullable(),
+  update_transfer_policy: z.enum(['overwrite', 'immutable']),
+  delete_transfer_policy: z.enum(['physical_delete', 'immutable', 'ignore']),
+  sign_inversion_columns: JsonObjectSchema.nullable(),
+  red_transfer_source_columns: JsonObjectSchema.nullable(),
+  diff_compare_excluded_columns: JsonObjectSchema.nullable(),
+  note: z.string().min(1).nullable()
+}).strict();
+
+export type InsertTransferDestinationDefinitionQueryParams = z.infer<typeof QueryParamsSchema>;
+
+const RowSchema = z.object({
+  transfer_destination_definition_id: z.coerce.string(),
+  transfer_destination_definition_name: z.string(),
+  description: z.string().nullable(),
+  destination_table_name: z.string(),
+  destination_columns: JsonObjectSchema,
+  destination_key_definition: JsonObjectSchema,
+  sequence_expression_definition: JsonObjectSchema.nullable(),
+  update_transfer_policy: z.enum(['overwrite', 'immutable']),
+  delete_transfer_policy: z.enum(['physical_delete', 'immutable', 'ignore']),
+  sign_inversion_columns: JsonObjectSchema.nullable(),
+  red_transfer_source_columns: JsonObjectSchema.nullable(),
+  diff_compare_excluded_columns: JsonObjectSchema.nullable(),
+  created_at: z.coerce.date(),
+  updated_at: z.coerce.date(),
+  note: z.string().nullable()
+}).strict();
+
+const QueryResultSchema = RowSchema;
+
+export type InsertTransferDestinationDefinitionQueryResult = z.infer<typeof QueryResultSchema>;
+
+type InsertTransferDestinationDefinitionRow = z.infer<typeof RowSchema>;
+
+function parseQueryParams(raw: unknown): InsertTransferDestinationDefinitionQueryParams {
+  return QueryParamsSchema.parse(raw);
+}
+
+function parseRow(raw: unknown): InsertTransferDestinationDefinitionRow {
+  return RowSchema.parse(raw);
+}
+
+function mapRowToResult(
+  row: InsertTransferDestinationDefinitionRow
+): InsertTransferDestinationDefinitionQueryResult {
+  return QueryResultSchema.parse(row);
+}
+
+async function loadInsertedRow(
+  executor: FeatureQueryExecutor,
+  sql: string,
+  params: Record<string, unknown>
+): Promise<InsertTransferDestinationDefinitionRow> {
+  const rows = await executor.query<Record<string, unknown>>(sql, params);
+  if (rows.length !== 1) {
+    throw new Error('Expected exactly one inserted transfer destination definition row.');
+  }
+  return parseRow(rows[0]);
+}
+
+export async function executeInsertTransferDestinationDefinitionQuerySpec(
+  executor: FeatureQueryExecutor,
+  rawParams: unknown
+): Promise<InsertTransferDestinationDefinitionQueryResult> {
+  const params = parseQueryParams(rawParams);
+  const row = await loadInsertedRow(executor, insertTransferDestinationDefinitionSqlResource, params);
+  return mapRowToResult(row);
+}

--- a/packages/transfer/src/features/create-transfer-destination-definition/queries/insert-transfer-destination-definition/insert-transfer-destination-definition.sql
+++ b/packages/transfer/src/features/create-transfer-destination-definition/queries/insert-transfer-destination-definition/insert-transfer-destination-definition.sql
@@ -1,0 +1,43 @@
+insert into "public"."transfer_destination_definition" (
+  "transfer_destination_definition_name"
+  , "description"
+  , "destination_table_name"
+  , "destination_columns"
+  , "destination_key_definition"
+  , "sequence_expression_definition"
+  , "update_transfer_policy"
+  , "delete_transfer_policy"
+  , "sign_inversion_columns"
+  , "red_transfer_source_columns"
+  , "diff_compare_excluded_columns"
+  , "note"
+)
+select
+  :transfer_destination_definition_name
+  , :description
+  , :destination_table_name
+  , :destination_columns::jsonb
+  , :destination_key_definition::jsonb
+  , :sequence_expression_definition::jsonb
+  , :update_transfer_policy
+  , :delete_transfer_policy
+  , :sign_inversion_columns::jsonb
+  , :red_transfer_source_columns::jsonb
+  , :diff_compare_excluded_columns::jsonb
+  , :note
+returning
+  "transfer_destination_definition_id"
+  , "transfer_destination_definition_name"
+  , "description"
+  , "destination_table_name"
+  , "destination_columns"
+  , "destination_key_definition"
+  , "sequence_expression_definition"
+  , "update_transfer_policy"
+  , "delete_transfer_policy"
+  , "sign_inversion_columns"
+  , "red_transfer_source_columns"
+  , "diff_compare_excluded_columns"
+  , "created_at"
+  , "updated_at"
+  , "note";

--- a/packages/transfer/src/features/create-transfer-destination-definition/queries/insert-transfer-destination-definition/tests/boundary-ztd-types.ts
+++ b/packages/transfer/src/features/create-transfer-destination-definition/queries/insert-transfer-destination-definition/tests/boundary-ztd-types.ts
@@ -1,8 +1,16 @@
 import type { QuerySpecZtdCase } from '#tests/support/ztd/case-types.js';
+import type {
+  InsertTransferDestinationDefinitionQueryParams,
+  InsertTransferDestinationDefinitionQueryResult
+} from '../boundary.js';
 
-export type InsertTransferDestinationDefinitionBeforeDb = { public: { transfer_destination_definition: readonly { transfer_destination_definition_name?: unknown; description?: unknown; destination_table_name?: unknown; destination_columns?: unknown; destination_key_definition?: unknown; sequence_expression_definition?: unknown; update_transfer_policy?: unknown; delete_transfer_policy?: unknown; sign_inversion_columns?: unknown; red_transfer_source_columns?: unknown; diff_compare_excluded_columns?: unknown; note?: unknown; transfer_destination_definition_id?: unknown; created_at?: unknown; updated_at?: unknown }[] } };
-export type InsertTransferDestinationDefinitionInput = { transfer_destination_definition_name: unknown; description: unknown; destination_table_name: unknown; destination_columns: unknown; destination_key_definition: unknown; sequence_expression_definition: unknown; update_transfer_policy: unknown; delete_transfer_policy: unknown; sign_inversion_columns: unknown; red_transfer_source_columns: unknown; diff_compare_excluded_columns: unknown; note: unknown };
-export type InsertTransferDestinationDefinitionOutput = { transfer_destination_definition_id: unknown; transfer_destination_definition_name: unknown; description: unknown; destination_table_name: unknown; destination_columns: unknown; destination_key_definition: unknown; sequence_expression_definition: unknown; update_transfer_policy: unknown; delete_transfer_policy: unknown; sign_inversion_columns: unknown; red_transfer_source_columns: unknown; diff_compare_excluded_columns: unknown; created_at: unknown; updated_at: unknown; note: unknown };
+export type InsertTransferDestinationDefinitionBeforeDb = {
+  public: {
+    transfer_destination_definition: readonly Partial<InsertTransferDestinationDefinitionQueryResult>[];
+  };
+};
+export type InsertTransferDestinationDefinitionInput = InsertTransferDestinationDefinitionQueryParams;
+export type InsertTransferDestinationDefinitionOutput = InsertTransferDestinationDefinitionQueryResult;
 
 export type InsertTransferDestinationDefinitionQueryBoundaryZtdCase = QuerySpecZtdCase<
   InsertTransferDestinationDefinitionBeforeDb,

--- a/packages/transfer/src/features/create-transfer-destination-definition/queries/insert-transfer-destination-definition/tests/boundary-ztd-types.ts
+++ b/packages/transfer/src/features/create-transfer-destination-definition/queries/insert-transfer-destination-definition/tests/boundary-ztd-types.ts
@@ -1,0 +1,11 @@
+import type { QuerySpecZtdCase } from '#tests/support/ztd/case-types.js';
+
+export type InsertTransferDestinationDefinitionBeforeDb = { public: { transfer_destination_definition: readonly { transfer_destination_definition_name?: unknown; description?: unknown; destination_table_name?: unknown; destination_columns?: unknown; destination_key_definition?: unknown; sequence_expression_definition?: unknown; update_transfer_policy?: unknown; delete_transfer_policy?: unknown; sign_inversion_columns?: unknown; red_transfer_source_columns?: unknown; diff_compare_excluded_columns?: unknown; note?: unknown; transfer_destination_definition_id?: unknown; created_at?: unknown; updated_at?: unknown }[] } };
+export type InsertTransferDestinationDefinitionInput = { transfer_destination_definition_name: unknown; description: unknown; destination_table_name: unknown; destination_columns: unknown; destination_key_definition: unknown; sequence_expression_definition: unknown; update_transfer_policy: unknown; delete_transfer_policy: unknown; sign_inversion_columns: unknown; red_transfer_source_columns: unknown; diff_compare_excluded_columns: unknown; note: unknown };
+export type InsertTransferDestinationDefinitionOutput = { transfer_destination_definition_id: unknown; transfer_destination_definition_name: unknown; description: unknown; destination_table_name: unknown; destination_columns: unknown; destination_key_definition: unknown; sequence_expression_definition: unknown; update_transfer_policy: unknown; delete_transfer_policy: unknown; sign_inversion_columns: unknown; red_transfer_source_columns: unknown; diff_compare_excluded_columns: unknown; created_at: unknown; updated_at: unknown; note: unknown };
+
+export type InsertTransferDestinationDefinitionQueryBoundaryZtdCase = QuerySpecZtdCase<
+  InsertTransferDestinationDefinitionBeforeDb,
+  InsertTransferDestinationDefinitionInput,
+  InsertTransferDestinationDefinitionOutput
+>;

--- a/packages/transfer/src/features/create-transfer-destination-definition/queries/insert-transfer-destination-definition/tests/cases/basic.case.ts
+++ b/packages/transfer/src/features/create-transfer-destination-definition/queries/insert-transfer-destination-definition/tests/cases/basic.case.ts
@@ -1,0 +1,163 @@
+import { expect } from 'vitest';
+
+import type {
+  InsertTransferDestinationDefinitionBeforeDb,
+  InsertTransferDestinationDefinitionQueryBoundaryZtdCase
+} from '../boundary-ztd-types.js';
+
+const emptyBeforeDb = {
+  public: {
+    transfer_destination_definition: []
+  }
+} satisfies InsertTransferDestinationDefinitionBeforeDb;
+
+const cases: readonly InsertTransferDestinationDefinitionQueryBoundaryZtdCase[] = [
+  {
+    name: 'creates journal transfer destination definition',
+    beforeDb: emptyBeforeDb,
+    input: {
+      transfer_destination_definition_name: 'journal',
+      description: '仕訳転送先',
+      destination_table_name: 'journal',
+      destination_columns: {
+        columns: [
+          { name: 'journal_id', type: 'bigint', role: 'key' },
+          { name: 'journal_date', type: 'date' },
+          { name: 'debit_account_code', type: 'text' },
+          { name: 'credit_account_code', type: 'text' },
+          { name: 'amount', type: 'numeric', role: 'amount' },
+          { name: 'remarks', type: 'text' }
+        ]
+      },
+      destination_key_definition: {
+        keys: ['journal_id']
+      },
+      sequence_expression_definition: {
+        journal_id: "nextval('journal_seq')"
+      },
+      update_transfer_policy: 'immutable',
+      delete_transfer_policy: 'immutable',
+      sign_inversion_columns: {
+        columns: ['amount']
+      },
+      red_transfer_source_columns: {
+        columns: ['journal_date', 'debit_account_code', 'credit_account_code', 'amount', 'remarks']
+      },
+      diff_compare_excluded_columns: {
+        columns: ['journal_id']
+      },
+      note: null
+    },
+    output: {
+      transfer_destination_definition_id: expect.any(String),
+      transfer_destination_definition_name: 'journal',
+      description: '仕訳転送先',
+      destination_table_name: 'journal',
+      destination_columns: {
+        columns: [
+          { name: 'journal_id', type: 'bigint', role: 'key' },
+          { name: 'journal_date', type: 'date' },
+          { name: 'debit_account_code', type: 'text' },
+          { name: 'credit_account_code', type: 'text' },
+          { name: 'amount', type: 'numeric', role: 'amount' },
+          { name: 'remarks', type: 'text' }
+        ]
+      },
+      destination_key_definition: {
+        keys: ['journal_id']
+      },
+      sequence_expression_definition: {
+        journal_id: "nextval('journal_seq')"
+      },
+      update_transfer_policy: 'immutable',
+      delete_transfer_policy: 'immutable',
+      sign_inversion_columns: {
+        columns: ['amount']
+      },
+      red_transfer_source_columns: {
+        columns: ['journal_date', 'debit_account_code', 'credit_account_code', 'amount', 'remarks']
+      },
+      diff_compare_excluded_columns: {
+        columns: ['journal_id']
+      },
+      created_at: expect.any(Date),
+      updated_at: expect.any(Date),
+      note: null
+    }
+  },
+  {
+    name: 'creates account balance transfer destination definition',
+    beforeDb: emptyBeforeDb,
+    input: {
+      transfer_destination_definition_name: 'account_balance',
+      description: '科目残高転送先',
+      destination_table_name: 'account_balance',
+      destination_columns: {
+        columns: [
+          { name: 'account_balance_id', type: 'bigint', role: 'key' },
+          { name: 'balance_date', type: 'date' },
+          { name: 'account_code', type: 'text' },
+          { name: 'customer_id', type: 'bigint' },
+          { name: 'amount', type: 'numeric', role: 'amount' },
+          { name: 'balance_side', type: 'text' }
+        ]
+      },
+      destination_key_definition: {
+        keys: ['account_balance_id']
+      },
+      sequence_expression_definition: {
+        account_balance_id: "nextval('account_balance_seq')"
+      },
+      update_transfer_policy: 'immutable',
+      delete_transfer_policy: 'immutable',
+      sign_inversion_columns: {
+        columns: ['amount']
+      },
+      red_transfer_source_columns: {
+        columns: ['balance_date', 'account_code', 'customer_id', 'amount', 'balance_side']
+      },
+      diff_compare_excluded_columns: {
+        columns: ['account_balance_id']
+      },
+      note: null
+    },
+    output: {
+      transfer_destination_definition_id: expect.any(String),
+      transfer_destination_definition_name: 'account_balance',
+      description: '科目残高転送先',
+      destination_table_name: 'account_balance',
+      destination_columns: {
+        columns: [
+          { name: 'account_balance_id', type: 'bigint', role: 'key' },
+          { name: 'balance_date', type: 'date' },
+          { name: 'account_code', type: 'text' },
+          { name: 'customer_id', type: 'bigint' },
+          { name: 'amount', type: 'numeric', role: 'amount' },
+          { name: 'balance_side', type: 'text' }
+        ]
+      },
+      destination_key_definition: {
+        keys: ['account_balance_id']
+      },
+      sequence_expression_definition: {
+        account_balance_id: "nextval('account_balance_seq')"
+      },
+      update_transfer_policy: 'immutable',
+      delete_transfer_policy: 'immutable',
+      sign_inversion_columns: {
+        columns: ['amount']
+      },
+      red_transfer_source_columns: {
+        columns: ['balance_date', 'account_code', 'customer_id', 'amount', 'balance_side']
+      },
+      diff_compare_excluded_columns: {
+        columns: ['account_balance_id']
+      },
+      created_at: expect.any(Date),
+      updated_at: expect.any(Date),
+      note: null
+    }
+  }
+];
+
+export default cases;

--- a/packages/transfer/src/features/create-transfer-destination-definition/queries/insert-transfer-destination-definition/tests/insert-transfer-destination-definition.boundary.ztd.test.ts
+++ b/packages/transfer/src/features/create-transfer-destination-definition/queries/insert-transfer-destination-definition/tests/insert-transfer-destination-definition.boundary.ztd.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'vitest';
+
+import { runQuerySpecZtdCases } from '#tests/support/ztd/harness.js';
+import { executeInsertTransferDestinationDefinitionQuerySpec } from '../boundary.js';
+import cases from './cases/basic.case.js';
+import type { InsertTransferDestinationDefinitionQueryBoundaryZtdCase } from './boundary-ztd-types.js';
+
+test('create-transfer-destination-definition/insert-transfer-destination-definition boundary ZTD cases run', async () => {
+  expect(cases.length).toBeGreaterThan(0);
+  const evidence = await runQuerySpecZtdCases(cases, executeInsertTransferDestinationDefinitionQuerySpec);
+  expect(evidence.every((entry) => entry.mode === 'ztd')).toBe(true);
+  expect(evidence.every((entry) => entry.physicalSetupUsed === false)).toBe(true);
+});

--- a/packages/transfer/src/features/create-transfer-destination-definition/tests/create-transfer-destination-definition.boundary.test.ts
+++ b/packages/transfer/src/features/create-transfer-destination-definition/tests/create-transfer-destination-definition.boundary.test.ts
@@ -1,0 +1,142 @@
+import { expect, test } from 'vitest';
+
+import {
+  executeCreateTransferDestinationDefinitionEntrySpec,
+  type CreateTransferDestinationDefinitionInput
+} from '../boundary.js';
+import type { FeatureQueryExecutor } from '../../_shared/featureQueryExecutor.js';
+
+const validInput: CreateTransferDestinationDefinitionInput = {
+  name: 'journal',
+  description: '仕訳転送先',
+  destinationTableName: 'journal',
+  destinationColumns: {
+    columns: [
+      { name: 'journal_id', type: 'bigint', role: 'key' },
+      { name: 'amount', type: 'numeric', role: 'amount' }
+    ]
+  },
+  destinationKeyDefinition: {
+    keys: ['journal_id']
+  },
+  sequenceExpressionDefinition: {
+    journal_id: "nextval('journal_seq')"
+  },
+  updateTransferPolicy: 'immutable',
+  deleteTransferPolicy: 'immutable',
+  signInversionColumns: {
+    columns: ['amount']
+  },
+  redTransferSourceColumns: {
+    columns: ['amount']
+  },
+  diffCompareExcludedColumns: {
+    columns: ['journal_id']
+  },
+  note: 'reviewed'
+};
+
+test('maps camelCase feature input to snake_case query params and response fields', async () => {
+  const seenParams: Record<string, unknown>[] = [];
+  const executor: FeatureQueryExecutor = {
+    async query<T = unknown>(_sql: string, params: Record<string, unknown>): Promise<T[]> {
+      seenParams.push(params);
+      return [
+        {
+          transfer_destination_definition_id: '1',
+          transfer_destination_definition_name: 'journal',
+          description: '仕訳転送先',
+          destination_table_name: 'journal',
+          destination_columns: validInput.destinationColumns,
+          destination_key_definition: validInput.destinationKeyDefinition,
+          sequence_expression_definition: validInput.sequenceExpressionDefinition,
+          update_transfer_policy: 'immutable',
+          delete_transfer_policy: 'immutable',
+          sign_inversion_columns: validInput.signInversionColumns,
+          red_transfer_source_columns: validInput.redTransferSourceColumns,
+          diff_compare_excluded_columns: validInput.diffCompareExcludedColumns,
+          created_at: new Date('2026-04-29T00:00:00.000Z'),
+          updated_at: new Date('2026-04-29T00:00:00.000Z'),
+          note: 'reviewed'
+        }
+      ] as T[];
+    }
+  };
+
+  const result = await executeCreateTransferDestinationDefinitionEntrySpec(executor, validInput);
+
+  expect(seenParams).toEqual([
+    {
+      transfer_destination_definition_name: 'journal',
+      description: '仕訳転送先',
+      destination_table_name: 'journal',
+      destination_columns: validInput.destinationColumns,
+      destination_key_definition: validInput.destinationKeyDefinition,
+      sequence_expression_definition: validInput.sequenceExpressionDefinition,
+      update_transfer_policy: 'immutable',
+      delete_transfer_policy: 'immutable',
+      sign_inversion_columns: validInput.signInversionColumns,
+      red_transfer_source_columns: validInput.redTransferSourceColumns,
+      diff_compare_excluded_columns: validInput.diffCompareExcludedColumns,
+      note: 'reviewed'
+    }
+  ]);
+  expect(result).toEqual({
+    transferDestinationDefinitionId: '1',
+    name: 'journal',
+    description: '仕訳転送先',
+    destinationTableName: 'journal',
+    destinationColumns: validInput.destinationColumns,
+    destinationKeyDefinition: validInput.destinationKeyDefinition,
+    sequenceExpressionDefinition: validInput.sequenceExpressionDefinition,
+    updateTransferPolicy: 'immutable',
+    deleteTransferPolicy: 'immutable',
+    signInversionColumns: validInput.signInversionColumns,
+    redTransferSourceColumns: validInput.redTransferSourceColumns,
+    diffCompareExcludedColumns: validInput.diffCompareExcludedColumns,
+    createdAt: new Date('2026-04-29T00:00:00.000Z'),
+    updatedAt: new Date('2026-04-29T00:00:00.000Z'),
+    note: 'reviewed'
+  });
+});
+
+test.each([
+  ['empty name', { name: '   ' }],
+  ['empty destination table name', { destinationTableName: '   ' }],
+  ['empty destination columns', { destinationColumns: { columns: [] } }],
+  [
+    'duplicate destination column names',
+    {
+      destinationColumns: {
+        columns: [
+          { name: 'journal_id', type: 'bigint' },
+          { name: 'journal_id', type: 'bigint' }
+        ]
+      }
+    }
+  ],
+  ['empty destination key definition', { destinationKeyDefinition: { keys: [] } }],
+  ['unknown destination key column', { destinationKeyDefinition: { keys: ['missing_id'] } }],
+  ['unknown sequence expression column', { sequenceExpressionDefinition: { missing_id: "nextval('x')" } }],
+  ['unknown sign inversion column', { signInversionColumns: { columns: ['missing_amount'] } }],
+  ['unknown red transfer source column', { redTransferSourceColumns: { columns: ['missing_amount'] } }],
+  ['unknown diff compare excluded column', { diffCompareExcludedColumns: { columns: ['missing_id'] } }],
+  ['invalid update transfer policy', { updateTransferPolicy: 'merge' }],
+  ['invalid delete transfer policy', { deleteTransferPolicy: 'archive' }]
+])('rejects invalid input: %s', async (_name, patch) => {
+  const executor = createGuardedExecutor();
+  await expect(
+    executeCreateTransferDestinationDefinitionEntrySpec(executor, {
+      ...validInput,
+      ...patch
+    })
+  ).rejects.toThrow();
+});
+
+function createGuardedExecutor(): FeatureQueryExecutor {
+  return {
+    async query() {
+      throw new Error('Validation failures must not reach the query boundary.');
+    }
+  };
+}

--- a/packages/transfer/src/index.ts
+++ b/packages/transfer/src/index.ts
@@ -1,0 +1,5 @@
+export {
+  executeCreateTransferDestinationDefinitionEntrySpec,
+  type CreateTransferDestinationDefinitionInput,
+  type CreateTransferDestinationDefinitionResult
+} from './features/create-transfer-destination-definition/boundary.js';

--- a/packages/transfer/src/libraries/sql/sql-client.ts
+++ b/packages/transfer/src/libraries/sql/sql-client.ts
@@ -1,0 +1,25 @@
+/**
+ * Promise that resolves to the array of rows produced by an SQL query.
+ * @template T Shape of each row yielded by the SQL client.
+ * @example
+ * const rows: SqlQueryRows<{ id: number; name: string }> = client.query('SELECT id, name FROM users');
+ */
+export type SqlQueryRows<T> = Promise<T[]>;
+
+/**
+ * Minimal SQL client contract shared by the app and adapter boundaries.
+ *
+ * - Production: adapt this contract to your preferred driver (pg, mysql2, etc.) and normalize the results to `T[]`.
+ * - Tests: replace the implementation with a mock, a fixture helper, or an adapter that follows this contract.
+ *
+ * Connection strategy note:
+ * - Prefer one live client per DB context or worker process for better performance.
+ * - Multiple clients can coexist in the same workflow as long as each one owns its own lifecycle.
+ * - Do not share a live client across parallel workers without proper synchronization.
+ */
+export type SqlClient = {
+  query<T extends Record<string, unknown> = Record<string, unknown>>(
+    text: string,
+    values?: readonly unknown[] | Record<string, unknown>
+  ): SqlQueryRows<T>;
+};

--- a/packages/transfer/src/libraries/sql/sql-client.ts
+++ b/packages/transfer/src/libraries/sql/sql-client.ts
@@ -20,6 +20,6 @@ export type SqlQueryRows<T> = Promise<T[]>;
 export type SqlClient = {
   query<T extends Record<string, unknown> = Record<string, unknown>>(
     text: string,
-    values?: readonly unknown[] | Record<string, unknown>
+    values?: readonly unknown[]
   ): SqlQueryRows<T>;
 };

--- a/packages/transfer/tests/support/postgres-testkit.ts
+++ b/packages/transfer/tests/support/postgres-testkit.ts
@@ -37,7 +37,10 @@ function normalizeSearchPath(searchPath: unknown): string[] {
     return [];
   }
 
-  return searchPath.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0);
+  return searchPath
+    .filter((entry): entry is string => typeof entry === 'string')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
 }
 
 function loadStarterProjectConfig(rootDir: string = process.cwd()): StarterProjectConfigFile {
@@ -60,10 +63,10 @@ export function loadStarterPostgresDefaults(rootDir: string = process.cwd()): St
   const projectConfig = loadStarterProjectConfig(rootDir);
   const resolvedProjectRootDir = path.resolve(rootDir);
   const resolvedZtdRootDir = path.resolve(rootDir, projectConfig.ztdRootDir ?? '.ztd');
+  const configuredDefaultSchema =
+    typeof projectConfig.defaultSchema === 'string' ? projectConfig.defaultSchema.trim() : '';
   const defaultSchema =
-    typeof projectConfig.defaultSchema === 'string' && projectConfig.defaultSchema.length > 0
-      ? projectConfig.defaultSchema
-      : 'public';
+    configuredDefaultSchema.length > 0 ? configuredDefaultSchema : 'public';
   const searchPath = normalizeSearchPath(projectConfig.searchPath);
   const resolvedDdlDir = path.resolve(
     resolvedProjectRootDir,

--- a/packages/transfer/tests/support/postgres-testkit.ts
+++ b/packages/transfer/tests/support/postgres-testkit.ts
@@ -1,0 +1,138 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import {
+  createPostgresTestkitClient,
+  type CreatePostgresTestkitClientOptions,
+  type PostgresTestkitClient
+} from '@rawsql-ts/testkit-postgres';
+import type { DdlFixtureLoaderOptions } from '@rawsql-ts/testkit-core';
+import { Pool } from 'pg';
+
+interface StarterProjectConfigFile {
+  ztdRootDir?: string;
+  ddlDir?: string;
+  defaultSchema?: string;
+  searchPath?: string[];
+}
+
+export interface StarterPostgresDefaults {
+  projectRootDir: string;
+  ztdRootDir: string;
+  defaultSchema: string;
+  searchPath: string[];
+  ddlDirectories: string[];
+}
+
+export interface StarterPostgresTestkitOptions<RowType extends Record<string, unknown> = Record<string, unknown>>
+  extends Pick<CreatePostgresTestkitClientOptions<RowType>, 'tableDefinitions' | 'tableRows' | 'ddl' | 'onExecute'> {
+  rootDir?: string;
+  connectionString?: string;
+  defaultSchema?: string;
+  searchPath?: string[];
+}
+
+function normalizeSearchPath(searchPath: unknown): string[] {
+  if (!Array.isArray(searchPath)) {
+    return [];
+  }
+
+  return searchPath.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0);
+}
+
+function loadStarterProjectConfig(rootDir: string = process.cwd()): StarterProjectConfigFile {
+  const configPath = path.join(rootDir, 'ztd.config.json');
+  if (!existsSync(configPath)) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(readFileSync(configPath, 'utf8')) as StarterProjectConfigFile;
+  } catch (error) {
+    if (isMissingConfigFileError(error)) {
+      return {};
+    }
+    throw error;
+  }
+}
+
+export function loadStarterPostgresDefaults(rootDir: string = process.cwd()): StarterPostgresDefaults {
+  const projectConfig = loadStarterProjectConfig(rootDir);
+  const resolvedProjectRootDir = path.resolve(rootDir);
+  const resolvedZtdRootDir = path.resolve(rootDir, projectConfig.ztdRootDir ?? '.ztd');
+  const defaultSchema =
+    typeof projectConfig.defaultSchema === 'string' && projectConfig.defaultSchema.length > 0
+      ? projectConfig.defaultSchema
+      : 'public';
+  const searchPath = normalizeSearchPath(projectConfig.searchPath);
+  const resolvedDdlDir = path.resolve(
+    resolvedProjectRootDir,
+    typeof projectConfig.ddlDir === 'string' && projectConfig.ddlDir.trim().length > 0
+      ? projectConfig.ddlDir
+      : 'db/ddl'
+  );
+
+  return {
+    projectRootDir: resolvedProjectRootDir,
+    ztdRootDir: resolvedZtdRootDir,
+    defaultSchema,
+    searchPath: searchPath.length > 0 ? searchPath : [defaultSchema],
+    ddlDirectories: existsSync(resolvedDdlDir) ? [resolvedDdlDir] : []
+  };
+}
+
+/**
+ * Create a reusable starter Postgres testkit client for DB-backed smoke tests.
+ *
+ * Call this helper once per DB context so a workflow can hold multiple clients at the same time.
+ *
+ * The helper keeps the setup defaults in one place, but leaves table definitions
+ * and rows next to the individual test so the sample stays readable.
+ */
+export function createStarterPostgresTestkitClient<RowType extends Record<string, unknown> = Record<string, unknown>>(
+  options: StarterPostgresTestkitOptions<RowType>
+): PostgresTestkitClient<RowType> {
+  const connectionString = options.connectionString ?? process.env.ZTD_DB_URL;
+  if (!connectionString) {
+    throw new Error(
+      'Set options.connectionString or ZTD_DB_URL before creating a starter Postgres testkit client.'
+    );
+  }
+
+  const defaults = loadStarterPostgresDefaults(options.rootDir);
+  const pool = new Pool({ connectionString });
+
+  return createPostgresTestkitClient({
+    queryExecutor: async (sql, params) => {
+      const result = await pool.query(sql, params as unknown[]);
+      return {
+        rows: result.rows,
+        rowCount: result.rowCount ?? undefined
+      };
+    },
+    defaultSchema: options.defaultSchema ?? defaults.defaultSchema,
+    searchPath: options.searchPath ?? defaults.searchPath,
+    tableDefinitions: options.tableDefinitions,
+    tableRows: options.tableRows,
+    ddl: options.ddl ?? resolveStarterDdlOptions(defaults.ddlDirectories),
+    onExecute: options.onExecute,
+    // Let the client own pool shutdown so test cleanup stays a single close() call.
+    disposeExecutor: async () => {
+      await pool.end();
+    }
+  });
+}
+
+function resolveStarterDdlOptions(ddlDirectories: string[]): DdlFixtureLoaderOptions | undefined {
+  if (ddlDirectories.length === 0) {
+    return undefined;
+  }
+
+  return {
+    directories: ddlDirectories
+  };
+}
+
+function isMissingConfigFileError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && (error as { code?: string }).code === 'ENOENT';
+}

--- a/packages/transfer/tests/support/ztd/README.md
+++ b/packages/transfer/tests/support/ztd/README.md
@@ -1,0 +1,18 @@
+# Query-Boundary Test Support
+
+This folder holds the starter-owned shared support for query-boundary ZTD and traditional cases.
+
+- `harness.ts` exposes the fixed app-level runners that query-local cases call.
+- `verifier.ts` adapts ZTD cases to fixture rewriting and traditional cases to physical DDL + fixture setup.
+- `case-types.ts` defines the small v1 case shapes.
+
+Query-local AI work should live in `src/features/<feature>/queries/<query>/tests/cases/`.
+Generated analysis belongs in `src/features/<feature>/queries/<query>/tests/generated/`.
+The Vitest entrypoint `src/features/<feature>/queries/<query>/tests/<query>.boundary.<kind>.test.ts` should stay thin and only adapt the cases to the fixed runner.
+`beforeDb` is a pure fixture skeleton with schema-qualified table keys.
+The query-boundary ZTD case type carries `beforeDb`, `input`, and `output`.
+The traditional case type uses the same core shape and may add `afterDb` for post-state assertions.
+The verifier returns machine-checkable evidence (`mode`, `rewriteApplied`, `physicalSetupUsed`) for each case.
+Traditional evidence should report `mode=traditional` and `physicalSetupUsed=true`.
+Enable SQL trace only when needed with `ZTD_SQL_TRACE=1` (optional `ZTD_SQL_TRACE_DIR`).
+Do not use `--force` to overwrite persistent case files.

--- a/packages/transfer/tests/support/ztd/case-types.ts
+++ b/packages/transfer/tests/support/ztd/case-types.ts
@@ -1,0 +1,29 @@
+export interface QuerySpecCase<
+  BeforeDb extends Record<string, unknown> = Record<string, unknown>,
+  Input = unknown,
+  Output = unknown
+> {
+  name: string;
+  beforeDb: BeforeDb;
+  input: Input;
+  output: Output;
+  afterDb?: BeforeDb;
+}
+
+export type QuerySpecZtdCase<
+  BeforeDb extends Record<string, unknown> = Record<string, unknown>,
+  Input = unknown,
+  Output = unknown
+> = Omit<QuerySpecCase<BeforeDb, Input, Output>, 'afterDb'>;
+
+export type QuerySpecTraditionalCase<
+  BeforeDb extends Record<string, unknown> = Record<string, unknown>,
+  Input = unknown,
+  Output = unknown
+> = QuerySpecCase<BeforeDb, Input, Output>;
+
+export type ZtdCase<
+  BeforeDb extends Record<string, unknown> = Record<string, unknown>,
+  Input = unknown,
+  Output = unknown
+> = QuerySpecZtdCase<BeforeDb, Input, Output>;

--- a/packages/transfer/tests/support/ztd/harness.ts
+++ b/packages/transfer/tests/support/ztd/harness.ts
@@ -1,0 +1,76 @@
+import type { QuerySpecTraditionalCase, QuerySpecZtdCase } from './case-types.js';
+import {
+  verifyQuerySpecTraditionalCase,
+  verifyQuerySpecZtdCase,
+  type QuerySpecExecutionEvidence
+} from './verifier.js';
+
+type QuerySpecExecutor<RowShape extends Record<string, unknown>, Input, Output> = (
+  client: QuerySpecExecutorClient<RowShape>,
+  input: Input
+) => Promise<Output>;
+
+export type QuerySpecExecutorClient<RowShape extends Record<string, unknown>> = {
+  query<T = unknown>(sql: string, params: Record<string, unknown>): Promise<T[]>;
+};
+
+export interface QuerySpecRunnerOptions {
+  mode?: 'ztd' | 'traditional';
+}
+
+/**
+ * Fixed runner for query-boundary ZTD cases.
+ *
+ * Keep the app-level harness stable and let query-local case files evolve.
+ */
+export async function runQuerySpecZtdCases<RowShape extends Record<string, unknown>, Input, Output>(
+  cases: readonly QuerySpecZtdCase<RowShape, Input, Output>[],
+  execute: QuerySpecExecutor<RowShape, Input, Output>
+): Promise<QuerySpecExecutionEvidence[]> {
+  const evidence: QuerySpecExecutionEvidence[] = [];
+  for (const querySpecCase of cases) {
+    evidence.push(await verifyQuerySpecZtdCase(querySpecCase, execute));
+  }
+  return evidence;
+}
+
+/**
+ * Supported mode-switching runner for query-boundary cases.
+ *
+ * `ztd` uses fixture rewriting. `traditional` physically prepares DDL and
+ * fixture rows before executing the same query boundary shape.
+ */
+export async function runQuerySpecCases<RowShape extends Record<string, unknown>, Input, Output>(
+  cases: readonly (QuerySpecZtdCase<RowShape, Input, Output> | QuerySpecTraditionalCase<RowShape, Input, Output>)[],
+  execute: QuerySpecExecutor<RowShape, Input, Output>,
+  options: QuerySpecRunnerOptions = {}
+): Promise<QuerySpecExecutionEvidence[]> {
+  if ((options.mode ?? 'ztd') === 'traditional') {
+    return runQuerySpecTraditionalCases(
+      cases as readonly QuerySpecTraditionalCase<RowShape, Input, Output>[],
+      execute
+    );
+  }
+
+  return runQuerySpecZtdCases(cases as readonly QuerySpecZtdCase<RowShape, Input, Output>[], execute);
+}
+
+export async function runQuerySpecTraditionalCases<RowShape extends Record<string, unknown>, Input, Output>(
+  cases: readonly QuerySpecTraditionalCase<RowShape, Input, Output>[],
+  execute: QuerySpecExecutor<RowShape, Input, Output>
+): Promise<QuerySpecExecutionEvidence[]> {
+  const evidence: QuerySpecExecutionEvidence[] = [];
+  for (const querySpecCase of cases) {
+    evidence.push(await verifyQuerySpecTraditionalCase(querySpecCase, execute));
+  }
+  return evidence;
+}
+
+/**
+ * Backward-compatible alias for older templates while the repo migrates to the queryspec-specific vocabulary.
+ */
+export const runZtdCases = runQuerySpecZtdCases;
+
+export type { QuerySpecCase, QuerySpecTraditionalCase, QuerySpecZtdCase } from './case-types.js';
+export type QuerySpecHarnessClient<RowShape extends Record<string, unknown>> = QuerySpecExecutorClient<RowShape>;
+export type { QuerySpecExecutionEvidence } from './verifier.js';

--- a/packages/transfer/tests/support/ztd/verifier.ts
+++ b/packages/transfer/tests/support/ztd/verifier.ts
@@ -278,7 +278,7 @@ async function createPhysicalQuerySpecExecutor(
 
   try {
     await client.query(`CREATE SCHEMA ${quoteIdentifier(schemaName)}`);
-    await client.query(`SET search_path TO ${quoteIdentifier(schemaName)}, public`);
+    await client.query(`SET search_path TO ${buildPhysicalSearchPath(defaults.searchPath, schemaName)}`);
     await applySqlFiles(client, defaults.ddlDirectories, defaults.defaultSchema, schemaName);
     await seedFixtureRows(client, flattenFixtureTableRows(beforeDb), defaults.defaultSchema, schemaName);
   } catch (error) {
@@ -393,32 +393,135 @@ function toPhysicalTableName(tableName: string, defaultSchema: string, schemaNam
 }
 
 function rewriteSchemaQualifiedSql(sql: string, defaultSchema: string, schemaName: string): string {
-  const escapedDefaultSchema = escapeRegExp(defaultSchema);
-  return sql
-    .replace(
-      new RegExp(`(?<![A-Za-z0-9_"])${quoteIdentifier(defaultSchema)}\\.`, 'g'),
-      `${quoteIdentifier(schemaName)}.`
-    )
-    .replace(
-    new RegExp(`(?<![A-Za-z0-9_"])${escapedDefaultSchema}\\.([A-Za-z_][A-Za-z0-9_]*)`, 'g'),
-    `${quoteIdentifier(schemaName)}.$1`
-    );
+  let index = 0;
+  let rewrittenSql = '';
+
+  while (index < sql.length) {
+    const current = sql[index];
+    const next = sql[index + 1] ?? '';
+
+    if (current === '\'') {
+      const end = skipSingleQuotedString(sql, index);
+      rewrittenSql += sql.slice(index, end);
+      index = end;
+      continue;
+    }
+    if (current === '-' && next === '-') {
+      const end = skipLineComment(sql, index);
+      rewrittenSql += sql.slice(index, end);
+      index = end;
+      continue;
+    }
+    if (current === '/' && next === '*') {
+      const end = skipBlockComment(sql, index);
+      rewrittenSql += sql.slice(index, end);
+      index = end;
+      continue;
+    }
+    if (current === '$') {
+      const dollarQuote = readDollarQuoteDelimiter(sql, index);
+      if (dollarQuote) {
+        const end = skipDollarQuotedString(sql, index, dollarQuote);
+        rewrittenSql += sql.slice(index, end);
+        index = end;
+        continue;
+      }
+    }
+
+    const qualifier = readDefaultSchemaQualifier(sql, index, defaultSchema);
+    if (qualifier) {
+      rewrittenSql += `${quoteIdentifier(schemaName)}.`;
+      index = qualifier.end;
+      continue;
+    }
+    if (current === '"') {
+      const end = skipDoubleQuotedIdentifier(sql, index);
+      rewrittenSql += sql.slice(index, end);
+      index = end;
+      continue;
+    }
+    if (/[A-Za-z_]/.test(current ?? '')) {
+      const end = consumeIdentifier(sql, index);
+      rewrittenSql += sql.slice(index, end);
+      index = end;
+      continue;
+    }
+
+    rewrittenSql += current;
+    index += 1;
+  }
+
+  return rewrittenSql;
 }
 
 function quoteIdentifier(value: string): string {
   return `"${value.replace(/"/g, '""')}"`;
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+function buildPhysicalSearchPath(searchPath: string[], schemaName: string): string {
+  const schemas = [schemaName, ...searchPath.filter((entry) => entry !== schemaName)];
+  return schemas.map(quoteIdentifier).join(', ');
+}
+
+function readDefaultSchemaQualifier(
+  sql: string,
+  start: number,
+  defaultSchema: string
+): { end: number } | null {
+  const previous = sql[start - 1] ?? '';
+  if (previous === '.' || /[A-Za-z0-9_"]/.test(previous)) {
+    return null;
+  }
+
+  if (sql[start] === '"') {
+    const quoted = readQuotedIdentifier(sql, start);
+    if (!quoted || quoted.value !== defaultSchema || sql[quoted.end] !== '.') {
+      return null;
+    }
+    return { end: quoted.end + 1 };
+  }
+
+  if (!/[A-Za-z_]/.test(sql[start] ?? '')) {
+    return null;
+  }
+
+  const end = consumeIdentifier(sql, start);
+  if (sql.slice(start, end) !== defaultSchema || sql[end] !== '.') {
+    return null;
+  }
+
+  return { end: end + 1 };
+}
+
+function readQuotedIdentifier(sql: string, start: number): { end: number; value: string } | null {
+  let index = start + 1;
+  let value = '';
+
+  while (index < sql.length) {
+    if (sql[index] === '"' && sql[index + 1] === '"') {
+      value += '"';
+      index += 2;
+      continue;
+    }
+    if (sql[index] === '"') {
+      return {
+        end: index + 1,
+        value
+      };
+    }
+    value += sql[index];
+    index += 1;
+  }
+
+  return null;
 }
 
 function loadStarterDefaults(rootDir: string): StarterProjectDefaults {
   const config = loadStarterProjectConfig(rootDir);
+  const configuredDefaultSchema =
+    typeof config.defaultSchema === 'string' ? config.defaultSchema.trim() : '';
   const defaultSchema =
-    typeof config.defaultSchema === 'string' && config.defaultSchema.length > 0
-      ? config.defaultSchema
-      : 'public';
+    configuredDefaultSchema.length > 0 ? configuredDefaultSchema : 'public';
   const searchPath = normalizeSearchPath(config.searchPath);
   const projectRootDir = path.resolve(rootDir);
   const ztdRootDir = path.resolve(rootDir, config.ztdRootDir ?? '.ztd');
@@ -462,7 +565,10 @@ function normalizeSearchPath(searchPath: unknown): string[] {
     return [];
   }
 
-  return searchPath.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0);
+  return searchPath
+    .filter((entry): entry is string => typeof entry === 'string')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
 }
 
 function writeTraceFileIfEnabled(

--- a/packages/transfer/tests/support/ztd/verifier.ts
+++ b/packages/transfer/tests/support/ztd/verifier.ts
@@ -1,0 +1,734 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { expect } from 'vitest';
+import { Pool } from 'pg';
+import type { PoolClient } from 'pg';
+
+import type { PostgresTestkitClient } from '@rawsql-ts/testkit-postgres';
+import type { QuerySpecTraditionalCase, QuerySpecZtdCase } from './case-types.js';
+
+type QuerySpecExecutorClient = {
+  query<T = unknown>(sql: string, params: Record<string, unknown>): Promise<T[]>;
+};
+
+type QuerySpecExecutor<Input, Output> = (
+  client: QuerySpecExecutorClient,
+  input: Input
+) => Promise<Output>;
+
+type FixtureTree = Record<string, unknown>;
+type FixtureRow = Record<string, unknown>;
+type FixtureTableRows = Array<{ tableName: string; rows: FixtureRow[] }>;
+
+export type QuerySpecExecutionMode = 'ztd';
+export type QuerySpecSupportedExecutionMode = 'ztd' | 'traditional';
+
+export interface QuerySpecExecutionEvidence {
+  mode: QuerySpecSupportedExecutionMode;
+  rewriteApplied: boolean;
+  physicalSetupUsed: boolean;
+  executedQueryCount: number;
+  traceFilePath?: string;
+}
+
+interface PhysicalQuerySpecExecutorClient extends QuerySpecExecutorClient {
+  close(): Promise<void>;
+  assertAfterDb(afterDb: FixtureTree): Promise<void>;
+}
+
+interface QueryExecutionTrace {
+  index: number;
+  originalSql: string;
+  boundSql: string;
+  boundParams: unknown[];
+  executedSql?: string;
+  executedParams?: unknown[];
+  fixturesApplied?: string[];
+  rewriteApplied: boolean;
+}
+
+interface StarterProjectConfigFile {
+  ztdRootDir?: string;
+  ddlDir?: string;
+  defaultSchema?: string;
+  searchPath?: string[];
+}
+
+interface StarterProjectDefaults {
+  projectRootDir: string;
+  ztdRootDir: string;
+  defaultSchema: string;
+  searchPath: string[];
+  ddlDirectories: string[];
+}
+
+export async function verifyQuerySpecZtdCase<BeforeDb extends FixtureTree, Input, Output>(
+  querySpecCase: QuerySpecZtdCase<BeforeDb, Input, Output>,
+  execute: QuerySpecExecutor<Input, Output>
+): Promise<QuerySpecExecutionEvidence> {
+  const connectionString = process.env.ZTD_DB_URL;
+  if (!connectionString) {
+    throw new Error('Set ZTD_DB_URL before running query-boundary ZTD cases.');
+  }
+
+  const tableRows = flattenFixtureTableRows(querySpecCase.beforeDb).map((tableFixture) => ({
+    tableName: tableFixture.tableName,
+    rows: tableFixture.rows
+  }));
+
+  const trace: QueryExecutionTrace[] = [];
+  const defaults = loadStarterDefaults(process.cwd());
+  let pool: Pool | undefined;
+  let testkitClient: PostgresTestkitClient | undefined;
+  let failure: unknown;
+
+  try {
+    pool = new Pool({ connectionString });
+    const { createPostgresTestkitClient } = await import('@rawsql-ts/testkit-postgres');
+    testkitClient = createPostgresTestkitClient({
+      queryExecutor: async (sql, params) => {
+        const result = await pool!.query(sql, params as unknown[]);
+        return {
+          rows: result.rows,
+          rowCount: result.rowCount ?? undefined
+        };
+      },
+      defaultSchema: defaults.defaultSchema,
+      searchPath: defaults.searchPath,
+      tableRows,
+      ddl: defaults.ddlDirectories.length > 0 ? { directories: defaults.ddlDirectories } : undefined,
+      onExecute: (sql, params, fixtures) => {
+        const latestTrace = trace[trace.length - 1];
+        if (!latestTrace) {
+          return;
+        }
+
+        latestTrace.executedSql = sql;
+        latestTrace.executedParams = params;
+        latestTrace.fixturesApplied = fixtures;
+        latestTrace.rewriteApplied =
+          normalizeSql(latestTrace.boundSql) !== normalizeSql(sql) || (fixtures?.length ?? 0) > 0;
+      }
+    });
+
+    const result = execute(createQuerySpecExecutor(testkitClient, trace), querySpecCase.input);
+    await expect(result).resolves.toEqual(querySpecCase.output);
+    if (trace.length === 0) {
+      throw new Error(
+        `ZTD verifier did not execute any SQL for case "${querySpecCase.name}". Check the query boundary and fixture setup before accepting the case.`
+      );
+    }
+  } catch (error) {
+    failure = error;
+  } finally {
+    if (testkitClient) {
+      await testkitClient.close();
+    }
+    if (pool) {
+      await pool.end();
+    }
+  }
+
+  const evidence: QuerySpecExecutionEvidence = {
+    mode: 'ztd',
+    rewriteApplied: trace.some((entry) => entry.rewriteApplied),
+    physicalSetupUsed: false,
+    executedQueryCount: trace.length
+  };
+
+  const traceFilePath = writeTraceFileIfEnabled(querySpecCase.name, trace, evidence, failure);
+  if (traceFilePath) {
+    evidence.traceFilePath = traceFilePath;
+  }
+
+  if (failure) {
+    throw failure;
+  }
+
+  return evidence;
+}
+
+export async function verifyQuerySpecTraditionalCase<BeforeDb extends FixtureTree, Input, Output>(
+  querySpecCase: QuerySpecTraditionalCase<BeforeDb, Input, Output>,
+  execute: QuerySpecExecutor<Input, Output>
+): Promise<QuerySpecExecutionEvidence> {
+  const connectionString = process.env.ZTD_DB_URL;
+  if (!connectionString) {
+    throw new Error('Set ZTD_DB_URL before running query-boundary traditional cases.');
+  }
+
+  const trace: QueryExecutionTrace[] = [];
+  const defaults = loadStarterDefaults(process.cwd());
+  const pool = new Pool({ connectionString });
+  let client: PhysicalQuerySpecExecutorClient | undefined;
+  let failure: unknown;
+
+  try {
+    client = await createPhysicalQuerySpecExecutor(pool, defaults, querySpecCase.beforeDb, trace);
+    const result = execute(client, querySpecCase.input);
+    await expect(result).resolves.toEqual(querySpecCase.output);
+    if (querySpecCase.afterDb) {
+      await client.assertAfterDb(querySpecCase.afterDb);
+    }
+    if (trace.length === 0) {
+      throw new Error(
+        `Traditional verifier did not execute any SQL for case "${querySpecCase.name}". Check the query boundary and fixture setup before accepting the case.`
+      );
+    }
+  } catch (error) {
+    failure = error;
+  } finally {
+    if (client) {
+      await client.close();
+    } else {
+      await pool.end();
+    }
+  }
+
+  const evidence: QuerySpecExecutionEvidence = {
+    mode: 'traditional',
+    rewriteApplied: false,
+    physicalSetupUsed: true,
+    executedQueryCount: trace.length
+  };
+
+  const traceFilePath = writeTraceFileIfEnabled(querySpecCase.name, trace, evidence, failure);
+  if (traceFilePath) {
+    evidence.traceFilePath = traceFilePath;
+  }
+
+  if (failure) {
+    throw failure;
+  }
+
+  return evidence;
+}
+
+function flattenFixtureTableRows(
+  fixture: FixtureTree,
+  pathSegments: string[] = []
+): FixtureTableRows {
+  const tableRows: FixtureTableRows = [];
+
+  for (const [key, value] of Object.entries(fixture)) {
+    const nextPathSegments = [...pathSegments, key];
+    if (Array.isArray(value)) {
+      tableRows.push({
+        tableName: nextPathSegments.join('.'),
+        rows: value.map((row) => assertRecordRow(row, nextPathSegments.join('.')))
+      });
+      continue;
+    }
+
+    if (isPlainRecord(value)) {
+      tableRows.push(...flattenFixtureTableRows(value, nextPathSegments));
+      continue;
+    }
+
+    throw new Error(
+      `Query-boundary fixture entry ${nextPathSegments.join('.')} must be an object or an array of rows.`
+    );
+  }
+
+  return tableRows;
+}
+
+function assertRecordRow(value: unknown, tableName: string): Record<string, unknown> {
+  if (isPlainRecord(value)) {
+    return value;
+  }
+
+  throw new Error(`Query-boundary fixture rows for ${tableName} must be objects.`);
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function createQuerySpecExecutor(
+  testkitClient: PostgresTestkitClient,
+  trace: QueryExecutionTrace[]
+): QuerySpecExecutorClient {
+  return {
+    async query<T = unknown>(sql: string, params: Record<string, unknown>): Promise<T[]> {
+      const bound = bindNamedParams(sql, params);
+      trace.push({
+        index: trace.length + 1,
+        originalSql: sql,
+        boundSql: bound.boundSql,
+        boundParams: bound.boundValues,
+        rewriteApplied: false
+      });
+
+      const result = await testkitClient.query(bound.boundSql, bound.boundValues);
+      return result.rows as T[];
+    }
+  };
+}
+
+async function createPhysicalQuerySpecExecutor(
+  pool: Pool,
+  defaults: StarterProjectDefaults,
+  beforeDb: FixtureTree,
+  trace: QueryExecutionTrace[]
+): Promise<PhysicalQuerySpecExecutorClient> {
+  const client = await pool.connect();
+  const schemaName = createPhysicalSchemaName();
+  let closed = false;
+
+  try {
+    await client.query(`CREATE SCHEMA ${quoteIdentifier(schemaName)}`);
+    await client.query(`SET search_path TO ${quoteIdentifier(schemaName)}, public`);
+    await applySqlFiles(client, defaults.ddlDirectories, defaults.defaultSchema, schemaName);
+    await seedFixtureRows(client, flattenFixtureTableRows(beforeDb), defaults.defaultSchema, schemaName);
+  } catch (error) {
+    try {
+      await dropPhysicalSchema(client, schemaName);
+    } finally {
+      client.release();
+      await pool.end();
+    }
+    throw error;
+  }
+
+  return {
+    async query<T = unknown>(sql: string, params: Record<string, unknown>): Promise<T[]> {
+      const bound = bindNamedParams(sql, params);
+      const executedSql = rewriteSchemaQualifiedSql(bound.boundSql, defaults.defaultSchema, schemaName);
+      trace.push({
+        index: trace.length + 1,
+        originalSql: sql,
+        boundSql: bound.boundSql,
+        boundParams: bound.boundValues,
+        executedSql,
+        executedParams: bound.boundValues,
+        rewriteApplied: false
+      });
+      const result = await client.query(executedSql, bound.boundValues);
+      return result.rows as T[];
+    },
+    async assertAfterDb(afterDb: FixtureTree): Promise<void> {
+      const expectedTables = flattenFixtureTableRows(afterDb);
+      for (const tableFixture of expectedTables) {
+        const tableName = toPhysicalTableName(tableFixture.tableName, defaults.defaultSchema, schemaName);
+        const rows = await client.query(`SELECT * FROM ${tableName}`);
+        if (tableFixture.rows.length === 0) {
+          expect(rows.rows).toEqual([]);
+          continue;
+        }
+        expect(rows.rows).toEqual(
+          expect.arrayContaining(tableFixture.rows.map((row) => expect.objectContaining(row)))
+        );
+      }
+    },
+    async close(): Promise<void> {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      try {
+        await dropPhysicalSchema(client, schemaName);
+      } finally {
+        client.release();
+        await pool.end();
+      }
+    }
+  };
+}
+
+async function applySqlFiles(
+  client: PoolClient,
+  ddlDirectories: string[],
+  defaultSchema: string,
+  schemaName: string
+): Promise<void> {
+  for (const ddlDirectory of ddlDirectories) {
+    for (const fileName of readdirSync(ddlDirectory).filter((entry) => entry.endsWith('.sql')).sort()) {
+      const sql = readFileSync(path.join(ddlDirectory, fileName), 'utf8').trim();
+      if (sql.length === 0) {
+        continue;
+      }
+      await client.query(rewriteSchemaQualifiedSql(sql, defaultSchema, schemaName));
+    }
+  }
+}
+
+async function seedFixtureRows(
+  client: PoolClient,
+  tableFixtures: FixtureTableRows,
+  defaultSchema: string,
+  schemaName: string
+): Promise<void> {
+  for (const tableFixture of tableFixtures) {
+    for (const row of tableFixture.rows) {
+      const columns = Object.keys(row);
+      if (columns.length === 0) {
+        continue;
+      }
+      const tableName = toPhysicalTableName(tableFixture.tableName, defaultSchema, schemaName);
+      const columnList = columns.map(quoteIdentifier).join(', ');
+      const placeholders = columns.map((_, index) => `$${index + 1}`).join(', ');
+      const values = columns.map((column) => row[column]);
+      await client.query(`INSERT INTO ${tableName} (${columnList}) VALUES (${placeholders})`, values);
+    }
+  }
+}
+
+async function dropPhysicalSchema(client: PoolClient, schemaName: string): Promise<void> {
+  await client.query(`DROP SCHEMA IF EXISTS ${quoteIdentifier(schemaName)} CASCADE`);
+}
+
+function createPhysicalSchemaName(): string {
+  const random = Math.random().toString(36).slice(2, 10);
+  return `ztd_traditional_${Date.now()}_${process.pid}_${random}`;
+}
+
+function toPhysicalTableName(tableName: string, defaultSchema: string, schemaName: string): string {
+  const segments = tableName.split('.').map((segment) => segment.trim()).filter(Boolean);
+  const tableSegment = segments.at(-1);
+  if (!tableSegment) {
+    throw new Error(`Invalid fixture table name: ${tableName}`);
+  }
+  return `${quoteIdentifier(schemaName)}.${quoteIdentifier(tableSegment)}`;
+}
+
+function rewriteSchemaQualifiedSql(sql: string, defaultSchema: string, schemaName: string): string {
+  const escapedDefaultSchema = escapeRegExp(defaultSchema);
+  return sql
+    .replace(
+      new RegExp(`(?<![A-Za-z0-9_"])${quoteIdentifier(defaultSchema)}\\.`, 'g'),
+      `${quoteIdentifier(schemaName)}.`
+    )
+    .replace(
+    new RegExp(`(?<![A-Za-z0-9_"])${escapedDefaultSchema}\\.([A-Za-z_][A-Za-z0-9_]*)`, 'g'),
+    `${quoteIdentifier(schemaName)}.$1`
+    );
+}
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function loadStarterDefaults(rootDir: string): StarterProjectDefaults {
+  const config = loadStarterProjectConfig(rootDir);
+  const defaultSchema =
+    typeof config.defaultSchema === 'string' && config.defaultSchema.length > 0
+      ? config.defaultSchema
+      : 'public';
+  const searchPath = normalizeSearchPath(config.searchPath);
+  const projectRootDir = path.resolve(rootDir);
+  const ztdRootDir = path.resolve(rootDir, config.ztdRootDir ?? '.ztd');
+  const ddlDirectory = path.resolve(
+    projectRootDir,
+    typeof config.ddlDir === 'string' && config.ddlDir.trim().length > 0 ? config.ddlDir : 'db/ddl'
+  );
+
+  return {
+    projectRootDir,
+    ztdRootDir,
+    defaultSchema,
+    searchPath: searchPath.length > 0 ? searchPath : [defaultSchema],
+    ddlDirectories: existsSync(ddlDirectory) ? [ddlDirectory] : []
+  };
+}
+
+function loadStarterProjectConfig(rootDir: string): StarterProjectConfigFile {
+  const configPath = path.join(rootDir, 'ztd.config.json');
+  if (!existsSync(configPath)) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(readFileSync(configPath, 'utf8')) as StarterProjectConfigFile;
+  } catch (error) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      (error as { code?: string }).code === 'ENOENT'
+    ) {
+      return {};
+    }
+    throw error;
+  }
+}
+
+function normalizeSearchPath(searchPath: unknown): string[] {
+  if (!Array.isArray(searchPath)) {
+    return [];
+  }
+
+  return searchPath.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0);
+}
+
+function writeTraceFileIfEnabled(
+  caseName: string,
+  trace: QueryExecutionTrace[],
+  evidence: QuerySpecExecutionEvidence,
+  failure?: unknown
+): string | undefined {
+  if (!isTraceEnabled()) {
+    return undefined;
+  }
+
+  const traceDir = resolveTraceDir();
+  mkdirSync(traceDir, { recursive: true });
+
+  const fileName = `${createSafeFileSegment(caseName)}-${Date.now()}-${process.pid}.json`;
+  const traceFilePath = path.join(traceDir, fileName);
+
+  writeFileSync(
+    traceFilePath,
+      `${JSON.stringify(
+        {
+          caseName,
+          evidence,
+          failure: serializeTraceFailure(failure),
+          trace
+        },
+        null,
+        2
+      )}\n`,
+    'utf8'
+  );
+
+  return traceFilePath;
+}
+
+function serializeTraceFailure(failure: unknown): Record<string, unknown> | undefined {
+  if (failure === undefined) {
+    return undefined;
+  }
+
+  if (failure instanceof Error) {
+    return {
+      name: failure.name,
+      message: failure.message,
+      stack: failure.stack
+    };
+  }
+
+  return {
+    name: 'Error',
+    message: String(failure)
+  };
+}
+
+function isTraceEnabled(): boolean {
+  const value = process.env.ZTD_SQL_TRACE;
+  if (!value) {
+    return false;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
+}
+
+function resolveTraceDir(): string {
+  const configuredDir = process.env.ZTD_SQL_TRACE_DIR;
+  if (configuredDir && configuredDir.trim().length > 0) {
+    return path.resolve(process.cwd(), configuredDir);
+  }
+
+  return path.join(process.cwd(), '.ztd', 'tmp', 'sql-trace');
+}
+
+function createSafeFileSegment(value: string): string {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return normalized.length > 0 ? normalized : 'queryspec-case';
+}
+
+function normalizeSql(sql: string): string {
+  return sql.replace(/\s+/g, ' ').trim();
+}
+
+interface BoundNamedSql {
+  boundSql: string;
+  boundValues: unknown[];
+}
+
+function bindNamedParams(sql: string, params: Record<string, unknown>): BoundNamedSql {
+  const scan = scanNamedParams(sql);
+  if (scan.mode !== 'named') {
+    return {
+      boundSql: sql,
+      boundValues: []
+    };
+  }
+
+  const orderedValues: unknown[] = [];
+  const slotByName = new Map<string, number>();
+  let cursor = 0;
+  let boundSql = '';
+
+  for (const token of scan.namedTokens) {
+    boundSql += sql.slice(cursor, token.start);
+    let slot = slotByName.get(token.name);
+    if (!slot) {
+      orderedValues.push(resolveNamedParam(params, token.name));
+      slot = orderedValues.length;
+      slotByName.set(token.name, slot);
+    }
+    boundSql += `$${slot}`;
+    cursor = token.end;
+  }
+
+  boundSql += sql.slice(cursor);
+  return {
+    boundSql,
+    boundValues: orderedValues
+  };
+}
+
+function resolveNamedParam(params: Record<string, unknown>, name: string): unknown {
+  if (!(name in params)) {
+    throw new Error(`Missing named query param: ${name}`);
+  }
+  return params[name];
+}
+
+type PlaceholderMode = 'none' | 'named' | 'positional';
+
+interface NamedToken {
+  start: number;
+  end: number;
+  name: string;
+}
+
+function scanNamedParams(sql: string): { mode: PlaceholderMode; namedTokens: NamedToken[] } {
+  const namedTokens: NamedToken[] = [];
+  let index = 0;
+
+  while (index < sql.length) {
+    const current = sql[index];
+    const next = sql[index + 1] ?? '';
+
+    if (current === '\'') {
+      index = skipSingleQuotedString(sql, index);
+      continue;
+    }
+    if (current === '"') {
+      index = skipDoubleQuotedIdentifier(sql, index);
+      continue;
+    }
+    if (current === '-' && next === '-') {
+      index = skipLineComment(sql, index);
+      continue;
+    }
+    if (current === '/' && next === '*') {
+      index = skipBlockComment(sql, index);
+      continue;
+    }
+    if (current === '$') {
+      const dollarQuote = readDollarQuoteDelimiter(sql, index);
+      if (dollarQuote) {
+        index = skipDollarQuotedString(sql, index, dollarQuote);
+        continue;
+      }
+    }
+    if (current === ':') {
+      if (next === ':') {
+        index += 2;
+        continue;
+      }
+      if (/[A-Za-z_]/.test(next)) {
+        const end = consumeIdentifier(sql, index + 1);
+        namedTokens.push({
+          start: index,
+          end,
+          name: sql.slice(index + 1, end)
+        });
+        index = end;
+        continue;
+      }
+    }
+
+    index += 1;
+  }
+
+  return {
+    mode: namedTokens.length > 0 ? 'named' : 'none',
+    namedTokens
+  };
+}
+
+function skipSingleQuotedString(sql: string, start: number): number {
+  let index = start + 1;
+  while (index < sql.length) {
+    if (sql[index] === '\'' && sql[index + 1] === '\'') {
+      index += 2;
+      continue;
+    }
+    if (sql[index] === '\'') {
+      return index + 1;
+    }
+    index += 1;
+  }
+  return sql.length;
+}
+
+function skipDoubleQuotedIdentifier(sql: string, start: number): number {
+  let index = start + 1;
+  while (index < sql.length) {
+    if (sql[index] === '"' && sql[index + 1] === '"') {
+      index += 2;
+      continue;
+    }
+    if (sql[index] === '"') {
+      return index + 1;
+    }
+    index += 1;
+  }
+  return sql.length;
+}
+
+function skipLineComment(sql: string, start: number): number {
+  let index = start + 2;
+  while (index < sql.length && sql[index] !== '\n') {
+    index += 1;
+  }
+  return index;
+}
+
+function skipBlockComment(sql: string, start: number): number {
+  let index = start + 2;
+  while (index < sql.length) {
+    if (sql[index] === '*' && sql[index + 1] === '/') {
+      return index + 2;
+    }
+    index += 1;
+  }
+  return sql.length;
+}
+
+function readDollarQuoteDelimiter(sql: string, start: number): string | null {
+  let index = start + 1;
+  while (index < sql.length && /[A-Za-z0-9_]/.test(sql[index] ?? '')) {
+    index += 1;
+  }
+  if (sql[index] === '$') {
+    return sql.slice(start, index + 1);
+  }
+  return null;
+}
+
+function skipDollarQuotedString(sql: string, start: number, delimiter: string): number {
+  const closeIndex = sql.indexOf(delimiter, start + delimiter.length);
+  return closeIndex >= 0 ? closeIndex + delimiter.length : sql.length;
+}
+
+function consumeIdentifier(sql: string, start: number): number {
+  let index = start;
+  while (index < sql.length && /[A-Za-z0-9_]/.test(sql[index] ?? '')) {
+    index += 1;
+  }
+  return index;
+}

--- a/packages/transfer/tsconfig.json
+++ b/packages/transfer/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "baseUrl": ".",
+    "paths": {
+      "#features/*": ["src/features/*"],
+      "#libraries/*": ["src/libraries/*"],
+      "#adapters/*": ["src/adapters/*"],
+      "#tests/*": ["tests/*"]
+    },
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/packages/transfer/vitest.config.ts
+++ b/packages/transfer/vitest.config.ts
@@ -1,0 +1,23 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '#features': fileURLToPath(new URL('./src/features', import.meta.url)),
+      '#libraries': fileURLToPath(new URL('./src/libraries', import.meta.url)),
+      '#adapters': fileURLToPath(new URL('./src/adapters', import.meta.url)),
+      '#tests': fileURLToPath(new URL('./tests', import.meta.url)),
+    },
+  },
+  test: {
+    include: ['tests/**/*.test.ts', 'src/features/**/*.test.ts'],
+    environment: 'node',
+    globals: true,
+    setupFiles: ['.ztd/support/setup-env.ts'],
+    globalSetup: ['.ztd/support/global-setup.ts'],
+    // Starting a Postgres testcontainer can exceed the default 5s timeout on some machines.
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
+  },
+});

--- a/packages/transfer/ztd.config.json
+++ b/packages/transfer/ztd.config.json
@@ -1,0 +1,11 @@
+{
+  "ztdRootDir": ".ztd",
+  "dialect": "postgres",
+  "ddlDir": "db/ddl",
+  "testsDir": ".ztd/tests",
+  "defaultSchema": "public",
+  "searchPath": [
+    "public"
+  ],
+  "ddlLint": "strict"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -457,6 +457,58 @@ importers:
         specifier: ^4.0.7
         version: 4.0.7(@types/node@22.19.17)(jiti@2.6.1)(yaml@2.8.3)
 
+  packages/transfer:
+    dependencies:
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@rawsql-ts/sql-contract':
+        specifier: workspace:*
+        version: link:../sql-contract
+      '@rawsql-ts/testkit-core':
+        specifier: workspace:*
+        version: link:../testkit-core
+      '@rawsql-ts/testkit-postgres':
+        specifier: workspace:*
+        version: link:../testkit-postgres
+      '@rawsql-ts/ztd-cli':
+        specifier: workspace:*
+        version: link:../ztd-cli
+      '@testcontainers/postgresql':
+        specifier: ^11.14.0
+        version: 11.14.0
+      '@types/node':
+        specifier: 22.18.7
+        version: 22.18.7
+      dotenv:
+        specifier: ^16.6.1
+        version: 16.6.1
+      eslint:
+        specifier: ^9.22.0
+        version: 9.39.2(jiti@2.6.1)
+      lint-staged:
+        specifier: ^16.2.7
+        version: 16.4.0
+      pg:
+        specifier: ^8.11.1
+        version: 8.20.0
+      prettier:
+        specifier: ^3.7.4
+        version: 3.7.4
+      prettier-plugin-sql:
+        specifier: ^0.19.2
+        version: 0.19.2(prettier@3.7.4)
+      simple-git-hooks:
+        specifier: ^2.13.1
+        version: 2.13.1
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.2
+      vitest:
+        specifier: ^4.0.7
+        version: 4.1.5(@types/node@22.18.7)(vite@7.3.2(@types/node@22.18.7)(jiti@2.6.1)(yaml@2.8.3))
+
   packages/ztd-cli:
     dependencies:
       '@rawsql-ts/sql-grep-core':
@@ -5280,7 +5332,7 @@ snapshots:
 
   '@types/better-sqlite3@7.6.13':
     dependencies:
-      '@types/node': 22.19.6
+      '@types/node': 22.19.17
 
   '@types/chai@5.2.3':
     dependencies:
@@ -5293,19 +5345,19 @@ snapshots:
 
   '@types/docker-modem@3.0.6':
     dependencies:
-      '@types/node': 22.19.6
+      '@types/node': 22.18.7
       '@types/ssh2': 1.15.5
 
   '@types/dockerode@3.3.47':
     dependencies:
       '@types/docker-modem': 3.0.6
-      '@types/node': 22.19.6
+      '@types/node': 22.18.7
       '@types/ssh2': 1.15.5
 
   '@types/dockerode@4.0.1':
     dependencies:
       '@types/docker-modem': 3.0.6
-      '@types/node': 22.19.17
+      '@types/node': 22.18.7
       '@types/ssh2': 1.15.5
 
   '@types/estree@1.0.8': {}
@@ -5361,15 +5413,15 @@ snapshots:
 
   '@types/readable-stream@4.0.23':
     dependencies:
-      '@types/node': 22.19.6
+      '@types/node': 22.18.7
 
   '@types/ssh2-streams@0.1.13':
     dependencies:
-      '@types/node': 22.19.6
+      '@types/node': 22.18.7
 
   '@types/ssh2@0.5.52':
     dependencies:
-      '@types/node': 22.19.6
+      '@types/node': 22.18.7
       '@types/ssh2-streams': 0.1.13
 
   '@types/ssh2@1.15.5':
@@ -7423,7 +7475,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 22.19.17
+      '@types/node': 22.18.7
       long: 5.3.2
 
   pump@3.0.3:
@@ -7812,7 +7864,7 @@ snapshots:
       '@azure/identity': 4.13.0
       '@azure/keyvault-keys': 4.10.0
       '@js-joda/core': 5.6.5
-      '@types/node': 22.19.6
+      '@types/node': 22.18.7
       bl: 6.1.6
       iconv-lite: 0.7.0
       js-md4: 0.3.2


### PR DESCRIPTION
## Summary

- Add the private `@rawsql-ts/transfer` package with PostgreSQL DDL for `transfer_destination_definition`.
- Add the RFBA `create-transfer-destination-definition` feature with camelCase feature input, feature-boundary validation, explicit snake_case query params, and `INSERT ... RETURNING` SQL that relies on DB defaults and DB constraints.
- Add ZTD-backed queryspec tests for the two approved create examples plus feature-boundary validation tests. No changeset is included because this package is not a publish target.

## Verification

- `pnpm --filter @rawsql-ts/transfer test` passed: 2 files, 14 tests.
- `pnpm --filter @rawsql-ts/transfer lint` passed.
- `pnpm --filter @rawsql-ts/transfer typecheck` passed.
- `pnpm --filter @rawsql-ts/transfer build` passed.
- `git diff --cached --check` passed.

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: not needed; no baseline exception requested.
Scoped checks run: not needed; no baseline exception requested.
Why full baseline is not required: full baseline exception path not used for this PR.

## Self Review

Self-review workflow: repo-local developer self-review skill, two cycles: consistency review and human acceptance review.
Self-review result: no unresolved blockers; stale duplicate-handling README wording was found and fixed before PR creation.

## CLI Surface Migration

- [ ] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: not selected for this PR.
Upgrade note: not selected for this PR.
Deprecation/removal plan or issue: not selected for this PR.
Docs/help/examples updated: not selected for this PR.
Release/changeset wording: not selected for this PR.

## Scaffold Contract Proof

- [ ] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: not selected for this PR.
Non-edit assertion: not selected for this PR.
Fail-fast input-contract proof: not selected for this PR.
Generated-output viability proof: not selected for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `@rawsql-ts/transfer` package with support for transfer destination definitions
  * Added create transfer destination definition feature with input validation for destination tables, columns, keys, and transfer policies
  * Created database schema to persist transfer destination configurations

* **Documentation**
  * Added comprehensive README files for the new package and its features
  * Documented query-boundary test support structure and conventions

* **Tests**
  * Established query-boundary test infrastructure with ZTD support
  * Added Postgres test utilities for integration testing

* **Chores**
  * Configured TypeScript, Vitest, Prettier, and ESLint for the new package
  * Added environment setup and pre-commit hooks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->