### PR TITLE
Clarify ZTD constraint coverage guidance

### DIFF
--- a/.changeset/ztd-constraint-boundary-guidance.md
+++ b/.changeset/ztd-constraint-boundary-guidance.md
@@ -1,0 +1,7 @@
+---
+"@rawsql-ts/ztd-cli": patch
+---
+
+Clarify ZTD constraint coverage in generated query-boundary scaffolds.
+
+`ztd feature tests scaffold` now records constraint-boundary guidance in generated test plans, analysis JSON, and JSON command output. When DDL for the affected tables contains PostgreSQL constraints that the ZTD fixture/CTE lane does not fully enforce, the scaffold emits TODO guidance that points users to traditional physical DB coverage for DB-enforced failure behavior.

--- a/packages/ztd-cli/src/commands/featureTests.ts
+++ b/packages/ztd-cli/src/commands/featureTests.ts
@@ -1,6 +1,13 @@
 import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { Command } from 'commander';
+import {
+  CreateTableQuery,
+  MultiQuerySplitter,
+  SqlParser,
+  type ColumnConstraintDefinition,
+  type TableConstraintDefinition
+} from 'rawsql-ts';
 
 import { emitDiagnostic, isJsonOutput, writeCommandEnvelope } from '../utils/agentCli';
 import { ensureDirectory } from '../utils/fs';
@@ -25,7 +32,16 @@ interface FeatureTestsScaffoldResult {
   queryName: string;
   testKind: FeatureTestKind;
   dryRun: boolean;
+  unsupportedConstraintGuidance: UnsupportedConstraintGuidance[];
   outputs: Array<{ path: string; written: boolean; kind: 'directory' | 'file' }>;
+}
+
+interface UnsupportedConstraintGuidance {
+  table: string;
+  constraint: 'unique' | 'check' | 'not-null' | 'foreign-key' | 'exclusion';
+  sourcePath: string;
+  recommendation: string;
+  todo: string;
 }
 
 interface QueryLayout {
@@ -52,6 +68,8 @@ interface FeatureTestAnalysis {
   writesTables: string[];
   validationScenarioHints: string[];
   dbScenarioHints: string[];
+  constraintCoverageNotes: string[];
+  unsupportedConstraintGuidance: UnsupportedConstraintGuidance[];
   resultCardinality: 'one' | 'many';
 }
 
@@ -156,6 +174,7 @@ export async function runFeatureTestsScaffoldCommand(options: FeatureTestsComman
       queryName: queryLayout.queryName,
       testKind,
       dryRun: true,
+      unsupportedConstraintGuidance: planDetails.unsupportedConstraintGuidance,
       outputs
     };
   }
@@ -185,6 +204,7 @@ export async function runFeatureTestsScaffoldCommand(options: FeatureTestsComman
     queryName: queryLayout.queryName,
     testKind,
     dryRun: false,
+    unsupportedConstraintGuidance: planDetails.unsupportedConstraintGuidance,
     outputs
   };
 }
@@ -246,6 +266,12 @@ function renderFeatureTestScaffoldFiles(params: {
   const dbHintsLine = params.planDetails.dbScenarioHints.length > 0
     ? params.planDetails.dbScenarioHints.map((field) => `- ${field}`).join('\n')
     : '- TODO: inspect the scaffolded query boundary and SQL for DB-backed hints.';
+  const constraintCoverageLine = params.planDetails.constraintCoverageNotes.map((note) => `- ${note}`).join('\n');
+  const unsupportedConstraintLine = params.planDetails.unsupportedConstraintGuidance.length > 0
+    ? params.planDetails.unsupportedConstraintGuidance
+      .map((guidance) => `- TODO: ${guidance.todo}`)
+      .join('\n')
+    : '- No unsupported constraint follow-up was detected from the current DDL/table hints.';
   const caseReadinessLine = isZtdLane
     ? '- Generated ZTD cases are intentionally placeholders. Fill `beforeDb`, `input`, and `output`, then change the generated Vitest entrypoint from `test.skip` to `test`.'
     : '- Generated traditional cases are intentionally placeholders. Fill `beforeDb`, `input`, `output`, and optional `afterDb`, then run the active traditional Vitest entrypoint against a disposable database.';
@@ -290,6 +316,14 @@ function renderFeatureTestScaffoldFiles(params: {
     '',
     dbHintsLine,
     '',
+    '## Constraint Coverage Boundary',
+    '',
+    constraintCoverageLine,
+    '',
+    '## Unsupported Constraint Follow-up',
+    '',
+    unsupportedConstraintLine,
+    '',
     '## Case Readiness',
     '',
     caseReadinessLine,
@@ -327,6 +361,8 @@ function renderFeatureTestScaffoldFiles(params: {
       writesTables: params.planDetails.writesTables,
       validationScenarioHints: params.planDetails.validationScenarioHints,
       dbScenarioHints: params.planDetails.dbScenarioHints,
+      constraintCoverageNotes: params.planDetails.constraintCoverageNotes,
+      unsupportedConstraintGuidance: params.planDetails.unsupportedConstraintGuidance,
       resultCardinality: params.planDetails.resultCardinality
     },
     null,
@@ -360,6 +396,9 @@ function renderFeatureTestScaffoldFiles(params: {
     'TODO: Replace the placeholder output with the exact result expected from the query boundary.',
     params.planDetails.queryOutputFields
   );
+  const unsupportedConstraintTodoLines = isZtdLane
+    ? params.planDetails.unsupportedConstraintGuidance.map((guidance) => `    // TODO: ${guidance.todo}`)
+    : [];
   const vitestEntrypointFile = isZtdLane
     ? [
       `import { expect, test } from 'vitest';`,
@@ -407,6 +446,7 @@ function renderFeatureTestScaffoldFiles(params: {
     `    input: {} as ${queryTypePrefix}Input,`,
     ...outputTodoLines,
     `    output: {} as ${queryTypePrefix}Output,`,
+    ...unsupportedConstraintTodoLines,
     ...(isZtdLane ? [] : [
       '    // TODO: Add afterDb when this case must assert physical post-state table rows.',
       '    // afterDb: async (db) => {',
@@ -484,6 +524,12 @@ function buildTestPlanDetails(params: {
   const resultCardinality = querySpecSource.includes('items: z.array(') || params.queryLayout.queryName === 'list' ? 'many' : 'one';
   const resolvedInputFields = queryInputFields.length > 0 ? queryInputFields : requestFields;
   const resolvedOutputFields = queryOutputFields.length > 0 ? queryOutputFields : sqlReturningColumns;
+  const unsupportedConstraintGuidance = buildUnsupportedConstraintGuidance({
+    rootDir: params.rootDir,
+    testKind: params.testKind,
+    fixtureCandidateTables,
+    writesTables
+  });
 
   return {
     schemaVersion: 1,
@@ -493,6 +539,8 @@ function buildTestPlanDetails(params: {
     writesTables,
     validationScenarioHints: buildValidationScenarioHints(requestFields, params.queryLayout.queryName),
     dbScenarioHints: buildDbScenarioHints(params.testKind, writesTables, params.queryLayout.queryName, fixtureCandidateTables),
+    constraintCoverageNotes: buildConstraintCoverageNotes(params.testKind),
+    unsupportedConstraintGuidance,
     resultCardinality,
     queryInputFields: resolvedInputFields,
     queryOutputFields: resolvedOutputFields,
@@ -524,6 +572,249 @@ function buildValidationScenarioHints(requestFields: string[], queryName: string
   }
 
   return hints;
+}
+
+function buildConstraintCoverageNotes(testKind: FeatureTestKind): string[] {
+  if (testKind === 'ztd') {
+    return [
+      'ZTD currently verifies rewritten SQL input/output, fixture table/column shape, evidence fields, and required INSERT column presence for NOT NULL columns without defaults when table definitions are available.',
+      'Explicit NULL values for NOT NULL columns and simple UNIQUE checks are feasible ZTD preflight candidates, but they are not enforced by the current fixture/CTE rewrite lane.',
+      'Use a traditional physical DB lane for DB-enforced fail-fast behavior today, especially CHECK, foreign key, exclusion, deferrable, partial/expression UNIQUE, collation-sensitive, or full PostgreSQL constraint semantics.'
+    ];
+  }
+
+  return [
+    'Traditional execution is the lane for PostgreSQL-enforced constraint failures because it runs against physical DB setup.',
+    'Use this lane for constraint failure cases that are not covered by ZTD preflight, including `unique`, `check`, `not null`, foreign key, exclusion, and similar DB-enforced fail-fast cases.',
+    'Keep the ZTD lane focused on rewritten SQL input/output, fixture shape, and evidence fields.'
+  ];
+}
+
+function buildUnsupportedConstraintGuidance(params: {
+  rootDir: string;
+  testKind: FeatureTestKind;
+  fixtureCandidateTables: string[];
+  writesTables: string[];
+}): UnsupportedConstraintGuidance[] {
+  if (params.testKind !== 'ztd') {
+    return [];
+  }
+
+  const candidateTables = new Set(
+    dedupeStrings([...params.fixtureCandidateTables, ...params.writesTables])
+      .flatMap((table) => buildTableLookupKeys(table, readDefaultSchema(params.rootDir)))
+  );
+  if (candidateTables.size === 0) {
+    return [];
+  }
+
+  const ddlSources = collectDdlSqlSources(params.rootDir);
+  const guidance: UnsupportedConstraintGuidance[] = [];
+
+  const defaultSchema = readDefaultSchema(params.rootDir);
+  for (const source of ddlSources) {
+    for (const table of collectCreateTableConstraintInfo(source.sql, defaultSchema)) {
+      const tableKeys = buildTableLookupKeys(table.name, readDefaultSchema(params.rootDir));
+      if (!tableKeys.some((key) => candidateTables.has(key))) {
+        continue;
+      }
+
+      for (const constraint of table.constraints) {
+        guidance.push({
+          table: table.normalizedName,
+          constraint,
+          sourcePath: source.path,
+          recommendation: buildConstraintRecommendation(constraint),
+          todo: buildConstraintTodo(table.normalizedName, constraint)
+        });
+      }
+    }
+  }
+
+  const seen = new Set<string>();
+  return guidance.filter((entry) => {
+    const key = `${entry.table}:${entry.constraint}:${entry.sourcePath}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+function buildConstraintRecommendation(constraint: UnsupportedConstraintGuidance['constraint']): string {
+  switch (constraint) {
+    case 'not-null':
+      return 'ZTD catches missing required INSERT columns, but explicit NULL or parameter-NULL failures need a traditional physical DB lane today.';
+    case 'unique':
+      return 'Simple UNIQUE preflight is feasible, but current ZTD fixture/CTE execution does not enforce UNIQUE violations.';
+    case 'check':
+      return 'CHECK expression semantics are PostgreSQL-enforced and should be covered by a traditional physical DB lane.';
+    case 'foreign-key':
+      return 'Foreign key existence and timing semantics are PostgreSQL-enforced and should be covered by a traditional physical DB lane.';
+    case 'exclusion':
+      return 'Exclusion constraints rely on PostgreSQL operator/index semantics and should be covered by a traditional physical DB lane.';
+  }
+}
+
+function buildConstraintTodo(table: string, constraint: UnsupportedConstraintGuidance['constraint']): string {
+  const label = constraint.toUpperCase().replace('-', ' ');
+  return `${table} has ${label} constraint coverage that is not fully enforced by the ZTD lane; add or run a traditional physical DB case for DB-enforced failure behavior.`;
+}
+
+function collectDdlSqlSources(rootDir: string): Array<{ path: string; sql: string }> {
+  const ddlDir = path.join(rootDir, readDdlDir(rootDir));
+  if (!existsSync(ddlDir)) {
+    return [];
+  }
+
+  const sources: Array<{ path: string; sql: string }> = [];
+  collectSqlSourcesRecursive(rootDir, ddlDir, sources);
+  return sources.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+function collectSqlSourcesRecursive(rootDir: string, directory: string, accumulator: Array<{ path: string; sql: string }>): void {
+  const entries = readdirSync(directory, { withFileTypes: true });
+  for (const entry of entries) {
+    const resolved = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      collectSqlSourcesRecursive(rootDir, resolved, accumulator);
+      continue;
+    }
+    if (!entry.isFile() || path.extname(entry.name).toLowerCase() !== '.sql') {
+      continue;
+    }
+    const sql = readFileSync(resolved, 'utf8');
+    if (!sql.trim()) {
+      continue;
+    }
+    accumulator.push({
+      path: toProjectRelativePath(rootDir, resolved),
+      sql
+    });
+  }
+}
+
+function collectCreateTableConstraintInfo(
+  sql: string,
+  defaultSchema: string
+): Array<{ name: string; normalizedName: string; constraints: UnsupportedConstraintGuidance['constraint'][] }> {
+  const tables: Array<{ name: string; normalizedName: string; constraints: UnsupportedConstraintGuidance['constraint'][] }> = [];
+  const batch = MultiQuerySplitter.split(sql);
+
+  for (const query of batch.queries) {
+    if (query.isEmpty) {
+      continue;
+    }
+    const parsed = tryParseCreateTable(query.sql);
+    if (!parsed) {
+      continue;
+    }
+    const schemaName = parsed.namespaces?.[parsed.namespaces.length - 1] ?? defaultSchema;
+    const tableName = parsed.tableName.name;
+    const normalizedName = `${schemaName}.${tableName}`.toLowerCase();
+    tables.push({
+      name: normalizedName,
+      normalizedName,
+      constraints: detectConstraintKinds(parsed, query.sql)
+    });
+  }
+
+  return tables;
+}
+
+function tryParseCreateTable(sql: string): CreateTableQuery | null {
+  try {
+    const parsed = SqlParser.parse(sql);
+    return parsed instanceof CreateTableQuery ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function detectConstraintKinds(query: CreateTableQuery, sql: string): UnsupportedConstraintGuidance['constraint'][] {
+  const constraints: UnsupportedConstraintGuidance['constraint'][] = [];
+  const columnConstraints = query.columns.flatMap((column) => column.constraints);
+  const tableConstraints = query.tableConstraints;
+
+  if (columnConstraints.some((constraint) => constraint.kind === 'not-null')) {
+    constraints.push('not-null');
+  }
+  if (
+    columnConstraints.some((constraint) => constraint.kind === 'unique') ||
+    tableConstraints.some((constraint) => constraint.kind === 'unique')
+  ) {
+    constraints.push('unique');
+  }
+  if (
+    columnConstraints.some((constraint) => isColumnCheckConstraint(constraint)) ||
+    tableConstraints.some((constraint) => isTableCheckConstraint(constraint))
+  ) {
+    constraints.push('check');
+  }
+  if (
+    columnConstraints.some((constraint) => constraint.kind === 'references') ||
+    tableConstraints.some((constraint) => constraint.kind === 'foreign-key')
+  ) {
+    constraints.push('foreign-key');
+  }
+  // rawsql-ts does not expose a structured CREATE TABLE exclusion constraint node yet (#802).
+  // This intentionally noisy fallback can false-positive on identifiers, comments, or string literals;
+  // acceptable here because it only emits advisory traditional-lane TODO guidance until parser support exists.
+  if (/\bexclude\b|\bexclusion\b/i.test(sql)) {
+    constraints.push('exclusion');
+  }
+  return constraints;
+}
+
+function isColumnCheckConstraint(constraint: ColumnConstraintDefinition): boolean {
+  return constraint.kind === 'check';
+}
+
+function isTableCheckConstraint(constraint: TableConstraintDefinition): boolean {
+  return constraint.kind === 'check';
+}
+
+function buildTableLookupKeys(tableName: string, defaultSchema: string): string[] {
+  const normalized = normalizeSqlIdentifierPath(tableName);
+  if (normalized.includes('.')) {
+    const [, table] = normalized.split('.');
+    return [normalized, table];
+  }
+  return [normalized, `${defaultSchema}.${normalized}`];
+}
+
+function normalizeSqlIdentifierPath(value: string): string {
+  return value
+    .split('.')
+    .map((part) => part.trim().replace(/^"|"$/g, '').toLowerCase())
+    .join('.');
+}
+
+function readDdlDir(rootDir: string): string {
+  const configPath = path.join(rootDir, 'ztd.config.json');
+  if (!existsSync(configPath)) {
+    return 'db/ddl';
+  }
+  try {
+    const raw = JSON.parse(readFileSync(configPath, 'utf8')) as { ddlDir?: unknown };
+    return typeof raw.ddlDir === 'string' && raw.ddlDir.length > 0 ? raw.ddlDir : 'db/ddl';
+  } catch {
+    return 'db/ddl';
+  }
+}
+
+function readDefaultSchema(rootDir: string): string {
+  const configPath = path.join(rootDir, 'ztd.config.json');
+  if (!existsSync(configPath)) {
+    return 'public';
+  }
+  try {
+    const raw = JSON.parse(readFileSync(configPath, 'utf8')) as { defaultSchema?: unknown };
+    return typeof raw.defaultSchema === 'string' && raw.defaultSchema.length > 0 ? raw.defaultSchema.toLowerCase() : 'public';
+  } catch {
+    return 'public';
+  }
 }
 
 function buildDbScenarioHints(

--- a/packages/ztd-cli/templates/README.md
+++ b/packages/ztd-cli/templates/README.md
@@ -76,6 +76,9 @@ After the SQL and DTO edits settle, refresh the query-local test scaffold:
 - Use `--test-kind traditional` when the same query-boundary case shape needs physical DDL setup, fixture seeding, or optional `afterDb` post-state checks.
 - If `ztd-config` has already run, use `.ztd/generated/ztd-fixture-manifest.generated.ts` as the source for `tableDefinitions` and fixture-shape hints.
 - Treat `beforeDb` as a pure fixture skeleton with schema-qualified table keys.
+- Treat the ZTD lane as rewritten SQL input/output coverage. It validates fixture table/column shape, evidence fields, and required `INSERT` column presence for `NOT NULL` columns without defaults when table definitions are available.
+- Explicit `NULL` values for `NOT NULL` columns and simple `UNIQUE` checks are feasible ZTD preflight candidates, but they are not enforced by the current fixture/CTE rewrite lane.
+- Use `--test-kind traditional` for DB-enforced fail-fast behavior today, especially `CHECK`, foreign key, exclusion, deferrable, partial/expression `UNIQUE`, collation-sensitive, or full PostgreSQL constraint semantics.
 - Check machine-readable evidence (`mode`, `rewriteApplied`, `physicalSetupUsed`): ZTD evidence should show `mode=ztd` and `physicalSetupUsed=false`; traditional evidence should show `mode=traditional` and `physicalSetupUsed=true`.
 - Enable SQL trace only when needed with `ZTD_SQL_TRACE=1` and optional `ZTD_SQL_TRACE_DIR`.
 - When the cases are ready, run the generated `.boundary.<kind>.test.ts` entrypoint with `npx vitest run`.
@@ -87,6 +90,7 @@ After the SQL and DTO edits settle, refresh the query-local test scaffold:
 - If the workspace is meant to reflect a source change, verify it resolves `rawsql-ts` from the local source tree instead of a registry copy.
 - Check the returned evidence in the ZTD entrypoint (`mode=ztd`, `physicalSetupUsed=false`) before debugging fixtures.
 - Use the traditional entrypoint (`mode=traditional`, `physicalSetupUsed=true`) for DB-side effects and post-state assertions.
+- Use the traditional entrypoint for constraint failures that are not covered by ZTD preflight; `CHECK`, foreign key, exclusion, deferrable, partial/expression `UNIQUE`, collation-sensitive, and full PostgreSQL constraint semantics belong there.
 - If an AI-authored ZTD test fails, do not assume the prompt or case file is the only problem; `ztd-cli` or `rawsql-ts` can still be the source of the bug.
 - A `user_id: null` symptom usually points at fixture manifest, metadata, or rewrite path trouble rather than the DB engine itself.
 - When a local-source workspace should reflect a source change, verify the local `rawsql-ts` checkout is being resolved instead of a registry copy.

--- a/packages/ztd-cli/templates/src/features/smoke/queries/smoke/tests/generated/TEST_PLAN.md
+++ b/packages/ztd-cli/templates/src/features/smoke/queries/smoke/tests/generated/TEST_PLAN.md
@@ -37,6 +37,17 @@ This file snapshots the current scaffold contract before AI adds case files.
 - Keep db/input/output visible in the case file so the AI can fill the query contract without re-deriving the scaffold.
 - Read from `public.users` by `user_id` so the smoke query proves connectivity and schema wiring.
 
+## Constraint Coverage Boundary
+
+- ZTD currently verifies rewritten SQL input/output, fixture table/column shape, evidence fields, and required INSERT column presence for NOT NULL columns without defaults when table definitions are available.
+- Explicit NULL values for NOT NULL columns and simple UNIQUE checks are feasible ZTD preflight candidates, but they are not enforced by the current fixture/CTE rewrite lane.
+- Use a traditional physical DB lane for DB-enforced fail-fast behavior today, especially CHECK, foreign key, exclusion, deferrable, partial/expression UNIQUE, collation-sensitive, or full PostgreSQL constraint semantics.
+
+## Unsupported Constraint Follow-up
+
+- TODO: public.users has NOT NULL constraint coverage that is not fully enforced by the ZTD lane; add or run a traditional physical DB case for DB-enforced failure behavior.
+- TODO: public.users has UNIQUE constraint coverage that is not fully enforced by the ZTD lane; add or run a traditional physical DB case for DB-enforced failure behavior.
+
 ## Ownership
 
 - Generated files live under src/features/smoke/queries/smoke/tests/generated.

--- a/packages/ztd-cli/templates/src/features/smoke/queries/smoke/tests/generated/analysis.json
+++ b/packages/ztd-cli/templates/src/features/smoke/queries/smoke/tests/generated/analysis.json
@@ -15,5 +15,26 @@
     "Keep db/input/output visible in the case file so the AI can fill the query contract without re-deriving the scaffold.",
     "Read from `public.users` by `user_id` so the smoke query proves connectivity and schema wiring."
   ],
+  "constraintCoverageNotes": [
+    "ZTD currently verifies rewritten SQL input/output, fixture table/column shape, evidence fields, and required INSERT column presence for NOT NULL columns without defaults when table definitions are available.",
+    "Explicit NULL values for NOT NULL columns and simple UNIQUE checks are feasible ZTD preflight candidates, but they are not enforced by the current fixture/CTE rewrite lane.",
+    "Use a traditional physical DB lane for DB-enforced fail-fast behavior today, especially CHECK, foreign key, exclusion, deferrable, partial/expression UNIQUE, collation-sensitive, or full PostgreSQL constraint semantics."
+  ],
+  "unsupportedConstraintGuidance": [
+    {
+      "table": "public.users",
+      "constraint": "not-null",
+      "sourcePath": "db/ddl/demo.sql",
+      "recommendation": "ZTD catches missing required INSERT columns, but explicit NULL or parameter-NULL failures need a traditional physical DB lane today.",
+      "todo": "public.users has NOT NULL constraint coverage that is not fully enforced by the ZTD lane; add or run a traditional physical DB case for DB-enforced failure behavior."
+    },
+    {
+      "table": "public.users",
+      "constraint": "unique",
+      "sourcePath": "db/ddl/demo.sql",
+      "recommendation": "Simple UNIQUE preflight is feasible, but current ZTD fixture/CTE execution does not enforce UNIQUE violations.",
+      "todo": "public.users has UNIQUE constraint coverage that is not fully enforced by the ZTD lane; add or run a traditional physical DB case for DB-enforced failure behavior."
+    }
+  ],
   "resultCardinality": "one"
 }

--- a/packages/ztd-cli/templates/tests/support/ztd/README.md
+++ b/packages/ztd-cli/templates/tests/support/ztd/README.md
@@ -13,6 +13,9 @@ The Vitest entrypoint `src/features/<feature>/queries/<query>/tests/<query>.boun
 The query-boundary ZTD case type carries `beforeDb`, `input`, and `output`.
 The traditional case type uses the same core shape and may add `afterDb` for post-state assertions.
 The verifier returns machine-checkable evidence (`mode`, `rewriteApplied`, `physicalSetupUsed`) for each case.
+ZTD currently verifies rewritten SQL input/output, fixture shape, and required `INSERT` column presence for `NOT NULL` columns without defaults when table definitions are available.
+Explicit `NULL` values for `NOT NULL` columns and simple `UNIQUE` checks are feasible ZTD preflight candidates, but they are not enforced by the current fixture/CTE rewrite lane.
+Use the traditional physical DB lane for DB-enforced fail-fast behavior today, especially `CHECK`, foreign key, exclusion, deferrable, partial/expression `UNIQUE`, collation-sensitive, or full PostgreSQL constraint semantics.
 Traditional evidence should report `mode=traditional` and `physicalSetupUsed=true`.
 Enable SQL trace only when needed with `ZTD_SQL_TRACE=1` (optional `ZTD_SQL_TRACE_DIR`).
 Do not use `--force` to overwrite persistent case files.

--- a/packages/ztd-cli/tests/directoryFinding.docs.test.ts
+++ b/packages/ztd-cli/tests/directoryFinding.docs.test.ts
@@ -67,6 +67,13 @@ test('readmes promote the feature-first layout without tables/views taxonomy', (
   expect(scaffoldReadme).toContain('Integration tests are opt-in and should be named as integration tests when they intentionally cross multiple live boundaries.');
   expect(featuresReadme).toContain('Use `src/libraries/` only for driver-neutral code reusable enough to stand as an external package');
   expect(readNormalizedFile('packages/ztd-cli/templates/src/libraries/README.md')).toContain('Do not move feature-specific validation, mapping, or orchestration helpers here');
+  expect(scaffoldReadme).toContain('simple `UNIQUE` checks are feasible ZTD preflight candidates');
+  expect(readNormalizedFile('packages/ztd-cli/templates/tests/support/ztd/README.md')).toContain(
+    'Use the traditional physical DB lane for DB-enforced fail-fast behavior today'
+  );
+  expect(readNormalizedFile('packages/ztd-cli/templates/src/features/smoke/queries/smoke/tests/generated/TEST_PLAN.md')).toContain(
+    'Constraint Coverage Boundary'
+  );
   expect(readNormalizedFile('docs/guide/sql-first-end-to-end-tutorial.md')).toContain('Scenario CLI at a glance');
   expect(readNormalizedFile('docs/dogfooding/ztd-migration-lifecycle.md')).toContain('Preferred CLI by scenario');
   expect(packageReadme).toContain('## Further Reading');

--- a/packages/ztd-cli/tests/featureTestsScaffold.unit.test.ts
+++ b/packages/ztd-cli/tests/featureTestsScaffold.unit.test.ts
@@ -91,6 +91,7 @@ test('runFeatureTestsScaffoldCommand writes query-local ZTD scaffolds from the c
   const featureDir = path.join(workspace, 'src', 'features', 'users-insert');
   const queryDir = path.join(featureDir, 'queries', 'insert-users');
   mkdirSync(queryDir, { recursive: true });
+  mkdirSync(path.join(workspace, 'db', 'ddl'), { recursive: true });
   seedSharedZtdSupport(workspace);
 
   writeFileSync(
@@ -125,6 +126,19 @@ test('runFeatureTestsScaffoldCommand writes query-local ZTD scaffolds from the c
     'insert into public.users (email) values (:email) returning user_id;',
     'utf8'
   );
+  writeFileSync(
+    path.join(workspace, 'db', 'ddl', 'public.sql'),
+    [
+      'create table public.users (',
+      '  user_id uuid primary key,',
+      '  email text not null unique,',
+      '  status text not null check (status in (\'active\', \'disabled\')),',
+      '  account_id uuid references public.accounts(account_id)',
+      ');',
+      ''
+    ].join('\n'),
+    'utf8'
+  );
 
   const result = await runFeatureTestsScaffoldCommand({
     feature: 'users-insert',
@@ -135,7 +149,29 @@ test('runFeatureTestsScaffoldCommand writes query-local ZTD scaffolds from the c
     featureName: 'users-insert',
     queryName: 'insert-users',
     testKind: 'ztd',
-    dryRun: false
+    dryRun: false,
+    unsupportedConstraintGuidance: expect.arrayContaining([
+      expect.objectContaining({
+        table: 'public.users',
+        constraint: 'unique',
+        sourcePath: 'db/ddl/public.sql'
+      }),
+      expect.objectContaining({
+        table: 'public.users',
+        constraint: 'not-null',
+        sourcePath: 'db/ddl/public.sql'
+      }),
+      expect.objectContaining({
+        table: 'public.users',
+        constraint: 'check',
+        sourcePath: 'db/ddl/public.sql'
+      }),
+      expect.objectContaining({
+        table: 'public.users',
+        constraint: 'foreign-key',
+        sourcePath: 'db/ddl/public.sql'
+      })
+    ])
   });
   expect(result.outputs.map((output) => output.path)).toEqual(
     expect.arrayContaining([
@@ -179,6 +215,8 @@ test('runFeatureTestsScaffoldCommand writes query-local ZTD scaffolds from the c
   expect(basicCaseFile).toContain('TODO: Replace the placeholder output with the exact result expected from the query boundary.');
   expect(basicCaseFile).toContain('CLI hints: user_id.');
   expect(basicCaseFile).toContain('output: {} as InsertUsersOutput,');
+  expect(basicCaseFile).toContain('public.users has UNIQUE constraint coverage that is not fully enforced by the ZTD lane');
+  expect(basicCaseFile).toContain('public.users has CHECK constraint coverage that is not fully enforced by the ZTD lane');
 
   const queryTypesFile = readFileSync(
     path.join(featureDir, 'queries', 'insert-users', 'tests', 'boundary-ztd-types.ts'),
@@ -214,6 +252,12 @@ test('runFeatureTestsScaffoldCommand writes query-local ZTD scaffolds from the c
   expect(testPlanFile).toContain('Write Tables');
   expect(testPlanFile).toContain('Validation Scenario Hints');
   expect(testPlanFile).toContain('DB Scenario Hints');
+  expect(testPlanFile).toContain('Constraint Coverage Boundary');
+  expect(testPlanFile).toContain('required INSERT column presence for NOT NULL columns without defaults');
+  expect(testPlanFile).toContain('simple UNIQUE checks are feasible ZTD preflight candidates');
+  expect(testPlanFile).toContain('Use a traditional physical DB lane for DB-enforced fail-fast behavior today');
+  expect(testPlanFile).toContain('Unsupported Constraint Follow-up');
+  expect(testPlanFile).toContain('TODO: public.users has UNIQUE constraint coverage that is not fully enforced by the ZTD lane');
   expect(testPlanFile).toContain('Case Readiness');
   expect(testPlanFile).toContain('Generated ZTD cases are intentionally placeholders.');
   expect(testPlanFile).toContain('change the generated Vitest entrypoint from `test.skip` to `test`');
@@ -233,6 +277,8 @@ test('runFeatureTestsScaffoldCommand writes query-local ZTD scaffolds from the c
     writesTables: string[];
     validationScenarioHints: string[];
     dbScenarioHints: string[];
+    constraintCoverageNotes: string[];
+    unsupportedConstraintGuidance: Array<{ table: string; constraint: string; sourcePath: string; recommendation: string; todo: string }>;
     resultCardinality: string;
   };
 
@@ -249,6 +295,23 @@ test('runFeatureTestsScaffoldCommand writes query-local ZTD scaffolds from the c
     dbScenarioHints: expect.arrayContaining([
       'Use the fixed app-level harness and query-local cases to keep the ZTD path thin.',
       'Keep db/input/output visible in the case file so the AI can fill the query contract without re-deriving the scaffold.'
+    ]),
+    constraintCoverageNotes: expect.arrayContaining([
+      'ZTD currently verifies rewritten SQL input/output, fixture table/column shape, evidence fields, and required INSERT column presence for NOT NULL columns without defaults when table definitions are available.',
+      'Explicit NULL values for NOT NULL columns and simple UNIQUE checks are feasible ZTD preflight candidates, but they are not enforced by the current fixture/CTE rewrite lane.',
+      'Use a traditional physical DB lane for DB-enforced fail-fast behavior today, especially CHECK, foreign key, exclusion, deferrable, partial/expression UNIQUE, collation-sensitive, or full PostgreSQL constraint semantics.'
+    ]),
+    unsupportedConstraintGuidance: expect.arrayContaining([
+      expect.objectContaining({
+        table: 'public.users',
+        constraint: 'unique',
+        recommendation: expect.stringContaining('current ZTD fixture/CTE execution does not enforce UNIQUE violations')
+      }),
+      expect.objectContaining({
+        table: 'public.users',
+        constraint: 'foreign-key',
+        todo: expect.stringContaining('traditional physical DB case')
+      })
     ]),
     resultCardinality: 'one'
   });
@@ -469,6 +532,9 @@ test('runFeatureTestsScaffoldCommand writes traditional lane scaffolds without o
   expect(traditionalAnalysis.testKind).toBe('traditional');
   expect(traditionalAnalysis.dbScenarioHints.join('\n')).toContain('shared mode-switching harness');
   expect(traditionalAnalysis.dbScenarioHints.join('\n')).not.toContain('fixed app-level harness');
+  expect((traditionalAnalysis as { constraintCoverageNotes: string[] }).constraintCoverageNotes.join('\n')).toContain(
+    'Traditional execution is the lane for PostgreSQL-enforced constraint failures'
+  );
 
   const traditionalPlan = readFileSync(
     path.join(featureDir, 'queries', 'insert-users', 'tests', 'generated', 'TEST_PLAN.traditional.md'),
@@ -478,6 +544,8 @@ test('runFeatureTestsScaffoldCommand writes traditional lane scaffolds without o
   expect(traditionalPlan).toContain('physically prepares DDL and fixture rows');
   expect(traditionalPlan).toContain('physicalSetupUsed=true');
   expect(traditionalPlan).toContain('Optional `afterDb` assertions');
+  expect(traditionalPlan).toContain('PostgreSQL-enforced constraint failures');
+  expect(traditionalPlan).toContain('constraint failure cases that are not covered by ZTD preflight');
 
   expect(
     existsSync(path.join(featureDir, 'queries', 'insert-users', 'tests', 'insert-users.boundary.ztd.test.ts'))

--- a/packages/ztd-cli/tests/init.command.test.ts
+++ b/packages/ztd-cli/tests/init.command.test.ts
@@ -272,6 +272,18 @@ test('init starter bootstraps compose, starter DDL, and smoke tests without visi
   expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'smoke', 'queries', 'smoke', 'tests', 'smoke.boundary.ztd.test.ts'))).toContain(
     "from '#tests/support/ztd/harness.js'"
   );
+  expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'smoke', 'queries', 'smoke', 'tests', 'generated', 'TEST_PLAN.md'))).toContain(
+    'Constraint Coverage Boundary'
+  );
+  expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'smoke', 'queries', 'smoke', 'tests', 'generated', 'TEST_PLAN.md'))).toContain(
+    'required INSERT column presence for NOT NULL columns without defaults'
+  );
+  expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'smoke', 'queries', 'smoke', 'tests', 'generated', 'analysis.json'))).toContain(
+    '"constraintCoverageNotes"'
+  );
+  expect(readNormalizedFile(path.join(workspace, 'tests', 'support', 'ztd', 'README.md'))).toContain(
+    'simple `UNIQUE` checks are feasible ZTD preflight candidates'
+  );
   expect(existsSync(path.join(workspace, 'src', 'libraries', 'README.md'))).toBe(true);
   expect(existsSync(path.join(workspace, 'src', 'libraries', 'sql', 'README.md'))).toBe(true);
   expect(existsSync(path.join(workspace, 'src', 'libraries', 'telemetry', 'types.ts'))).toBe(true);


### PR DESCRIPTION
## Summary

- Closes #802.
- Clarifies generated ZTD query test plans, analysis JSON, and starter docs so constraint coverage is not over-claimed.
- Adds DDL-derived unsupportedConstraintGuidance for ZTD scaffolds and TODO comments that direct DB-enforced failure behavior to the traditional lane.
- Resolves main-branch conflicts and documents the exclusion-constraint heuristic requested in review.

## Verification

- pnpm --filter @rawsql-ts/ztd-cli test -- featureTestsScaffold.unit.test.ts init.command.test.ts directoryFinding.docs.test.ts sqlFirstTutorial.docs.test.ts
- pnpm --filter @rawsql-ts/ztd-cli build
- git diff --check

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: not needed; no baseline exception requested.
Scoped checks run: not needed; no baseline exception requested.
Why full baseline is not required: full baseline exception path not used for this PR.

## Self Review

Self-review workflow: Codex review pass after rebase and CodeRabbit comment triage.
Self-review result: Ready for PR; merge conflict resolved and the exclusion fallback trade-off is documented inline.

## CLI Surface Migration

- [ ] No migration packet required for this CLI change.
- [x] CLI/user-facing surface change and migration packet completed.

No-migration rationale: not selected for this PR.
Upgrade note: No migration required. Existing commands keep their flags, but ztd feature tests scaffold now emits extra constraint-boundary guidance in generated files and JSON output.
Deprecation/removal plan or issue: None; this is additive guidance and does not remove or rename CLI behavior.
Docs/help/examples updated: Template README, support README, starter TEST_PLAN.md, starter analysis.json, and scaffold tests were updated.
Release/changeset wording: Added .changeset/ztd-constraint-boundary-guidance.md for @rawsql-ts/ztd-cli patch release.

## Scaffold Contract Proof

- [ ] No scaffold contract proof required for this PR.
- [x] Scaffold contract proof completed.

No-proof rationale: not selected for this PR.
Non-edit assertion: Existing persistent case files are still created only if missing; generated plan and analysis remain the refreshed scaffold-owned files.
Fail-fast input-contract proof: featureTestsScaffold.unit.test.ts asserts unsupportedConstraintGuidance in the command result and analysis JSON when DDL contains unsupported constraint coverage.
Generated-output viability proof: featureTestsScaffold.unit.test.ts and init.command.test.ts assert generated TEST_PLAN.md, analysis.json, and case TODO guidance include the constraint boundary.
