### PR TITLE
Add leading-comma SQL lint rule

### DIFF
--- a/.changeset/leading-comma-lint.md
+++ b/.changeset/leading-comma-lint.md
@@ -1,0 +1,6 @@
+---
+"rawsql-ts": minor
+"@rawsql-ts/ztd-cli": minor
+---
+
+Export rawsql-ts tokenizer metadata and add an opt-in `ztd query lint --rules leading-comma` SQL style rule that reports multiline trailing commas without rewriting SQL comments.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -45,6 +45,13 @@ export default defineConfig({
             { text: 'Impact Checks', link: '/guide/query-uses-impact-checks' },
           ]
         },
+        {
+          text: 'Query Lint',
+          items: [
+            { text: 'JOIN Direction', link: '/guide/join-direction-lint-spec' },
+            { text: 'SQL Style', link: '/guide/sql-style-lint-spec' },
+          ]
+        },
         { text: 'Testkit Concept', link: '/guide/testkit-concept' },
         { text: 'ZTD Benchmarking', link: '/guide/ztd-benchmarking' },
         {

--- a/docs/guide/sql-style-lint-spec.md
+++ b/docs/guide/sql-style-lint-spec.md
@@ -1,0 +1,67 @@
+---
+title: SQL Style Lint Specification
+---
+
+# SQL Style Lint Specification
+
+`ztd query lint --rules leading-comma` checks generated or maintained SQL for multiline comma placement without rewriting the file.
+
+Use this rule when a package wants leading commas in multiline SQL lists and wants the check to be enforced by tooling instead of reviewer memory.
+
+## Why lint-only
+
+The style check is intentionally lint-only. SQL formatting can change comment placement, and comment round-tripping must be proven separately before automatic style rewrites become safe for generated SQL workflows.
+
+The rule validates that the SQL parses through rawsql-ts first, then reports source locations where a comma remains at the end of a continued line.
+
+## Usage
+
+```sh
+ztd query lint path/to/query.sql --rules leading-comma
+```
+
+Use comma-separated rules when combining style and structure checks:
+
+```sh
+ztd query lint path/to/query.sql --rules join-direction,leading-comma
+```
+
+## Reported pattern
+
+This reports a warning because the comma trails the previous line:
+
+```sql
+select
+  id,
+  email
+from public.users
+```
+
+The preferred leading-comma form is clean:
+
+```sql
+select
+  id
+  , email
+from public.users
+```
+
+One-line lists are not reported:
+
+```sql
+select id, email from public.users
+```
+
+## Suppression
+
+Use a local suppression only when a generated query needs an intentional exception:
+
+```sql
+-- ztd-lint-disable leading-comma
+select
+  id,
+  email
+from public.users
+```
+
+The suppression disables only the `leading-comma` rule for that SQL text.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 // Entry point for rawsql-ts package
 export * from './parsers/SqlParser';
+export * from './parsers/SqlTokenizer';
 export * from './parsers/SelectQueryParser';
 export { ParseAnalysisResult } from './parsers/SelectQueryParser';
 export * from './parsers/InsertQueryParser';

--- a/packages/ztd-cli/src/commands/query.ts
+++ b/packages/ztd-cli/src/commands/query.ts
@@ -2,7 +2,7 @@ import { Command, Option } from 'commander';
 import { createTwoFilesPatch } from 'diff';
 import { applyQueryOutputControls, formatQueryUsageReport } from '../query/format';
 import { applyQueryPatch } from '../query/patch';
-import { buildQueryLintReport, formatQueryLintReport, type QueryLintFormat } from '../query/lint';
+import { buildQueryLintReport, formatQueryLintReport, type QueryLintFormat, type QueryLintRule } from '../query/lint';
 import {
   buildQueryPipelinePlan,
   formatQueryPipelinePlan,
@@ -271,7 +271,7 @@ Notes:
     .command('lint <sqlFile>')
     .description('Report structural maintainability and analysis-safety issues in a SQL query')
     .option('--format <format>', 'Output format (text|json)', 'text')
-    .option('--rules <list>', 'Comma-separated lint rules to enable (for example: join-direction)')
+    .option('--rules <list>', 'Comma-separated lint rules to enable (for example: join-direction,leading-comma)')
     .option('--out <path>', 'Write output to file')
     .addHelpText(
       'after',
@@ -279,8 +279,10 @@ Notes:
 Notes:
   - If your installed CLI does not list --rules in this help output, upgrade to a newer published ztd-cli release before trying join-direction examples from Further Reading.
   - Use --rules join-direction to enable the FK-aware JOIN direction readability check.
+  - Use --rules leading-comma to enforce leading commas in multiline SQL lists without rewriting comments.
   - Suppress a specific query with "-- ztd-lint-disable join-direction" when the reverse path is intentional.
-  - The rule is opt-in in v1 and currently focuses on top-level inner joins with explicit FK evidence.
+  - Suppress leading-comma style checks with "-- ztd-lint-disable leading-comma" when a generated query needs a local exception.
+  - These rules are opt-in in v1. join-direction focuses on top-level inner joins with explicit FK evidence.
 `
     )
     .action((sqlFile: string, options: QueryLintOptions) => {
@@ -515,13 +517,13 @@ function runQueryMatchObservedCommand(options: QueryMatchObservedOptions): void 
   }
 }
 
-function normalizeRuleList(value: unknown): Array<'join-direction'> | undefined {
+function normalizeRuleList(value: unknown): QueryLintRule[] | undefined {
   if (value === undefined || value === null || value === '') {
     return undefined;
   }
 
   const rawValues = Array.isArray(value) ? value : [value];
-  const rules = new Set<'join-direction'>();
+  const rules = new Set<QueryLintRule>();
   for (const rawValue of rawValues) {
     if (typeof rawValue !== 'string') {
       throw new Error(`Expected lint rules to be a string or string[] but received ${typeof rawValue}.`);
@@ -533,14 +535,18 @@ function normalizeRuleList(value: unknown): Array<'join-direction'> | undefined 
       if (!normalized) {
         continue;
       }
-      if (normalized !== 'join-direction') {
-        throw new Error(`Unsupported lint rule: ${item}. Supported rules: join-direction`);
+      if (!isSupportedQueryLintRule(normalized)) {
+        throw new Error(`Unsupported lint rule: ${item}. Supported rules: join-direction, leading-comma`);
       }
-      rules.add('join-direction');
+      rules.add(normalized);
     }
   }
 
   return rules.size > 0 ? [...rules] : undefined;
+}
+
+function isSupportedQueryLintRule(value: string): value is QueryLintRule {
+  return value === 'join-direction' || value === 'leading-comma';
 }
 
 function runQueryPatchApplyCommand(sqlFile: string, options: QueryPatchApplyOptions): void {

--- a/packages/ztd-cli/src/query/lint.ts
+++ b/packages/ztd-cli/src/query/lint.ts
@@ -22,6 +22,7 @@ import {
   TableSource,
   SqlFormatter,
   SqlParser,
+  SqlTokenizer,
   MultiQuerySplitter,
   UpdateQuery,
   ValuesQuery,
@@ -44,7 +45,7 @@ import { buildRelationGraphFromCreateTableQueries, getOutgoingRelations } from '
 
 export type QueryLintFormat = 'text' | 'json';
 export type QueryLintSeverity = 'error' | 'warning' | 'info';
-export type QueryLintRule = 'join-direction';
+export type QueryLintRule = 'join-direction' | 'leading-comma';
 export type QueryLintIssueType =
   | 'unused-cte'
   | 'duplicate-join-block'
@@ -52,7 +53,8 @@ export type QueryLintIssueType =
   | 'dependency-cycle'
   | 'analysis-risk'
   | 'large-cte'
-  | 'join-direction';
+  | 'join-direction'
+  | 'leading-comma';
 
 export interface QueryLintIssue {
   type: QueryLintIssueType;
@@ -63,6 +65,8 @@ export interface QueryLintIssue {
   fragment?: string;
   occurrences?: string[];
   line_count?: number;
+  line?: number;
+  column?: number;
   risk_pattern?: string;
   join_type?: string;
   subject_table?: string;
@@ -192,9 +196,15 @@ export function buildQueryLintReport(sqlFile: string, options: QueryLintBuildOpt
     }
   }
 
+  if (enabledRules.has('leading-comma') && !hasLintSuppression(sql, 'leading-comma')) {
+    issues.push(...buildLeadingCommaIssues(sql));
+  }
+
   const sortedIssues = issues.sort((left, right) =>
     SEVERITY_ORDER[left.severity] - SEVERITY_ORDER[right.severity]
     || left.type.localeCompare(right.type)
+    || (left.line ?? 0) - (right.line ?? 0)
+    || (left.column ?? 0) - (right.column ?? 0)
     || left.message.localeCompare(right.message)
   );
 
@@ -548,7 +558,7 @@ function buildJoinDirectionIssues(
   relationGraph: RelationGraph,
   sql: string
 ): QueryLintIssue[] {
-  if (hasJoinDirectionSuppression(sql)) {
+  if (hasLintSuppression(sql, 'join-direction')) {
     return [];
   }
 
@@ -951,8 +961,41 @@ function isInspectableInnerJoin(joinType: string): boolean {
   return normalized === 'join' || normalized === 'inner join';
 }
 
-function hasJoinDirectionSuppression(sql: string): boolean {
-  return /ztd-lint-disable\s+join-direction/i.test(sql);
+function buildLeadingCommaIssues(sql: string): QueryLintIssue[] {
+  const issues: QueryLintIssue[] = [];
+
+  const lexemes = new SqlTokenizer(sql).tokenize();
+  for (let index = 0; index < lexemes.length; index++) {
+    const comma = lexemes[index];
+    if (comma.value !== ',') {
+      continue;
+    }
+
+    const next = lexemes[index + 1];
+    const commaPosition = comma.position;
+    const nextPosition = next?.position;
+    if (
+      commaPosition?.startLine !== undefined &&
+      commaPosition.startColumn !== undefined &&
+      nextPosition?.startLine !== undefined &&
+      nextPosition.startColumn !== undefined &&
+      nextPosition.startLine > commaPosition.startLine
+    ) {
+      issues.push({
+        type: 'leading-comma',
+        severity: 'warning',
+        line: commaPosition.startLine,
+        column: commaPosition.startColumn,
+        message: `comma should lead the continued line at ${nextPosition.startLine}:${nextPosition.startColumn} instead of trailing line ${commaPosition.startLine}`
+      });
+    }
+  }
+
+  return issues;
+}
+
+function hasLintSuppression(sql: string, rule: QueryLintRule): boolean {
+  return new RegExp(`ztd-lint-disable\\s+${rule}`, 'i').test(sql);
 }
 
 function normalizeSqlFragment(sql: string): string {

--- a/packages/ztd-cli/tests/queryLint.unit.test.ts
+++ b/packages/ztd-cli/tests/queryLint.unit.test.ts
@@ -262,6 +262,134 @@ test('formatQueryLintReport renders json for agents and compact text for humans'
   expect(textOutput).toContain('WARN  unused-cte: unused_stage is defined but never used');
 });
 
+test('buildQueryLintReport warns on multiline trailing commas when leading-comma is enabled', () => {
+  const workspace = createSqlWorkspace('query-lint-leading-comma-trailing');
+  writeFileSync(
+    workspace.sqlFile,
+    `
+      select
+        id,
+        email
+      from public.users
+    `,
+    'utf8'
+  );
+
+  const report = buildQueryLintReport(workspace.sqlFile, {
+    rules: ['leading-comma']
+  });
+
+  expect(report.issues).toEqual(expect.arrayContaining([
+    expect.objectContaining({
+      type: 'leading-comma',
+      severity: 'warning',
+      line: expect.any(Number),
+      column: expect.any(Number)
+    })
+  ]));
+});
+
+test('buildQueryLintReport keeps multiline leading commas clean', () => {
+  const workspace = createSqlWorkspace('query-lint-leading-comma-clean');
+  writeFileSync(
+    workspace.sqlFile,
+    `
+      select
+        id
+        , email
+      from public.users
+    `,
+    'utf8'
+  );
+
+  const report = buildQueryLintReport(workspace.sqlFile, {
+    rules: ['leading-comma']
+  });
+
+  expect(report.issues.filter((issue) => issue.type === 'leading-comma')).toEqual([]);
+});
+
+test('buildQueryLintReport keeps one-line comma lists clean', () => {
+  const workspace = createSqlWorkspace('query-lint-leading-comma-oneline');
+  writeFileSync(workspace.sqlFile, 'select id, email from public.users', 'utf8');
+
+  const report = buildQueryLintReport(workspace.sqlFile, {
+    rules: ['leading-comma']
+  });
+
+  expect(report.issues.filter((issue) => issue.type === 'leading-comma')).toEqual([]);
+});
+
+test('buildQueryLintReport ignores commas inside dollar-quoted SQL literals', () => {
+  const workspace = createSqlWorkspace('query-lint-leading-comma-dollar-quote');
+  writeFileSync(
+    workspace.sqlFile,
+    `
+      select
+        $$first,
+      second$$ as body
+        , id
+      from public.users
+    `,
+    'utf8'
+  );
+
+  const report = buildQueryLintReport(workspace.sqlFile, {
+    rules: ['leading-comma']
+  });
+
+  expect(report.issues.filter((issue) => issue.type === 'leading-comma')).toEqual([]);
+});
+
+test('buildQueryLintReport suppresses leading-comma when explicitly disabled in SQL text', () => {
+  const workspace = createSqlWorkspace('query-lint-leading-comma-suppressed');
+  writeFileSync(
+    workspace.sqlFile,
+    `
+      -- ztd-lint-disable leading-comma
+      select
+        id,
+        email
+      from public.users
+    `,
+    'utf8'
+  );
+
+  const report = buildQueryLintReport(workspace.sqlFile, {
+    rules: ['leading-comma']
+  });
+
+  expect(report.issues.filter((issue) => issue.type === 'leading-comma')).toEqual([]);
+});
+
+test('formatQueryLintReport exposes leading-comma line and column in json mode', () => {
+  const workspace = createSqlWorkspace('query-lint-leading-comma-json');
+  writeFileSync(
+    workspace.sqlFile,
+    `
+      select
+        id,
+        email
+      from public.users
+    `,
+    'utf8'
+  );
+
+  const report = buildQueryLintReport(workspace.sqlFile, {
+    rules: ['leading-comma']
+  });
+  const payload = JSON.parse(formatQueryLintReport(report, 'json'));
+
+  expect(payload.issues).toEqual(expect.arrayContaining([
+    expect.objectContaining({
+      type: 'leading-comma',
+      severity: 'warning',
+      line: expect.any(Number),
+      column: expect.any(Number)
+    })
+  ]));
+});
+
 test('buildQueryLintReport keeps the forward join-direction dogfood query clean', () => {
   const workspace = createJoinDirectionWorkspace('query-lint-join-direction');
   writeJoinDirectionSchema(workspace.ddlDir);
@@ -423,6 +551,35 @@ test('query lint command emits join-direction diagnostics in json mode', async (
       child_table: 'public.orders'
     })
   ]));
+});
+
+test('query lint command enables leading-comma through --rules', async () => {
+  const workspace = createSqlWorkspace('query-lint-leading-comma-cli');
+  writeFileSync(
+    workspace.sqlFile,
+    `
+      select
+        id,
+        email
+      from public.users
+    `,
+    'utf8'
+  );
+
+  const capture = { stdout: [] as string[], stderr: [] as string[] };
+  const program = createQueryLintProgram(capture);
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((value?: unknown) => {
+    capture.stdout.push(String(value ?? ''));
+  });
+
+  try {
+    await program.parseAsync(['query', 'lint', workspace.sqlFile, '--rules', 'leading-comma'], { from: 'user' });
+  } finally {
+    logSpy.mockRestore();
+  }
+
+  expect(capture.stderr).toEqual([]);
+  expect(capture.stdout.join('')).toContain('WARN  leading-comma: comma should lead the continued line');
 });
 
 test('activeOrdersCatalog.sql stays clean because it already follows child-to-parent join direction', () => {


### PR DESCRIPTION
## Summary

- Fixes #803.
- Adds an opt-in `ztd query lint --rules leading-comma` rule for multiline SQL comma style.
- Exports `SqlTokenizer` from `rawsql-ts` so the lint can use tokenizer source-position metadata instead of rewriting SQL.
- Documents the lint-only path and records release wording in a changeset.

## Verification

- `pnpm --filter @rawsql-ts/ztd-cli test -- queryLint.unit.test.ts cliCommands.test.ts`
- `pnpm --filter @rawsql-ts/ztd-cli lint`
- `pnpm --filter @rawsql-ts/ztd-cli build`
- `pnpm --filter rawsql-ts build`
- `pnpm --filter rawsql-ts exec eslint . --ext .ts,.tsx`
- `pnpm exec vitepress build docs`
- `git diff --check`

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

<!-- Write values on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. -->
<!-- Do not add list markers like "-" before these labels; `Tracking issue:` and `Scoped checks run:` must start at column 0. -->
Tracking issue: #803
Scoped checks run: Focused ztd-cli query lint/CLI tests, ztd-cli lint/build, rawsql-ts build/eslint, VitePress docs build, git diff --check.
Why full baseline is not required: No baseline exception requested; scoped checks cover the changed CLI lint, tokenizer export, docs, and changeset surfaces.

## Self Review

<!-- Fill these fields after running the repo self-review workflow or available self-review skill. -->
Self-review workflow: developer-self-review skill, two cycles; plus pre-pr-retro-gate check (`tmp/RETRO.md` absent).
Self-review result: No blockers remain. Cycle 1 found and fixed the tokenizer-position alignment issue before PR; Cycle 2 confirmed repository evidence and PR body readiness.

## CLI Surface Migration

- [ ] No migration packet required for this CLI change.
- [x] CLI/user-facing surface change and migration packet completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-migration rationale: Migration packet completed because `ztd query lint --rules` gains a user-facing rule.
Upgrade note: Use `ztd query lint <sql-file> --rules leading-comma` to enforce multiline leading-comma SQL style; combine with existing rules via comma-separated values.
Deprecation/removal plan or issue: No deprecation or removal; this is an additive opt-in lint rule tracked by #803.
Docs/help/examples updated: CLI help mentions `leading-comma`, and `docs/guide/sql-style-lint-spec.md` documents usage, clean/reported patterns, and suppression.
Release/changeset wording: `.changeset/leading-comma-lint.md` covers both `rawsql-ts` tokenizer export and `@rawsql-ts/ztd-cli` leading-comma lint.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-proof rationale: No scaffold command, template, or generated scaffold contract files changed.
Non-edit assertion: This PR does not edit scaffold templates or scaffold writers.
Fail-fast input-contract proof: Not applicable; no scaffold input contract changed.
Generated-output viability proof: Not applicable; no scaffold generated output changed.
