### PR TITLE
ci: harden publish OIDC and cache boundaries

### DIFF
--- a/.github/actions/setup-publish-runtime/action.yml
+++ b/.github/actions/setup-publish-runtime/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: "Whether this job needs pnpm on PATH"
     required: false
     default: "true"
+  use-pnpm-cache:
+    description: "Whether to enable pnpm cache"
+    required: false
+    default: "true"
   install-dependencies:
     description: "Whether to run pnpm install --frozen-lockfile"
     required: false
@@ -53,7 +57,7 @@ runs:
         run_install: false
 
     - name: Setup Node with pnpm cache
-      if: ${{ inputs.use-pnpm == 'true' }}
+      if: ${{ inputs.use-pnpm == 'true' && inputs.use-pnpm-cache == 'true' }}
       uses: actions/setup-node@v5
       with:
         node-version: ${{ inputs.node-version }}
@@ -61,7 +65,7 @@ runs:
         registry-url: ${{ inputs.registry-url }}
 
     - name: Setup Node without pnpm cache
-      if: ${{ inputs.use-pnpm != 'true' }}
+      if: ${{ inputs.use-pnpm != 'true' || inputs.use-pnpm-cache != 'true' }}
       uses: actions/setup-node@v5
       with:
         node-version: ${{ inputs.node-version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,8 +17,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 env:
   READINESS_CONTRACT_ARTIFACT_NAME: publish-readiness-contract
@@ -34,6 +33,8 @@ env:
 jobs:
   verify_publish_readiness:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       should_publish: ${{ steps.plan.outputs.should_publish }}
     steps:
@@ -58,6 +59,7 @@ jobs:
         with:
           node-version: "24"
           use-pnpm: "true"
+          use-pnpm-cache: "false"
           install-dependencies: "true"
           update-npm: "false"
           required-commands: "node,npm,pnpm"
@@ -96,6 +98,8 @@ jobs:
     needs: verify_publish_readiness
     if: ${{ needs.verify_publish_readiness.outputs.should_publish == 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -104,6 +108,7 @@ jobs:
         with:
           node-version: "24"
           use-pnpm: "true"
+          use-pnpm-cache: "false"
           install-dependencies: "true"
           update-npm: "false"
           required-commands: "node,npm,pnpm"
@@ -150,6 +155,8 @@ jobs:
     needs: [verify_publish_readiness, build_publish_artifacts]
     if: ${{ needs.verify_publish_readiness.outputs.should_publish == 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -158,6 +165,7 @@ jobs:
         with:
           node-version: "24"
           use-pnpm: "true"
+          use-pnpm-cache: "false"
           install-dependencies: "true"
           update-npm: "false"
           required-commands: "node,npm,pnpm"
@@ -199,6 +207,9 @@ jobs:
     needs: [verify_publish_readiness, build_publish_artifacts, verify_publish_artifacts]
     if: ${{ needs.verify_publish_readiness.outputs.should_publish == 'true' && inputs.verification_mode != 'proof' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

- Harden the manual npm publish workflow by removing workflow-wide OIDC permission and granting `id-token: write` only to `actual_publish`.
- Keep publish preflight jobs read-only and disable pnpm dependency caching for the readiness, artifact build, and artifact verification jobs.
- Add `use-pnpm-cache` to `setup-publish-runtime` so pnpm can remain available without enabling the pnpm cache.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm test` after build: 347 files passed, 5 skipped; 3166 tests passed, 26 skipped.
- pre-commit hook: `pnpm typecheck`, `pnpm test`, `pnpm run build`, and `pnpm lint` all passed.
- `git diff --check`
- Static workflow inspection: workflow-level permissions are `contents: read`; only `actual_publish` has `contents: write` and `id-token: write`; publish preflight jobs pass `use-pnpm-cache: "false"`.

GitHub Actions workflow dispatch was not run from this local environment. The PR keeps the existing `verification_mode` conditions intact, including the `actual_publish` guard that excludes proof mode.

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

<!-- Write values on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. -->
<!-- Do not add list markers like "-" before these labels; `Tracking issue:` and `Scoped checks run:` must start at column 0. -->
Tracking issue: none
Scoped checks run: pnpm install --frozen-lockfile; pnpm run build; pnpm test; pre-commit typecheck/test/build/lint; git diff --check
Why full baseline is not required: Full local baseline was covered by the pre-commit hook and requested publish workflow checks.

## Self Review

<!-- Fill these fields after running the repo self-review workflow or available self-review skill. -->
Self-review workflow: self-review skill, plus repository PR readiness skill and local readiness script.
Self-review result: No blockers found; remaining GitHub Actions proof/release dispatch validation is explicitly not run locally.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-migration rationale: This changes GitHub Actions publish permissions and cache behavior only; no CLI command, help text, or user-facing CLI behavior changes.
Upgrade note: Not applicable.
Deprecation/removal plan or issue: Not applicable.
Docs/help/examples updated: Not applicable.
Release/changeset wording: Not applicable.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-proof rationale: This PR does not change scaffold templates, scaffold commands, or generated project output.
Non-edit assertion: Not applicable.
Fail-fast input-contract proof: Not applicable.
Generated-output viability proof: Not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal build and release process configuration for improved efficiency
  * Enhanced security controls in the publication workflow by implementing principle of least privilege for access permissions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mk3008/rawsql-ts/pull/821)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->