### PR TITLE
Add package scope review plan support

### DIFF
--- a/.changeset/scope-review-plan.md
+++ b/.changeset/scope-review-plan.md
@@ -1,0 +1,7 @@
+---
+"@rawsql-ts/ddl-docs-cli": minor
+---
+
+Add package scope rule validation and deterministic review-plan generation.
+
+`ddl-docs check` can now validate package-level scope rules and DDL relationship references to those rules, while `ddl-docs review-plan` emits review input JSON from changed files so AI and human reviews can read the relevant scope rules, concepts, DFDs, process maps, and DDL relationship metadata without rediscovering them by inference.

--- a/docs/scope/index.md
+++ b/docs/scope/index.md
@@ -1,0 +1,83 @@
+<!-- generated-by: transfer-docs -->
+
+# Transfer Package Scope Spec
+
+この文書は `@rawsql-ts/transfer` の Package Scope Spec である。
+
+これは Concept Spec ではない。個別概念の意味、責務、非責務、不変条件は `docs/concepts/` 配下の Concept Spec に置く。
+
+この文書は、package 全体の目的、所有境界、外部境界、非目標、全体不変条件、拡張方針を定義する scope harness である。
+
+## Purpose
+
+`@rawsql-ts/transfer` は、DB中心かつSQL-firstの転送制御 package である。
+
+この package は、転送元データソースをSQLで定義し、Destination / Destination Link に基づいて転送SQLと転送実行に必要な状態を管理する。
+
+## In Scope
+
+- SQL-based source definition
+- Destination
+- Destination Link
+- Dirty Key intake and persistence
+- Transfer Run
+- Work Item
+- Dirty Key Processing
+- Active Black
+- Lineage
+- generated transfer SQL metadata
+- DB内で評価可能なDDL、SQL、DB function hookを前提にした転送制御
+
+## Out of Scope
+
+- CDC engine の実装または所有
+- file loading の実装または所有
+- 外部resource ingestion の実装または所有
+- scheduler または runtime hosting environment の提供
+- source application の業務責務
+- destination table の業務意味
+- generated docs を source of truth として扱うこと
+
+## Owned Domains
+
+- transfer package が持つDDL、metadata、Concept Spec、DFD、Process Map
+- Dirty Key の受け口と永続化
+- transfer 実行時に必要なrun/work/current-state/history metadata
+- generated transfer SQL をレビュー可能な形で保持するためのmetadata
+
+## External Domains
+
+- 転送元テーブルの変更検知
+- CDC runtime
+- producer scheduling
+- file ingestion
+- runtime host
+- source application の業務判断
+- destination table が表す業務上の意味
+- package利用側が定義するDB functionや外部adapter
+
+## Global Invariants
+
+- transfer は DB-centered / SQL-first である。
+- transfer は generated SQL をレビュー不能な形へ隠さない。
+- transfer は source key や destination key を暗黙に推測しない。
+- transfer は logical model を人間レビュー可能な source of truth として扱う。
+- generated docs は review view であり、source of truth ではない。
+- AI は durable scope、concept、DFD、process meaning を決定しない。人間が承認する。
+
+## Extension Policy
+
+外部I/O、CDC、file loading、scheduler、runtime hosting を transfer core に入れる変更は scope expansion として扱う。
+
+新しい要件が既存scope内の変更か、新しいConcept追加か、外部producer / adapter の責務か、別packageの責務か、out of scopeかをレビューしてから実装へ進む。
+
+## Review Usage
+
+実装レビューでは、個別Conceptだけでなくこの Package Scope Spec も読む。
+
+`scope-rules.json` は、この文書の境界をAIとCLIが参照しやすくするための機械可読review indexである。仕様本文の代替ではない。
+
+## Source
+
+- `packages/transfer/docs/scope/SYSTEM_SCOPE.md`
+- `packages/transfer/docs/scope/scope-rules.json`

--- a/docs/transfer-docs.md
+++ b/docs/transfer-docs.md
@@ -25,6 +25,7 @@ Start with Concepts, then DFDs, then Processes, and finally Table Definitions wh
 
 ## Specification Views
 
+- [Scope](./scope/)
 - [Concepts](./concepts/)
 - [DFDs](./dfd/)
 - [Roles](./roles/)

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "verify:customer-consumers": "node scripts/verify-published-package-mode.mjs",
     "verify:published-package-mode": "node scripts/verify-published-package-mode.mjs",
     "verify:generated-project-mode": "node scripts/verify-generated-project-mode.mjs",
-    "verify:transfer-ddl-metadata": "pnpm --filter @rawsql-ts/ddl-docs-cli run build && node packages/ddl-docs-cli/dist/src/index.js check --ddl-dir packages/transfer/db/ddl --table-docs packages/transfer/db/ddl/table-docs.json --relationship packages/transfer/db/ddl/relationship.json --order packages/transfer/db/ddl/order.json --concept-relationship packages/transfer/docs/concepts/concept-relationship.json --dfd-relationship packages/transfer/docs/dfd/relationship.json --process-dir packages/transfer/docs/processes --default-schema rawsql_transfer",
+    "verify:transfer-ddl-metadata": "pnpm --filter @rawsql-ts/ddl-docs-cli run build && node packages/ddl-docs-cli/dist/src/index.js check --ddl-dir packages/transfer/db/ddl --table-docs packages/transfer/db/ddl/table-docs.json --relationship packages/transfer/db/ddl/relationship.json --order packages/transfer/db/ddl/order.json --concept-relationship packages/transfer/docs/concepts/concept-relationship.json --dfd-relationship packages/transfer/docs/dfd/relationship.json --scope-rules packages/transfer/docs/scope/scope-rules.json --process-dir packages/transfer/docs/processes --default-schema rawsql_transfer",
     "verify:transfer-docs": "pnpm verify:transfer-ddl-metadata && pnpm docs:transfer && pnpm verify:transfer-ddl-metadata && node scripts/verify-transfer-docs-drift.mjs"
   },
   "keywords": [

--- a/packages/ddl-docs-cli/src/cli.ts
+++ b/packages/ddl-docs-cli/src/cli.ts
@@ -3,7 +3,8 @@ import { runCheckDocs } from './commands/check';
 import { runGenerateConceptSite } from './commands/conceptSite';
 import { runGenerateDocs } from './commands/generate';
 import { runPruneDocs } from './commands/prune';
-import type { CheckDocsOptions, GenerateConceptSiteOptions, GenerateDocsOptions, PruneDocsOptions } from './types';
+import { runReviewPlan } from './commands/reviewPlan';
+import type { CheckDocsOptions, GenerateConceptSiteOptions, GenerateDocsOptions, PruneDocsOptions, ReviewPlanOptions } from './types';
 import { dedupeDdlInputsByInstanceAndPath } from './utils/ddlInputDedupe';
 
 const DEFAULT_DDL_DIRECTORY = 'ztd/ddl';
@@ -30,7 +31,7 @@ export async function runCli(argv: string[]): Promise<void> {
       printHelp('all');
       return;
     }
-    if (target === 'generate' || target === 'prune' || target === 'check' || target === 'concept-site') {
+    if (target === 'generate' || target === 'prune' || target === 'check' || target === 'concept-site' || target === 'review-plan') {
       printHelp(target);
       return;
     }
@@ -70,6 +71,15 @@ export async function runCli(argv: string[]): Promise<void> {
       return;
     }
     runGenerateConceptSite(options);
+    return;
+  }
+
+  if (command === 'review-plan') {
+    const options = parseReviewPlanOptions(rest);
+    if (!options) {
+      return;
+    }
+    runReviewPlan(options);
     return;
   }
 
@@ -269,6 +279,7 @@ function parseCheckOptions(args: string[]): CheckDocsOptions | null {
     orderPath: undefined,
     conceptRelationshipPath: undefined,
     dfdRelationshipPath: undefined,
+    scopeRulesPath: undefined,
     processDirectories: [],
     configPath: undefined,
     defaultSchema: undefined,
@@ -335,6 +346,11 @@ function parseCheckOptions(args: string[]): CheckDocsOptions | null {
       continue;
     }
 
+    if (arg === '--scope-rules') {
+      options.scopeRulesPath = readRequiredValue(args, ++index, '--scope-rules');
+      continue;
+    }
+
     if (arg === '--process-dir') {
       options.processDirectories?.push(readRequiredValue(args, ++index, '--process-dir'));
       continue;
@@ -371,6 +387,91 @@ function parseCheckOptions(args: string[]): CheckDocsOptions | null {
   options.ddlFiles = dedupeDdlInputsByInstanceAndPath(options.ddlFiles);
   options.ddlGlobs = dedupeDdlInputsByInstanceAndPath(options.ddlGlobs);
   options.extensions = dedupe(options.extensions);
+  return options;
+}
+
+function parseReviewPlanOptions(args: string[]): ReviewPlanOptions | null {
+  const options: ReviewPlanOptions = {
+    changedFilesPath: '',
+    ddlDirectories: [],
+    relationshipPath: undefined,
+    tableDocsPath: undefined,
+    conceptRelationshipPath: undefined,
+    dfdRelationshipPath: undefined,
+    processDirectories: [],
+    scopeRulesPath: undefined,
+    scopeDocPath: undefined,
+    outPath: undefined,
+    packageName: undefined,
+  };
+
+  let currentInstance = '';
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === '--changed-files') {
+      options.changedFilesPath = readRequiredValue(args, ++index, '--changed-files');
+      continue;
+    }
+    if (arg === '--ddl-instance') {
+      currentInstance = readRequiredValue(args, ++index, '--ddl-instance');
+      continue;
+    }
+    if (arg === '--ddl-dir') {
+      options.ddlDirectories.push({ path: readRequiredValue(args, ++index, '--ddl-dir'), instance: currentInstance });
+      continue;
+    }
+    if (arg === '--relationship') {
+      options.relationshipPath = readRequiredValue(args, ++index, '--relationship');
+      continue;
+    }
+    if (arg === '--table-docs') {
+      options.tableDocsPath = readRequiredValue(args, ++index, '--table-docs');
+      continue;
+    }
+    if (arg === '--concept-relationship') {
+      options.conceptRelationshipPath = readRequiredValue(args, ++index, '--concept-relationship');
+      continue;
+    }
+    if (arg === '--dfd-relationship') {
+      options.dfdRelationshipPath = readRequiredValue(args, ++index, '--dfd-relationship');
+      continue;
+    }
+    if (arg === '--process-dir') {
+      options.processDirectories?.push(readRequiredValue(args, ++index, '--process-dir'));
+      continue;
+    }
+    if (arg === '--scope-rules') {
+      options.scopeRulesPath = readRequiredValue(args, ++index, '--scope-rules');
+      continue;
+    }
+    if (arg === '--scope-doc') {
+      options.scopeDocPath = readRequiredValue(args, ++index, '--scope-doc');
+      continue;
+    }
+    if (arg === '--package') {
+      options.packageName = readRequiredValue(args, ++index, '--package');
+      continue;
+    }
+    if (arg === '--out') {
+      options.outPath = readRequiredValue(args, ++index, '--out');
+      continue;
+    }
+    if (arg === '--help' || arg === '-h') {
+      printHelp('review-plan');
+      return null;
+    }
+    throw new Error(`Unknown option for review-plan: ${arg}`);
+  }
+
+  if (!options.changedFilesPath) {
+    throw new Error('review-plan requires --changed-files.');
+  }
+  if (options.ddlDirectories.length === 0) {
+    options.ddlDirectories = [{ path: DEFAULT_DDL_DIRECTORY, instance: '' }];
+  }
+  options.ddlDirectories = dedupeDdlInputsByInstanceAndPath(options.ddlDirectories);
   return options;
 }
 
@@ -443,7 +544,7 @@ function dedupe(values: string[]): string[] {
   return Array.from(new Set(values));
 }
 
-function printHelp(target: 'all' | 'generate' | 'prune' | 'check' | 'concept-site'): void {
+function printHelp(target: 'all' | 'generate' | 'prune' | 'check' | 'concept-site' | 'review-plan'): void {
   const generateHelp = `ddl-docs generate [options]
   --ddl-instance <name>   DB instance name for subsequent --ddl-dir/--ddl-file/--ddl-glob (repeatable)
   --ddl-dir <directory>   Recursively scan DDL files under directory (repeatable)
@@ -487,6 +588,7 @@ function printHelp(target: 'all' | 'generate' | 'prune' | 'check' | 'concept-sit
   --order <path>                 Optional DDL execution order metadata json
   --concept-relationship <path>  Optional concept relationship registry json
   --dfd-relationship <path>      Optional DFD relationship metadata json
+  --scope-rules <path>           Optional package scope rules metadata json
   --process-dir <directory>      Optional Process Map directory for logical-model checks (repeatable)
   --default-schema <name>        Override default schema for unqualified tables
   --search-path <list>           Comma-separated schema search path
@@ -497,6 +599,20 @@ function printHelp(target: 'all' | 'generate' | 'prune' | 'check' | 'concept-sit
   --concept-relationship <path>  Concept relationship registry json
   --dfd-relationship <path>      Optional DFD relationship metadata json
   --out-dir <directory>          Output root directory for generated VitePress pages
+`;
+
+  const reviewPlanHelp = `ddl-docs review-plan [options]
+  --changed-files <path>         Newline list or JSON array of changed files
+  --ddl-dir <directory>          DDL directory used to classify DDL changed files (repeatable)
+  --relationship <path>          Optional DDL relationship metadata json
+  --table-docs <path>            Optional table documentation metadata json
+  --concept-relationship <path>  Optional concept relationship registry json
+  --dfd-relationship <path>      Optional DFD relationship metadata json
+  --process-dir <directory>      Optional Process Map directory (repeatable)
+  --scope-rules <path>           Optional package scope rules metadata json
+  --scope-doc <path>             Optional package scope markdown source
+  --package <name>               Package name for the review plan
+  --out <path>                   Write JSON output to file instead of stdout
 `;
 
   if (target === 'generate') {
@@ -515,6 +631,10 @@ function printHelp(target: 'all' | 'generate' | 'prune' | 'check' | 'concept-sit
     console.log(conceptSiteHelp);
     return;
   }
+  if (target === 'review-plan') {
+    console.log(reviewPlanHelp);
+    return;
+  }
 
   console.log(`ddl-docs <command> [options]
 
@@ -523,10 +643,12 @@ Commands:
   prune                  Remove stale generated markdown docs
   check                  Check DDL review metadata references
   concept-site           Generate VitePress Concept Spec review pages from concept metadata
+  review-plan            Build deterministic review input JSON from changed files
   help [command]         Show help for all commands or one command
 
 ${generateHelp}
 ${pruneHelp}
 ${checkHelp}
-${conceptSiteHelp}`);
+${conceptSiteHelp}
+${reviewPlanHelp}`);
 }

--- a/packages/ddl-docs-cli/src/commands/check.ts
+++ b/packages/ddl-docs-cli/src/commands/check.ts
@@ -30,14 +30,48 @@ interface RelationshipEntry {
   path: string;
   kind: string;
   reason?: string;
+  scopeRules?: RelationshipScopeRuleRef[];
   concepts?: RelationshipTarget[];
   processes?: RelationshipTarget[];
+}
+
+interface RelationshipScopeRuleRef {
+  id: string;
+  reason?: string;
 }
 
 interface RelationshipTarget {
   path: string;
   reason?: string;
 }
+
+interface ScopeRulesMetadata {
+  schemaVersion: 1;
+  metadataLanguagePolicy?: unknown;
+  scopeRules: ScopeRuleEntry[];
+}
+
+interface ScopeRuleEntry {
+  id: string;
+  kind: ScopeRuleKind;
+  statement: string;
+  reviewRisk?: string;
+  riskProbes?: string[];
+  allowedInstead?: string[];
+  reviewAction?: string;
+  ownedDomains?: string[];
+  externalDomains?: string[];
+}
+
+type ScopeRuleKind =
+  | 'purpose'
+  | 'in-scope'
+  | 'out-of-scope'
+  | 'global-invariant'
+  | 'ownership-boundary'
+  | 'extension-policy'
+  | 'assumption'
+  | 'review-policy';
 
 interface OrderMetadata {
   schemaVersion: 1;
@@ -169,6 +203,16 @@ interface ProcessMapViewEntry {
 const CONCEPT_SUMMARY_MAX_LENGTH = 160;
 const CONCEPT_METADATA_NOTE_MAX_LENGTH = 240;
 const PROCESS_MAP_RULE_REFERENCE_TARGET = 'concept-spec-overview.md#process-map-rules';
+const SCOPE_RULE_KINDS = new Set<ScopeRuleKind>([
+  'purpose',
+  'in-scope',
+  'out-of-scope',
+  'global-invariant',
+  'ownership-boundary',
+  'extension-policy',
+  'assumption',
+  'review-policy',
+]);
 
 /**
  * Checks DDL review metadata for structural drift.
@@ -206,8 +250,11 @@ export function checkDocs(options: CheckDocsOptions): CheckDocsResult {
     ? readConceptRegistry(options.conceptRelationshipPath, issues)
     : { allIds: new Set<string>(), definedIds: new Set<string>() };
   const conceptIds = conceptRegistry.allIds;
-  const processIds = options.relationshipPath ? readProcessIds(options.relationshipPath, issues) : new Set<string>();
+  const processIds = readProcessIdsFromProcessMapMetadata(options.processDirectories ?? [], issues);
   const processFiles = collectProcessMapFiles(options.relationshipPath, options.processDirectories ?? [], issues);
+  const scopeRuleRegistry = options.scopeRulesPath
+    ? readScopeRuleRegistry(options.scopeRulesPath, issues)
+    : undefined;
 
   if (options.tableDocsPath) {
     checkTableDocsMetadata(options.tableDocsPath, tableIndex, { conceptIds, processIds }, issues);
@@ -216,7 +263,7 @@ export function checkDocs(options: CheckDocsOptions): CheckDocsResult {
     checkOrderMetadata(options.orderPath, sources, issues);
   }
   if (options.relationshipPath) {
-    checkRelationshipMetadata(options.relationshipPath, sources, issues);
+    checkRelationshipMetadata(options.relationshipPath, sources, scopeRuleRegistry, issues);
   }
   if (options.conceptRelationshipPath) {
     checkConceptRelationshipMetadata(options.conceptRelationshipPath, issues);
@@ -465,7 +512,12 @@ function checkOrderMetadata(orderPath: string, sources: SqlSource[], issues: Che
   }
 }
 
-function checkRelationshipMetadata(relationshipPath: string, sources: SqlSource[], issues: CheckIssue[]): void {
+function checkRelationshipMetadata(
+  relationshipPath: string,
+  sources: SqlSource[],
+  scopeRuleRegistry: Set<string> | undefined,
+  issues: CheckIssue[]
+): void {
   const resolvedPath = path.resolve(process.cwd(), relationshipPath);
   const value = readJsonFile(resolvedPath, 'relationship.json', issues);
   if (!value) {
@@ -512,6 +564,9 @@ function checkRelationshipMetadata(relationshipPath: string, sources: SqlSource[
     for (const target of entry.processes ?? []) {
       checkRelationshipTarget(baseDir, 'process', entry.path, target, issues);
     }
+    for (const scopeRule of entry.scopeRules ?? []) {
+      checkRelationshipScopeRule(entry.path, scopeRule, scopeRuleRegistry, issues);
+    }
   }
 
   for (const ddlPath of ddlPaths) {
@@ -522,6 +577,36 @@ function checkRelationshipMetadata(relationshipPath: string, sources: SqlSource[
         message: `DDL file is not registered in relationship.json: ${ddlPath}`,
       });
     }
+  }
+}
+
+function checkRelationshipScopeRule(
+  entryPath: string,
+  scopeRule: RelationshipScopeRuleRef,
+  scopeRuleRegistry: Set<string> | undefined,
+  issues: CheckIssue[]
+): void {
+  if (!scopeRuleRegistry) {
+    issues.push({
+      severity: 'warning',
+      code: 'RELATIONSHIP_SCOPE_RULES_WITHOUT_REGISTRY',
+      message: `relationship.json references scope rule without --scope-rules validation for ${entryPath}: ${scopeRule.id}`,
+    });
+    return;
+  }
+  if (!scopeRuleRegistry.has(scopeRule.id)) {
+    issues.push({
+      severity: 'error',
+      code: 'RELATIONSHIP_UNKNOWN_SCOPE_RULE',
+      message: `relationship.json references unknown scope rule for ${entryPath}: ${scopeRule.id}`,
+    });
+  }
+  if (scopeRule.reason !== undefined && scopeRule.reason.trim() === '') {
+    issues.push({
+      severity: 'warning',
+      code: 'RELATIONSHIP_EMPTY_SCOPE_RULE_REASON',
+      message: `relationship.json scope rule reason is empty for ${entryPath}: ${scopeRule.id}`,
+    });
   }
 }
 
@@ -1305,16 +1390,57 @@ function readConceptRegistry(conceptRelationshipPath: string, issues: CheckIssue
   };
 }
 
-function readProcessIds(relationshipPath: string, issues: CheckIssue[]): Set<string> {
-  const resolvedPath = path.resolve(process.cwd(), relationshipPath);
-  const value = readJsonFile(resolvedPath, 'relationship.json', issues);
-  if (!isRelationshipMetadata(value)) {
+function readScopeRuleRegistry(scopeRulesPath: string, issues: CheckIssue[]): Set<string> {
+  const resolvedPath = path.resolve(process.cwd(), scopeRulesPath);
+  const value = readJsonFile(resolvedPath, 'scope-rules.json', issues);
+  if (!value) {
+    return new Set();
+  }
+  if (!isScopeRulesMetadata(value)) {
+    issues.push({
+      severity: 'error',
+      code: 'SCOPE_RULES_SCHEMA_ERROR',
+      message: `scope-rules.json must be an object with schemaVersion: 1 and scopeRules[]: ${resolvedPath}`,
+    });
     return new Set();
   }
   const ids = new Set<string>();
-  for (const entry of value.relationships) {
-    for (const process of entry.processes ?? []) {
-      ids.add(path.basename(process.path, path.extname(process.path)));
+  for (const scopeRule of value.scopeRules) {
+    if (ids.has(scopeRule.id)) {
+      issues.push({
+        severity: 'error',
+        code: 'SCOPE_RULE_DUPLICATE_ID',
+        message: `scope-rules.json contains duplicate scope rule id: ${scopeRule.id}`,
+      });
+    }
+    ids.add(scopeRule.id);
+    if (!SCOPE_RULE_KINDS.has(scopeRule.kind)) {
+      issues.push({
+        severity: 'error',
+        code: 'SCOPE_RULE_UNKNOWN_KIND',
+        message: `scope-rules.json uses unknown scope rule kind for ${scopeRule.id}: ${scopeRule.kind}`,
+      });
+    }
+    if (scopeRule.statement.trim() === '') {
+      issues.push({
+        severity: 'error',
+        code: 'SCOPE_RULE_EMPTY_STATEMENT',
+        message: `scope-rules.json scope rule statement must not be empty: ${scopeRule.id}`,
+      });
+    }
+  }
+  return ids;
+}
+
+function readProcessIdsFromProcessMapMetadata(processDirectories: string[], issues: CheckIssue[]): Set<string> {
+  const ids = new Set<string>();
+  for (const processMapPath of collectProcessMapMetadataPaths(processDirectories)) {
+    const value = readJsonFile(processMapPath, 'process-map.json', issues);
+    if (!isProcessMapMetadata(value)) {
+      continue;
+    }
+    for (const processMap of value.processMaps ?? []) {
+      ids.add(processMap.id);
     }
   }
   return ids;
@@ -1439,8 +1565,43 @@ function isRelationshipMetadata(value: unknown): value is RelationshipMetadata {
     if (entry.reason !== undefined && typeof entry.reason !== 'string') {
       return false;
     }
-    return isTargetArray(entry.concepts) && isTargetArray(entry.processes);
+    return isScopeRuleRefArray(entry.scopeRules)
+      && isTargetArray(entry.concepts)
+      && isTargetArray(entry.processes);
   });
+}
+
+function isScopeRulesMetadata(value: unknown): value is ScopeRulesMetadata {
+  if (!isRecord(value) || value.schemaVersion !== 1 || !Array.isArray(value.scopeRules)) {
+    return false;
+  }
+  return value.scopeRules.every((entry) =>
+    isRecord(entry)
+      && typeof entry.id === 'string'
+      && typeof entry.kind === 'string'
+      && typeof entry.statement === 'string'
+      && (entry.reviewRisk === undefined || typeof entry.reviewRisk === 'string')
+      && isOptionalStringArray(entry.riskProbes)
+      && isOptionalStringArray(entry.allowedInstead)
+      && isOptionalStringArray(entry.ownedDomains)
+      && isOptionalStringArray(entry.externalDomains)
+      && (entry.reviewAction === undefined || typeof entry.reviewAction === 'string')
+  );
+}
+
+function isScopeRuleRefArray(value: unknown): value is RelationshipScopeRuleRef[] | undefined {
+  if (value === undefined) {
+    return true;
+  }
+  return Array.isArray(value) && value.every((entry) =>
+    isRecord(entry)
+      && typeof entry.id === 'string'
+      && (entry.reason === undefined || typeof entry.reason === 'string')
+  );
+}
+
+function isOptionalStringArray(value: unknown): value is string[] | undefined {
+  return value === undefined || (Array.isArray(value) && value.every((entry) => typeof entry === 'string'));
 }
 
 function isTargetArray(value: unknown): value is RelationshipTarget[] | undefined {

--- a/packages/ddl-docs-cli/src/commands/reviewPlan.ts
+++ b/packages/ddl-docs-cli/src/commands/reviewPlan.ts
@@ -1,0 +1,591 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import {
+  loadConceptRegistry,
+  loadDdlRelationshipMetadata,
+  loadDfdRegistry,
+  type ConceptRegistry,
+  type DdlRelationshipEntry,
+  type DdlRelationshipMetadata,
+  type DfdRegistry,
+} from '../relationshipMetadata';
+import type { ReviewPlanOptions } from '../types';
+
+type ArtifactKind =
+  | 'ddl'
+  | 'table-docs-metadata'
+  | 'ddl-relationship-metadata'
+  | 'concept-spec'
+  | 'concept-relationship-metadata'
+  | 'dfd'
+  | 'dfd-relationship-metadata'
+  | 'process-map'
+  | 'scope-spec'
+  | 'scope-rules'
+  | 'generated-doc'
+  | 'script'
+  | 'workflow'
+  | 'unknown';
+
+type ReviewClass =
+  | 'business-bearing'
+  | 'metadata'
+  | 'generated-review-view'
+  | 'mechanical-support'
+  | 'workflow-support'
+  | 'unknown';
+
+interface ScopeRulesMetadata {
+  schemaVersion: 1;
+  scopeRules: ScopeRuleEntry[];
+}
+
+interface ScopeRuleEntry {
+  id: string;
+  kind: string;
+  statement: string;
+  reviewRisk?: string;
+}
+
+interface ProcessRegistry {
+  processes: ProcessRegistryEntry[];
+}
+
+interface ProcessRegistryEntry {
+  id: string;
+  path: string;
+}
+
+interface ReviewPlanDiagnostic {
+  severity: 'warning' | 'error';
+  message: string;
+}
+
+interface RequiredReads {
+  scopeRules: string[];
+  concepts: string[];
+  dfds: string[];
+  processes: string[];
+  ddlRelationships: string[];
+}
+
+interface ChangedFileReviewPlan {
+  path: string;
+  artifactKind: ArtifactKind;
+  reviewClass: ReviewClass;
+  packageWideImpact?: boolean;
+  requiredReads: RequiredReads;
+  reviewRisks: string[];
+  diagnostics: ReviewPlanDiagnostic[];
+}
+
+interface ReviewPlan {
+  schemaVersion: 1;
+  package: string;
+  mandatoryScope: {
+    files: string[];
+    rules: Array<{ id: string; reason: string }>;
+  };
+  changedFiles: ChangedFileReviewPlan[];
+  unmappedArtifacts: ChangedFileReviewPlan[];
+  generatedDrift: {
+    status: 'not-checked';
+  };
+  reviewCoverage: Array<{ artifact: string; status: 'unknown' }>;
+}
+
+const MANDATORY_SCOPE_RULES = [
+  {
+    id: 'db-centered-transfer',
+    reason: 'All transfer changes must be checked against the DB-centered transfer invariant.',
+  },
+  {
+    id: 'human-owned-logical-model',
+    reason: 'Logical model changes require semantic review against human-owned meaning.',
+  },
+  {
+    id: 'generated-docs-not-source',
+    reason: 'Generated docs must not be reviewed as source of truth.',
+  },
+] as const;
+
+export function runReviewPlan(options: ReviewPlanOptions): ReviewPlan {
+  const plan = buildReviewPlan(options);
+  const json = `${JSON.stringify(plan, null, 2)}\n`;
+  if (options.outPath) {
+    writeFileSync(path.resolve(process.cwd(), options.outPath), json);
+  } else {
+    process.stdout.write(json);
+  }
+  return plan;
+}
+
+export function buildReviewPlan(options: ReviewPlanOptions): ReviewPlan {
+  const changedFiles = readChangedFiles(options.changedFilesPath);
+  const ddlRelationship = loadDdlRelationshipMetadata(options.relationshipPath);
+  const conceptRegistry = loadConceptRegistry(options.conceptRelationshipPath);
+  const dfdRegistry = loadDfdRegistry(options.dfdRelationshipPath);
+  const processRegistry = loadProcessRegistry(options.processDirectories ?? []);
+  const scopeRules = loadScopeRules(options.scopeRulesPath);
+
+  const changedFilePlans = changedFiles.map((changedFile) =>
+    buildChangedFilePlan(changedFile, {
+      options,
+      ddlRelationship,
+      conceptRegistry,
+      dfdRegistry,
+      processRegistry,
+      scopeRules,
+    })
+  );
+
+  return {
+    schemaVersion: 1,
+    package: options.packageName ?? '@rawsql-ts/transfer',
+    mandatoryScope: {
+      files: [options.scopeDocPath, options.scopeRulesPath].filter((entry): entry is string => Boolean(entry)),
+      rules: MANDATORY_SCOPE_RULES.filter((rule) => scopeRules.has(rule.id)),
+    },
+    changedFiles: changedFilePlans,
+    unmappedArtifacts: changedFilePlans.filter((entry) =>
+      entry.reviewRisks.includes('unmapped-business-artifact')
+    ),
+    generatedDrift: {
+      status: 'not-checked',
+    },
+    reviewCoverage: [
+      ...(options.scopeDocPath ? [{ artifact: options.scopeDocPath, status: 'unknown' as const }] : []),
+      ...(options.scopeRulesPath ? [{ artifact: options.scopeRulesPath, status: 'unknown' as const }] : []),
+    ],
+  };
+}
+
+function buildChangedFilePlan(
+  changedFile: string,
+  context: {
+    options: ReviewPlanOptions;
+    ddlRelationship: DdlRelationshipMetadata | undefined;
+    conceptRegistry: ConceptRegistry | undefined;
+    dfdRegistry: DfdRegistry | undefined;
+    processRegistry: ProcessRegistry;
+    scopeRules: Map<string, ScopeRuleEntry>;
+  }
+): ChangedFileReviewPlan {
+  const normalizedPath = normalizeRelativePath(changedFile);
+  const artifactKind = classifyArtifactKind(normalizedPath, context.options);
+  const reviewClass = classifyReviewClass(artifactKind);
+  const basePlan: ChangedFileReviewPlan = {
+    path: normalizedPath,
+    artifactKind,
+    reviewClass,
+    requiredReads: emptyRequiredReads(),
+    reviewRisks: [],
+    diagnostics: [],
+  };
+
+  if (artifactKind === 'scope-spec' || artifactKind === 'scope-rules') {
+    basePlan.packageWideImpact = true;
+    basePlan.requiredReads.scopeRules = MANDATORY_SCOPE_RULES
+      .filter((rule) => context.scopeRules.has(rule.id))
+      .map((rule) => rule.id);
+    basePlan.reviewRisks.push('package-scope-impact');
+    return basePlan;
+  }
+
+  if (artifactKind === 'ddl') {
+    applyDdlRelationship(basePlan, context);
+  }
+
+  if (artifactKind === 'concept-spec') {
+    const conceptId = resolveConceptIdForPath(normalizedPath, context.conceptRegistry);
+    if (conceptId) {
+      basePlan.requiredReads.concepts = [conceptId];
+    } else {
+      basePlan.diagnostics.push({
+        severity: 'warning',
+        message: 'Concept Spec changed file is not registered in concept-relationship metadata.',
+      });
+    }
+  }
+
+  if (artifactKind === 'dfd') {
+    applyDfdRelationship(basePlan, context.dfdRegistry);
+  }
+
+  if (artifactKind === 'process-map') {
+    const processId = resolveProcessIdForPath(normalizedPath, context.processRegistry);
+    if (processId) {
+      basePlan.requiredReads.processes = [processId];
+    } else {
+      basePlan.diagnostics.push({
+        severity: 'warning',
+        message: 'Process Map changed file is not registered in process-map metadata.',
+      });
+    }
+  }
+
+  return basePlan;
+}
+
+function applyDdlRelationship(
+  plan: ChangedFileReviewPlan,
+  context: {
+    options: ReviewPlanOptions;
+    ddlRelationship: DdlRelationshipMetadata | undefined;
+    conceptRegistry: ConceptRegistry | undefined;
+    dfdRegistry: DfdRegistry | undefined;
+    processRegistry: ProcessRegistry;
+    scopeRules: Map<string, ScopeRuleEntry>;
+  }
+): void {
+  const entry = findDdlRelationshipEntry(plan.path, context.ddlRelationship);
+  plan.requiredReads.ddlRelationships = context.options.relationshipPath ? [context.options.relationshipPath] : [];
+  if (!entry) {
+    plan.requiredReads.scopeRules = ['db-centered-transfer'].filter((id) => context.scopeRules.has(id));
+    plan.reviewRisks.push('unmapped-business-artifact');
+    plan.diagnostics.push({
+      severity: 'warning',
+      message: 'This DDL file has no relationship metadata entry.',
+    });
+    return;
+  }
+
+  plan.requiredReads.scopeRules = dedupe(entry.scopeRules.map((scopeRule) => scopeRule.id));
+  plan.requiredReads.concepts = dedupe(
+    entry.concepts
+      .map((target) => resolveConceptIdForRelationshipTarget(target.path, context.ddlRelationship, context.conceptRegistry))
+      .filter((entry): entry is string => Boolean(entry))
+  );
+  plan.requiredReads.processes = dedupe(
+    entry.processes
+      .map((target) => resolveProcessIdForRelationshipTarget(target.path, context.ddlRelationship, context.processRegistry))
+      .filter((entry): entry is string => Boolean(entry))
+  );
+  for (const target of entry.processes) {
+    const processId = resolveProcessIdForRelationshipTarget(target.path, context.ddlRelationship, context.processRegistry);
+    if (!processId) {
+      plan.diagnostics.push({
+        severity: 'warning',
+        message: `Process target could not be resolved from structured metadata: ${target.path}`,
+      });
+    }
+  }
+  const dfdReads = collectDfdReadsForConcepts(new Set(plan.requiredReads.concepts), context.dfdRegistry);
+  plan.requiredReads.dfds = dedupe(dfdReads.dfds);
+  plan.requiredReads.processes = dedupe([...plan.requiredReads.processes, ...dfdReads.processes]);
+  plan.reviewRisks = dedupe(
+    plan.requiredReads.scopeRules
+      .map((scopeRuleId) => context.scopeRules.get(scopeRuleId)?.reviewRisk)
+      .filter((entry): entry is string => Boolean(entry))
+  );
+  if (
+    plan.requiredReads.scopeRules.length === 0
+    && plan.requiredReads.concepts.length === 0
+    && plan.requiredReads.processes.length === 0
+  ) {
+    plan.reviewRisks.push('unmapped-business-artifact');
+    plan.diagnostics.push({
+      severity: 'warning',
+      message: 'This DDL file has no concept, process, scope rule, or explicit technical-support relationship.',
+    });
+  }
+}
+
+function collectDfdReadsForConcepts(
+  conceptIds: Set<string>,
+  dfdRegistry: DfdRegistry | undefined
+): { dfds: string[]; processes: string[] } {
+  if (!dfdRegistry || conceptIds.size === 0) {
+    return { dfds: [], processes: [] };
+  }
+  const dfds = new Set<string>();
+  const processes = new Set<string>();
+  for (const dfd of dfdRegistry.dfds) {
+    let dfdMatched = false;
+    for (const operation of dfd.businessOperations ?? []) {
+      let operationMatched = false;
+      const refs = [...(operation.inputs ?? []), ...(operation.outputs ?? []), ...(operation.uses ?? [])];
+      for (const ref of refs) {
+        if (ref.type === 'concept' && conceptIds.has(ref.id)) {
+          operationMatched = true;
+        }
+        if (ref.type === 'concept-group') {
+          const group = dfdRegistry.conceptGroups.find((entry) => entry.id === ref.id);
+          if (group?.members.some((member) => member.type === 'concept' && conceptIds.has(member.id))) {
+            operationMatched = true;
+          }
+        }
+      }
+      if (operationMatched) {
+        dfdMatched = true;
+        for (const process of operation.relatedProcesses ?? []) {
+          processes.add(process.id);
+        }
+      }
+    }
+    if (dfdMatched) {
+      dfds.add(dfd.id);
+    }
+  }
+  return {
+    dfds: Array.from(dfds).sort(),
+    processes: Array.from(processes).sort(),
+  };
+}
+
+function applyDfdRelationship(plan: ChangedFileReviewPlan, dfdRegistry: DfdRegistry | undefined): void {
+  if (!dfdRegistry) {
+    return;
+  }
+  const dfd = dfdRegistry.dfds.find((entry) =>
+    normalizeRelativePath(path.relative(process.cwd(), path.resolve(dfdRegistry.baseDir, entry.path))) === plan.path
+  );
+  if (!dfd) {
+    plan.diagnostics.push({
+      severity: 'warning',
+      message: 'DFD changed file is not registered in DFD relationship metadata.',
+    });
+    return;
+  }
+  plan.requiredReads.dfds = [dfd.id];
+  const concepts = new Set<string>();
+  const processes = new Set<string>();
+  for (const operation of dfd.businessOperations ?? []) {
+    for (const ref of [...(operation.inputs ?? []), ...(operation.outputs ?? []), ...(operation.uses ?? [])]) {
+      if (ref.type === 'concept') {
+        concepts.add(ref.id);
+      }
+      if (ref.type === 'concept-group') {
+        const group = dfdRegistry.conceptGroups.find((entry) => entry.id === ref.id);
+        for (const member of group?.members ?? []) {
+          if (member.type === 'concept') {
+            concepts.add(member.id);
+          }
+        }
+      }
+    }
+    for (const process of operation.relatedProcesses ?? []) {
+      processes.add(process.id);
+    }
+  }
+  plan.requiredReads.concepts = Array.from(concepts).sort();
+  plan.requiredReads.processes = Array.from(processes).sort();
+}
+
+function readChangedFiles(changedFilesPath: string): string[] {
+  const resolvedPath = path.resolve(process.cwd(), changedFilesPath);
+  const body = readFileSync(resolvedPath, 'utf8').trim();
+  if (!body) {
+    return [];
+  }
+  if (body.startsWith('[')) {
+    const value = JSON.parse(body) as unknown;
+    if (!Array.isArray(value) || !value.every((entry) => typeof entry === 'string')) {
+      throw new Error(`changed files JSON must be a string array: ${resolvedPath}`);
+    }
+    return value.map(normalizeRelativePath);
+  }
+  return body
+    .split(/\r?\n/)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map(normalizeRelativePath);
+}
+
+function loadScopeRules(scopeRulesPath: string | undefined): Map<string, ScopeRuleEntry> {
+  if (!scopeRulesPath) {
+    return new Map();
+  }
+  const resolvedPath = path.resolve(process.cwd(), scopeRulesPath);
+  const raw = JSON.parse(readFileSync(resolvedPath, 'utf8')) as unknown;
+  if (!isScopeRulesMetadata(raw)) {
+    throw new Error(`scope-rules metadata must have schemaVersion: 1 and scopeRules[]: ${resolvedPath}`);
+  }
+  return new Map(raw.scopeRules.map((entry) => [entry.id, entry]));
+}
+
+function loadProcessRegistry(processDirectories: string[]): ProcessRegistry {
+  const processes: ProcessRegistryEntry[] = [];
+  for (const directory of processDirectories) {
+    const resolvedDirectory = path.resolve(process.cwd(), directory);
+    const processMapPath = path.join(resolvedDirectory, 'process-map.json');
+    if (!existsSync(processMapPath)) {
+      continue;
+    }
+    const raw = JSON.parse(readFileSync(processMapPath, 'utf8')) as unknown;
+    if (!isRecord(raw) || raw.schemaVersion !== 1 || !Array.isArray(raw.processMaps)) {
+      throw new Error(`process-map metadata must have schemaVersion: 1 and processMaps[]: ${processMapPath}`);
+    }
+    for (const entry of raw.processMaps) {
+      if (!isRecord(entry) || typeof entry.id !== 'string' || typeof entry.path !== 'string') {
+        throw new Error(`process-map entry must include id and path: ${processMapPath}`);
+      }
+      processes.push({ id: entry.id, path: normalizeRelativePath(path.relative(process.cwd(), path.resolve(resolvedDirectory, entry.path))) });
+    }
+  }
+  return { processes };
+}
+
+function classifyArtifactKind(changedFile: string, options: ReviewPlanOptions): ArtifactKind {
+  if (options.scopeDocPath && samePath(changedFile, options.scopeDocPath)) {
+    return 'scope-spec';
+  }
+  if (options.scopeRulesPath && samePath(changedFile, options.scopeRulesPath)) {
+    return 'scope-rules';
+  }
+  if (options.relationshipPath && samePath(changedFile, options.relationshipPath)) {
+    return 'ddl-relationship-metadata';
+  }
+  if (options.tableDocsPath && samePath(changedFile, options.tableDocsPath)) {
+    return 'table-docs-metadata';
+  }
+  if (options.conceptRelationshipPath && samePath(changedFile, options.conceptRelationshipPath)) {
+    return 'concept-relationship-metadata';
+  }
+  if (options.dfdRelationshipPath && samePath(changedFile, options.dfdRelationshipPath)) {
+    return 'dfd-relationship-metadata';
+  }
+  if (changedFile.includes('/docs/concepts/') && changedFile.endsWith('.md')) {
+    return 'concept-spec';
+  }
+  if (changedFile.includes('/docs/dfd/') && changedFile.endsWith('.md')) {
+    return 'dfd';
+  }
+  if (changedFile.includes('/docs/processes/') && changedFile.endsWith('.md')) {
+    return 'process-map';
+  }
+  if (isDdlPath(changedFile, options)) {
+    return 'ddl';
+  }
+  if (changedFile.startsWith('docs/')) {
+    return 'generated-doc';
+  }
+  if (changedFile.startsWith('.github/workflows/')) {
+    return 'workflow';
+  }
+  if (changedFile.startsWith('scripts/') || changedFile.includes('/scripts/')) {
+    return 'script';
+  }
+  return 'unknown';
+}
+
+function classifyReviewClass(kind: ArtifactKind): ReviewClass {
+  if (kind === 'generated-doc') {
+    return 'generated-review-view';
+  }
+  if (kind.endsWith('-metadata') || kind === 'scope-rules') {
+    return 'metadata';
+  }
+  if (kind === 'script') {
+    return 'mechanical-support';
+  }
+  if (kind === 'workflow') {
+    return 'workflow-support';
+  }
+  if (kind === 'ddl' || kind === 'concept-spec' || kind === 'dfd' || kind === 'process-map' || kind === 'scope-spec') {
+    return 'business-bearing';
+  }
+  return 'unknown';
+}
+
+function isDdlPath(changedFile: string, options: ReviewPlanOptions): boolean {
+  if (!changedFile.endsWith('.sql')) {
+    return false;
+  }
+  return options.ddlDirectories.some((entry) => {
+    const ddlDir = normalizeRelativePath(entry.path).replace(/\/$/, '');
+    return changedFile.startsWith(`${ddlDir}/`);
+  });
+}
+
+function findDdlRelationshipEntry(
+  changedFile: string,
+  relationshipMetadata: DdlRelationshipMetadata | undefined
+): DdlRelationshipEntry | undefined {
+  if (!relationshipMetadata) {
+    return undefined;
+  }
+  const changedRelativeToRelationship = normalizeRelativePath(
+    path.relative(relationshipMetadata.baseDir, path.resolve(process.cwd(), changedFile))
+  );
+  return relationshipMetadata.relationships.find((entry) => entry.path === changedRelativeToRelationship);
+}
+
+function resolveConceptIdForRelationshipTarget(
+  targetPath: string,
+  relationshipMetadata: DdlRelationshipMetadata | undefined,
+  conceptRegistry: ConceptRegistry | undefined
+): string | undefined {
+  if (!relationshipMetadata || !conceptRegistry) {
+    return undefined;
+  }
+  const resolvedTarget = path.resolve(relationshipMetadata.baseDir, targetPath);
+  return conceptRegistry.concepts.find((entry) =>
+    entry.path != null && path.resolve(conceptRegistry.baseDir, entry.path) === resolvedTarget
+  )?.id;
+}
+
+function resolveProcessIdForRelationshipTarget(
+  targetPath: string,
+  relationshipMetadata: DdlRelationshipMetadata | undefined,
+  processRegistry: ProcessRegistry
+): string | undefined {
+  if (!relationshipMetadata) {
+    return undefined;
+  }
+  const resolvedTarget = normalizeRelativePath(path.relative(process.cwd(), path.resolve(relationshipMetadata.baseDir, targetPath)));
+  return processRegistry.processes.find((entry) => entry.path === resolvedTarget)?.id;
+}
+
+function resolveConceptIdForPath(
+  changedFile: string,
+  conceptRegistry: ConceptRegistry | undefined
+): string | undefined {
+  return conceptRegistry?.concepts.find((entry) =>
+    entry.path != null
+      && normalizeRelativePath(path.relative(process.cwd(), path.resolve(conceptRegistry.baseDir, entry.path))) === changedFile
+  )?.id;
+}
+
+function resolveProcessIdForPath(changedFile: string, processRegistry: ProcessRegistry): string | undefined {
+  return processRegistry.processes.find((entry) => entry.path === changedFile)?.id;
+}
+
+function emptyRequiredReads(): RequiredReads {
+  return {
+    scopeRules: [],
+    concepts: [],
+    dfds: [],
+    processes: [],
+    ddlRelationships: [],
+  };
+}
+
+function samePath(left: string, right: string): boolean {
+  return normalizeRelativePath(left) === normalizeRelativePath(right);
+}
+
+function dedupe(values: string[]): string[] {
+  return Array.from(new Set(values)).sort();
+}
+
+function normalizeRelativePath(value: string): string {
+  return value.replace(/\\/g, '/').replace(/^\.\//, '');
+}
+
+function isScopeRulesMetadata(value: unknown): value is ScopeRulesMetadata {
+  return isRecord(value)
+    && value.schemaVersion === 1
+    && Array.isArray(value.scopeRules)
+    && value.scopeRules.every((entry) =>
+      isRecord(entry)
+        && typeof entry.id === 'string'
+        && typeof entry.kind === 'string'
+        && typeof entry.statement === 'string'
+        && (entry.reviewRisk === undefined || typeof entry.reviewRisk === 'string')
+    );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/ddl-docs-cli/src/relationshipMetadata.ts
+++ b/packages/ddl-docs-cli/src/relationshipMetadata.ts
@@ -12,8 +12,14 @@ export interface DdlRelationshipEntry {
   path: string;
   kind: string;
   reason?: string;
+  scopeRules: DdlRelationshipScopeRuleRef[];
   concepts: DdlRelationshipTarget[];
   processes: DdlRelationshipTarget[];
+}
+
+export interface DdlRelationshipScopeRuleRef {
+  id: string;
+  reason?: string;
 }
 
 export interface DdlRelationshipTarget {
@@ -154,6 +160,7 @@ export function loadDdlRelationshipMetadata(metadataPath: string | undefined): D
         path: normalizeRelativePath(entry.path),
         kind: entry.kind,
         reason: typeof entry.reason === 'string' ? entry.reason : undefined,
+        scopeRules: parseScopeRuleRefs(entry.scopeRules, resolvedPath),
         concepts: parseTargets(entry.concepts, resolvedPath),
         processes: parseTargets(entry.processes, resolvedPath),
       };
@@ -554,6 +561,24 @@ function parseTargets(value: unknown, sourcePath: string): DdlRelationshipTarget
     }
     return {
       path: entry.path,
+      reason: typeof entry.reason === 'string' ? entry.reason : undefined,
+    };
+  });
+}
+
+function parseScopeRuleRefs(value: unknown, sourcePath: string): DdlRelationshipScopeRuleRef[] {
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new Error(`DDL relationship scopeRules must be an array when provided: ${sourcePath}`);
+  }
+  return value.map((entry) => {
+    if (!isRecord(entry) || typeof entry.id !== 'string') {
+      throw new Error(`DDL relationship scope rule reference must include id: ${sourcePath}`);
+    }
+    return {
+      id: entry.id,
       reason: typeof entry.reason === 'string' ? entry.reason : undefined,
     };
   });

--- a/packages/ddl-docs-cli/src/types.ts
+++ b/packages/ddl-docs-cli/src/types.ts
@@ -42,11 +42,26 @@ export interface CheckDocsOptions {
   orderPath?: string;
   conceptRelationshipPath?: string;
   dfdRelationshipPath?: string;
+  scopeRulesPath?: string;
   processDirectories?: string[];
   configPath?: string;
   defaultSchema?: string;
   searchPath?: string[];
   filterPgDump?: boolean;
+}
+
+export interface ReviewPlanOptions {
+  changedFilesPath: string;
+  ddlDirectories: DdlInput[];
+  relationshipPath?: string;
+  tableDocsPath?: string;
+  conceptRelationshipPath?: string;
+  dfdRelationshipPath?: string;
+  processDirectories?: string[];
+  scopeRulesPath?: string;
+  scopeDocPath?: string;
+  outPath?: string;
+  packageName?: string;
 }
 
 export interface GenerateConceptSiteOptions {

--- a/packages/ddl-docs-cli/tests/check.integration.test.ts
+++ b/packages/ddl-docs-cli/tests/check.integration.test.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { expect, test } from 'vitest';
 import { checkDocs, runCheckDocs } from '../src/commands/check';
+import { buildReviewPlan } from '../src/commands/reviewPlan';
 
 const repoRoot = path.resolve(__dirname, '..', '..', '..');
 const tmpRoot = path.join(repoRoot, 'tmp');
@@ -760,4 +761,208 @@ test('check fails when order metadata does not cover discovered DDL files', () =
   });
 
   expect(result.errors.map((issue) => issue.code)).toContain('ORDER_UNTRACKED_DDL_FILE');
+});
+
+test('check validates scope rules and relationship scope references', () => {
+  const work = createTempDir('ddl-docs-check-scope-rules');
+  const ddlDir = path.join(work, 'ddl');
+  const scopeRulesPath = path.join(work, 'docs', 'scope', 'scope-rules.json');
+  const relationshipPath = path.join(ddlDir, 'relationship.json');
+
+  writeText(path.join(ddlDir, 'accounts.sql'), 'CREATE TABLE public.accounts (account_id bigint PRIMARY KEY);');
+  writeText(scopeRulesPath, JSON.stringify({
+    schemaVersion: 1,
+    scopeRules: [
+      { id: 'db-centered-transfer', kind: 'global-invariant', statement: 'DB centered.' },
+      { id: 'dirty-key-intake-only', kind: 'ownership-boundary', statement: 'Dirty Key intake only.' },
+    ],
+  }, null, 2));
+  writeText(relationshipPath, JSON.stringify({
+    schemaVersion: 1,
+    relationships: [
+      {
+        path: 'accounts.sql',
+        kind: 'table-ddl',
+        scopeRules: [{ id: 'dirty-key-intake-only' }],
+      },
+    ],
+  }, null, 2));
+
+  const result = checkDocs({
+    ddlDirectories: [{ path: ddlDir, instance: '' }],
+    ddlFiles: [],
+    ddlGlobs: [],
+    extensions: ['.sql'],
+    relationshipPath,
+    scopeRulesPath,
+  });
+
+  expect(result.errors).toHaveLength(0);
+});
+
+test('check reports invalid scope rule metadata', () => {
+  const work = createTempDir('ddl-docs-check-invalid-scope-rules');
+  const ddlDir = path.join(work, 'ddl');
+  const scopeRulesPath = path.join(work, 'docs', 'scope', 'scope-rules.json');
+
+  writeText(path.join(ddlDir, 'accounts.sql'), 'CREATE TABLE public.accounts (account_id bigint PRIMARY KEY);');
+  writeText(scopeRulesPath, JSON.stringify({
+    schemaVersion: 1,
+    scopeRules: [
+      { id: 'duplicate', kind: 'global-invariant', statement: 'A.' },
+      { id: 'duplicate', kind: 'global-invariant', statement: 'B.' },
+      { id: 'unknown-kind', kind: 'not-a-kind', statement: 'C.' },
+    ],
+  }, null, 2));
+
+  const result = checkDocs({
+    ddlDirectories: [{ path: ddlDir, instance: '' }],
+    ddlFiles: [],
+    ddlGlobs: [],
+    extensions: ['.sql'],
+    scopeRulesPath,
+  });
+
+  expect(result.errors.map((issue) => issue.code)).toContain('SCOPE_RULE_DUPLICATE_ID');
+  expect(result.errors.map((issue) => issue.code)).toContain('SCOPE_RULE_UNKNOWN_KIND');
+});
+
+test('check fails when relationship metadata references an unknown scope rule', () => {
+  const work = createTempDir('ddl-docs-check-unknown-scope-rule');
+  const ddlDir = path.join(work, 'ddl');
+  const scopeRulesPath = path.join(work, 'docs', 'scope', 'scope-rules.json');
+  const relationshipPath = path.join(ddlDir, 'relationship.json');
+
+  writeText(path.join(ddlDir, 'accounts.sql'), 'CREATE TABLE public.accounts (account_id bigint PRIMARY KEY);');
+  writeText(scopeRulesPath, JSON.stringify({
+    schemaVersion: 1,
+    scopeRules: [
+      { id: 'db-centered-transfer', kind: 'global-invariant', statement: 'DB centered.' },
+    ],
+  }, null, 2));
+  writeText(relationshipPath, JSON.stringify({
+    schemaVersion: 1,
+    relationships: [
+      {
+        path: 'accounts.sql',
+        kind: 'table-ddl',
+        scopeRules: [{ id: 'missing-scope-rule' }],
+      },
+    ],
+  }, null, 2));
+
+  const result = checkDocs({
+    ddlDirectories: [{ path: ddlDir, instance: '' }],
+    ddlFiles: [],
+    ddlGlobs: [],
+    extensions: ['.sql'],
+    relationshipPath,
+    scopeRulesPath,
+  });
+
+  expect(result.errors.map((issue) => issue.code)).toContain('RELATIONSHIP_UNKNOWN_SCOPE_RULE');
+});
+
+test('review-plan resolves DDL required reads from relationship metadata', () => {
+  const work = createTempDir('ddl-docs-review-plan');
+  const ddlDir = path.join(work, 'ddl');
+  const conceptsDir = path.join(work, 'docs', 'concepts');
+  const processesDir = path.join(work, 'docs', 'processes');
+  const scopeDir = path.join(work, 'docs', 'scope');
+  const changedFilesPath = path.join(work, 'changed-files.txt');
+  const relationshipPath = path.join(ddlDir, 'relationship.json');
+  const conceptRelationshipPath = path.join(conceptsDir, 'concept-relationship.json');
+  const scopeRulesPath = path.join(scopeDir, 'scope-rules.json');
+  const scopeDocPath = path.join(scopeDir, 'SYSTEM_SCOPE.md');
+
+  writeText(path.join(ddlDir, 'accounts.sql'), 'CREATE TABLE public.accounts (account_id bigint PRIMARY KEY);');
+  writeText(path.join(conceptsDir, 'account/SPEC.md'), '# Account Concept\n');
+  writeText(path.join(processesDir, 'account-process.md'), '# Account Process\n');
+  writeText(scopeDocPath, '# Scope\n');
+  writeText(changedFilesPath, `${path.join(ddlDir, 'accounts.sql')}\n`);
+  writeText(scopeRulesPath, JSON.stringify({
+    schemaVersion: 1,
+    scopeRules: [
+      { id: 'db-centered-transfer', kind: 'global-invariant', statement: 'DB centered.', reviewRisk: 'architecture-boundary' },
+      { id: 'human-owned-logical-model', kind: 'review-policy', statement: 'Human-owned.' },
+      { id: 'generated-docs-not-source', kind: 'global-invariant', statement: 'Generated docs are views.' },
+      { id: 'account-scope', kind: 'ownership-boundary', statement: 'Account scope.', reviewRisk: 'ownership-boundary' },
+    ],
+  }, null, 2));
+  writeText(relationshipPath, JSON.stringify({
+    schemaVersion: 1,
+    relationships: [
+      {
+        path: 'accounts.sql',
+        kind: 'table-ddl',
+        scopeRules: [{ id: 'account-scope' }],
+        concepts: [{ path: '../docs/concepts/account/SPEC.md' }],
+        processes: [{ path: '../docs/processes/account-process.md' }],
+      },
+    ],
+  }, null, 2));
+  writeText(conceptRelationshipPath, JSON.stringify({
+    schemaVersion: 1,
+    concepts: [{ id: 'account', path: 'account/SPEC.md', status: 'defined' }],
+  }, null, 2));
+  writeText(path.join(processesDir, 'process-map.json'), JSON.stringify({
+    schemaVersion: 1,
+    processMaps: [{ id: 'account-process', path: 'account-process.md' }],
+  }, null, 2));
+
+  const plan = buildReviewPlan({
+    changedFilesPath,
+    ddlDirectories: [{ path: ddlDir, instance: '' }],
+    relationshipPath,
+    conceptRelationshipPath,
+    processDirectories: [processesDir],
+    scopeRulesPath,
+    scopeDocPath,
+  });
+
+  expect(plan.mandatoryScope.files).toContain(scopeDocPath);
+  expect(plan.mandatoryScope.rules.map((rule) => rule.id)).toEqual([
+    'db-centered-transfer',
+    'human-owned-logical-model',
+    'generated-docs-not-source',
+  ]);
+  expect(plan.changedFiles[0]?.requiredReads.scopeRules).toEqual(['account-scope']);
+  expect(plan.changedFiles[0]?.requiredReads.concepts).toEqual(['account']);
+  expect(plan.changedFiles[0]?.requiredReads.processes).toEqual(['account-process']);
+  expect(plan.changedFiles[0]?.reviewRisks).toEqual(['ownership-boundary']);
+});
+
+test('review-plan reports unmapped DDL and classifies generated docs as review views', () => {
+  const work = createTempDir('ddl-docs-review-plan-unmapped');
+  const ddlDir = path.join(work, 'ddl');
+  const scopeDir = path.join(work, 'docs', 'scope');
+  const changedFilesPath = path.join(work, 'changed-files.txt');
+  const scopeRulesPath = path.join(scopeDir, 'scope-rules.json');
+  const scopeDocPath = path.join(scopeDir, 'SYSTEM_SCOPE.md');
+
+  writeText(path.join(ddlDir, 'unmapped.sql'), 'CREATE TABLE public.unmapped (id bigint PRIMARY KEY);');
+  writeText(scopeDocPath, '# Scope\n');
+  const unmappedDdlPath = path.join(ddlDir, 'unmapped.sql');
+  writeText(changedFilesPath, [
+    unmappedDdlPath,
+    'docs/concepts/account.md',
+  ].join('\n'));
+  writeText(scopeRulesPath, JSON.stringify({
+    schemaVersion: 1,
+    scopeRules: [
+      { id: 'db-centered-transfer', kind: 'global-invariant', statement: 'DB centered.' },
+      { id: 'human-owned-logical-model', kind: 'review-policy', statement: 'Human-owned.' },
+      { id: 'generated-docs-not-source', kind: 'global-invariant', statement: 'Generated docs are views.' },
+    ],
+  }, null, 2));
+
+  const plan = buildReviewPlan({
+    changedFilesPath,
+    ddlDirectories: [{ path: ddlDir, instance: '' }],
+    scopeRulesPath,
+    scopeDocPath,
+  });
+
+  expect(plan.unmappedArtifacts.map((entry) => entry.path)).toContain(unmappedDdlPath.replace(/\\/g, '/'));
+  expect(plan.changedFiles.find((entry) => entry.path === 'docs/concepts/account.md')?.reviewClass).toBe('generated-review-view');
 });

--- a/packages/transfer/db/ddl/relationship.json
+++ b/packages/transfer/db/ddl/relationship.json
@@ -10,6 +10,16 @@
     {
       "path": "dirty_key.sql",
       "kind": "table-ddl",
+      "scopeRules": [
+        {
+          "id": "dirty-key-intake-only",
+          "reason": "dirty_key は変更検知producerではなく、Dirty Key の受け口と永続化を担う。"
+        },
+        {
+          "id": "no-cdc-engine",
+          "reason": "Dirty Key は CDC から登録されてもよいが、CDC実装は transfer core の外側にある。"
+        }
+      ],
       "concepts": [
         {
           "path": "../../docs/concepts/dirty-key/SPEC.md",
@@ -20,6 +30,12 @@
     {
       "path": "destination_definition.sql",
       "kind": "table-ddl",
+      "scopeRules": [
+        {
+          "id": "db-centered-transfer",
+          "reason": "Destination は DB上の転送先定義としてSQL生成と転送実行に使われる。"
+        }
+      ],
       "concepts": [
         {
           "path": "../../docs/concepts/destination/SPEC.md",
@@ -34,6 +50,12 @@
     {
       "path": "setting.sql",
       "kind": "table-ddl",
+      "scopeRules": [
+        {
+          "id": "db-centered-transfer",
+          "reason": "Transfer Setting は SQL-based source definition を保持する。"
+        }
+      ],
       "concepts": [
         {
           "path": "../../docs/concepts/transfer-setting/SPEC.md",
@@ -44,6 +66,12 @@
     {
       "path": "destination_link.sql",
       "kind": "table-ddl",
+      "scopeRules": [
+        {
+          "id": "db-centered-transfer",
+          "reason": "Destination Link は generated transfer SQL metadata とDestination接続をDB上で保持する。"
+        }
+      ],
       "concepts": [
         {
           "path": "../../docs/concepts/destination-link/SPEC.md",
@@ -59,6 +87,16 @@
     {
       "path": "run.sql",
       "kind": "table-ddl",
+      "scopeRules": [
+        {
+          "id": "db-centered-transfer",
+          "reason": "Transfer Run はDB内の転送実行コンテキストとして管理する。"
+        },
+        {
+          "id": "no-runtime-hosting",
+          "reason": "Transfer Run は実行記録であり、schedulerやruntime hostそのものではない。"
+        }
+      ],
       "concepts": [
         {
           "path": "../../docs/concepts/transfer-run/SPEC.md",
@@ -75,6 +113,12 @@
     {
       "path": "active_black.sql",
       "kind": "table-ddl",
+      "scopeRules": [
+        {
+          "id": "db-centered-transfer",
+          "reason": "Active Black は転送プロセス内で参照するcurrent-state tableである。"
+        }
+      ],
       "concepts": [
         {
           "path": "../../docs/concepts/active-black/SPEC.md",
@@ -91,6 +135,12 @@
     {
       "path": "work_item.sql",
       "kind": "table-ddl",
+      "scopeRules": [
+        {
+          "id": "db-centered-transfer",
+          "reason": "Work Item はDirty Keyを転送実行内で固定化したDB上の作業対象である。"
+        }
+      ],
       "concepts": [
         {
           "path": "../../docs/concepts/work-item/SPEC.md",
@@ -107,6 +157,12 @@
     {
       "path": "lineage.sql",
       "kind": "table-ddl",
+      "scopeRules": [
+        {
+          "id": "db-centered-transfer",
+          "reason": "Lineage はDB上の転送結果追跡情報として保持する。"
+        }
+      ],
       "concepts": [
         {
           "path": "../../docs/concepts/lineage/SPEC.md",
@@ -127,6 +183,16 @@
     {
       "path": "dirty_key_processing.sql",
       "kind": "table-ddl",
+      "scopeRules": [
+        {
+          "id": "dirty-key-intake-only",
+          "reason": "Dirty Key Processing はDirty Keyの処理済み記録であり、変更検知そのものではない。"
+        },
+        {
+          "id": "db-centered-transfer",
+          "reason": "Dirty Key Processing は転送実行内の重複処理防止をDB上で記録する。"
+        }
+      ],
       "concepts": [
         {
           "path": "../../docs/concepts/dirty-key-processing/SPEC.md",

--- a/packages/transfer/db/ddl/table-docs.json
+++ b/packages/transfer/db/ddl/table-docs.json
@@ -305,7 +305,7 @@
         "active-black"
       ],
       "processRefs": [
-        "transfer-execution-process"
+        "transfer-execution"
       ],
       "tradeoff": [
         "Destination Link と source key から現在有効な黒伝を高速に見つけるため、source_key_hash をlookup補助値として保持する。",

--- a/packages/transfer/docs/scope/SYSTEM_SCOPE.md
+++ b/packages/transfer/docs/scope/SYSTEM_SCOPE.md
@@ -1,0 +1,76 @@
+# Transfer Package Scope Spec
+
+この文書は `@rawsql-ts/transfer` の Package Scope Spec である。
+
+これは Concept Spec ではない。個別概念の意味、責務、非責務、不変条件は `docs/concepts/` 配下の Concept Spec に置く。
+
+この文書は、package 全体の目的、所有境界、外部境界、非目標、全体不変条件、拡張方針を定義する scope harness である。
+
+## Purpose
+
+`@rawsql-ts/transfer` は、DB中心かつSQL-firstの転送制御 package である。
+
+この package は、転送元データソースをSQLで定義し、Destination / Destination Link に基づいて転送SQLと転送実行に必要な状態を管理する。
+
+## In Scope
+
+- SQL-based source definition
+- Destination
+- Destination Link
+- Dirty Key intake and persistence
+- Transfer Run
+- Work Item
+- Dirty Key Processing
+- Active Black
+- Lineage
+- generated transfer SQL metadata
+- DB内で評価可能なDDL、SQL、DB function hookを前提にした転送制御
+
+## Out of Scope
+
+- CDC engine の実装または所有
+- file loading の実装または所有
+- 外部resource ingestion の実装または所有
+- scheduler または runtime hosting environment の提供
+- source application の業務責務
+- destination table の業務意味
+- generated docs を source of truth として扱うこと
+
+## Owned Domains
+
+- transfer package が持つDDL、metadata、Concept Spec、DFD、Process Map
+- Dirty Key の受け口と永続化
+- transfer 実行時に必要なrun/work/current-state/history metadata
+- generated transfer SQL をレビュー可能な形で保持するためのmetadata
+
+## External Domains
+
+- 転送元テーブルの変更検知
+- CDC runtime
+- producer scheduling
+- file ingestion
+- runtime host
+- source application の業務判断
+- destination table が表す業務上の意味
+- package利用側が定義するDB functionや外部adapter
+
+## Global Invariants
+
+- transfer は DB-centered / SQL-first である。
+- transfer は generated SQL をレビュー不能な形へ隠さない。
+- transfer は source key や destination key を暗黙に推測しない。
+- transfer は logical model を人間レビュー可能な source of truth として扱う。
+- generated docs は review view であり、source of truth ではない。
+- AI は durable scope、concept、DFD、process meaning を決定しない。人間が承認する。
+
+## Extension Policy
+
+外部I/O、CDC、file loading、scheduler、runtime hosting を transfer core に入れる変更は scope expansion として扱う。
+
+新しい要件が既存scope内の変更か、新しいConcept追加か、外部producer / adapter の責務か、別packageの責務か、out of scopeかをレビューしてから実装へ進む。
+
+## Review Usage
+
+実装レビューでは、個別Conceptだけでなくこの Package Scope Spec も読む。
+
+`scope-rules.json` は、この文書の境界をAIとCLIが参照しやすくするための機械可読review indexである。仕様本文の代替ではない。

--- a/packages/transfer/docs/scope/scope-rules.json
+++ b/packages/transfer/docs/scope/scope-rules.json
@@ -1,0 +1,74 @@
+{
+  "schemaVersion": 1,
+  "metadataLanguagePolicy": {
+    "humanFacingLanguage": "ja",
+    "generatedViewLanguage": "en",
+    "policy": "CLI-generated boilerplate may be English. Human-authored docs and AI-authored human-facing metadata should use the package human-facing language unless a file explicitly overrides it."
+  },
+  "scopeRules": [
+    {
+      "id": "db-centered-transfer",
+      "kind": "global-invariant",
+      "statement": "transfer は DB-centered / SQL-first の転送制御 package である。",
+      "reviewRisk": "architecture-boundary",
+      "riskProbes": [
+        "この変更は転送実行中にDB外部I/Oを必要としていないか。",
+        "この変更は generated SQL をレビュー不能な形に隠していないか。",
+        "この変更は利用アプリ固有の業務ロジックを transfer core に移していないか。"
+      ]
+    },
+    {
+      "id": "human-owned-logical-model",
+      "kind": "review-policy",
+      "statement": "安定した論理モデルの意味は人間が所有し、AIはdraftや候補提案を行う。",
+      "reviewRisk": "review-authority"
+    },
+    {
+      "id": "generated-docs-not-source",
+      "kind": "global-invariant",
+      "statement": "generated docs は review view であり、source of truth ではない。",
+      "reviewRisk": "source-of-truth-drift"
+    },
+    {
+      "id": "dirty-key-intake-only",
+      "kind": "ownership-boundary",
+      "statement": "transfer は Dirty Key の受け口と永続化を所有するが、変更検知そのものは所有しない。",
+      "reviewRisk": "ownership-boundary",
+      "ownedDomains": [
+        "dirty-key table",
+        "dirty-key processing records"
+      ],
+      "externalDomains": [
+        "source table mutation detection",
+        "CDC runtime",
+        "producer scheduling"
+      ]
+    },
+    {
+      "id": "no-cdc-engine",
+      "kind": "out-of-scope",
+      "statement": "transfer は CDC engine を実装または所有しない。",
+      "reviewRisk": "scope-creep",
+      "allowedInstead": [
+        "external producer writes Dirty Key",
+        "database trigger writes Dirty Key",
+        "manual process writes Dirty Key"
+      ],
+      "reviewAction": "CDC ownership は scope expansion として扱う。"
+    },
+    {
+      "id": "no-file-load",
+      "kind": "out-of-scope",
+      "statement": "transfer は file loading または external resource ingestion を所有しない。",
+      "reviewRisk": "scope-creep",
+      "reviewAction": "file loading は upstream producer、adapter、または別packageの責務として扱う。"
+    },
+    {
+      "id": "no-runtime-hosting",
+      "kind": "out-of-scope",
+      "statement": "transfer は runtime hosting environment または scheduler を提供しない。",
+      "reviewRisk": "scope-creep",
+      "reviewAction": "runtime execution は CLI、Lambda adapter、または別host boundaryの責務として扱う。"
+    }
+  ]
+}

--- a/scripts/generate-transfer-docs.mjs
+++ b/scripts/generate-transfer-docs.mjs
@@ -41,6 +41,30 @@ function copyDir(sourcePath, targetPath) {
   fs.cpSync(source, target, { recursive: true });
 }
 
+function copyScopeDoc() {
+  const sourcePath = path.join(workspaceRoot, "packages", "transfer", "docs", "scope", "SYSTEM_SCOPE.md");
+  const targetDir = path.join(workspaceRoot, "docs", "scope");
+  const targetPath = path.join(targetDir, "index.md");
+  removeDir(targetDir);
+  fs.mkdirSync(assertInsideWorkspace(targetDir), { recursive: true });
+  const body = fs.readFileSync(assertInsideWorkspace(sourcePath), "utf8");
+  fs.writeFileSync(
+    assertInsideWorkspace(targetPath),
+    [
+      "<!-- generated-by: transfer-docs -->",
+      "",
+      body.trimEnd(),
+      "",
+      "## Source",
+      "",
+      "- `packages/transfer/docs/scope/SYSTEM_SCOPE.md`",
+      "- `packages/transfer/docs/scope/scope-rules.json`",
+      "",
+    ].join("\n"),
+    "utf8"
+  );
+}
+
 function writeProductReviewReport() {
   const ddlReviewPath = path.join(workspaceRoot, "docs", "rawsql-transfer", "review.md");
   const productReviewPath = path.join(workspaceRoot, "docs", "review.md");
@@ -129,6 +153,7 @@ run([
 for (const dir of generatedSiteDirs) {
   copyDir(path.join(tempConceptSiteDir, dir), path.join(workspaceRoot, "docs", dir));
 }
+copyScopeDoc();
 
 removeDir(path.join(workspaceRoot, "docs", "rawsql-transfer"));
 run([

--- a/scripts/verify-transfer-docs-drift.mjs
+++ b/scripts/verify-transfer-docs-drift.mjs
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 
 const generatedPaths = [
   'docs/transfer-docs.md',
+  'docs/scope',
   'docs/review.md',
   'docs/concepts',
   'docs/dfd',


### PR DESCRIPTION
## Summary

- Adds Package Scope Spec metadata for @rawsql-ts/transfer and validates scope rule references from DDL relationship metadata.
- Adds ddl-docs review-plan so changed files deterministically report required scope, concept, DFD, process, and DDL relationship reads for AI/human review.
- Wires transfer docs generation and verification to include the scope entry point and scope metadata checks.

## Verification

- pnpm --filter @rawsql-ts/ddl-docs-cli run build
- pnpm --filter @rawsql-ts/ddl-docs-cli test
- pnpm verify:transfer-docs
- pre-commit hook ran workspace typecheck, tests, build, and lint successfully during commit

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: not needed; no baseline exception requested.
Scoped checks run: not needed; no baseline exception requested.
Why full baseline is not required: full baseline exception path not used for this PR.

## Self Review

Self-review workflow: self-review skill: two-cycle blocker/evidence review before PR authoring.
Self-review result: no unresolved self-review blockers; remaining semantic scope acceptance is for human review.

## CLI Surface Migration

- [ ] No migration packet required for this CLI change.
- [x] CLI/user-facing surface change and migration packet completed.

No-migration rationale: not selected for this PR.
Upgrade note: ddl-docs check accepts --scope-rules; ddl-docs review-plan emits mandatoryScope and per-file requiredReads for review harnesses.
Deprecation/removal plan or issue: No removals or deprecations; new CLI surface is additive.
Docs/help/examples updated: Transfer generated docs now expose Scope; changeset documents the ddl-docs-cli surface addition.
Release/changeset wording: Changeset .changeset/scope-review-plan.md marks @rawsql-ts/ddl-docs-cli minor for scope validation and review-plan support.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: No ztd-cli scaffold templates or scaffold contracts are changed.
Non-edit assertion: not selected for this PR.
Fail-fast input-contract proof: not selected for this PR.
Generated-output viability proof: not selected for this PR.
