### PR TITLE
Make feature scaffold emit camelCase DTOs by default

### DIFF
--- a/.changeset/camel-dtos-scaffold.md
+++ b/.changeset/camel-dtos-scaffold.md
@@ -1,0 +1,7 @@
+---
+"@rawsql-ts/ztd-cli": minor
+---
+
+Make `ztd feature scaffold` generate camelCase feature-boundary DTOs by default while keeping query-boundary params DB-shaped.
+
+Generated feature boundaries now map camelCase request fields to explicit snake_case query params, map DB-shaped query results back into camelCase responses, and scaffold JSON/JSONB columns as object inputs when they can be represented safely.

--- a/packages/ztd-cli/src/commands/feature.ts
+++ b/packages/ztd-cli/src/commands/feature.ts
@@ -710,8 +710,10 @@ function renderFeatureScaffoldFiles(params: {
   const queryPascalName = toPascalCase(params.queryName);
   const queryCamelName = toCamelCase(params.queryName);
   const actionPlan = buildActionPlan(params.action, params.table, params.primaryKeyColumn);
-  const requestFields = actionPlan.requestColumns.map((column) => toRenderField(column));
-  const responseFields = actionPlan.resultColumns.map((column) => toRenderField(column));
+  const requestFields = actionPlan.requestColumns.map((column) => toRenderField(column, { boundary: 'feature' }));
+  const responseFields = actionPlan.resultColumns.map((column) => toRenderField(column, { boundary: 'feature' }));
+  const queryRequestFields = actionPlan.requestColumns.map((column) => toRenderField(column, { boundary: 'query' }));
+  const queryResponseFields = actionPlan.resultColumns.map((column) => toRenderField(column, { boundary: 'query' }));
   const sqlFile = renderActionSql(actionPlan, params.table.canonicalName, params.primaryKeyColumn);
   const sharedSupportFiles = renderFeatureSharedSupportFiles();
   const entrySpecFile = renderEntrySpecFile({
@@ -731,8 +733,8 @@ function renderFeatureScaffoldFiles(params: {
     boundaryRelativeDir: normalizeCliPath(path.join('src', 'features', params.featureName)),
     queryPascalName,
     queryCamelName,
-    requestFields,
-    responseFields,
+    requestFields: queryRequestFields,
+    responseFields: queryResponseFields,
     sharedExecutorImportPath: sharedImports.executorImportPath,
     sharedLoadSqlResourceImportPath: sharedImports.loadSqlResourceImportPath
   });
@@ -768,8 +770,9 @@ function renderFeatureScaffoldFiles(params: {
 
 type RenderField = {
   name: string;
+  sourceName: string;
   typeScriptType: string;
-  parserKind: 'string' | 'number' | 'boolean';
+  parserKind: 'string' | 'number' | 'boolean' | 'jsonObject';
   nullable: boolean;
   sourceType: string;
 };
@@ -857,8 +860,8 @@ function renderExistingBoundaryQueryScaffoldFiles(params: {
   const queryPascalName = toPascalCase(params.queryName);
   const queryCamelName = toCamelCase(params.queryName);
   const actionPlan = buildActionPlan(params.action, params.table, params.primaryKeyColumn);
-  const requestFields = actionPlan.requestColumns.map((column) => toRenderField(column));
-  const responseFields = actionPlan.resultColumns.map((column) => toRenderField(column));
+  const requestFields = actionPlan.requestColumns.map((column) => toRenderField(column, { boundary: 'query' }));
+  const responseFields = actionPlan.resultColumns.map((column) => toRenderField(column, { boundary: 'query' }));
   const sharedSupportFiles = renderFeatureSharedSupportFiles();
 
   return {
@@ -1169,11 +1172,23 @@ function quoteSqlIdentifier(value: string): string {
   return `"${value.replace(/"/g, '""')}"`;
 }
 
-function toRenderField(column: ScaffoldColumnMetadata): RenderField {
+function toRenderField(column: ScaffoldColumnMetadata, options: { boundary: 'feature' | 'query' }): RenderField {
+  const fieldName = options.boundary === 'feature' ? toCamelCase(column.name) : column.name;
   const typeName = (column.typeName ?? '').trim().toLowerCase();
+  if (typeName === 'json' || typeName === 'jsonb') {
+    return {
+      name: fieldName,
+      sourceName: column.name,
+      typeScriptType: column.isNotNull ? 'Record<string, unknown>' : 'Record<string, unknown> | null',
+      parserKind: 'jsonObject',
+      nullable: !column.isNotNull,
+      sourceType: column.typeName ?? 'jsonb'
+    };
+  }
   if (isBigIntLikeType(typeName)) {
     return {
-      name: column.name,
+      name: fieldName,
+      sourceName: column.name,
       typeScriptType: column.isNotNull ? 'string' : 'string | null',
       parserKind: 'string',
       nullable: !column.isNotNull,
@@ -1182,7 +1197,8 @@ function toRenderField(column: ScaffoldColumnMetadata): RenderField {
   }
   if (isStringEncodedNumericType(typeName)) {
     return {
-      name: column.name,
+      name: fieldName,
+      sourceName: column.name,
       typeScriptType: column.isNotNull ? 'string' : 'string | null',
       parserKind: 'string',
       nullable: !column.isNotNull,
@@ -1191,7 +1207,8 @@ function toRenderField(column: ScaffoldColumnMetadata): RenderField {
   }
   if (isNumberType(typeName)) {
     return {
-      name: column.name,
+      name: fieldName,
+      sourceName: column.name,
       typeScriptType: column.isNotNull ? 'number' : 'number | null',
       parserKind: 'number',
       nullable: !column.isNotNull,
@@ -1200,7 +1217,8 @@ function toRenderField(column: ScaffoldColumnMetadata): RenderField {
   }
   if (typeName === 'boolean' || typeName === 'bool') {
     return {
-      name: column.name,
+      name: fieldName,
+      sourceName: column.name,
       typeScriptType: column.isNotNull ? 'boolean' : 'boolean | null',
       parserKind: 'boolean',
       nullable: !column.isNotNull,
@@ -1208,7 +1226,8 @@ function toRenderField(column: ScaffoldColumnMetadata): RenderField {
     };
   }
   return {
-    name: column.name,
+    name: fieldName,
+    sourceName: column.name,
     typeScriptType: column.isNotNull ? 'string' : 'string | null',
     parserKind: 'string',
     nullable: !column.isNotNull,
@@ -1355,7 +1374,8 @@ function renderEntrySpecFile(params: {
     '',
     '/** Maps the query result into the feature response contract. */',
     `function fromQueryResult(result: ${params.queryPascalName}QueryResult): ${params.pascalName}Response {`,
-    '  return ResponseSchema.parse(result);',
+    '  // TODO: Review domain-specific response naming before exposing this feature boundary publicly.',
+    ...renderParsedObjectFromSource('result', params.responseFields, 'ResponseSchema'),
     '}',
     '',
     '/** Executes the feature boundary flow for this feature. */',
@@ -1874,7 +1894,11 @@ function renderGetByIdEntrySpecFile(params: {
     '',
     '/** Maps the query result into the feature response contract. */',
     `function fromQueryResult(result: ${params.queryPascalName}QueryResult): ${params.pascalName}Response {`,
-    `  return ResponseSchema.parse(result);`,
+    '  if (result === null) {',
+    '    return null;',
+    '  }',
+    '  // TODO: Review domain-specific response naming before exposing this feature boundary publicly.',
+    ...renderParsedObjectFromSource('result', params.responseFields, 'ResponseSchema'),
     '}',
     '',
     '/** Executes the feature boundary flow for this feature. */',
@@ -1961,7 +1985,12 @@ function renderListEntrySpecFile(params: {
     '',
     '/** Maps the query result into the feature response contract. */',
     `function fromQueryResult(result: ${params.queryPascalName}QueryResult): ${params.pascalName}Response {`,
-    '  return ResponseSchema.parse(result);',
+    '  // TODO: Review domain-specific response naming before exposing this feature boundary publicly.',
+    '  return ResponseSchema.parse({',
+    '    items: result.items.map((item) => ({',
+    ...params.responseFields.map((field) => `      ${field.name}: item.${field.sourceName},`),
+    '    })),',
+    '  });',
     '}',
     '',
     '/** Executes the feature boundary flow for this feature. */',
@@ -2188,6 +2217,9 @@ function renderExampleValue(field: RenderField): string {
   if (field.nullable) {
     return 'null';
   }
+  if (field.parserKind === 'jsonObject') {
+    return "{ example: 'value' }";
+  }
   if (field.parserKind === 'number') {
     return '1';
   }
@@ -2219,6 +2251,8 @@ function renderZodField(
     base = 'z.number().finite()';
   } else if (field.parserKind === 'boolean') {
     base = 'z.boolean()';
+  } else if (field.parserKind === 'jsonObject') {
+    base = 'z.record(z.string(), z.unknown())';
   } else {
     base = 'z.string()';
     if (options.trimStrings) {
@@ -2240,8 +2274,19 @@ function renderTypedReturnObject(fields: RenderField[], typeName: string): strin
   }
   return [
     '  return {',
-    ...fields.map((field) => `    ${field.name}: request.${field.name},`),
+    ...fields.map((field) => `    ${field.sourceName}: request.${field.name},`),
     '  };'
+  ];
+}
+
+function renderParsedObjectFromSource(sourceName: string, fields: RenderField[], schemaName: string): string[] {
+  if (fields.length === 0) {
+    return [`  return ${schemaName}.parse({});`];
+  }
+  return [
+    `  return ${schemaName}.parse({`,
+    ...fields.map((field) => `    ${field.name}: ${sourceName}.${field.sourceName},`),
+    '  });'
   ];
 }
 

--- a/packages/ztd-cli/tests/featureScaffold.unit.test.ts
+++ b/packages/ztd-cli/tests/featureScaffold.unit.test.ts
@@ -605,6 +605,8 @@ test('runFeatureScaffoldCommand writes the boundary baseline and excludes genera
   expect(entrySpecFile).not.toContain('created_at: request.created_at,');
   expect(entrySpecFile).toContain('/** Maps the query result into the feature response contract. */');
   expect(entrySpecFile).toContain('function fromQueryResult');
+  expect(entrySpecFile).toContain('TODO: Review domain-specific response naming');
+  expect(entrySpecFile).toContain('id: result.id,');
   expect(entrySpecFile).toContain('/** Executes the feature boundary flow for this feature. */');
   expect(entrySpecFile).toContain('export async function executeUsersInsertEntrySpec');
   expect(entrySpecFile).toContain('executor: FeatureQueryExecutor,');
@@ -705,6 +707,64 @@ test('runFeatureScaffoldCommand writes the boundary baseline and excludes genera
   expect(readmeFile).toContain('featureQueryExecutor.ts` is the shared runtime contract for DB execution injection');
   expect(readmeFile).toContain('Catalog runtime primitives from `@rawsql-ts/sql-contract`');
   expect(readmeFile).toContain('Keep this baseline as one workflow and one primary query by default');
+});
+
+test('runFeatureScaffoldCommand emits camelCase feature DTOs while keeping query params DB-shaped', async () => {
+  const workspace = createTempDir('feature-scaffold-camel-dto');
+  const ddlDir = path.join(workspace, 'db', 'ddl');
+  mkdirSync(ddlDir, { recursive: true });
+  writeFileSync(
+    path.join(ddlDir, 'account_events.sql'),
+    [
+      'create table public.account_events (',
+      '  id serial8 primary key,',
+      '  account_id integer not null,',
+      '  display_name text,',
+      '  event_payload jsonb not null,',
+      '  created_at timestamptz not null default now()',
+      ');'
+    ].join('\n'),
+    'utf8'
+  );
+
+  await runFeatureScaffoldCommand({
+    table: 'account_events',
+    action: 'insert',
+    rootDir: workspace
+  });
+
+  const entrySpecFile = readFileSync(
+    path.join(workspace, 'src', 'features', 'account-events-insert', 'boundary.ts'),
+    'utf8'
+  );
+  expect(entrySpecFile).toContain('accountId: z.number().finite()');
+  expect(entrySpecFile).toContain('displayName: z.string().nullable()');
+  expect(entrySpecFile).toContain('eventPayload: z.record(z.string(), z.unknown())');
+  expect(entrySpecFile).not.toContain('account_id: z.number().finite()');
+  expect(entrySpecFile).not.toContain('display_name: z.string().nullable()');
+  expect(entrySpecFile).toContain('account_id: request.accountId,');
+  expect(entrySpecFile).toContain('display_name: request.displayName,');
+  expect(entrySpecFile).toContain('event_payload: request.eventPayload,');
+  expect(entrySpecFile).toContain('id: result.id,');
+
+  const querySpecFile = readFileSync(
+    path.join(workspace, 'src', 'features', 'account-events-insert', 'queries', 'insert-account-events', 'boundary.ts'),
+    'utf8'
+  );
+  expect(querySpecFile).toContain('account_id: z.number().finite()');
+  expect(querySpecFile).toContain("display_name: z.string().min(1, 'display_name must not be empty.').nullable()");
+  expect(querySpecFile).toContain('event_payload: z.record(z.string(), z.unknown())');
+  expect(querySpecFile).not.toContain('accountId: z.number().finite()');
+  expect(querySpecFile).not.toContain('displayName: z.string().nullable()');
+
+  const sqlFile = readFileSync(
+    path.join(workspace, 'src', 'features', 'account-events-insert', 'queries', 'insert-account-events', 'insert-account-events.sql'),
+    'utf8'
+  );
+  expect(sqlFile).toContain(':account_id');
+  expect(sqlFile).toContain(':display_name');
+  expect(sqlFile).toContain(':event_payload');
+  expect(sqlFile).not.toContain(':accountId');
 });
 
 test('runFeatureScaffoldCommand uses stable shared imports when the workspace supports #features', async () => {
@@ -887,8 +947,10 @@ test('runFeatureScaffoldCommand writes the update baseline with pk predicate and
   expect(entrySpecFile).toContain('export type UsersUpdateRequest');
   expect(entrySpecFile).toContain('id: z.number().finite()');
   expect(entrySpecFile).toContain('email: z.string()');
-  expect(entrySpecFile).toContain('display_name: z.string().nullable()');
-  expect(entrySpecFile).toContain('created_at: z.string()');
+  expect(entrySpecFile).toContain('displayName: z.string().nullable()');
+  expect(entrySpecFile).toContain('createdAt: z.string()');
+  expect(entrySpecFile).toContain('display_name: request.displayName,');
+  expect(entrySpecFile).toContain('created_at: request.createdAt,');
   expect(entrySpecFile).toContain('const ResponseSchema = z.object({');
   expect(entrySpecFile).toContain('}).strict();');
 


### PR DESCRIPTION
## Summary

- Closes #800.
- Updates `ztd feature scaffold` so generated feature-boundary DTOs use camelCase fields by default.
- Keeps query-boundary params and SQL named params DB-shaped with explicit snake_case mappings.
- Adds JSON/JSONB object scaffolding and visible TODO review markers for response naming that cannot be inferred safely.
- Adds a changeset for `@rawsql-ts/ztd-cli`.

## Verification

- `pnpm --filter @rawsql-ts/ztd-cli test -- tests/featureScaffold.unit.test.ts` passed.
- `pnpm --filter @rawsql-ts/ztd-cli build` passed.
- `pnpm --filter @rawsql-ts/ztd-cli test -- tests/cliCommands.test.ts` passed with DB-dependent CLI tests skipped because `pg_dump` is missing from PATH.
- Commit hook passed `@rawsql-ts/ztd-cli` typecheck, `test:essential`, build, and lint.
- `pnpm changeset status --since origin/main` detects a minor bump for `@rawsql-ts/ztd-cli`.

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: #800
Scoped checks run: `pnpm --filter @rawsql-ts/ztd-cli test -- tests/featureScaffold.unit.test.ts`; `pnpm --filter @rawsql-ts/ztd-cli build`; `pnpm --filter @rawsql-ts/ztd-cli test -- tests/cliCommands.test.ts`; commit hook `test:essential`, build, lint
Why full baseline is not required: Change is scoped to ztd-cli feature scaffold generation and covered by scaffold unit tests, CLI command tests, ztd-cli build, and the pre-commit ztd-cli gate.

## Self Review

Self-review workflow: Repo-local developer-self-review skill, two cycles: consistency review and human acceptance review.
Self-review result: No blockers found. Query-boundary snake_case behavior, camelCase feature DTO generation, JSON/JSONB object schema generation, changeset wording, and PR evidence were checked.

## CLI Surface Migration

- [ ] No migration packet required for this CLI change.
- [x] CLI/user-facing surface change and migration packet completed.

No-migration rationale: Migration packet completed because generated scaffold output changes.
Upgrade note: `ztd feature scaffold` now emits camelCase feature-boundary DTO fields by default, while query-boundary params remain DB-shaped snake_case.
Deprecation/removal plan or issue: No CLI flag or API removal; issue #800 tracks the default scaffold behavior change.
Docs/help/examples updated: No help text change was needed because the command surface is unchanged; generated-output examples are covered by `tests/featureScaffold.unit.test.ts` and `tests/cliCommands.test.ts`.
Release/changeset wording: `.changeset/camel-dtos-scaffold.md` describes the camelCase DTO default, snake_case query params, response mapping, and JSON/JSONB object input behavior.

## Scaffold Contract Proof

- [ ] No scaffold contract proof required for this PR.
- [x] Scaffold contract proof completed.

No-proof rationale: Scaffold proof completed because this changes `packages/ztd-cli/src/commands/feature.ts`.
Non-edit assertion: Existing-boundary query scaffold still renders query-boundary fields with DB-shaped names, and parent boundary non-edit behavior remains covered by existing `runExistingBoundaryQueryScaffoldCommand` tests.
Fail-fast input-contract proof: Existing fail-fast scaffold coverage remains in `tests/featureScaffold.unit.test.ts` for invalid boundaries, existing query collisions, unsupported primary-key shapes, and invalid feature/query names; commit hook `test:essential` passed those lanes.
Generated-output viability proof: `runFeatureScaffoldCommand emits camelCase feature DTOs while keeping query params DB-shaped` asserts camelCase feature DTO fields, explicit snake_case query params, JSONB object schema output, snake_case SQL named params, and no camelCase SQL params. `tests/cliCommands.test.ts` and ztd-cli build also passed.
