### PR TITLE
docs: add review-plan driven logical model review skill

### DIFF
--- a/.agents/skills/logical-model-review/SKILL.md
+++ b/.agents/skills/logical-model-review/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: logical-model-review
+description: Review rawsql-ts logical-model and implementation changes using ddl-docs review-plan output as the deterministic read order. Use when reviewing Concept Specs, Package Scope Specs, DFDs, Process Maps, DDL metadata, table docs, generated transfer docs, or RFBA changes that should be grounded in package scope, concept, process, and verification policy context.
+---
+
+# Logical Model Review
+
+Use this skill to review changes without rediscovering context by inference.
+
+The review source order is:
+
+1. `review-plan.mandatoryScope.files`
+2. `review-plan.mandatoryScope.rules`
+3. `review-plan.mandatoryVerification.files`
+4. `review-plan.mandatoryVerification.policies`
+5. `changedFiles[].requiredReads.scopeRules`
+6. `changedFiles[].requiredReads.concepts`
+7. `changedFiles[].requiredReads.dfds`
+8. `changedFiles[].requiredReads.processes`
+9. `changedFiles[].requiredReads.ddlRelationships`
+10. `changedFiles[].requiredReads.testPolicies`
+11. the changed file itself
+
+## Workflow
+
+1. Generate or request a `review-plan` for the changed files.
+2. Read mandatory scope and verification files before reviewing individual changes.
+3. Read each changed file's required reads in the order above.
+4. Treat `review-plan.diagnostics` and `unmappedArtifacts` as review inputs, not as optional noise.
+5. Review semantic consistency only after the deterministic context has been loaded.
+
+## Review Rules
+
+- Do not infer missing Concept, DFD, Process, DDL, Scope, or Test Policy links when `review-plan` can provide them.
+- If `review-plan` cannot resolve a link, report the diagnostic or metadata gap instead of guessing.
+- Treat generated docs as review views, not source of truth.
+- Treat `summary`, `reason`, `note`, and `reviewAction` metadata as review aids, not authoritative domain meaning.
+- Ground semantic findings in the owning Package Scope Spec, Concept Spec, DFD, Process Map, DDL relationship metadata, or Test Policy.
+- When a changed artifact is business-bearing and unmapped, report a reviewability gap before reviewing implementation details.
+- Keep meaning review separate from mechanical check results: cite mechanical failures, then add semantic findings only where human judgment is needed.
+
+## If No Review Plan Exists
+
+Prefer creating one instead of manually searching.
+
+Use the repository command shape:
+
+```bash
+node packages/ddl-docs-cli/dist/src/index.js review-plan \
+  --changed-files <changed-files.txt> \
+  --ddl-dir packages/transfer/db/ddl \
+  --relationship packages/transfer/db/ddl/relationship.json \
+  --table-docs packages/transfer/db/ddl/table-docs.json \
+  --concept-relationship packages/transfer/docs/concepts/concept-relationship.json \
+  --dfd-relationship packages/transfer/docs/dfd/relationship.json \
+  --process-dir packages/transfer/docs/processes \
+  --scope-doc packages/transfer/docs/scope/SYSTEM_SCOPE.md \
+  --scope-rules packages/transfer/docs/scope/scope-rules.json \
+  --test-policy packages/transfer/docs/testing/TEST_POLICY.md \
+  --test-rules packages/transfer/docs/testing/test-rules.json \
+  --out <review-plan.json>
+```
+
+Build `@rawsql-ts/ddl-docs-cli` first when `dist/` is stale.
+
+## Output Shape
+
+Use this structure:
+
+```md
+# Logical Model Review
+
+## Status
+pass | needs-revision | needs-human-decision
+
+## Review Plan Inputs
+- mandatory scope:
+- mandatory verification:
+- changed files:
+- diagnostics:
+- unmapped artifacts:
+
+## Findings
+
+### scope-boundary
+- severity:
+- location or quote:
+- why it matters:
+- suggested direction:
+
+### concept-process-consistency
+- severity:
+- location or quote:
+- why it matters:
+- suggested direction:
+
+### verification-policy-gap
+- severity:
+- location or quote:
+- why it matters:
+- suggested direction:
+
+### relationship-metadata-gap
+- severity:
+- location or quote:
+- why it matters:
+- suggested direction:
+
+### generated-view-drift
+- severity:
+- location or quote:
+- why it matters:
+- suggested direction:
+
+## Human Decisions Required
+
+## Verification Not Run
+```
+
+Omit empty finding categories.

--- a/docs/guide/concept-spec-overview.md
+++ b/docs/guide/concept-spec-overview.md
@@ -394,10 +394,15 @@ The intended layering is:
 | Process Map | check whether complex use cases can be expressed from approved concepts |
 | RFBA | expose the implementation surfaces humans should review |
 | ztd-cli / ZTD / tests | provide scaffold, generated artifacts, drift checks, and executable verification |
+| review-plan | provide deterministic review inputs from changed files, relationship metadata, Package Scope, and Test Policy |
 | agent workflow skills | guide planning, TDD, verification, review, branch work, and subagent execution |
 
 Agent workflow skills are useful after the concept and process context is known.
 For example, they may enforce verification before completion, help split implementation tasks, or structure review checkpoints.
+
+When a `review-plan` is available, review skills should treat it as the read-order harness instead of rediscovering related context by inference.
+The review should load Package Scope, Package Test Policy, changed-file required reads, relationship metadata, and then the changed artifact itself.
+If `review-plan` reports unresolved links or unmapped business-bearing artifacts, the review should surface those metadata gaps rather than guessing the missing relationships.
 
 They should not generate authoritative concept prose, promote draft concepts, reorganize Concept Spec layout, or decide concept ownership.
 If a workflow skill discovers an unclear concept boundary, it should report the ambiguity and route the work back to Concept Spec or Process Map review.


### PR DESCRIPTION
## Summary

- Add a repo-local `logical-model-review` skill that uses `ddl-docs review-plan` as the deterministic read-order harness for logical-model and implementation reviews.
- Update the Concept Spec overview to explain that review skills should consume `review-plan` instead of rediscovering package scope, test policy, relationship metadata, and changed-file context by inference.

## Verification

- `python C:\Users\mssgm\.codex\skills\.system\skill-creator\scripts\quick_validate.py .agents\skills\logical-model-review` attempted; blocked because the local Python environment lacks `yaml`.
- `pnpm --filter @rawsql-ts/ztd-cli exec vitest run --config vitest.config.ts tests/repoGuidance.unit.test.ts tests/intentProcedure.docs.test.ts`
- `pnpm --filter @rawsql-ts/ddl-docs-cli test -- check.integration.test.ts`
- pre-commit hook: workspace `typecheck`, workspace `test`, workspace `build`, workspace `lint`

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: none
Scoped checks run: ztd-cli repo guidance/docs tests; ddl-docs-cli check integration test; pre-commit workspace typecheck/test/build/lint
Why full baseline is not required: pre-commit ran the full workspace gates; no baseline exception is requested.

## Self Review

Self-review workflow: developer-self-review skill two-cycle pass: consistency review plus human acceptance review.
Self-review result: no unresolved blockers; quick_validate remains supplementary-only because local Python lacks PyYAML, and repository checks passed.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: no CLI command, option, output schema, or package runtime behavior changed; this adds repo-local review guidance.
Upgrade note: none
Deprecation/removal plan or issue: none
Docs/help/examples updated: docs/guide/concept-spec-overview.md now documents review-plan driven review-skill usage.
Release/changeset wording: no changeset; no published package behavior changed.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: no scaffold code, templates, generated project output, or ztd-cli scaffold contract changed.
Non-edit assertion: n/a
Fail-fast input-contract proof: n/a
Generated-output viability proof: n/a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added specification for logical model review workflow including deterministic review order, findings categories, and required output structure.
  * Updated guidance on how review workflows should utilize review plans to determine read order and handle missing links.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mk3008/rawsql-ts/pull/827?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->