### PR TITLE
Add transfer technology policy

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -103,7 +103,7 @@ jobs:
         changed_files=$(git diff --name-only "$base_sha...$head_sha")
         printf '%s\n' "$changed_files"
 
-        if printf '%s\n' "$changed_files" | grep -Eq '^(package\.json|packages/ddl-docs-cli/|packages/transfer/db/ddl/|packages/transfer/docs/(concepts|dfd|processes|scope|testing)/|docs/(transfer-docs|review)\.md|docs/(concepts|dfd|processes|roles|scope|testing|rawsql-transfer)/|scripts/generate-transfer-docs\.mjs|\.github/workflows/pr-check\.yml$)'; then
+        if printf '%s\n' "$changed_files" | grep -Eq '^(package\.json|packages/ddl-docs-cli/|packages/transfer/db/ddl/|packages/transfer/docs/(concepts|dfd|processes|scope|testing|review|technology)/|docs/(transfer-docs|review)\.md|docs/(authority|concepts|dfd|processes|roles|scope|testing|technology|rawsql-transfer)/|scripts/(generate-transfer-docs|verify-transfer-docs-drift)\.mjs|\.github/workflows/pr-check\.yml$)'; then
           echo "run=true" >> "$GITHUB_OUTPUT"
         else
           echo "run=false" >> "$GITHUB_OUTPUT"

--- a/docs/authority/index.md
+++ b/docs/authority/index.md
@@ -1,0 +1,69 @@
+<!-- generated-by: transfer-docs -->
+
+# Transfer Review Authority Model
+
+この文書は `@rawsql-ts/transfer` の review authority model である。
+
+これは Concept Spec ではない。Concept Spec、DFD、Process Map、Technology Policy、Test Policy、generated review report を、誰が主体で扱うかを定義する。
+
+## Purpose
+
+Concept Spec 全体の思想は、AIやCLIを正本にすることではなく、人間が承認できる review harness を作ることである。
+
+文書、AI review、CLI output はそれぞれ役割が異なる。役割を分けることで、AIが要件を勝手に確定したり、CLI生成物を仕様本文として扱ったり、レビュースキルの推論を人間承認なしに確定扱いすることを防ぐ。
+
+## Authority Classes
+
+### Human-owned Requirements
+
+人間が主体で、AIはフォロー、整理、質問、提案を行う。
+
+主な対象:
+
+- Concept Spec
+- DFD
+- Process Map
+- Scope Spec
+- Issueや人間が明示した要件
+
+AIの提案は review input であり、承認済み要件ではない。
+
+### AI-led Review Management
+
+AIが主体で、手順管理、比較、指摘、レビュー観点の適用を行う。人間は結果を承認または差し戻す。
+
+主な対象:
+
+- review skill の実行
+- Concept / DFD / Process / DDL / Technology / Test Policy の横断レビュー
+- review-plan の required reads に基づく確認
+- 機械化できない矛盾、曖昧さ、責務境界の指摘
+
+AIのレビュー結果は承認待ちの判断であり、Concept Specやpolicy本文を置き換えない。
+
+### CLI-owned Review Views
+
+CLIが主体で、構造化metadata、DDL、Concept/DFD/Process index、review-plan を入力に deterministic な review view を生成する。
+
+AIはCLI outputを仕様としてではなく、機械的に再現可能な review input として読む。必要な場合に少しだけ推論を加え、人間が結果を承認する。
+
+主な対象:
+
+- Review Report
+- VitePress generated pages
+- `tmp/transfer-review-plan.json`
+- metadata check output
+- generated DDL / Concept / DFD / Process review pages
+
+generated view は source of truth ではない。修正は source document または metadata に入れる。
+
+## Review Usage
+
+`authority-rules.json` は、この authority model をAIとCLIが参照しやすくするための機械可読review indexである。
+
+`authority-rules.json` は仕様本文の代替ではない。
+
+## Source
+
+- `packages/transfer/docs/review/AUTHORITY_MODEL.md`
+- `packages/transfer/docs/review/authority-rules.json`

--- a/docs/review.md
+++ b/docs/review.md
@@ -42,11 +42,13 @@ This section aggregates the package-level review harness inputs used before sema
 
 - Metadata check errors: 0
 - Metadata check warnings: 0
-- Review-plan source artifacts: 38
+- Review-plan source artifacts: 42
 - Unmapped business artifacts: 0
 - Review-plan diagnostics: 0
 - Mandatory scope rules: `db-centered-transfer`, `human-owned-logical-model`, `generated-docs-not-source`
 - Mandatory verification policies: `db-backed-contract-verification`, `no-hot-path-runtime-validation`
+- Mandatory authority rules: `human-owned-requirements`, `ai-owned-review-management`, `cli-owned-review-views`
+- Mandatory technology rules: `postgres-primary-db`, `sql-first-ztd-cli`, `no-standard-orm-path`, `cli-front-facing-surface`
 
 ### Review-plan Diagnostics
 
@@ -62,4 +64,8 @@ This section aggregates the package-level review harness inputs used before sema
 - Scope rules: `packages/transfer/docs/scope/scope-rules.json`
 - Test policy: `packages/transfer/docs/testing/TEST_POLICY.md`
 - Test rules: `packages/transfer/docs/testing/test-rules.json`
+- Authority model: `packages/transfer/docs/review/AUTHORITY_MODEL.md`
+- Authority rules: `packages/transfer/docs/review/authority-rules.json`
+- Technology policy: `packages/transfer/docs/technology/TECHNOLOGY_POLICY.md`
+- Technology rules: `packages/transfer/docs/technology/tech-rules.json`
 - Review plan snapshot: `tmp/transfer-review-plan.json`

--- a/docs/technology/index.md
+++ b/docs/technology/index.md
@@ -1,0 +1,58 @@
+<!-- generated-by: transfer-docs -->
+
+# Transfer Package Technology Policy
+
+この文書は `@rawsql-ts/transfer` の package-level technology policy である。
+
+これは Concept Spec ではない。個別概念の意味、責務、非責務、不変条件は `docs/concepts/` 配下の Concept Spec に置く。
+
+この文書は、package の標準技術選定と、その選定から外れる変更をレビュー対象にするための implementation constraint harness である。
+
+## Purpose
+
+`@rawsql-ts/transfer` は、PostgreSQL、SQL-first、ztd-cli / rawsql-ts を標準経路にした転送制御 package である。
+
+コードから現在の実装技術を観測することはできるが、コードだけでは「その技術が意図した制約なのか、偶然の現状なのか」を判定しにくい。
+
+この文書は、未知の要件が来たときに、技術選定の例外、scope expansion、または別 boundary の責務として扱うべきかを判断するために使う。
+
+## Standard Technology Constraints
+
+- Primary database: PostgreSQL
+- Data access style: SQL-first
+- Standard generation / verification path: ztd-cli and rawsql-ts
+- Standard transfer implementation path: reviewed SQL, DDL metadata, queryspec contracts, generated mapper checks, and DB-backed tests
+- Standard front-facing surface: CLI
+- Web UI is not a standard surface for this package. If a Web surface is needed, treat it as an owning application boundary outside `@rawsql-ts/transfer`.
+
+## Non-Standard Paths
+
+以下は標準経路ではない。
+
+- ORM を transfer の標準 data access path として導入すること
+- PostgreSQL 以外を transfer の primary database 前提にすること
+- SQL-first の代わりに ORM model-first / schema-first を標準にすること
+- generated SQL を人間がレビューできない runtime 内部だけに閉じ込めること
+- Web UI を transfer package の標準front-facing surface として扱うこと
+
+## Exception Policy
+
+標準経路から外れる変更は、禁止ではなく review-trigger として扱う。
+
+例外を採用する場合は、少なくとも次を明示する。
+
+- なぜ既存の PostgreSQL / SQL-first / ztd-cli / rawsql-ts 経路では不足するのか
+- 例外が一時的な adapter なのか、package の標準経路を変える scope expansion なのか
+- Concept Spec、Scope Spec、Test Policy、DDL metadata、generated docs への影響
+- 追加で必要になる検証方法
+
+## Review Usage
+
+`tech-rules.json` は、この文書の技術制約をAIとCLIが参照しやすくするための機械可読review indexである。
+
+`tech-rules.json` は仕様本文の代替ではない。
+
+## Source
+
+- `packages/transfer/docs/technology/TECHNOLOGY_POLICY.md`
+- `packages/transfer/docs/technology/tech-rules.json`

--- a/docs/transfer-docs.md
+++ b/docs/transfer-docs.md
@@ -27,6 +27,8 @@ Start with Concepts, then DFDs, then Processes, and finally Table Definitions wh
 
 - [Scope](./scope/)
 - [Testing Policy](./testing/)
+- [Review Authority Model](./authority/)
+- [Technology Policy](./technology/)
 - [Concepts](./concepts/)
 - [DFDs](./dfd/)
 - [Roles](./roles/)

--- a/packages/ddl-docs-cli/src/cli.ts
+++ b/packages/ddl-docs-cli/src/cli.ts
@@ -409,6 +409,10 @@ function parseReviewPlanOptions(args: string[]): ReviewPlanOptions | null {
     scopeDocPath: undefined,
     testRulesPath: undefined,
     testPolicyPath: undefined,
+    authorityRulesPath: undefined,
+    authorityModelPath: undefined,
+    technologyRulesPath: undefined,
+    technologyPolicyPath: undefined,
     outPath: undefined,
     packageName: undefined,
   };
@@ -464,6 +468,22 @@ function parseReviewPlanOptions(args: string[]): ReviewPlanOptions | null {
     }
     if (arg === '--test-policy') {
       options.testPolicyPath = readRequiredValue(args, ++index, '--test-policy');
+      continue;
+    }
+    if (arg === '--authority-rules') {
+      options.authorityRulesPath = readRequiredValue(args, ++index, '--authority-rules');
+      continue;
+    }
+    if (arg === '--authority-model') {
+      options.authorityModelPath = readRequiredValue(args, ++index, '--authority-model');
+      continue;
+    }
+    if (arg === '--technology-rules') {
+      options.technologyRulesPath = readRequiredValue(args, ++index, '--technology-rules');
+      continue;
+    }
+    if (arg === '--technology-policy') {
+      options.technologyPolicyPath = readRequiredValue(args, ++index, '--technology-policy');
       continue;
     }
     if (arg === '--package') {
@@ -630,6 +650,10 @@ function printHelp(target: 'all' | 'generate' | 'prune' | 'check' | 'concept-sit
   --scope-doc <path>             Optional package scope markdown source
   --test-rules <path>            Optional package verification/test rules metadata json
   --test-policy <path>           Optional package verification/test policy markdown source
+  --authority-rules <path>       Optional package review authority rules metadata json
+  --authority-model <path>       Optional package review authority model markdown source
+  --technology-rules <path>      Optional package technology rules metadata json
+  --technology-policy <path>     Optional package technology policy markdown source
   --package <name>               Package name for the review plan
   --out <path>                   Write JSON output to file instead of stdout
 `;

--- a/packages/ddl-docs-cli/src/commands/reviewPlan.ts
+++ b/packages/ddl-docs-cli/src/commands/reviewPlan.ts
@@ -24,6 +24,10 @@ type ArtifactKind =
   | 'scope-rules'
   | 'test-policy'
   | 'test-rules'
+  | 'authority-model'
+  | 'authority-rules'
+  | 'technology-policy'
+  | 'technology-rules'
   | 'generated-doc'
   | 'script'
   | 'workflow'
@@ -42,6 +46,10 @@ const ARTIFACT_KINDS = new Set<ArtifactKind>([
   'scope-rules',
   'test-policy',
   'test-rules',
+  'authority-model',
+  'authority-rules',
+  'technology-policy',
+  'technology-rules',
   'generated-doc',
   'script',
   'workflow',
@@ -68,6 +76,18 @@ interface TestRulesMetadata {
   testPolicies: TestPolicyEntry[];
 }
 
+interface TechnologyRulesMetadata {
+  schemaVersion: 1;
+  metadataLanguagePolicy?: MetadataLanguagePolicy;
+  technologyRules: TechnologyRuleEntry[];
+}
+
+interface AuthorityRulesMetadata {
+  schemaVersion: 1;
+  metadataLanguagePolicy?: MetadataLanguagePolicy;
+  authorityRules: AuthorityRuleEntry[];
+}
+
 type MetadataLanguagePolicy = string | StructuredMetadataLanguagePolicy;
 
 interface StructuredMetadataLanguagePolicy {
@@ -88,6 +108,20 @@ interface TestPolicyEntry {
   kind: string;
   statement: string;
   appliesTo?: ArtifactKind[];
+  reviewRisk?: string;
+}
+
+interface TechnologyRuleEntry {
+  id: string;
+  kind: string;
+  statement: string;
+  reviewRisk?: string;
+}
+
+interface AuthorityRuleEntry {
+  id: string;
+  kind: string;
+  statement: string;
   reviewRisk?: string;
 }
 
@@ -112,6 +146,8 @@ interface RequiredReads {
   processes: string[];
   ddlRelationships: string[];
   testPolicies: string[];
+  authorityRules: string[];
+  technologyRules: string[];
 }
 
 interface ChangedFileReviewPlan {
@@ -134,6 +170,14 @@ interface ReviewPlan {
   mandatoryVerification?: {
     files: string[];
     policies: Array<{ id: string; reason: string }>;
+  };
+  mandatoryAuthority?: {
+    files: string[];
+    rules: Array<{ id: string; reason: string }>;
+  };
+  mandatoryTechnology?: {
+    files: string[];
+    rules: Array<{ id: string; reason: string }>;
   };
   changedFiles: ChangedFileReviewPlan[];
   unmappedArtifacts: ChangedFileReviewPlan[];
@@ -169,6 +213,40 @@ const MANDATORY_TEST_POLICIES = [
   },
 ] as const;
 
+const MANDATORY_AUTHORITY_RULES = [
+  {
+    id: 'human-owned-requirements',
+    reason: 'Requirement-like Concept Spec sources are human-owned; AI may follow up, propose, and clarify but must not promote its proposal as authority.',
+  },
+  {
+    id: 'ai-owned-review-management',
+    reason: 'Review management and review-skill execution are AI-led workflows whose conclusions require human approval.',
+  },
+  {
+    id: 'cli-owned-review-views',
+    reason: 'Review reports and generated VitePress views are CLI-owned review artifacts; AI may add bounded interpretation and humans approve the outcome.',
+  },
+] as const;
+
+const MANDATORY_TECHNOLOGY_RULES = [
+  {
+    id: 'postgres-primary-db',
+    reason: 'Transfer implementation assumes PostgreSQL-compatible DDL, SQL, and database behavior.',
+  },
+  {
+    id: 'sql-first-ztd-cli',
+    reason: 'Transfer changes should preserve the SQL-first, ztd-cli/rawsql-ts standard implementation path.',
+  },
+  {
+    id: 'no-standard-orm-path',
+    reason: 'Introducing an ORM as the standard path is a technology policy exception and must be reviewed explicitly.',
+  },
+  {
+    id: 'cli-front-facing-surface',
+    reason: 'Transfer package front-facing surfaces should remain CLI-first; Web UI belongs to a separate owning application boundary.',
+  },
+] as const;
+
 export function runReviewPlan(options: ReviewPlanOptions): ReviewPlan {
   const plan = buildReviewPlan(options);
   const json = `${JSON.stringify(plan, null, 2)}\n`;
@@ -188,6 +266,8 @@ export function buildReviewPlan(options: ReviewPlanOptions): ReviewPlan {
   const processRegistry = loadProcessRegistry(options.processDirectories ?? []);
   const scopeRules = loadScopeRules(options.scopeRulesPath);
   const testPolicies = loadTestPolicies(options.testRulesPath);
+  const authorityRules = loadAuthorityRules(options.authorityRulesPath);
+  const technologyRules = loadTechnologyRules(options.technologyRulesPath);
 
   const changedFilePlans = changedFiles.map((changedFile) =>
     buildChangedFilePlan(changedFile, {
@@ -198,6 +278,8 @@ export function buildReviewPlan(options: ReviewPlanOptions): ReviewPlan {
       processRegistry,
       scopeRules,
       testPolicies,
+      authorityRules,
+      technologyRules,
     })
   );
 
@@ -214,6 +296,18 @@ export function buildReviewPlan(options: ReviewPlanOptions): ReviewPlan {
         policies: MANDATORY_TEST_POLICIES.filter((policy) => testPolicies.has(policy.id)),
       },
     } : {}),
+    ...(options.authorityModelPath || options.authorityRulesPath ? {
+      mandatoryAuthority: {
+        files: [options.authorityModelPath, options.authorityRulesPath].filter((entry): entry is string => Boolean(entry)),
+        rules: MANDATORY_AUTHORITY_RULES.filter((rule) => authorityRules.has(rule.id)),
+      },
+    } : {}),
+    ...(options.technologyPolicyPath || options.technologyRulesPath ? {
+      mandatoryTechnology: {
+        files: [options.technologyPolicyPath, options.technologyRulesPath].filter((entry): entry is string => Boolean(entry)),
+        rules: MANDATORY_TECHNOLOGY_RULES.filter((rule) => technologyRules.has(rule.id)),
+      },
+    } : {}),
     changedFiles: changedFilePlans,
     unmappedArtifacts: changedFilePlans.filter((entry) =>
       entry.reviewRisks.includes('unmapped-business-artifact')
@@ -226,6 +320,10 @@ export function buildReviewPlan(options: ReviewPlanOptions): ReviewPlan {
       ...(options.scopeRulesPath ? [{ artifact: options.scopeRulesPath, status: 'unknown' as const }] : []),
       ...(options.testPolicyPath ? [{ artifact: options.testPolicyPath, status: 'unknown' as const }] : []),
       ...(options.testRulesPath ? [{ artifact: options.testRulesPath, status: 'unknown' as const }] : []),
+      ...(options.authorityModelPath ? [{ artifact: options.authorityModelPath, status: 'unknown' as const }] : []),
+      ...(options.authorityRulesPath ? [{ artifact: options.authorityRulesPath, status: 'unknown' as const }] : []),
+      ...(options.technologyPolicyPath ? [{ artifact: options.technologyPolicyPath, status: 'unknown' as const }] : []),
+      ...(options.technologyRulesPath ? [{ artifact: options.technologyRulesPath, status: 'unknown' as const }] : []),
     ],
   };
 }
@@ -240,6 +338,8 @@ function buildChangedFilePlan(
     processRegistry: ProcessRegistry;
     scopeRules: Map<string, ScopeRuleEntry>;
     testPolicies: Map<string, TestPolicyEntry>;
+    authorityRules: Map<string, AuthorityRuleEntry>;
+    technologyRules: Map<string, TechnologyRuleEntry>;
   }
 ): ChangedFileReviewPlan {
   const normalizedPath = normalizeRelativePath(changedFile);
@@ -269,6 +369,24 @@ function buildChangedFilePlan(
       .filter((policy) => context.testPolicies.has(policy.id))
       .map((policy) => policy.id);
     basePlan.reviewRisks.push('package-verification-policy-impact');
+    return basePlan;
+  }
+
+  if (artifactKind === 'authority-model' || artifactKind === 'authority-rules') {
+    basePlan.packageWideImpact = true;
+    basePlan.requiredReads.authorityRules = MANDATORY_AUTHORITY_RULES
+      .filter((rule) => context.authorityRules.has(rule.id))
+      .map((rule) => rule.id);
+    basePlan.reviewRisks.push('package-review-authority-impact');
+    return basePlan;
+  }
+
+  if (artifactKind === 'technology-policy' || artifactKind === 'technology-rules') {
+    basePlan.packageWideImpact = true;
+    basePlan.requiredReads.technologyRules = MANDATORY_TECHNOLOGY_RULES
+      .filter((rule) => context.technologyRules.has(rule.id))
+      .map((rule) => rule.id);
+    basePlan.reviewRisks.push('package-technology-policy-impact');
     return basePlan;
   }
 
@@ -332,6 +450,10 @@ function applyDdlRelationship(
     return;
   }
 
+  if (entry.kind === 'ddl-control' || entry.kind === 'technical-support') {
+    return;
+  }
+
   plan.requiredReads.scopeRules = dedupe(entry.scopeRules.map((scopeRule) => scopeRule.id));
   plan.requiredReads.concepts = dedupe(
     entry.concepts
@@ -360,9 +482,6 @@ function applyDdlRelationship(
       .map((scopeRuleId) => context.scopeRules.get(scopeRuleId)?.reviewRisk)
       .filter((entry): entry is string => Boolean(entry))
   );
-  if (entry.kind === 'ddl-control' || entry.kind === 'technical-support') {
-    return;
-  }
   if (
     plan.requiredReads.scopeRules.length === 0
     && plan.requiredReads.concepts.length === 0
@@ -501,6 +620,30 @@ function loadTestPolicies(testRulesPath: string | undefined): Map<string, TestPo
   return new Map(raw.testPolicies.map((entry) => [entry.id, entry]));
 }
 
+function loadTechnologyRules(technologyRulesPath: string | undefined): Map<string, TechnologyRuleEntry> {
+  if (!technologyRulesPath) {
+    return new Map();
+  }
+  const resolvedPath = path.resolve(process.cwd(), technologyRulesPath);
+  const raw = JSON.parse(readFileSync(resolvedPath, 'utf8')) as unknown;
+  if (!isTechnologyRulesMetadata(raw)) {
+    throw new Error(`technology-rules metadata must have schemaVersion: 1 and technologyRules[]: ${resolvedPath}`);
+  }
+  return new Map(raw.technologyRules.map((entry) => [entry.id, entry]));
+}
+
+function loadAuthorityRules(authorityRulesPath: string | undefined): Map<string, AuthorityRuleEntry> {
+  if (!authorityRulesPath) {
+    return new Map();
+  }
+  const resolvedPath = path.resolve(process.cwd(), authorityRulesPath);
+  const raw = JSON.parse(readFileSync(resolvedPath, 'utf8')) as unknown;
+  if (!isAuthorityRulesMetadata(raw)) {
+    throw new Error(`authority-rules metadata must have schemaVersion: 1 and authorityRules[]: ${resolvedPath}`);
+  }
+  return new Map(raw.authorityRules.map((entry) => [entry.id, entry]));
+}
+
 function resolveTestPoliciesForArtifact(
   artifactKind: ArtifactKind,
   testPolicies: Map<string, TestPolicyEntry>
@@ -549,6 +692,18 @@ function classifyArtifactKind(changedFile: string, options: ReviewPlanOptions): 
   if (options.testRulesPath && samePath(changedFile, options.testRulesPath)) {
     return 'test-rules';
   }
+  if (options.authorityModelPath && samePath(changedFile, options.authorityModelPath)) {
+    return 'authority-model';
+  }
+  if (options.authorityRulesPath && samePath(changedFile, options.authorityRulesPath)) {
+    return 'authority-rules';
+  }
+  if (options.technologyPolicyPath && samePath(changedFile, options.technologyPolicyPath)) {
+    return 'technology-policy';
+  }
+  if (options.technologyRulesPath && samePath(changedFile, options.technologyRulesPath)) {
+    return 'technology-rules';
+  }
   if (options.relationshipPath && samePath(changedFile, options.relationshipPath)) {
     return 'ddl-relationship-metadata';
   }
@@ -589,7 +744,7 @@ function classifyReviewClass(kind: ArtifactKind): ReviewClass {
   if (kind === 'generated-doc') {
     return 'generated-review-view';
   }
-  if (kind.endsWith('-metadata') || kind === 'scope-rules' || kind === 'test-rules') {
+  if (kind.endsWith('-metadata') || kind === 'scope-rules' || kind === 'test-rules' || kind === 'authority-rules' || kind === 'technology-rules') {
     return 'metadata';
   }
   if (kind === 'script') {
@@ -598,7 +753,7 @@ function classifyReviewClass(kind: ArtifactKind): ReviewClass {
   if (kind === 'workflow') {
     return 'workflow-support';
   }
-  if (kind === 'ddl' || kind === 'concept-spec' || kind === 'dfd' || kind === 'process-map' || kind === 'scope-spec' || kind === 'test-policy') {
+  if (kind === 'ddl' || kind === 'concept-spec' || kind === 'dfd' || kind === 'process-map' || kind === 'scope-spec' || kind === 'test-policy' || kind === 'authority-model' || kind === 'technology-policy') {
     return 'business-bearing';
   }
   return 'unknown';
@@ -675,6 +830,8 @@ function emptyRequiredReads(): RequiredReads {
     processes: [],
     ddlRelationships: [],
     testPolicies: [],
+    authorityRules: [],
+    technologyRules: [],
   };
 }
 
@@ -719,6 +876,34 @@ function isTestRulesMetadata(value: unknown): value is TestRulesMetadata {
           && entry.appliesTo.every(isArtifactKind)
         ))
         && (entry.reviewRisk === undefined || typeof entry.reviewRisk === 'string')
+    );
+}
+
+function isTechnologyRulesMetadata(value: unknown): value is TechnologyRulesMetadata {
+  return isRecord(value)
+    && value.schemaVersion === 1
+    && (value.metadataLanguagePolicy === undefined || isMetadataLanguagePolicy(value.metadataLanguagePolicy))
+    && Array.isArray(value.technologyRules)
+    && value.technologyRules.every((entry) =>
+      isRecord(entry)
+        && typeof entry.id === 'string'
+        && typeof entry.kind === 'string'
+        && typeof entry.statement === 'string'
+        && (entry.reviewRisk === undefined || typeof entry.reviewRisk === 'string')
+    );
+}
+
+function isAuthorityRulesMetadata(value: unknown): value is AuthorityRulesMetadata {
+  return isRecord(value)
+    && value.schemaVersion === 1
+    && (value.metadataLanguagePolicy === undefined || isMetadataLanguagePolicy(value.metadataLanguagePolicy))
+    && Array.isArray(value.authorityRules)
+    && value.authorityRules.every((entry) =>
+      isRecord(entry)
+      && typeof entry.id === 'string'
+      && typeof entry.kind === 'string'
+      && typeof entry.statement === 'string'
+      && (entry.reviewRisk === undefined || typeof entry.reviewRisk === 'string')
     );
 }
 

--- a/packages/ddl-docs-cli/src/types.ts
+++ b/packages/ddl-docs-cli/src/types.ts
@@ -63,6 +63,10 @@ export interface ReviewPlanOptions {
   scopeDocPath?: string;
   testRulesPath?: string;
   testPolicyPath?: string;
+  authorityRulesPath?: string;
+  authorityModelPath?: string;
+  technologyRulesPath?: string;
+  technologyPolicyPath?: string;
   outPath?: string;
   packageName?: string;
 }

--- a/packages/ddl-docs-cli/tests/check.integration.test.ts
+++ b/packages/ddl-docs-cli/tests/check.integration.test.ts
@@ -1152,6 +1152,108 @@ test('review-plan treats DDL control files as technical support when explicitly 
 
   expect(plan.unmappedArtifacts).toHaveLength(0);
   expect(plan.changedFiles[0]?.diagnostics).toHaveLength(0);
+  expect(plan.changedFiles[0]?.requiredReads.scopeRules).toEqual([]);
+  expect(plan.changedFiles[0]?.requiredReads.concepts).toEqual([]);
+  expect(plan.changedFiles[0]?.requiredReads.processes).toEqual([]);
+  expect(plan.changedFiles[0]?.reviewRisks).toEqual([]);
+});
+
+test('review-plan includes package technology policy as mandatory review input', () => {
+  const work = createTempDir('ddl-docs-review-plan-technology-policy');
+  const ddlDir = path.join(work, 'ddl');
+  const technologyDir = path.join(work, 'docs', 'technology');
+  const changedFilesPath = path.join(work, 'changed-files.txt');
+  const technologyPolicyPath = path.join(technologyDir, 'TECHNOLOGY_POLICY.md');
+  const technologyRulesPath = path.join(technologyDir, 'tech-rules.json');
+
+  writeText(path.join(ddlDir, 'accounts.sql'), 'CREATE TABLE public.accounts (account_id bigint PRIMARY KEY);');
+  writeText(technologyPolicyPath, '# Technology Policy\n');
+  writeText(technologyRulesPath, JSON.stringify({
+    schemaVersion: 1,
+    metadataLanguagePolicy: {
+      humanFacingLanguage: 'ja',
+      generatedViewLanguage: 'en',
+      policy: 'Human-authored technology metadata follows the package documentation language.',
+    },
+    technologyRules: [
+      { id: 'postgres-primary-db', kind: 'database-platform', statement: 'Use PostgreSQL.' },
+      { id: 'sql-first-ztd-cli', kind: 'data-access', statement: 'Use SQL-first ztd-cli.' },
+      { id: 'no-standard-orm-path', kind: 'data-access-boundary', statement: 'Do not introduce an ORM standard path.' },
+      { id: 'cli-front-facing-surface', kind: 'front-facing-surface', statement: 'Use CLI as the package front-facing surface.' },
+    ],
+  }, null, 2));
+  writeText(changedFilesPath, `${technologyPolicyPath}\n${technologyRulesPath}\n`);
+
+  const plan = buildReviewPlan({
+    changedFilesPath,
+    ddlDirectories: [{ path: ddlDir, instance: '' }],
+    technologyPolicyPath,
+    technologyRulesPath,
+  });
+
+  expect(plan.mandatoryTechnology?.files).toEqual([technologyPolicyPath, technologyRulesPath]);
+  expect(plan.mandatoryTechnology?.rules.map((entry) => entry.id)).toEqual([
+    'postgres-primary-db',
+    'sql-first-ztd-cli',
+    'no-standard-orm-path',
+    'cli-front-facing-surface',
+  ]);
+  expect(plan.changedFiles.map((entry) => entry.artifactKind)).toEqual(['technology-policy', 'technology-rules']);
+  expect(plan.changedFiles[0]?.packageWideImpact).toBe(true);
+  expect(plan.changedFiles[0]?.requiredReads.technologyRules).toEqual([
+    'postgres-primary-db',
+    'sql-first-ztd-cli',
+    'no-standard-orm-path',
+    'cli-front-facing-surface',
+  ]);
+});
+
+test('review-plan includes package review authority model as mandatory review input', () => {
+  const work = createTempDir('ddl-docs-review-plan-authority-model');
+  const ddlDir = path.join(work, 'ddl');
+  const reviewDir = path.join(work, 'docs', 'review');
+  const changedFilesPath = path.join(work, 'changed-files.txt');
+  const authorityModelPath = path.join(reviewDir, 'AUTHORITY_MODEL.md');
+  const authorityRulesPath = path.join(reviewDir, 'authority-rules.json');
+
+  writeText(path.join(ddlDir, 'accounts.sql'), 'CREATE TABLE public.accounts (account_id bigint PRIMARY KEY);');
+  writeText(authorityModelPath, '# Authority Model\n');
+  writeText(authorityRulesPath, JSON.stringify({
+    schemaVersion: 1,
+    metadataLanguagePolicy: {
+      humanFacingLanguage: 'ja',
+      generatedViewLanguage: 'en',
+      policy: 'Human-authored authority metadata follows the package documentation language.',
+    },
+    authorityRules: [
+      { id: 'human-owned-requirements', kind: 'requirements-authority', statement: 'Humans own requirements.' },
+      { id: 'ai-owned-review-management', kind: 'review-workflow-authority', statement: 'AI manages review workflows.' },
+      { id: 'cli-owned-review-views', kind: 'generated-review-authority', statement: 'CLI owns generated review views.' },
+    ],
+  }, null, 2));
+  writeText(changedFilesPath, `${authorityModelPath}\n${authorityRulesPath}\n`);
+
+  const plan = buildReviewPlan({
+    changedFilesPath,
+    ddlDirectories: [{ path: ddlDir, instance: '' }],
+    authorityModelPath,
+    authorityRulesPath,
+  });
+
+  expect(plan.mandatoryAuthority?.files).toEqual([authorityModelPath, authorityRulesPath]);
+  expect(plan.mandatoryAuthority?.rules.map((entry) => entry.id)).toEqual([
+    'human-owned-requirements',
+    'ai-owned-review-management',
+    'cli-owned-review-views',
+  ]);
+  expect(plan.changedFiles.map((entry) => entry.artifactKind)).toEqual(['authority-model', 'authority-rules']);
+  expect(plan.changedFiles[0]?.packageWideImpact).toBe(true);
+  expect(plan.changedFiles[0]?.requiredReads.authorityRules).toEqual([
+    'human-owned-requirements',
+    'ai-owned-review-management',
+    'cli-owned-review-views',
+  ]);
+  expect(plan.changedFiles[0]?.reviewRisks).toEqual(['package-review-authority-impact']);
 });
 
 test('review-plan reports unmapped DDL and classifies generated docs as review views', () => {

--- a/packages/transfer/docs/review/AUTHORITY_MODEL.md
+++ b/packages/transfer/docs/review/AUTHORITY_MODEL.md
@@ -1,0 +1,62 @@
+# Transfer Review Authority Model
+
+この文書は `@rawsql-ts/transfer` の review authority model である。
+
+これは Concept Spec ではない。Concept Spec、DFD、Process Map、Technology Policy、Test Policy、generated review report を、誰が主体で扱うかを定義する。
+
+## Purpose
+
+Concept Spec 全体の思想は、AIやCLIを正本にすることではなく、人間が承認できる review harness を作ることである。
+
+文書、AI review、CLI output はそれぞれ役割が異なる。役割を分けることで、AIが要件を勝手に確定したり、CLI生成物を仕様本文として扱ったり、レビュースキルの推論を人間承認なしに確定扱いすることを防ぐ。
+
+## Authority Classes
+
+### Human-owned Requirements
+
+人間が主体で、AIはフォロー、整理、質問、提案を行う。
+
+主な対象:
+
+- Concept Spec
+- DFD
+- Process Map
+- Scope Spec
+- Issueや人間が明示した要件
+
+AIの提案は review input であり、承認済み要件ではない。
+
+### AI-led Review Management
+
+AIが主体で、手順管理、比較、指摘、レビュー観点の適用を行う。人間は結果を承認または差し戻す。
+
+主な対象:
+
+- review skill の実行
+- Concept / DFD / Process / DDL / Technology / Test Policy の横断レビュー
+- review-plan の required reads に基づく確認
+- 機械化できない矛盾、曖昧さ、責務境界の指摘
+
+AIのレビュー結果は承認待ちの判断であり、Concept Specやpolicy本文を置き換えない。
+
+### CLI-owned Review Views
+
+CLIが主体で、構造化metadata、DDL、Concept/DFD/Process index、review-plan を入力に deterministic な review view を生成する。
+
+AIはCLI outputを仕様としてではなく、機械的に再現可能な review input として読む。必要な場合に少しだけ推論を加え、人間が結果を承認する。
+
+主な対象:
+
+- Review Report
+- VitePress generated pages
+- `tmp/transfer-review-plan.json`
+- metadata check output
+- generated DDL / Concept / DFD / Process review pages
+
+generated view は source of truth ではない。修正は source document または metadata に入れる。
+
+## Review Usage
+
+`authority-rules.json` は、この authority model をAIとCLIが参照しやすくするための機械可読review indexである。
+
+`authority-rules.json` は仕様本文の代替ではない。

--- a/packages/transfer/docs/review/authority-rules.json
+++ b/packages/transfer/docs/review/authority-rules.json
@@ -1,0 +1,40 @@
+{
+  "schemaVersion": 1,
+  "metadataLanguagePolicy": {
+    "humanFacingLanguage": "ja",
+    "generatedViewLanguage": "en",
+    "policy": "CLI-generated boilerplate may be English. Human-authored docs and AI-authored human-facing metadata should use the package human-facing language unless a file explicitly overrides it."
+  },
+  "authorityRules": [
+    {
+      "id": "human-owned-requirements",
+      "kind": "requirements-authority",
+      "statement": "Concept Spec、DFD、Process Map、Scope Spec、Issueや人間が明示した要件は人間主体であり、AIはフォロー、整理、質問、提案を行う。",
+      "reviewRisk": "authority-boundary",
+      "probes": [
+        "AIの提案が承認済み要件として扱われていないか。",
+        "Concept SpecやProcess Mapの意味を、実装や生成物に合わせてAIが書き換えていないか。"
+      ]
+    },
+    {
+      "id": "ai-owned-review-management",
+      "kind": "review-workflow-authority",
+      "statement": "review skill、横断レビュー、review-plan required reads の確認はAIが主体で管理し、人間が結果を承認または差し戻す。",
+      "reviewRisk": "review-authority",
+      "probes": [
+        "AIレビュー結果が人間承認なしに確定判断として扱われていないか。",
+        "review-plan の required reads と mandatory inputs をAIが確認したか。"
+      ]
+    },
+    {
+      "id": "cli-owned-review-views",
+      "kind": "generated-review-authority",
+      "statement": "Review Report、VitePress generated pages、tmp/transfer-review-plan.json、metadata check output はCLI主体のreview inputであり、source of truth ではない。",
+      "reviewRisk": "generated-view-authority",
+      "probes": [
+        "generated viewを直接編集して正本扱いしていないか。",
+        "CLI outputをAIが少し推論して読む場合、その推論が人間承認待ちとして扱われているか。"
+      ]
+    }
+  ]
+}

--- a/packages/transfer/docs/technology/TECHNOLOGY_POLICY.md
+++ b/packages/transfer/docs/technology/TECHNOLOGY_POLICY.md
@@ -1,0 +1,51 @@
+# Transfer Package Technology Policy
+
+この文書は `@rawsql-ts/transfer` の package-level technology policy である。
+
+これは Concept Spec ではない。個別概念の意味、責務、非責務、不変条件は `docs/concepts/` 配下の Concept Spec に置く。
+
+この文書は、package の標準技術選定と、その選定から外れる変更をレビュー対象にするための implementation constraint harness である。
+
+## Purpose
+
+`@rawsql-ts/transfer` は、PostgreSQL、SQL-first、ztd-cli / rawsql-ts を標準経路にした転送制御 package である。
+
+コードから現在の実装技術を観測することはできるが、コードだけでは「その技術が意図した制約なのか、偶然の現状なのか」を判定しにくい。
+
+この文書は、未知の要件が来たときに、技術選定の例外、scope expansion、または別 boundary の責務として扱うべきかを判断するために使う。
+
+## Standard Technology Constraints
+
+- Primary database: PostgreSQL
+- Data access style: SQL-first
+- Standard generation / verification path: ztd-cli and rawsql-ts
+- Standard transfer implementation path: reviewed SQL, DDL metadata, queryspec contracts, generated mapper checks, and DB-backed tests
+- Standard front-facing surface: CLI
+- Web UI is not a standard surface for this package. If a Web surface is needed, treat it as an owning application boundary outside `@rawsql-ts/transfer`.
+
+## Non-Standard Paths
+
+以下は標準経路ではない。
+
+- ORM を transfer の標準 data access path として導入すること
+- PostgreSQL 以外を transfer の primary database 前提にすること
+- SQL-first の代わりに ORM model-first / schema-first を標準にすること
+- generated SQL を人間がレビューできない runtime 内部だけに閉じ込めること
+- Web UI を transfer package の標準front-facing surface として扱うこと
+
+## Exception Policy
+
+標準経路から外れる変更は、禁止ではなく review-trigger として扱う。
+
+例外を採用する場合は、少なくとも次を明示する。
+
+- なぜ既存の PostgreSQL / SQL-first / ztd-cli / rawsql-ts 経路では不足するのか
+- 例外が一時的な adapter なのか、package の標準経路を変える scope expansion なのか
+- Concept Spec、Scope Spec、Test Policy、DDL metadata、generated docs への影響
+- 追加で必要になる検証方法
+
+## Review Usage
+
+`tech-rules.json` は、この文書の技術制約をAIとCLIが参照しやすくするための機械可読review indexである。
+
+`tech-rules.json` は仕様本文の代替ではない。

--- a/packages/transfer/docs/technology/tech-rules.json
+++ b/packages/transfer/docs/technology/tech-rules.json
@@ -1,0 +1,60 @@
+{
+  "schemaVersion": 1,
+  "metadataLanguagePolicy": {
+    "humanFacingLanguage": "ja",
+    "generatedViewLanguage": "en",
+    "policy": "CLI-generated boilerplate may be English. Human-authored docs and AI-authored human-facing metadata should use the package human-facing language unless a file explicitly overrides it."
+  },
+  "technologyRules": [
+    {
+      "id": "postgres-primary-db",
+      "kind": "database-platform",
+      "statement": "transfer の primary database 前提は PostgreSQL である。",
+      "reviewRisk": "technology-boundary",
+      "probes": [
+        "この変更は PostgreSQL 以外のDBを primary assumption にしていないか。",
+        "PostgreSQL 固有のDDL、SQL、DB function hook との整合性は保たれているか。"
+      ]
+    },
+    {
+      "id": "sql-first-ztd-cli",
+      "kind": "data-access",
+      "statement": "transfer の標準実装経路は SQL-first、ztd-cli、rawsql-ts である。",
+      "reviewRisk": "implementation-boundary",
+      "probes": [
+        "この変更はレビュー可能なSQLを標準経路として維持しているか。",
+        "ztd-cli / rawsql-ts の生成・検証経路を迂回していないか。"
+      ]
+    },
+    {
+      "id": "no-standard-orm-path",
+      "kind": "data-access-boundary",
+      "statement": "ORM は transfer の標準 data access path ではない。",
+      "reviewRisk": "architecture-boundary",
+      "probes": [
+        "ORM 導入が adapter-level の例外ではなく標準経路変更になっていないか。",
+        "ORM を使う場合、なぜ SQL-first / ztd-cli / rawsql-ts では不足するのかが明示されているか。"
+      ]
+    },
+    {
+      "id": "cli-front-facing-surface",
+      "kind": "front-facing-surface",
+      "statement": "transfer package の標準 front-facing surface は CLI である。Web UI は package 標準frontではなく、必要な場合は別アプリ境界の責務として扱う。",
+      "reviewRisk": "surface-boundary",
+      "probes": [
+        "この変更は Web UI を transfer package の標準front-facing surface として扱っていないか。",
+        "Web surface が必要な場合、transfer package ではなく別アプリ境界の責務として説明されているか。"
+      ]
+    },
+    {
+      "id": "technology-exception-record-required",
+      "kind": "review-policy",
+      "statement": "標準技術経路から外れる変更は、例外理由、scope impact、検証方法を明示する。",
+      "reviewRisk": "review-authority",
+      "probes": [
+        "例外が一時的な adapter なのか package 標準経路の変更なのかが明示されているか。",
+        "Concept Spec、Scope Spec、Test Policy、DDL metadata、generated docs への影響がレビューされているか。"
+      ]
+    }
+  ]
+}

--- a/scripts/generate-transfer-docs.mjs
+++ b/scripts/generate-transfer-docs.mjs
@@ -104,6 +104,54 @@ function copyTestingDoc() {
   );
 }
 
+function copyAuthorityDoc() {
+  const sourcePath = path.join(workspaceRoot, "packages", "transfer", "docs", "review", "AUTHORITY_MODEL.md");
+  const targetDir = path.join(workspaceRoot, "docs", "authority");
+  const targetPath = path.join(targetDir, "index.md");
+  removeDir(targetDir);
+  fs.mkdirSync(assertInsideWorkspace(targetDir), { recursive: true });
+  const body = fs.readFileSync(assertInsideWorkspace(sourcePath), "utf8");
+  fs.writeFileSync(
+    assertInsideWorkspace(targetPath),
+    [
+      "<!-- generated-by: transfer-docs -->",
+      "",
+      body.trimEnd(),
+      "",
+      "## Source",
+      "",
+      "- `packages/transfer/docs/review/AUTHORITY_MODEL.md`",
+      "- `packages/transfer/docs/review/authority-rules.json`",
+      "",
+    ].join("\n"),
+    "utf8"
+  );
+}
+
+function copyTechnologyDoc() {
+  const sourcePath = path.join(workspaceRoot, "packages", "transfer", "docs", "technology", "TECHNOLOGY_POLICY.md");
+  const targetDir = path.join(workspaceRoot, "docs", "technology");
+  const targetPath = path.join(targetDir, "index.md");
+  removeDir(targetDir);
+  fs.mkdirSync(assertInsideWorkspace(targetDir), { recursive: true });
+  const body = fs.readFileSync(assertInsideWorkspace(sourcePath), "utf8");
+  fs.writeFileSync(
+    assertInsideWorkspace(targetPath),
+    [
+      "<!-- generated-by: transfer-docs -->",
+      "",
+      body.trimEnd(),
+      "",
+      "## Source",
+      "",
+      "- `packages/transfer/docs/technology/TECHNOLOGY_POLICY.md`",
+      "- `packages/transfer/docs/technology/tech-rules.json`",
+      "",
+    ].join("\n"),
+    "utf8"
+  );
+}
+
 function collectFilesRecursive(rootPath, extensions) {
   const resolvedRoot = assertInsideWorkspace(rootPath);
   if (!fs.existsSync(resolvedRoot)) {
@@ -140,6 +188,10 @@ function getTransferReviewSourcePaths() {
     "packages/transfer/docs/scope/scope-rules.json",
     "packages/transfer/docs/testing/TEST_POLICY.md",
     "packages/transfer/docs/testing/test-rules.json",
+    "packages/transfer/docs/review/AUTHORITY_MODEL.md",
+    "packages/transfer/docs/review/authority-rules.json",
+    "packages/transfer/docs/technology/TECHNOLOGY_POLICY.md",
+    "packages/transfer/docs/technology/tech-rules.json",
     "packages/transfer/docs/concepts/concept-relationship.json",
     ...collectFilesRecursive(path.join(workspaceRoot, "packages", "transfer", "docs", "concepts"), [".md"]),
     "packages/transfer/docs/dfd/relationship.json",
@@ -212,6 +264,14 @@ function runTransferReviewPlan() {
     "packages/transfer/docs/testing/test-rules.json",
     "--test-policy",
     "packages/transfer/docs/testing/TEST_POLICY.md",
+    "--authority-rules",
+    "packages/transfer/docs/review/authority-rules.json",
+    "--authority-model",
+    "packages/transfer/docs/review/AUTHORITY_MODEL.md",
+    "--technology-rules",
+    "packages/transfer/docs/technology/tech-rules.json",
+    "--technology-policy",
+    "packages/transfer/docs/technology/TECHNOLOGY_POLICY.md",
     "--package",
     "@rawsql-ts/transfer",
     "--out",
@@ -257,6 +317,8 @@ function renderReviewHarnessSummary(metadataCheck, reviewPlan) {
     "- Review-plan diagnostics: " + diagnostics.length,
     "- Mandatory scope rules: " + formatIdList(reviewPlan.mandatoryScope?.rules),
     "- Mandatory verification policies: " + formatIdList(reviewPlan.mandatoryVerification?.policies),
+    "- Mandatory authority rules: " + formatIdList(reviewPlan.mandatoryAuthority?.rules),
+    "- Mandatory technology rules: " + formatIdList(reviewPlan.mandatoryTechnology?.rules),
     "",
     "### Review-plan Diagnostics",
     "",
@@ -276,6 +338,10 @@ function renderReviewHarnessSummary(metadataCheck, reviewPlan) {
     "- Scope rules: `packages/transfer/docs/scope/scope-rules.json`",
     "- Test policy: `packages/transfer/docs/testing/TEST_POLICY.md`",
     "- Test rules: `packages/transfer/docs/testing/test-rules.json`",
+    "- Authority model: `packages/transfer/docs/review/AUTHORITY_MODEL.md`",
+    "- Authority rules: `packages/transfer/docs/review/authority-rules.json`",
+    "- Technology policy: `packages/transfer/docs/technology/TECHNOLOGY_POLICY.md`",
+    "- Technology rules: `packages/transfer/docs/technology/tech-rules.json`",
     "- Review plan snapshot: `tmp/transfer-review-plan.json`",
     "",
   ].join("\n");
@@ -374,6 +440,8 @@ for (const dir of generatedSiteDirs) {
 }
 copyScopeDoc();
 copyTestingDoc();
+copyAuthorityDoc();
+copyTechnologyDoc();
 
 const metadataCheck = runTransferMetadataCheck();
 const reviewPlan = runTransferReviewPlan();

--- a/scripts/verify-transfer-docs-drift.mjs
+++ b/scripts/verify-transfer-docs-drift.mjs
@@ -2,8 +2,10 @@ import { spawnSync } from 'node:child_process';
 
 const generatedPaths = [
   'docs/transfer-docs.md',
+  'docs/authority',
   'docs/scope',
   'docs/testing',
+  'docs/technology',
   'docs/review.md',
   'docs/concepts',
   'docs/dfd',


### PR DESCRIPTION
## Summary

- Fix controlled DDL relationship review-plan handling so ddl-control and technical-support relationships do not collect business mapping or risk reads.
- Add transfer Technology Policy and tech-rules metadata for PostgreSQL, SQL-first, ztd-cli/rawsql-ts, no standard ORM path, CLI as the standard front-facing surface, and exception review.
- Add a transfer review authority model that separates human-owned requirements, AI-led review management, and CLI-owned generated review views, then expose it through review-plan mandatoryAuthority and generated docs.
- Extend review-plan, generated transfer docs, and PR gate matching so mandatory authority and technology rules are tracked.

## Verification

- pnpm --filter @rawsql-ts/ddl-docs-cli test -- check.integration.test.ts
- pnpm --filter @rawsql-ts/ddl-docs-cli build
- pnpm docs:transfer
- pnpm --filter @rawsql-ts/ddl-docs-cli test
- pnpm --filter @rawsql-ts/ddl-docs-cli lint
- git diff --check
- pre-commit hook: workspace typecheck, tests, build, and lint
- pnpm verify:transfer-docs
- Technology policy text search: no HonoX, HTMX, or SPA state-first matches remain.

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: not needed; no baseline exception requested.
Scoped checks run: not needed; no baseline exception requested.
Why full baseline is not required: full baseline exception path not used for this PR.

## Self Review

Self-review workflow: planning, concept-spec-review, ddl-concept-process-review, verification, and self-review applied before PR authoring and after authority-model correction.
Self-review result: no unresolved blockers; review-plan now exposes mandatoryAuthority and mandatoryTechnology, generated docs are drift-clean, and local review skills were updated to consume these inputs.

## CLI Surface Migration

- [ ] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: not selected for this PR.
Upgrade note: not selected for this PR.
Deprecation/removal plan or issue: not selected for this PR.
Docs/help/examples updated: not selected for this PR.
Release/changeset wording: not selected for this PR.

## Scaffold Contract Proof

- [ ] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: not selected for this PR.
Non-edit assertion: not selected for this PR.
Fail-fast input-contract proof: not selected for this PR.
Generated-output viability proof: not selected for this PR.
