### PR TITLE
Improve ztd-cli scaffold template contracts

### DIFF
--- a/.changeset/brave-starters-improve.md
+++ b/.changeset/brave-starters-improve.md
@@ -1,0 +1,5 @@
+---
+"@rawsql-ts/ztd-cli": patch
+---
+
+Improve generated starter templates for formatting hooks, SQL client adapter contracts, query-boundary test types, config normalization, and traditional queryspec schema rewriting.

--- a/packages/ztd-cli/src/commands/featureTests.ts
+++ b/packages/ztd-cli/src/commands/featureTests.ts
@@ -342,6 +342,7 @@ function renderFeatureTestScaffoldFiles(params: {
   const queryTypePrefix = toPascalCase(params.queryName);
   const queryCaseTypeName = isZtdLane ? `${queryTypePrefix}QueryBoundaryZtdCase` : `${queryTypePrefix}QueryBoundaryTraditionalCase`;
   const queryTypesImportPath = isZtdLane ? './boundary-ztd-types.js' : './boundary-traditional-types.js';
+  const queryBoundaryTypesImport = `import type { ${queryTypePrefix}QueryParams, ${queryTypePrefix}QueryResult } from '../boundary.js';`;
   const beforeDbTypeLiteral = buildQueryFixtureTypeLiteral(
     params.planDetails.fixtureCandidateTables,
     buildQueryFixtureRowTypeLiteral(params.planDetails.queryFixtureRowFields)
@@ -422,7 +423,7 @@ function renderFeatureTestScaffoldFiles(params: {
   const queryTypesFile = isZtdLane
     ? [
       `import type { QuerySpecZtdCase } from '${useStableTestSupportImports ? TESTS_SUPPORT_CASE_TYPES_IMPORT_PATH : '../../../../../../tests/support/ztd/case-types.js'}';`,
-      `import type { ${queryTypePrefix}QueryParams, ${queryTypePrefix}QueryResult } from '../boundary.js';`,
+      queryBoundaryTypesImport,
       '',
       `export type ${queryTypePrefix}BeforeDb = ${beforeDbTypeLiteral};`,
       `export type ${queryTypePrefix}Input = ${queryTypePrefix}QueryParams;`,
@@ -437,7 +438,7 @@ function renderFeatureTestScaffoldFiles(params: {
     ].join('\n')
     : [
       `import type { QuerySpecTraditionalCase } from '${useStableTestSupportImports ? TESTS_SUPPORT_CASE_TYPES_IMPORT_PATH : '../../../../../../tests/support/ztd/case-types.js'}';`,
-      `import type { ${queryTypePrefix}QueryParams, ${queryTypePrefix}QueryResult } from '../boundary.js';`,
+      queryBoundaryTypesImport,
       '',
       `export type ${queryTypePrefix}BeforeDb = ${beforeDbTypeLiteral};`,
       `export type ${queryTypePrefix}Input = ${queryTypePrefix}QueryParams;`,

--- a/packages/ztd-cli/src/commands/featureTests.ts
+++ b/packages/ztd-cli/src/commands/featureTests.ts
@@ -347,8 +347,6 @@ function renderFeatureTestScaffoldFiles(params: {
     buildQueryFixtureRowTypeLiteral(params.planDetails.queryFixtureRowFields)
   );
   const beforeDbValueLiteral = buildQueryFixtureValueLiteral(params.planDetails.fixtureCandidateTables);
-  const queryInputTypeLiteral = buildRecordShapeTypeLiteral(params.planDetails.queryInputFields);
-  const queryOutputTypeLiteral = buildRecordShapeTypeLiteral(params.planDetails.queryOutputFields);
   const beforeDbTodoLines = renderTodoCommentLines(
     'TODO: Fill fixture rows for the tables the CLI could identify. Remove rows that are not needed for this case.',
     params.planDetails.fixtureCandidateTables
@@ -424,10 +422,11 @@ function renderFeatureTestScaffoldFiles(params: {
   const queryTypesFile = isZtdLane
     ? [
       `import type { QuerySpecZtdCase } from '${useStableTestSupportImports ? TESTS_SUPPORT_CASE_TYPES_IMPORT_PATH : '../../../../../../tests/support/ztd/case-types.js'}';`,
+      `import type { ${queryTypePrefix}QueryParams, ${queryTypePrefix}QueryResult } from '../boundary.js';`,
       '',
       `export type ${queryTypePrefix}BeforeDb = ${beforeDbTypeLiteral};`,
-      `export type ${queryTypePrefix}Input = ${queryInputTypeLiteral};`,
-      `export type ${queryTypePrefix}Output = ${queryOutputTypeLiteral};`,
+      `export type ${queryTypePrefix}Input = ${queryTypePrefix}QueryParams;`,
+      `export type ${queryTypePrefix}Output = ${queryTypePrefix}QueryResult;`,
       '',
       `export type ${queryCaseTypeName} = QuerySpecZtdCase<`,
       `  ${queryTypePrefix}BeforeDb,`,
@@ -438,10 +437,11 @@ function renderFeatureTestScaffoldFiles(params: {
     ].join('\n')
     : [
       `import type { QuerySpecTraditionalCase } from '${useStableTestSupportImports ? TESTS_SUPPORT_CASE_TYPES_IMPORT_PATH : '../../../../../../tests/support/ztd/case-types.js'}';`,
+      `import type { ${queryTypePrefix}QueryParams, ${queryTypePrefix}QueryResult } from '../boundary.js';`,
       '',
       `export type ${queryTypePrefix}BeforeDb = ${beforeDbTypeLiteral};`,
-      `export type ${queryTypePrefix}Input = ${queryInputTypeLiteral};`,
-      `export type ${queryTypePrefix}Output = ${queryOutputTypeLiteral};`,
+      `export type ${queryTypePrefix}Input = ${queryTypePrefix}QueryParams;`,
+      `export type ${queryTypePrefix}Output = ${queryTypePrefix}QueryResult;`,
       '',
       `export type ${queryCaseTypeName} = QuerySpecTraditionalCase<`,
       `  ${queryTypePrefix}BeforeDb,`,
@@ -607,15 +607,6 @@ function buildQueryFixtureRowTypeLiteral(fieldNames: string[]): string {
   }
 
   return `{ ${normalized.map((field) => `${field}?: unknown`).join('; ')} }`;
-}
-
-function buildRecordShapeTypeLiteral(fieldNames: string[]): string {
-  const normalized = dedupeStrings(fieldNames);
-  if (normalized.length === 0) {
-    return 'Record<string, unknown>';
-  }
-
-  return `{ ${normalized.map((field) => `${field}: unknown`).join('; ')} }`;
 }
 
 function renderTodoCommentLines(message: string, hints: string[]): string[] {

--- a/packages/ztd-cli/src/commands/init.ts
+++ b/packages/ztd-cli/src/commands/init.ts
@@ -1943,6 +1943,7 @@ function ensurePackageJsonFormatting(
   scaffoldProfile: InitScaffoldProfile,
   starter: boolean
 ): FileSummary | null {
+  const packageManager = detectPackageManager(rootDir, defaultPackageManagerForScaffold(scaffoldProfile));
   const packagePath = path.join(rootDir, 'package.json');
   const packageExists = dependencies.fileExists(packagePath);
   const parsed = packageExists
@@ -2028,7 +2029,7 @@ function ensurePackageJsonFormatting(
   // Wire simple-git-hooks only if the user has not already customized it.
   if (!('simple-git-hooks' in parsed)) {
     parsed['simple-git-hooks'] = {
-      'pre-commit': 'pnpm lint-staged'
+      'pre-commit': resolveLintStagedCommand(packageManager)
     };
     changed = true;
   }
@@ -2101,6 +2102,16 @@ function ensurePackageJsonFormatting(
   // Persist the updated manifest so the new scripts and tools are available immediately.
   dependencies.writeFile(packagePath, `${JSON.stringify(parsed, null, 2)}\n`);
   return { relativePath: relative, outcome: packageExists ? 'overwritten' : 'created' };
+}
+
+function resolveLintStagedCommand(packageManager: PackageManager): string {
+  if (packageManager === 'pnpm') {
+    return 'pnpm lint-staged';
+  }
+  if (packageManager === 'yarn') {
+    return 'yarn lint-staged';
+  }
+  return 'npx lint-staged';
 }
 
 function inferPackageName(rootDir: string): string {

--- a/packages/ztd-cli/src/commands/init.ts
+++ b/packages/ztd-cli/src/commands/init.ts
@@ -2020,7 +2020,7 @@ function ensurePackageJsonFormatting(
   // Provide lint-staged wiring for the formatting pipeline when no configuration is present.
   if (!('lint-staged' in parsed)) {
     parsed['lint-staged'] = {
-      '*.{ts,tsx,js,jsx,json,md,sql}': ['pnpm format']
+      '*.{ts,tsx,js,jsx,json,md,sql}': ['prettier --write']
     };
     changed = true;
   }

--- a/packages/ztd-cli/templates/.prettierrc
+++ b/packages/ztd-cli/templates/.prettierrc
@@ -9,13 +9,13 @@
   "plugins": ["prettier-plugin-sql"],
   "overrides": [
     {
-      "files": "*.sql",
+      "files": "**/*.sql",
       "options": {
         "parser": "sql"
       }
     },
     {
-      "files": "*.md",
+      "files": "**/*.md",
       "options": {
         "parser": "markdown"
       }

--- a/packages/ztd-cli/templates/src/adapters/pg/sql-client.ts
+++ b/packages/ztd-cli/templates/src/adapters/pg/sql-client.ts
@@ -21,14 +21,9 @@ export function fromPg(
   return {
     query<T extends Record<string, unknown> = Record<string, unknown>>(
       text: string,
-      values?: readonly unknown[] | Record<string, unknown>
+      values?: readonly unknown[]
     ): Promise<T[]> {
-      if (values != null && !Array.isArray(values)) {
-        throw new Error('fromPg adapter does not support named parameter objects; use positional parameter arrays');
-      }
-      return queryable
-        .query(text, values as readonly unknown[])
-        .then((result) => result.rows as T[]);
+      return queryable.query(text, values).then((result) => result.rows as T[]);
     }
   };
 }

--- a/packages/ztd-cli/templates/src/db/sql-client-adapters.ts
+++ b/packages/ztd-cli/templates/src/db/sql-client-adapters.ts
@@ -19,14 +19,9 @@ export function fromPg(
   return {
     query<T extends Record<string, unknown> = Record<string, unknown>>(
       text: string,
-      values?: readonly unknown[] | Record<string, unknown>
+      values?: readonly unknown[]
     ): Promise<T[]> {
-      if (values != null && !Array.isArray(values)) {
-        throw new Error('fromPg adapter does not support named parameter objects; use positional parameter arrays');
-      }
-      return queryable
-        .query(text, values as readonly unknown[])
-        .then((result) => result.rows as T[]);
+      return queryable.query(text, values).then((result) => result.rows as T[]);
     }
   };
 }

--- a/packages/ztd-cli/templates/src/db/sql-client.ts
+++ b/packages/ztd-cli/templates/src/db/sql-client.ts
@@ -20,6 +20,6 @@ export type SqlQueryRows<T> = Promise<T[]>;
 export type SqlClient = {
   query<T extends Record<string, unknown> = Record<string, unknown>>(
     text: string,
-    values?: readonly unknown[] | Record<string, unknown>
+    values?: readonly unknown[]
   ): SqlQueryRows<T>;
 };

--- a/packages/ztd-cli/templates/src/features/smoke/queries/smoke/tests/boundary-ztd-types.ts
+++ b/packages/ztd-cli/templates/src/features/smoke/queries/smoke/tests/boundary-ztd-types.ts
@@ -1,4 +1,5 @@
 import type { QuerySpecZtdCase } from '#tests/support/ztd/case-types.js';
+import type { SmokeQueryParams, SmokeQueryResult } from '../boundary.js';
 
 export type SmokeBeforeDb = {
   public: {
@@ -12,7 +13,7 @@ export type SmokeBeforeDb = {
   };
 };
 
-export type SmokeInput = { user_id: unknown };
-export type SmokeOutput = { user_id: unknown; email: unknown };
+export type SmokeInput = SmokeQueryParams;
+export type SmokeOutput = SmokeQueryResult;
 
 export type SmokeQueryBoundaryZtdCase = QuerySpecZtdCase<SmokeBeforeDb, SmokeInput, SmokeOutput>;

--- a/packages/ztd-cli/templates/src/infrastructure/db/sql-client-adapters.ts
+++ b/packages/ztd-cli/templates/src/infrastructure/db/sql-client-adapters.ts
@@ -21,14 +21,9 @@ export function fromPg(
   return {
     query<T extends Record<string, unknown> = Record<string, unknown>>(
       text: string,
-      values?: readonly unknown[] | Record<string, unknown>
+      values?: readonly unknown[]
     ): Promise<T[]> {
-      if (values != null && !Array.isArray(values)) {
-        throw new Error('fromPg adapter does not support named parameter objects; use positional parameter arrays');
-      }
-      return queryable
-        .query(text, values as readonly unknown[])
-        .then((result) => result.rows as T[]);
+      return queryable.query(text, values).then((result) => result.rows as T[]);
     }
   };
 }

--- a/packages/ztd-cli/templates/src/infrastructure/db/sql-client.ts
+++ b/packages/ztd-cli/templates/src/infrastructure/db/sql-client.ts
@@ -20,6 +20,6 @@ export type SqlQueryRows<T> = Promise<T[]>;
 export type SqlClient = {
   query<T extends Record<string, unknown> = Record<string, unknown>>(
     text: string,
-    values?: readonly unknown[] | Record<string, unknown>
+    values?: readonly unknown[]
   ): SqlQueryRows<T>;
 };

--- a/packages/ztd-cli/templates/src/libraries/sql/sql-client.ts
+++ b/packages/ztd-cli/templates/src/libraries/sql/sql-client.ts
@@ -20,6 +20,6 @@ export type SqlQueryRows<T> = Promise<T[]>;
 export type SqlClient = {
   query<T extends Record<string, unknown> = Record<string, unknown>>(
     text: string,
-    values?: readonly unknown[] | Record<string, unknown>
+    values?: readonly unknown[]
   ): SqlQueryRows<T>;
 };

--- a/packages/ztd-cli/templates/tests/support/postgres-testkit.ts
+++ b/packages/ztd-cli/templates/tests/support/postgres-testkit.ts
@@ -37,7 +37,10 @@ function normalizeSearchPath(searchPath: unknown): string[] {
     return [];
   }
 
-  return searchPath.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0);
+  return searchPath
+    .filter((entry): entry is string => typeof entry === 'string')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
 }
 
 function loadStarterProjectConfig(rootDir: string = process.cwd()): StarterProjectConfigFile {
@@ -60,10 +63,9 @@ export function loadStarterPostgresDefaults(rootDir: string = process.cwd()): St
   const projectConfig = loadStarterProjectConfig(rootDir);
   const resolvedProjectRootDir = path.resolve(rootDir);
   const resolvedZtdRootDir = path.resolve(rootDir, projectConfig.ztdRootDir ?? '.ztd');
-  const defaultSchema =
-    typeof projectConfig.defaultSchema === 'string' && projectConfig.defaultSchema.length > 0
-      ? projectConfig.defaultSchema
-      : 'public';
+  const configuredDefaultSchema =
+    typeof projectConfig.defaultSchema === 'string' ? projectConfig.defaultSchema.trim() : '';
+  const defaultSchema = configuredDefaultSchema.length > 0 ? configuredDefaultSchema : 'public';
   const searchPath = normalizeSearchPath(projectConfig.searchPath);
   const resolvedDdlDir = path.resolve(
     resolvedProjectRootDir,

--- a/packages/ztd-cli/templates/tests/support/ztd/verifier.ts
+++ b/packages/ztd-cli/templates/tests/support/ztd/verifier.ts
@@ -278,7 +278,7 @@ async function createPhysicalQuerySpecExecutor(
 
   try {
     await client.query(`CREATE SCHEMA ${quoteIdentifier(schemaName)}`);
-    await client.query(`SET search_path TO ${quoteIdentifier(schemaName)}, public`);
+    await client.query(`SET search_path TO ${buildPhysicalSearchPath(defaults.searchPath, schemaName)}`);
     await applySqlFiles(client, defaults.ddlDirectories, defaults.defaultSchema, schemaName);
     await seedFixtureRows(client, flattenFixtureTableRows(beforeDb), defaults.defaultSchema, schemaName);
   } catch (error) {
@@ -393,27 +393,117 @@ function toPhysicalTableName(tableName: string, defaultSchema: string, schemaNam
 }
 
 function rewriteSchemaQualifiedSql(sql: string, defaultSchema: string, schemaName: string): string {
-  const escapedDefaultSchema = escapeRegExp(defaultSchema);
-  return sql.replace(
-    new RegExp(`(?<![A-Za-z0-9_"])${escapedDefaultSchema}\\.([A-Za-z_][A-Za-z0-9_]*)`, 'g'),
-    `${quoteIdentifier(schemaName)}.$1`
-  );
+  let rewritten = '';
+  let index = 0;
+
+  while (index < sql.length) {
+    const current = sql[index];
+    const next = sql[index + 1] ?? '';
+
+    if (current === '\'') {
+      const end = skipSingleQuotedString(sql, index);
+      rewritten += sql.slice(index, end);
+      index = end;
+      continue;
+    }
+    if (current === '-' && next === '-') {
+      const end = skipLineComment(sql, index);
+      rewritten += sql.slice(index, end);
+      index = end;
+      continue;
+    }
+    if (current === '/' && next === '*') {
+      const end = skipBlockComment(sql, index);
+      rewritten += sql.slice(index, end);
+      index = end;
+      continue;
+    }
+    if (current === '$') {
+      const dollarQuote = readDollarQuoteDelimiter(sql, index);
+      if (dollarQuote) {
+        const end = skipDollarQuotedString(sql, index, dollarQuote);
+        rewritten += sql.slice(index, end);
+        index = end;
+        continue;
+      }
+    }
+
+    const qualifier = readDefaultSchemaQualifier(sql, index, defaultSchema);
+    if (qualifier) {
+      rewritten += `${quoteIdentifier(schemaName)}.`;
+      index = qualifier.end;
+      continue;
+    }
+
+    rewritten += current;
+    index += 1;
+  }
+
+  return rewritten;
 }
 
 function quoteIdentifier(value: string): string {
   return `"${value.replace(/"/g, '""')}"`;
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+function buildPhysicalSearchPath(searchPath: string[], schemaName: string): string {
+  const schemas = [schemaName, ...searchPath.filter((entry) => entry !== schemaName)];
+  return schemas.map(quoteIdentifier).join(', ');
+}
+
+function readDefaultSchemaQualifier(
+  sql: string,
+  start: number,
+  defaultSchema: string
+): { end: number } | null {
+  const previous = sql[start - 1] ?? '';
+  if (previous === '.' || /[A-Za-z0-9_"]/.test(previous)) {
+    return null;
+  }
+
+  if (sql[start] === '"') {
+    const quoted = readQuotedIdentifier(sql, start);
+    if (!quoted || quoted.value !== defaultSchema || sql[quoted.end] !== '.') {
+      return null;
+    }
+    return { end: quoted.end + 1 };
+  }
+
+  if (!/[A-Za-z_]/.test(sql[start] ?? '')) {
+    return null;
+  }
+
+  const end = consumeIdentifier(sql, start);
+  if (sql.slice(start, end) !== defaultSchema || sql[end] !== '.') {
+    return null;
+  }
+
+  return { end: end + 1 };
+}
+
+function readQuotedIdentifier(sql: string, start: number): { end: number; value: string } | null {
+  let index = start + 1;
+  let value = '';
+  while (index < sql.length) {
+    if (sql[index] === '"' && sql[index + 1] === '"') {
+      value += '"';
+      index += 2;
+      continue;
+    }
+    if (sql[index] === '"') {
+      return { end: index + 1, value };
+    }
+    value += sql[index];
+    index += 1;
+  }
+  return null;
 }
 
 function loadStarterDefaults(rootDir: string): StarterProjectDefaults {
   const config = loadStarterProjectConfig(rootDir);
-  const defaultSchema =
-    typeof config.defaultSchema === 'string' && config.defaultSchema.length > 0
-      ? config.defaultSchema
-      : 'public';
+  const configuredDefaultSchema =
+    typeof config.defaultSchema === 'string' ? config.defaultSchema.trim() : '';
+  const defaultSchema = configuredDefaultSchema.length > 0 ? configuredDefaultSchema : 'public';
   const searchPath = normalizeSearchPath(config.searchPath);
   const projectRootDir = path.resolve(rootDir);
   const ztdRootDir = path.resolve(rootDir, config.ztdRootDir ?? '.ztd');
@@ -457,7 +547,10 @@ function normalizeSearchPath(searchPath: unknown): string[] {
     return [];
   }
 
-  return searchPath.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0);
+  return searchPath
+    .filter((entry): entry is string => typeof entry === 'string')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
 }
 
 function writeTraceFileIfEnabled(

--- a/packages/ztd-cli/templates/tests/support/ztd/verifier.ts
+++ b/packages/ztd-cli/templates/tests/support/ztd/verifier.ts
@@ -448,7 +448,15 @@ function quoteIdentifier(value: string): string {
 
 function buildPhysicalSearchPath(searchPath: string[], schemaName: string): string {
   const schemas = [schemaName, ...searchPath.filter((entry) => entry !== schemaName)];
-  return schemas.map(quoteIdentifier).join(', ');
+  return schemas.map(formatSearchPathEntry).join(', ');
+}
+
+function formatSearchPathEntry(entry: string): string {
+  const normalized = entry.toLowerCase();
+  if (entry === '$user' || /^pg_temp($|_)/.test(normalized)) {
+    return entry;
+  }
+  return quoteIdentifier(entry);
 }
 
 function readDefaultSchemaQualifier(

--- a/packages/ztd-cli/tests/featureTestsScaffold.unit.test.ts
+++ b/packages/ztd-cli/tests/featureTestsScaffold.unit.test.ts
@@ -98,6 +98,9 @@ test('runFeatureTestsScaffoldCommand writes query-local ZTD scaffolds from the c
   writeFileSync(
     path.join(queryDir, 'boundary.ts'),
     [
+      'export type InsertUsersQueryParams = { email: string };',
+      'export type InsertUsersQueryResult = { user_id: string };',
+      '',
       "export async function executeInsertUsersBoundary() {",
       '  return { user_id: "placeholder" };',
       '}'
@@ -169,9 +172,10 @@ test('runFeatureTestsScaffoldCommand writes query-local ZTD scaffolds from the c
     'utf8'
   );
   expect(queryTypesFile).toContain('export type InsertUsersBeforeDb = { public: { users: readonly { email?: unknown; user_id?: unknown }[] } };');
-  expect(queryTypesFile).toContain('export type InsertUsersInput = { email: unknown };');
-  expect(queryTypesFile).toContain('export type InsertUsersOutput = { user_id: unknown };');
   expect(queryTypesFile).toContain("import type { QuerySpecZtdCase } from '../../../../../../tests/support/ztd/case-types.js';");
+  expect(queryTypesFile).toContain("import type { InsertUsersQueryParams, InsertUsersQueryResult } from '../boundary.js';");
+  expect(queryTypesFile).toContain('export type InsertUsersInput = InsertUsersQueryParams;');
+  expect(queryTypesFile).toContain('export type InsertUsersOutput = InsertUsersQueryResult;');
   expect(queryTypesFile).not.toContain('AfterDb');
   expect(queryTypesFile).not.toContain('InsertUsersBeforeDb = Record<string, unknown>');
 
@@ -307,7 +311,11 @@ test('runFeatureTestsScaffoldCommand uses stable shared test imports when the wo
   seedStableTestAliases(workspace);
 
   writeFileSync(path.join(featureDir, 'boundary.ts'), 'export const RequestSchema = null;\n', 'utf8');
-  writeFileSync(path.join(queryDir, 'boundary.ts'), 'export async function executeInsertUsersBoundary() { return {}; }\n', 'utf8');
+  writeFileSync(
+    path.join(queryDir, 'boundary.ts'),
+    'export type InsertUsersQueryParams = Record<string, never>;\nexport type InsertUsersQueryResult = Record<string, never>;\nexport async function executeInsertUsersBoundary() { return {}; }\n',
+    'utf8'
+  );
   writeFileSync(path.join(queryDir, 'insert-users.sql'), 'select 1;', 'utf8');
 
   await runFeatureTestsScaffoldCommand({
@@ -326,6 +334,7 @@ test('runFeatureTestsScaffoldCommand uses stable shared test imports when the wo
     'utf8'
   );
   expect(queryTypesFile).toContain("import type { QuerySpecZtdCase } from '#tests/support/ztd/case-types.js';");
+  expect(queryTypesFile).toContain("import type { InsertUsersQueryParams, InsertUsersQueryResult } from '../boundary.js';");
 });
 
 test('runFeatureTestsScaffoldCommand fails fast when #tests alias support is partial', async () => {
@@ -351,7 +360,11 @@ test('runFeatureTestsScaffoldCommand fails fast when #tests alias support is par
   );
 
   writeFileSync(path.join(featureDir, 'boundary.ts'), 'export const RequestSchema = null;\n', 'utf8');
-  writeFileSync(path.join(queryDir, 'boundary.ts'), 'export async function executeInsertUsersBoundary() { return {}; }\n', 'utf8');
+  writeFileSync(
+    path.join(queryDir, 'boundary.ts'),
+    'export type InsertUsersQueryParams = Record<string, never>;\nexport type InsertUsersQueryResult = Record<string, never>;\nexport async function executeInsertUsersBoundary() { return {}; }\n',
+    'utf8'
+  );
   writeFileSync(path.join(queryDir, 'insert-users.sql'), 'select 1;', 'utf8');
 
   await expect(
@@ -434,6 +447,9 @@ test('runFeatureTestsScaffoldCommand writes traditional lane scaffolds without o
     'utf8'
   );
   expect(traditionalTypes).toContain("import type { QuerySpecTraditionalCase } from '../../../../../../tests/support/ztd/case-types.js';");
+  expect(traditionalTypes).toContain("import type { InsertUsersQueryParams, InsertUsersQueryResult } from '../boundary.js';");
+  expect(traditionalTypes).toContain('export type InsertUsersInput = InsertUsersQueryParams;');
+  expect(traditionalTypes).toContain('export type InsertUsersOutput = InsertUsersQueryResult;');
   expect(traditionalTypes).toContain('export type InsertUsersQueryBoundaryTraditionalCase = QuerySpecTraditionalCase<');
 
   const traditionalCaseFile = readFileSync(

--- a/packages/ztd-cli/tests/featureTestsScaffold.unit.test.ts
+++ b/packages/ztd-cli/tests/featureTestsScaffold.unit.test.ts
@@ -73,6 +73,19 @@ function seedStableTestAliases(workspace: string): void {
   );
 }
 
+function seedQueryBoundaryWithTypedContracts(queryDir: string): void {
+  writeFileSync(
+    path.join(queryDir, 'boundary.ts'),
+    [
+      'export type InsertUsersQueryParams = Record<string, never>;',
+      'export type InsertUsersQueryResult = Record<string, never>;',
+      'export async function executeInsertUsersBoundary() { return {}; }',
+      ''
+    ].join('\n'),
+    'utf8'
+  );
+}
+
 test('runFeatureTestsScaffoldCommand writes query-local ZTD scaffolds from the current feature files', async () => {
   const workspace = createTempDir('feature-tests-scaffold');
   const featureDir = path.join(workspace, 'src', 'features', 'users-insert');
@@ -311,11 +324,7 @@ test('runFeatureTestsScaffoldCommand uses stable shared test imports when the wo
   seedStableTestAliases(workspace);
 
   writeFileSync(path.join(featureDir, 'boundary.ts'), 'export const RequestSchema = null;\n', 'utf8');
-  writeFileSync(
-    path.join(queryDir, 'boundary.ts'),
-    'export type InsertUsersQueryParams = Record<string, never>;\nexport type InsertUsersQueryResult = Record<string, never>;\nexport async function executeInsertUsersBoundary() { return {}; }\n',
-    'utf8'
-  );
+  seedQueryBoundaryWithTypedContracts(queryDir);
   writeFileSync(path.join(queryDir, 'insert-users.sql'), 'select 1;', 'utf8');
 
   await runFeatureTestsScaffoldCommand({
@@ -360,11 +369,7 @@ test('runFeatureTestsScaffoldCommand fails fast when #tests alias support is par
   );
 
   writeFileSync(path.join(featureDir, 'boundary.ts'), 'export const RequestSchema = null;\n', 'utf8');
-  writeFileSync(
-    path.join(queryDir, 'boundary.ts'),
-    'export type InsertUsersQueryParams = Record<string, never>;\nexport type InsertUsersQueryResult = Record<string, never>;\nexport async function executeInsertUsersBoundary() { return {}; }\n',
-    'utf8'
-  );
+  seedQueryBoundaryWithTypedContracts(queryDir);
   writeFileSync(path.join(queryDir, 'insert-users.sql'), 'select 1;', 'utf8');
 
   await expect(

--- a/packages/ztd-cli/tests/init.command.test.ts
+++ b/packages/ztd-cli/tests/init.command.test.ts
@@ -137,8 +137,10 @@ test('init bootstraps a feature-first scaffold', { timeout: 60_000 }, async () =
     devDependencies: Record<string, string>;
     imports?: Record<string, { types: string; default: string }>;
     'lint-staged'?: Record<string, string[]>;
+    'simple-git-hooks'?: Record<string, string>;
   };
   expect(packageJson['lint-staged']?.['*.{ts,tsx,js,jsx,json,md,sql}']).toEqual(['prettier --write']);
+  expect(packageJson['simple-git-hooks']?.['pre-commit']).toBe('pnpm lint-staged');
   expect(packageJson.devDependencies).toHaveProperty('dotenv');
   expect(packageJson.devDependencies).toHaveProperty('@rawsql-ts/sql-contract');
   expect(packageJson.devDependencies).toHaveProperty('@rawsql-ts/testkit-core');
@@ -396,6 +398,26 @@ test('init dry-run plan for non-starter init excludes starter-only readmes', () 
     'compose.yaml',
     'src/features/smoke/README.md'
   ]));
+});
+
+test('init derives generated lint-staged hook command from the package manager lockfile', async () => {
+  const workspace = createTempDir('cli-init-npm-hook');
+  const prompter = new TestPrompter([]);
+  writeFileSync(path.join(workspace, 'package-lock.json'), '{}\n', 'utf8');
+
+  await runInitCommand(prompter, {
+    rootDir: workspace,
+    nonInteractive: true,
+    forceOverwrite: true,
+    workflow: 'empty',
+    validator: 'zod',
+    skipInstall: true
+  });
+
+  const packageJson = JSON.parse(readNormalizedFile(path.join(workspace, 'package.json'))) as {
+    'simple-git-hooks'?: Record<string, string>;
+  };
+  expect(packageJson['simple-git-hooks']?.['pre-commit']).toBe('npx lint-staged');
 });
 
 test('default scaffold omits AI control files', async () => {

--- a/packages/ztd-cli/tests/init.command.test.ts
+++ b/packages/ztd-cli/tests/init.command.test.ts
@@ -100,6 +100,8 @@ test('init bootstraps a feature-first scaffold', { timeout: 60_000 }, async () =
   expect(readNormalizedFile(path.join(workspace, 'vitest.config.ts'))).toContain(
     "src/features/**/*.test.ts"
   );
+  expect(readNormalizedFile(path.join(workspace, '.prettierrc'))).toContain('"files": "**/*.sql"');
+  expect(readNormalizedFile(path.join(workspace, '.prettierrc'))).toContain('"files": "**/*.md"');
   expect(existsSync(path.join(workspace, 'src', 'domain'))).toBe(false);
   expect(existsSync(path.join(workspace, 'src', 'application'))).toBe(false);
   expect(existsSync(path.join(workspace, 'src', 'presentation'))).toBe(false);
@@ -134,7 +136,9 @@ test('init bootstraps a feature-first scaffold', { timeout: 60_000 }, async () =
     type?: string;
     devDependencies: Record<string, string>;
     imports?: Record<string, { types: string; default: string }>;
+    'lint-staged'?: Record<string, string[]>;
   };
+  expect(packageJson['lint-staged']?.['*.{ts,tsx,js,jsx,json,md,sql}']).toEqual(['prettier --write']);
   expect(packageJson.devDependencies).toHaveProperty('dotenv');
   expect(packageJson.devDependencies).toHaveProperty('@rawsql-ts/sql-contract');
   expect(packageJson.devDependencies).toHaveProperty('@rawsql-ts/testkit-core');
@@ -225,6 +229,15 @@ test('init starter bootstraps compose, starter DDL, and smoke tests without visi
   expect(existsSync(path.join(workspace, 'src', 'features', 'smoke', 'queries', 'smoke', 'tests', 'boundary-ztd-types.ts'))).toBe(true);
   expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'smoke', 'queries', 'smoke', 'tests', 'boundary-ztd-types.ts'))).toContain(
     "from '#tests/support/ztd/case-types.js'"
+  );
+  expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'smoke', 'queries', 'smoke', 'tests', 'boundary-ztd-types.ts'))).toContain(
+    "import type { SmokeQueryParams, SmokeQueryResult } from '../boundary.js';"
+  );
+  expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'smoke', 'queries', 'smoke', 'tests', 'boundary-ztd-types.ts'))).toContain(
+    'export type SmokeInput = SmokeQueryParams;'
+  );
+  expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'smoke', 'queries', 'smoke', 'tests', 'boundary-ztd-types.ts'))).toContain(
+    'export type SmokeOutput = SmokeQueryResult;'
   );
   expect(existsSync(path.join(workspace, 'src', 'features', 'smoke', 'queries', 'smoke', 'tests', 'cases', 'basic.case.ts'))).toBe(true);
   expect(existsSync(path.join(workspace, 'src', 'features', 'smoke', 'queries', 'smoke', 'tests', 'generated', 'TEST_PLAN.md'))).toBe(true);

--- a/packages/ztd-cli/tests/postgresTestkitHelper.unit.test.ts
+++ b/packages/ztd-cli/tests/postgresTestkitHelper.unit.test.ts
@@ -26,8 +26,8 @@ test('loadStarterPostgresDefaults reads top-level starter defaults and falls bac
     JSON.stringify(
       {
         ztdRootDir: '.',
-        defaultSchema: 'app',
-        searchPath: ['app']
+        defaultSchema: ' app ',
+        searchPath: [' app ', '', ' public ']
       },
       null,
       2
@@ -39,7 +39,7 @@ test('loadStarterPostgresDefaults reads top-level starter defaults and falls bac
     projectRootDir: rootDir,
     ztdRootDir: rootDir,
     defaultSchema: 'app',
-    searchPath: ['app'],
+    searchPath: ['app', 'public'],
     ddlDirectories: []
   });
 });

--- a/packages/ztd-cli/tests/sqlClientAdapterTemplate.unit.test.ts
+++ b/packages/ztd-cli/tests/sqlClientAdapterTemplate.unit.test.ts
@@ -14,15 +14,14 @@ test('fromPg unwraps QueryResult.rows from the underlying pg queryable', async (
   expect(queryable.query).toHaveBeenCalledWith('select id from users where team_id = $1', [7]);
 });
 
-test('fromPg rejects named parameter objects before calling the underlying queryable', () => {
+test('fromPg forwards queries without values to the underlying pg queryable', async () => {
   const queryable = {
-    query: vi.fn()
+    query: vi.fn().mockResolvedValue({ rows: [{ ok: true }] })
   };
 
   const client = fromPg(queryable);
+  const rows = await client.query<{ ok: boolean }>('select true as ok');
 
-  expect(() => client.query('select id from users where id = :id', { id: 7 })).toThrowError(
-    'fromPg adapter does not support named parameter objects; use positional parameter arrays'
-  );
-  expect(queryable.query).not.toHaveBeenCalled();
+  expect(rows).toEqual([{ ok: true }]);
+  expect(queryable.query).toHaveBeenCalledWith('select true as ok', undefined);
 });

--- a/packages/ztd-cli/tests/ztdVerifier.unit.test.ts
+++ b/packages/ztd-cli/tests/ztdVerifier.unit.test.ts
@@ -76,7 +76,7 @@ test('verifyQuerySpecTraditionalCase physically prepares fixtures and returns tr
     path.join(rootDir, 'ztd.config.json'),
     JSON.stringify({
       defaultSchema: ' public ',
-      searchPath: [' app ', '', ' public ']
+      searchPath: [' app ', '', ' $user ', ' pg_temp ', ' pg_temp_3 ', ' public ']
     }),
     'utf8'
   );
@@ -128,12 +128,15 @@ test('verifyQuerySpecTraditionalCase physically prepares fixtures and returns tr
   });
   expect(poolConnectMock).toHaveBeenCalledTimes(1);
   expect(poolClientQueryMock).toHaveBeenCalledWith(expect.stringMatching(/^CREATE SCHEMA/));
-  expect(poolClientQueryMock).toHaveBeenCalledWith(expect.stringMatching(/^SET search_path TO "ztd_traditional_[^"]+", "app", "public"$/));
+  expect(poolClientQueryMock).toHaveBeenCalledWith(
+    expect.stringMatching(/^SET search_path TO "ztd_traditional_[^"]+", "app", \$user, pg_temp, pg_temp_3, "public"$/)
+  );
   expect(poolClientQueryMock).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO'), [1, 'alice@example.com']);
   expect(poolClientQueryMock).toHaveBeenCalledWith(expect.stringContaining("'public.users' as literal"), [1]);
   const executedQuery = poolClientQueryMock.mock.calls
     .map((call) => String(call[0]))
     .find((sql) => sql.includes("'public.users' as literal"));
+  expect(executedQuery).toBeDefined();
   expect(executedQuery).toContain("'public.users' as literal");
   expect(executedQuery).toContain('-- public.comment_table');
   expect(executedQuery).toContain('$$public.dollar_table$$');

--- a/packages/ztd-cli/tests/ztdVerifier.unit.test.ts
+++ b/packages/ztd-cli/tests/ztdVerifier.unit.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, expect, test, vi } from 'vitest';
@@ -70,6 +70,18 @@ afterEach(() => {
 });
 
 test('verifyQuerySpecTraditionalCase physically prepares fixtures and returns traditional evidence', async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), 'ztd-verifier-project-'));
+  tempDirs.push(rootDir);
+  writeFileSync(
+    path.join(rootDir, 'ztd.config.json'),
+    JSON.stringify({
+      defaultSchema: ' public ',
+      searchPath: [' app ', '', ' public ']
+    }),
+    'utf8'
+  );
+  vi.spyOn(process, 'cwd').mockReturnValue(rootDir);
+
   process.env.ZTD_DB_URL = 'postgres://localhost:5432/ztd';
 
   poolConnectMock.mockResolvedValue({
@@ -101,7 +113,11 @@ test('verifyQuerySpecTraditionalCase physically prepares fixtures and returns tr
         }
       }
     },
-    (client, input) => client.query('select true as ok from public.users where user_id = :userId', input)
+    (client, input) =>
+      client.query(
+        "select 'public.users' as literal, true as ok from public.users -- public.comment_table\nwhere note = $$public.dollar_table$$ and user_id = :userId",
+        input
+      )
   );
 
   expect(evidence).toMatchObject({
@@ -112,8 +128,17 @@ test('verifyQuerySpecTraditionalCase physically prepares fixtures and returns tr
   });
   expect(poolConnectMock).toHaveBeenCalledTimes(1);
   expect(poolClientQueryMock).toHaveBeenCalledWith(expect.stringMatching(/^CREATE SCHEMA/));
+  expect(poolClientQueryMock).toHaveBeenCalledWith(expect.stringMatching(/^SET search_path TO "ztd_traditional_[^"]+", "app", "public"$/));
   expect(poolClientQueryMock).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO'), [1, 'alice@example.com']);
-  expect(poolClientQueryMock).toHaveBeenCalledWith(expect.stringContaining('select true as ok from'), [1]);
+  expect(poolClientQueryMock).toHaveBeenCalledWith(expect.stringContaining("'public.users' as literal"), [1]);
+  const executedQuery = poolClientQueryMock.mock.calls
+    .map((call) => String(call[0]))
+    .find((sql) => sql.includes("'public.users' as literal"));
+  expect(executedQuery).toContain("'public.users' as literal");
+  expect(executedQuery).toContain('-- public.comment_table');
+  expect(executedQuery).toContain('$$public.dollar_table$$');
+  expect(executedQuery).toMatch(/from "ztd_traditional_[^"]+"\.users/);
+  expect(executedQuery).not.toContain('from public.users');
   expect(poolClientQueryMock).toHaveBeenCalledWith(expect.stringContaining('SELECT * FROM'));
   expect(poolClientQueryMock).toHaveBeenCalledWith(expect.stringMatching(/^DROP SCHEMA IF EXISTS/));
   expect(poolClientReleaseMock).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary

- Harden ztd-cli generated starter and scaffold templates after the transfer package dogfooding review.
- Query-boundary test type aliases now follow real boundary params/results, starter formatting hooks are safer, pg adapters expose positional-only values, and traditional queryspec schema rewriting avoids comments and literals.

## Verification

- pnpm --filter @rawsql-ts/ztd-cli test -- featureTestsScaffold.unit.test.ts init.command.test.ts sqlClientAdapterTemplate.unit.test.ts postgresTestkitHelper.unit.test.ts ztdVerifier.unit.test.ts
- pnpm --filter @rawsql-ts/ztd-cli build
- pnpm --filter @rawsql-ts/ztd-cli test:essential
- pre-commit on git commit reran ztd-cli typecheck, test:essential, build, and lint successfully.

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: not needed; no baseline exception requested.
Scoped checks run: not needed; no baseline exception requested.
Why full baseline is not required: full baseline exception path not used for this PR.

## Self Review

Self-review workflow: Codex self-review skill completed two passes before PR authoring.
Self-review result: No unresolved blockers; only residual risk is broader generated-project combinations beyond the covered scaffold lanes.

## CLI Surface Migration

- [ ] No migration packet required for this CLI change.
- [x] CLI/user-facing surface change and migration packet completed.

No-migration rationale: not selected for this PR.
Upgrade note: New ztd-cli scaffolds generate recursive Prettier SQL/Markdown globs, staged-file Prettier hooks, positional-only pg SQL client adapters, trimmed ztd config defaults, safer traditional queryspec schema rewriting, and queryspec case aliases derived from boundary params/results.
Deprecation/removal plan or issue: No deprecation or removal; this tightens newly generated template contracts only.
Docs/help/examples updated: Generated templates, starter smoke boundary types, scaffold tests, and init tests updated; no standalone documentation page required for this template quality fix.
Release/changeset wording: Patch changeset .changeset/brave-starters-improve.md describes the generated template contract improvements.

## Scaffold Contract Proof

- [ ] No scaffold contract proof required for this PR.
- [x] Scaffold contract proof completed.

No-proof rationale: not selected for this PR.
Non-edit assertion: Persistent query case files remain human-owned; this PR changes generated type aliases, starter templates, and scaffold-owned generated files only.
Fail-fast input-contract proof: featureTestsScaffold.unit.test.ts verifies generated type aliases import real boundary QueryParams/QueryResult; sqlClientAdapterTemplate.unit.test.ts verifies the positional pg adapter contract; config helper tests verify trimmed defaults.
Generated-output viability proof: init.command.test.ts verifies generated .prettierrc, lint-staged, smoke boundary-ztd-types, and starter outputs; ztdVerifier.unit.test.ts verifies traditional search_path and schema rewrite behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed SQL schema rewriting to properly handle quoted identifiers, comments, and dollar-quoted strings
  * Improved configuration normalization with whitespace trimming

* **New Features**
  * Expanded Prettier formatting scope for SQL and Markdown files in nested directories

* **Changes**
  * SQL adapter now accepts only positional parameter arrays (removed support for named parameters)
  * Generated boundary test types now properly import and re-export from shared boundary modules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->