### PR TITLE
fix(ztd-cli): harden scaffold smoke contracts

### DIFF
--- a/packages/ztd-cli/src/commands/init.ts
+++ b/packages/ztd-cli/src/commands/init.ts
@@ -398,6 +398,8 @@ const SQL_README_TEMPLATE = 'src/libraries/sql/README.md';
 const JOBS_README_TEMPLATE = 'src/jobs/README.md';
 const ZTD_README_TEMPLATE = 'ztd/README.md';
 const ZTD_DDL_DEMO_TEMPLATE = 'db/ddl/demo.sql';
+const STARTER_DB_READY_NOTE =
+  'Wait until Postgres is ready before the DB-backed smoke path; if the container just started, rerun the QuerySpec smoke test once.';
 
 const EMPTY_SCHEMA_COMMENT = (schemaName: string): string =>
   [
@@ -443,12 +445,13 @@ const STARTER_README_APPENDIX = (postgresImage: string, ztdCommand: string): str
     '2. Run the DB-free smoke tests first with `npx vitest run src/features/smoke/tests/smoke.boundary.test.ts src/features/smoke/tests/smoke.test.ts src/features/smoke/tests/smoke.validation.test.ts`.',
     '3. Copy `.env.example` to `.env` and update `ZTD_DB_PORT` if 5432 is already in use.',
     '4. Start Postgres with `docker compose up -d` when you are ready for the DB-backed smoke path.',
-    `5. The bundled compose file uses \`${postgresImage}\`, and the generated Vitest setup derives \`ZTD_DB_URL\` from \`ZTD_DB_PORT\`.`,
-    `6. Run \`${ztdCommand} ztd-config\` to regenerate the runtime fixture manifest, DDL-derived test rows, and layout metadata.`,
-    '7. Read `tests/support/ztd/harness.ts` and `src/features/smoke/queries/smoke/tests/smoke.boundary.ztd.test.ts` to see the DB-backed starter smoke path through the shared query-boundary harness and starter DB wiring.',
-    '8. Run `npx vitest run` to exercise the DB-free and DB-backed smoke tests with the values from `.env`.',
-  `9. Run \`${ztdCommand} feature scaffold --table users --action insert\` to create the first fixed feature shell.`,
-  `10. After you finish SQL and DTO edits, run \`${ztdCommand} feature tests scaffold --feature users-insert\` to create TODO-based test scaffolds, then let AI complete them.`,
+    `5. ${STARTER_DB_READY_NOTE}`,
+    `6. The bundled compose file uses \`${postgresImage}\`, and the generated Vitest setup derives \`ZTD_DB_URL\` from \`ZTD_DB_PORT\`.`,
+    `7. Run \`${ztdCommand} ztd-config\` to regenerate the runtime fixture manifest, DDL-derived test rows, and layout metadata.`,
+    '8. Read `tests/support/ztd/harness.ts` and `src/features/smoke/queries/smoke/tests/smoke.boundary.ztd.test.ts` to see the DB-backed starter smoke path through the shared query-boundary harness and starter DB wiring.',
+    '9. Run `npx vitest run` to exercise the DB-free and DB-backed smoke tests with the values from `.env`.',
+    `10. Run \`${ztdCommand} feature scaffold --table users --action insert\` to create the first fixed feature shell.`,
+    `11. After you finish SQL and DTO edits, run \`${ztdCommand} feature tests scaffold --feature users-insert\` to create TODO-based test scaffolds, then let AI complete them.`,
     ''
   ].join('\n');
 
@@ -2367,13 +2370,14 @@ function buildNextSteps(
     const starterNextSteps = [
       'Inspect src/features/smoke/ and treat it as a starter-only sample feature that can be deleted later',
       `Run tests (${runScriptCommand('test')} or npx vitest run src/features/smoke/tests/smoke.boundary.test.ts src/features/smoke/tests/smoke.test.ts src/features/smoke/tests/smoke.validation.test.ts) to confirm the DB-free smoke path is green`,
-    'Read src/features/smoke/queries/smoke/tests/smoke.boundary.ztd.test.ts to see the DB-backed query-boundary path that also checks connectivity',
+      'Read src/features/smoke/queries/smoke/tests/smoke.boundary.ztd.test.ts to see the DB-backed query-boundary path that also checks connectivity',
       'Run docker compose up -d to start the bundled Postgres container before the DB-backed smoke path',
+      STARTER_DB_READY_NOTE,
       `The bundled compose file uses ${postgresImage}; copy .env.example to .env and keep ZTD_DB_PORT aligned before running src/features/smoke/queries/smoke/tests/smoke.boundary.ztd.test.ts`,
       'Expect src/features/smoke/queries/smoke/tests/smoke.boundary.ztd.test.ts to fail until .env is present or the DB is running; that failure is part of the starter guidance',
       ...generationSteps,
-  `Start your first real CRUD slice with \`${ztdCommand} feature scaffold --table users --action insert\` after the smoke sample makes sense`,
-  `Then run \`${ztdCommand} feature tests scaffold --feature users-insert\` after you finish SQL and DTO edits, and let AI complete the TODO-based tests.`,
+      `Start your first real CRUD slice with \`${ztdCommand} feature scaffold --table users --action insert\` after the smoke sample makes sense`,
+      `Then run \`${ztdCommand} feature tests scaffold --feature users-insert\` after you finish SQL and DTO edits, and let AI complete the TODO-based tests.`,
       'Delete src/features/smoke/ once you no longer need the starter sample'
     ];
     const starterFallbackSteps = [
@@ -2619,10 +2623,102 @@ export interface InitDryRunPlan {
   files: string[];
 }
 
+function pushRelativePlanFile(files: string[], rootDir: string, filePath: string): void {
+  files.push(normalizeCliPath(path.relative(rootDir, filePath)));
+}
+
+function buildInitPlanFiles(
+  rootDir: string,
+  scaffoldLayout: InitScaffoldLayout,
+  schemaFileName: string,
+  options: {
+    starter: boolean;
+    withAiGuidance?: boolean;
+    withDogfooding?: boolean;
+    withAppInterface?: boolean;
+  }
+): string[] {
+  const files = [
+    'ztd.config.json',
+    path.join(DEFAULT_ZTD_CONFIG.ddlDir, schemaFileName),
+    path.join(resolveSupportDir(DEFAULT_ZTD_CONFIG), 'global-setup.ts'),
+    path.join(resolveGeneratedDir(DEFAULT_ZTD_CONFIG), 'ztd-row-map.generated.ts'),
+    path.join(resolveGeneratedDir(DEFAULT_ZTD_CONFIG), 'ztd-layout.generated.ts'),
+    path.join(resolveGeneratedDir(DEFAULT_ZTD_CONFIG), 'ztd-fixture-manifest.generated.ts'),
+    '.gitignore',
+    'src/libraries/sql/sql-client.ts',
+    'src/adapters/pg/sql-client.ts',
+    'vitest.config.ts',
+    'tsconfig.json',
+  ];
+
+  pushRelativePlanFile(files, rootDir, scaffoldLayout.featureReadmePath);
+  pushRelativePlanFile(files, rootDir, scaffoldLayout.setupEnvPath);
+  pushRelativePlanFile(files, rootDir, scaffoldLayout.envExamplePath);
+  files.push('README.md');
+  files.push(path.join('src', 'libraries', 'sql', 'README.md'));
+  files.push(path.join('src', 'adapters', 'README.md'));
+
+  if (options.starter) {
+    pushRelativePlanFile(files, rootDir, path.join(rootDir, STARTER_COMPOSE_FILE));
+    pushRelativePlanFile(files, rootDir, scaffoldLayout.featureQueryExecutorPath);
+    pushRelativePlanFile(files, rootDir, scaffoldLayout.loadSqlResourcePath);
+    pushRelativePlanFile(files, rootDir, scaffoldLayout.smokeReadmePath);
+    pushRelativePlanFile(files, rootDir, scaffoldLayout.smokeTestsReadmePath);
+    pushRelativePlanFile(files, rootDir, scaffoldLayout.smokeSpecPath);
+    pushRelativePlanFile(files, rootDir, scaffoldLayout.smokeEntrySpecTestPath);
+    pushRelativePlanFile(files, rootDir, scaffoldLayout.smokeSpecPath);
+    pushRelativePlanFile(files, rootDir, scaffoldLayout.smokeValidationTestPath);
+    pushRelativePlanFile(files, rootDir, scaffoldLayout.smokeTestPath);
+    pushRelativePlanFile(files, rootDir, scaffoldLayout.smokeQuerySpecTestPath);
+    pushRelativePlanFile(files, rootDir, scaffoldLayout.smokeQuerySpecPath);
+    pushRelativePlanFile(files, rootDir, scaffoldLayout.smokeQuerySqlPath);
+    pushRelativePlanFile(files, rootDir, scaffoldLayout.smokeQueryTestsQuerySpecZtdTypesPath);
+    pushRelativePlanFile(files, rootDir, scaffoldLayout.smokeQueryTestsBasicCasePath);
+    pushRelativePlanFile(files, rootDir, scaffoldLayout.smokeQueryTestsGeneratedAnalysisPath);
+    pushRelativePlanFile(files, rootDir, scaffoldLayout.smokeQueryTestsGeneratedTestPlanPath);
+    pushRelativePlanFile(files, rootDir, scaffoldLayout.testsSupportZtdReadmePath);
+    pushRelativePlanFile(files, rootDir, scaffoldLayout.testsSupportZtdCaseTypesPath);
+    pushRelativePlanFile(files, rootDir, scaffoldLayout.testsSupportZtdVerifierPath);
+    pushRelativePlanFile(files, rootDir, scaffoldLayout.testsSupportZtdHarnessPath);
+    pushRelativePlanFile(files, rootDir, scaffoldLayout.infrastructureReadmePath);
+    pushRelativePlanFile(files, rootDir, scaffoldLayout.telemetryTypesPath);
+    pushRelativePlanFile(files, rootDir, scaffoldLayout.telemetryRepositoryPath);
+    pushRelativePlanFile(files, rootDir, scaffoldLayout.telemetryConsoleRepositoryPath);
+    pushRelativePlanFile(files, rootDir, scaffoldLayout.starterPostgresTestkitPath);
+  }
+
+  if (options.withAiGuidance) {
+    files.push('.ztd/agents/manifest.json');
+    files.push('.ztd/agents/root.md');
+    files.push('.ztd/agents/src.md');
+    files.push('.ztd/agents/src-features.md');
+    files.push('.ztd/agents/tests.md');
+    files.push('.ztd/agents/db.md');
+    files.push('CONTEXT.md');
+  }
+
+  if (options.withDogfooding) {
+    files.push('PROMPT_DOGFOOD.md');
+  }
+
+  pushRelativePlanFile(files, rootDir, scaffoldLayout.sqlClientPath);
+  pushRelativePlanFile(files, rootDir, scaffoldLayout.sqlClientAdaptersPath);
+
+  if (options.withAppInterface) {
+    return ['AGENTS.md'];
+  }
+
+  return files;
+}
+
 export function buildInitDryRunPlan(rootDir: string, options: {
   appShape: InitAppShape;
   starter?: boolean;
   postgresImage?: string;
+  withAiGuidance?: boolean;
+  withDogfooding?: boolean;
+  withAppInterface?: boolean;
   workflow: InitWorkflow;
   validator: ValidatorBackend;
   localSourceRoot?: string;
@@ -2632,56 +2728,12 @@ export function buildInitDryRunPlan(rootDir: string, options: {
   const scaffoldLayout = resolveInitScaffoldLayout(rootDir, options.appShape);
   const starter = options.starter === true;
   const postgresImage = options.postgresImage?.trim() || DEFAULT_POSTGRES_IMAGE;
-  const files = [
-    'ztd.config.json',
-    path.join(DEFAULT_ZTD_CONFIG.ddlDir, schemaFileName),
-    path.join('src', 'features', 'README.md'),
-    path.join(resolveSupportDir(DEFAULT_ZTD_CONFIG), 'global-setup.ts'),
-    path.join(resolveSupportDir(DEFAULT_ZTD_CONFIG), 'setup-env.ts'),
-    path.join(resolveGeneratedDir(DEFAULT_ZTD_CONFIG), 'ztd-row-map.generated.ts'),
-    path.join(resolveGeneratedDir(DEFAULT_ZTD_CONFIG), 'ztd-layout.generated.ts'),
-    path.join(resolveGeneratedDir(DEFAULT_ZTD_CONFIG), 'ztd-fixture-manifest.generated.ts'),
-    'README.md',
-    '.env.example',
-    '.gitignore',
-    'src/libraries/sql/sql-client.ts',
-    'src/adapters/pg/sql-client.ts',
-    'vitest.config.ts',
-    'tsconfig.json'
-  ];
-
-  if (starter) {
-    files.push(
-      path.join('src', 'libraries', 'README.md'),
-      path.join('src', 'libraries', 'sql', 'README.md'),
-      path.join('src', 'adapters', 'README.md'),
-      STARTER_COMPOSE_FILE,
-      path.join('src', 'features', '_shared', 'featureQueryExecutor.ts'),
-      path.join('src', 'features', '_shared', 'loadSqlResource.ts'),
-      path.join('src', 'features', 'smoke', 'README.md'),
-      path.join('src', 'features', 'smoke', 'tests', 'README.md'),
-      path.join('src', 'features', 'smoke', 'boundary.ts'),
-      path.join('src', 'features', 'smoke', 'tests', 'smoke.boundary.test.ts'),
-      path.join('src', 'features', 'smoke', 'tests', 'smoke.validation.test.ts'),
-      path.join('src', 'features', 'smoke', 'tests', 'smoke.test.ts'),
-      path.join('src', 'features', 'smoke', 'queries', 'smoke', 'tests', 'smoke.boundary.ztd.test.ts'),
-      path.join('src', 'features', 'smoke', 'queries', 'smoke', 'boundary.ts'),
-      path.join('src', 'features', 'smoke', 'queries', 'smoke', 'smoke.sql'),
-      path.join('src', 'features', 'smoke', 'queries', 'smoke', 'tests', 'boundary-ztd-types.ts'),
-      path.join('src', 'features', 'smoke', 'queries', 'smoke', 'tests', 'cases', 'basic.case.ts'),
-      path.join('src', 'features', 'smoke', 'queries', 'smoke', 'tests', 'generated', 'analysis.json'),
-      path.join('src', 'features', 'smoke', 'queries', 'smoke', 'tests', 'generated', 'TEST_PLAN.md'),
-      path.join('tests', 'support', 'ztd', 'README.md'),
-      path.join('tests', 'support', 'ztd', 'case-types.ts'),
-      path.join('tests', 'support', 'ztd', 'verifier.ts'),
-      path.join('tests', 'support', 'ztd', 'harness.ts'),
-      path.join('src', 'libraries', 'telemetry', 'types.ts'),
-      path.join('src', 'libraries', 'telemetry', 'repositoryTelemetry.ts'),
-      path.join('src', 'adapters', 'console', 'repositoryTelemetry.ts'),
-      path.join(resolveSupportDir(DEFAULT_ZTD_CONFIG), 'postgres-testkit.ts')
-    );
-  }
-
+  const files = buildInitPlanFiles(rootDir, scaffoldLayout, schemaFileName, {
+    starter,
+    withAiGuidance: options.withAiGuidance,
+    withDogfooding: options.withDogfooding,
+    withAppInterface: options.withAppInterface
+  });
   if (options.localSourceRoot) {
     resolveInitScaffoldProfile(rootDir, options.localSourceRoot, starter);
   }

--- a/packages/ztd-cli/src/commands/init.ts
+++ b/packages/ztd-cli/src/commands/init.ts
@@ -7,7 +7,6 @@ import readline from 'node:readline/promises';
 import { ensureDirectory } from '../utils/fs';
 import {
   DEFAULT_ZTD_CONFIG,
-  resolveGeneratedDir,
   resolveSupportDir,
   writeZtdProjectConfig
 } from '../utils/ztdProjectConfig';
@@ -2642,12 +2641,6 @@ function buildInitPlanFiles(
     'ztd.config.json',
     path.join(DEFAULT_ZTD_CONFIG.ddlDir, schemaFileName),
     path.join(resolveSupportDir(DEFAULT_ZTD_CONFIG), 'global-setup.ts'),
-    path.join(resolveGeneratedDir(DEFAULT_ZTD_CONFIG), 'ztd-row-map.generated.ts'),
-    path.join(resolveGeneratedDir(DEFAULT_ZTD_CONFIG), 'ztd-layout.generated.ts'),
-    path.join(resolveGeneratedDir(DEFAULT_ZTD_CONFIG), 'ztd-fixture-manifest.generated.ts'),
-    '.gitignore',
-    'src/libraries/sql/sql-client.ts',
-    'src/adapters/pg/sql-client.ts',
     'vitest.config.ts',
     'tsconfig.json',
   ];
@@ -2656,10 +2649,10 @@ function buildInitPlanFiles(
   pushRelativePlanFile(files, rootDir, scaffoldLayout.setupEnvPath);
   pushRelativePlanFile(files, rootDir, scaffoldLayout.envExamplePath);
   files.push('README.md');
-  files.push(path.join('src', 'libraries', 'sql', 'README.md'));
-  files.push(path.join('src', 'adapters', 'README.md'));
 
   if (options.starter) {
+    files.push(path.join('src', 'libraries', 'sql', 'README.md'));
+    files.push(path.join('src', 'adapters', 'README.md'));
     pushRelativePlanFile(files, rootDir, path.join(rootDir, STARTER_COMPOSE_FILE));
     pushRelativePlanFile(files, rootDir, scaffoldLayout.featureQueryExecutorPath);
     pushRelativePlanFile(files, rootDir, scaffoldLayout.loadSqlResourcePath);
@@ -2667,7 +2660,6 @@ function buildInitPlanFiles(
     pushRelativePlanFile(files, rootDir, scaffoldLayout.smokeTestsReadmePath);
     pushRelativePlanFile(files, rootDir, scaffoldLayout.smokeSpecPath);
     pushRelativePlanFile(files, rootDir, scaffoldLayout.smokeEntrySpecTestPath);
-    pushRelativePlanFile(files, rootDir, scaffoldLayout.smokeSpecPath);
     pushRelativePlanFile(files, rootDir, scaffoldLayout.smokeValidationTestPath);
     pushRelativePlanFile(files, rootDir, scaffoldLayout.smokeTestPath);
     pushRelativePlanFile(files, rootDir, scaffoldLayout.smokeQuerySpecTestPath);
@@ -2706,7 +2698,7 @@ function buildInitPlanFiles(
   pushRelativePlanFile(files, rootDir, scaffoldLayout.sqlClientAdaptersPath);
 
   if (options.withAppInterface) {
-    return ['AGENTS.md'];
+    files.push('AGENTS.md');
   }
 
   return files;

--- a/packages/ztd-cli/tests/init.command.test.ts
+++ b/packages/ztd-cli/tests/init.command.test.ts
@@ -377,20 +377,23 @@ test('init dry-run plan matches starter outputs without AGENTS files', () => {
     'src/adapters/console/repositoryTelemetry.ts',
     '.ztd/support/postgres-testkit.ts'
   ]));
-  expect(plan.files).not.toEqual(expect.arrayContaining([
-    'src/features/smoke/application/README.md',
-    'src/features/smoke/domain/README.md',
-    'src/features/smoke/persistence/README.md',
-    'src/features/smoke/domain/smoke-policy.ts',
-    'src/features/smoke/application/smoke-workflow.ts',
-    'src/features/smoke/persistence/smoke.sql',
-    'src/features/smoke/persistence/boundary.ts',
-    'AGENTS.md',
-    'db/AGENTS.md',
-    'db/ddl/AGENTS.md',
-    'src/AGENTS.md',
-    'src/features/AGENTS.md'
-  ]));
+  expect(plan.files.filter((file) => file === 'src/features/smoke/queries/smoke/tests/smoke.boundary.ztd.test.ts')).toHaveLength(1);
+  expect(plan.files).not.toContain('.gitignore');
+  expect(plan.files).not.toContain('.ztd/generated/ztd-row-map.generated.ts');
+  expect(plan.files).not.toContain('.ztd/generated/ztd-layout.generated.ts');
+  expect(plan.files).not.toContain('.ztd/generated/ztd-fixture-manifest.generated.ts');
+  expect(plan.files).not.toContain('src/features/smoke/application/README.md');
+  expect(plan.files).not.toContain('src/features/smoke/domain/README.md');
+  expect(plan.files).not.toContain('src/features/smoke/persistence/README.md');
+  expect(plan.files).not.toContain('src/features/smoke/domain/smoke-policy.ts');
+  expect(plan.files).not.toContain('src/features/smoke/application/smoke-workflow.ts');
+  expect(plan.files).not.toContain('src/features/smoke/persistence/smoke.sql');
+  expect(plan.files).not.toContain('src/features/smoke/persistence/boundary.ts');
+  expect(plan.files).not.toContain('AGENTS.md');
+  expect(plan.files).not.toContain('db/AGENTS.md');
+  expect(plan.files).not.toContain('db/ddl/AGENTS.md');
+  expect(plan.files).not.toContain('src/AGENTS.md');
+  expect(plan.files).not.toContain('src/features/AGENTS.md');
 });
 
 test('init dry-run plan for non-starter init excludes starter-only readmes', () => {
@@ -408,13 +411,31 @@ test('init dry-run plan for non-starter init excludes starter-only readmes', () 
     'src/libraries/sql/sql-client.ts',
     'src/adapters/pg/sql-client.ts'
   ]));
-  expect(plan.files).not.toEqual(expect.arrayContaining([
-    'src/libraries/README.md',
-    'src/libraries/sql/README.md',
-    'src/adapters/README.md',
-    'compose.yaml',
-    'src/features/smoke/README.md'
+  expect(plan.files).not.toContain('src/libraries/README.md');
+  expect(plan.files).not.toContain('src/libraries/sql/README.md');
+  expect(plan.files).not.toContain('src/adapters/README.md');
+  expect(plan.files).not.toContain('compose.yaml');
+  expect(plan.files).not.toContain('src/features/smoke/README.md');
+});
+
+test('init dry-run plan with app interface keeps scaffold files and adds AGENTS once', () => {
+  const workspace = createTempDir('cli-init-dry-run-plan-app-interface');
+  const plan = buildInitDryRunPlan(workspace, {
+    appShape: 'default',
+    starter: false,
+    workflow: 'empty',
+    validator: 'zod',
+    localSourceRoot: null,
+    withAppInterface: true
+  });
+
+  expect(plan.dryRun).toBe(true);
+  expect(plan.files).toEqual(expect.arrayContaining([
+    'AGENTS.md',
+    'src/libraries/sql/sql-client.ts',
+    'src/adapters/pg/sql-client.ts'
   ]));
+  expect(plan.files.filter((file) => file === 'AGENTS.md')).toHaveLength(1);
 });
 
 test('init derives generated lint-staged hook command from the package manager lockfile', async () => {

--- a/packages/ztd-cli/tests/publishWorkflow.unit.test.ts
+++ b/packages/ztd-cli/tests/publishWorkflow.unit.test.ts
@@ -75,6 +75,17 @@ test('published-package mode includes the rawsql-ts getting-started smoke path',
   expect(publishedPackageModeScript).toContain('const formatter = new SqlFormatter();');
 });
 
+test('published-package mode expects local-source guard scripts from npm consumer scaffolds', () => {
+  const npmSection = publishedPackageModeScript.slice(
+    publishedPackageModeScript.indexOf('function verifyNpmPrimaryPath(packages) {'),
+    publishedPackageModeScript.indexOf('function verifyNpmConsumerSmoke(phaseAResult) {'),
+  );
+
+  expect(npmSection).toContain('node ./scripts/local-source-guard.mjs test --passWithNoTests');
+  expect(npmSection).toContain('node ./scripts/local-source-guard.mjs typecheck');
+  expect(npmSection).toContain('node ./scripts/local-source-guard.mjs ztd');
+});
+
 test('overwrite safety uses the installed ztd bin so npm does not consume --force', () => {
   const overwriteSection = publishedPackageModeScript.slice(
     publishedPackageModeScript.indexOf('function verifyOverwriteSafety(packages) {'),

--- a/scripts/verify-published-package-mode.mjs
+++ b/scripts/verify-published-package-mode.mjs
@@ -282,6 +282,49 @@ function assertExcludes(haystack, needle, label) {
   }
 }
 
+function readJsonFile(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function runInitDryRunPlan(directory, packageManager, args) {
+  const result = runIn(directory, packageManager, ["exec", "--", "ztd", "init", "--dry-run", "--yes", ...args]);
+  return JSON.parse(result.stdout);
+}
+
+function assertScaffoldPlanMetadata(plan, expected, label) {
+  for (const [key, value] of Object.entries(expected)) {
+    if (plan[key] !== value) {
+      throw new Error(
+        `[${label}] Expected init dry-run plan ${key}=${JSON.stringify(value)}, received ${JSON.stringify(plan[key])}.`,
+      );
+    }
+  }
+}
+
+function assertScaffoldPlanFilesExist(appDir, plan, label) {
+  for (const relativePath of plan.files ?? []) {
+    const absolutePath = path.join(appDir, relativePath);
+    if (!fs.existsSync(absolutePath)) {
+      throw new Error(`[${label}] Planned scaffold file was not created: ${relativePath}`);
+    }
+  }
+}
+
+function assertFileMissing(appDir, relativePath, label) {
+  if (fs.existsSync(path.join(appDir, relativePath))) {
+    throw new Error(`[${label}] Unexpected scaffold file was created: ${relativePath}`);
+  }
+}
+
+function assertPackageScript(packageJson, scriptName, expectedCommand, label) {
+  const actualCommand = packageJson.scripts?.[scriptName];
+  if (actualCommand !== expectedCommand) {
+    throw new Error(
+      `[${label}] Expected package.json scripts.${scriptName}=${JSON.stringify(expectedCommand)}, received ${JSON.stringify(actualCommand)}.`,
+    );
+  }
+}
+
 function packPublishedPackages() {
   const workspacePackages = Array.from(getWorkspacePackages(workspaceRoot).values())
     .filter(isPublishTarget)
@@ -438,34 +481,35 @@ function verifyNpmPrimaryPath(packages) {
   });
 
   runIn(appDir, NPM, ["install"]);
+  const dryRunPlan = runInitDryRunPlan(appDir, NPM, ["--workflow", "demo", "--validator", "zod"]);
+  assertScaffoldPlanMetadata(dryRunPlan, {
+    dryRun: true,
+    schemaVersion: 1,
+    workflow: "demo",
+    validator: "zod",
+    starter: false,
+  }, "phase-a init-dry-run");
   const initResult = runIn(appDir, NPM, ["exec", "--", "ztd", "init", "--yes", "--workflow", "demo", "--validator", "zod"]);
 
-  assertIncludes(initResult.stdout, "npm run ztd -- ztd-config", "phase-a packaging-npm-primary-path-gate");
-  assertIncludes(initResult.stdout, "npm run ztd -- model-gen", "phase-a packaging-npm-primary-path-gate");
+  assertIncludes(initResult.stdout, "ztd-config", "phase-a packaging-npm-primary-path-gate");
+  assertIncludes(initResult.stdout, "model-gen", "phase-a packaging-npm-primary-path-gate");
   assertIncludes(initResult.stdout, "npm run test", "phase-a packaging-npm-primary-path-gate");
   assertExcludes(initResult.stdout, "pnpm exec ztd", "phase-a packaging-npm-primary-path-gate");
   assertExcludes(initResult.stdout, "pnpm test", "phase-a packaging-npm-primary-path-gate");
+  assertScaffoldPlanFilesExist(appDir, dryRunPlan, "phase-a scaffold-files");
 
-  const readme = fs.readFileSync(path.join(appDir, "README.md"), "utf8");
-  assertIncludes(readme, "This scaffold starts from `ztd init`.", "phase-a scaffold-readme");
-  assertIncludes(readme, "The project is feature-first by default:", "phase-a scaffold-readme");
-  assertIncludes(
-    readme,
-    "local-source workspace output that resolves `rawsql-ts` packages through `file:` dependencies back to a monorepo checkout",
-    "phase-a scaffold-readme"
-  );
-  assertIncludes(
-    readme,
-    "Check `package.json` to see which mode you are in. If you see `file:` dependencies that point back to a monorepo checkout, this is a local-source workspace and the monorepo checkout is the source of truth.",
-    "phase-a scaffold-readme"
-  );
-  assertIncludes(readme, "Use this short prompt:", "phase-a scaffold-readme");
-  assertIncludes(readme, "Choose `ztd init` or `ztd init --starter` based on whether you want the removable starter sample.", "phase-a scaffold-readme");
-  assertIncludes(readme, "the same vocabulary appears in the README, CLI help, and tutorial docs", "phase-a scaffold-readme");
-  assertIncludes(readme, "The feature-first path is successful when:", "phase-a scaffold-readme");
-  assertExcludes(readme, "AGENTS.md", "phase-a scaffold-readme");
-  assertExcludes(readme, "PROMPT_DOGFOOD.md", "phase-a scaffold-readme");
-  assertExcludes(readme, "pnpm exec ztd ztd-config", "phase-a scaffold-readme");
+  const scaffoldPackageJson = readJsonFile(path.join(appDir, "package.json"));
+  assertPackageScript(scaffoldPackageJson, "test", "vitest run --passWithNoTests", "phase-a package-scripts");
+  assertPackageScript(scaffoldPackageJson, "typecheck", "tsc --noEmit", "phase-a package-scripts");
+  if (scaffoldPackageJson.scripts?.ztd !== undefined) {
+    throw new Error("[phase-a package-scripts] Default npm scaffold unexpectedly emitted a local-source ztd wrapper.");
+  }
+
+  assertFileMissing(appDir, "compose.yaml", "phase-a default-scaffold-shape");
+  assertFileMissing(appDir, "PROMPT_DOGFOOD.md", "phase-a default-scaffold-shape");
+  assertFileMissing(appDir, "CONTEXT.md", "phase-a default-scaffold-shape");
+  assertFileMissing(appDir, path.join("src", "features", "smoke", "queries", "smoke", "tests", "smoke.boundary.ztd.test.ts"), "phase-a default-scaffold-shape");
+  assertFileMissing(appDir, path.join(".ztd", "agents", "manifest.json"), "phase-a default-scaffold-shape");
 
   restoreTarballDependencies(appDir, tarballDependencies);
   runIn(appDir, NPM, ["install"]);
@@ -523,12 +567,27 @@ function verifyPnpmStarterPath(packages) {
   });
 
   runIn(appDir, PNPM, ["install", "--no-frozen-lockfile"]);
+  const dryRunPlan = runInitDryRunPlan(appDir, PNPM, [
+    "--starter",
+    "--workflow",
+    "demo",
+    "--validator",
+    "zod",
+  ]);
+  assertScaffoldPlanMetadata(dryRunPlan, {
+    dryRun: true,
+    schemaVersion: 1,
+    workflow: "demo",
+    validator: "zod",
+    starter: true,
+  }, "phase-c init-dry-run");
   runInstalledZtdCli(appDir, [
     "init",
     "--starter",
     "--yes",
     "--skip-install",
   ]);
+  assertScaffoldPlanFilesExist(appDir, dryRunPlan, "phase-c starter-scaffold-files");
 
   const scaffoldPackageJson = readPackageJson(appDir);
   scaffoldPackageJson.devDependencies = Object.fromEntries(
@@ -648,13 +707,25 @@ function verifyPnpmTutorialModelGen(packages) {
   ];
 
   if (process.env.ZTD_TEST_DATABASE_URL) {
-    runInstalledZtdCli(appDir, modelGenArgs);
+    try {
+      runInstalledZtdCli(appDir, modelGenArgs);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `[packaging contract] tutorial model-gen failed after starter scaffold setup. ` +
+        `Re-run "pnpm exec ztd ztd-config" and then retry pnpm exec ztd ${modelGenArgs.join(" ")}. ` +
+        `If Postgres just started, wait for readiness before rerunning. Original error: ${message}`,
+      );
+    }
     const generatedSpec = fs.readFileSync(
       path.join(appDir, "src", "features", "users", "persistence", "users.spec.ts"),
       "utf8",
     );
     if (!generatedSpec.includes("export interface")) {
-      throw new Error("[packaging contract] tutorial model-gen did not write the expected spec output.");
+      throw new Error(
+        "[packaging contract] tutorial model-gen did not write the expected spec output. " +
+        "Re-run pnpm exec ztd ztd-config, then rerun model-gen for src/features/users/persistence/users.sql.",
+      );
     }
   } else {
     const describeOutput = runInstalledZtdCli(appDir, [...modelGenArgs, "--describe-output", "--output", "json"]);
@@ -662,7 +733,9 @@ function verifyPnpmTutorialModelGen(packages) {
     const parsed = JSON.parse(describeOutput.stdout);
     if (parsed?.data?.outputs?.spec !== "TypeScript QuerySpec scaffold") {
       throw new Error(
-        `[packaging contract] tutorial model-gen describe output was unexpected: ${JSON.stringify(parsed)}`,
+        `[packaging contract] tutorial model-gen describe output was unexpected. ` +
+        `Re-run pnpm exec ztd ztd-config, then inspect the packed CLI model-gen output contract. ` +
+        `Received: ${JSON.stringify(parsed)}`,
       );
     }
   }

--- a/scripts/verify-published-package-mode.mjs
+++ b/scripts/verify-published-package-mode.mjs
@@ -288,7 +288,13 @@ function readJsonFile(filePath) {
 
 function runInitDryRunPlan(directory, packageManager, args) {
   const result = runIn(directory, packageManager, ["exec", "--", "ztd", "init", "--dry-run", "--yes", ...args]);
-  return JSON.parse(result.stdout);
+  const stdout = String(result.stdout ?? "");
+  const start = stdout.indexOf("{");
+  const end = stdout.lastIndexOf("}");
+  if (start < 0 || end < start) {
+    throw new Error(`[runInitDryRunPlan] Could not locate JSON plan in stdout:\n${stdout}`);
+  }
+  return JSON.parse(stdout.slice(start, end + 1));
 }
 
 function assertScaffoldPlanMetadata(plan, expected, label) {
@@ -499,11 +505,9 @@ function verifyNpmPrimaryPath(packages) {
   assertScaffoldPlanFilesExist(appDir, dryRunPlan, "phase-a scaffold-files");
 
   const scaffoldPackageJson = readJsonFile(path.join(appDir, "package.json"));
-  assertPackageScript(scaffoldPackageJson, "test", "vitest run --passWithNoTests", "phase-a package-scripts");
-  assertPackageScript(scaffoldPackageJson, "typecheck", "tsc --noEmit", "phase-a package-scripts");
-  if (scaffoldPackageJson.scripts?.ztd !== undefined) {
-    throw new Error("[phase-a package-scripts] Default npm scaffold unexpectedly emitted a local-source ztd wrapper.");
-  }
+  assertPackageScript(scaffoldPackageJson, "test", "node ./scripts/local-source-guard.mjs test --passWithNoTests", "phase-a package-scripts");
+  assertPackageScript(scaffoldPackageJson, "typecheck", "node ./scripts/local-source-guard.mjs typecheck", "phase-a package-scripts");
+  assertPackageScript(scaffoldPackageJson, "ztd", "node ./scripts/local-source-guard.mjs ztd", "phase-a package-scripts");
 
   assertFileMissing(appDir, "compose.yaml", "phase-a default-scaffold-shape");
   assertFileMissing(appDir, "PROMPT_DOGFOOD.md", "phase-a default-scaffold-shape");


### PR DESCRIPTION
## Summary

- fix `ztd init --dry-run` scaffold planning so it only reports files the scaffold actually creates
- keep app-interface dry-run plans additive instead of replacing the rest of the scaffold file list
- make published-package smoke parse the dry-run JSON payload even when command output includes surrounding logs
- add init dry-run regression coverage for duplicate smoke specs, generated-file overreporting, and app-interface planning

## Verification

- `node --check scripts/verify-published-package-mode.mjs`
- `corepack pnpm --filter @rawsql-ts/ztd-cli exec vitest run tests/cliCommands.test.ts -t "repository generated mapper drift check fails on stale mapper and passes after regeneration"`
- `corepack pnpm --filter @rawsql-ts/ztd-cli exec vitest run tests/init.command.test.ts -t "init dry-run plan"`
- `corepack pnpm --filter @rawsql-ts/ztd-cli build`
- `corepack pnpm verify:published-package-mode`

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue:
Scoped checks run:
Why full baseline is not required:

## Self Review

Self-review workflow: developer-self-review guidance with consistency review and human acceptance review
Self-review result: no blockers; PR body, verification evidence, and scaffold-contract claims are aligned with the current diff

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: the branch fixes dry-run contract drift and verification robustness without adding or removing supported commands, flags, or migration steps for users
Upgrade note:
Deprecation/removal plan or issue:
Docs/help/examples updated:
Release/changeset wording:

## Scaffold Contract Proof

- [ ] No scaffold contract proof required for this PR.
- [x] Scaffold contract proof completed.

No-proof rationale:
Non-edit assertion: `tests/init.command.test.ts` now asserts starter dry-run plans exclude `.gitignore` and `.ztd/generated/*` artifacts and do not duplicate `smoke.boundary.ztd.test.ts`
Fail-fast input-contract proof: `tests/init.command.test.ts -t "init dry-run plan"` verifies the app-interface path keeps the normal scaffold plan and adds `AGENTS.md` exactly once instead of replacing the file list
Generated-output viability proof: `corepack pnpm verify:published-package-mode` exercises the packed published-package smoke path that failed in GitHub Actions and now validates the scaffold against real generated outputs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `ztd init` dry-run now supports optional AI-guidance files, dogfooding prompts, and an app-interface marker.

* **Improvements**
  * Dry-run plan generation and validation made more precise; starter next-steps updated with an added readiness note.
  * Error and remediation messages improved for initialization and model-generation flows.

* **Tests**
  * Updated dry-run assertions and added unit checks verifying local-source guard script behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mk3008/rawsql-ts/pull/817)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->