### PR TITLE
Clarify node-postgres adapter as testkit-only

### DIFF
--- a/.changeset/testkit-adapter-node-pg.md
+++ b/.changeset/testkit-adapter-node-pg.md
@@ -1,0 +1,5 @@
+---
+"@rawsql-ts/adapter-node-pg": patch
+---
+
+Clarify that `@rawsql-ts/adapter-node-pg` is the compatible legacy package name for the node-postgres testkit adapter, not the production driver adapter package space. The docs now separate production `driver-adapter-*` packages from future `testkit-adapter-*` packages and describe the non-breaking rename path toward an alias such as `@rawsql-ts/testkit-adapter-node-postgres`.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Use this section as the shortest repo-level map. It is intentionally brief: pack
 | SQL parsing and AST rewriting | `rawsql-ts` | [packages/core](./packages/core) |
 | SQL impact analysis / grep | `@rawsql-ts/sql-grep-core` | [packages/sql-grep-core](./packages/sql-grep-core) |
 | Execution helpers | `@rawsql-ts/executor` | [packages/executor](./packages/executor) |
-| SQL driver adapter primitives | `@rawsql-ts/driver-adapter-core` | [packages/drivers/driver-adapter-core](./packages/drivers/driver-adapter-core) |
+| Production SQL driver adapter primitives | `@rawsql-ts/driver-adapter-core` | [packages/drivers/driver-adapter-core](./packages/drivers/driver-adapter-core) |
 | ZTD fixture rewriting and testkits | `@rawsql-ts/testkit-*` | [packages/testkit-core](./packages/testkit-core) |
 | Test evidence storage and rendering | `@rawsql-ts/test-evidence-*` | [packages/test-evidence-core](./packages/test-evidence-core) |
 | Schema documentation generation | `@rawsql-ts/ddl-docs-*` | [packages/ddl-docs-cli](./packages/ddl-docs-cli) |
@@ -52,7 +52,7 @@ These capabilities are important at the repo level even though they are mostly e
 | [rawsql-ts](./packages/core) | ![npm](https://img.shields.io/npm/v/rawsql-ts) | SQL parser and AST transformer. Zero dependencies, browser-ready. |
 | [@rawsql-ts/sql-grep-core](./packages/sql-grep-core) | ![npm](https://img.shields.io/npm/v/@rawsql-ts/sql-grep-core) | Low-dependency SQL usage analysis engine for AST-based schema impact checks. |
 
-### Driver Adapters
+### Production Driver Adapters
 
 | Package | Version | Description |
 |---------|---------|-------------|
@@ -70,8 +70,17 @@ These capabilities are important at the repo level even though they are mostly e
 |---------|---------|-------------|
 | [@rawsql-ts/testkit-core](./packages/testkit-core) | ![npm](https://img.shields.io/npm/v/@rawsql-ts/testkit-core) | Fixture-backed CTE rewriting and schema validation engine. Driver-agnostic ZTD foundation. |
 | [@rawsql-ts/testkit-postgres](./packages/testkit-postgres) | ![npm](https://img.shields.io/npm/v/@rawsql-ts/testkit-postgres) | Postgres-specific CTE rewriting and fixture validation. Works with any executor. |
-| [@rawsql-ts/adapter-node-pg](./packages/adapters/adapter-node-pg) | ![npm](https://img.shields.io/npm/v/@rawsql-ts/adapter-node-pg) | Adapter connecting `pg` (node-postgres) to testkit-postgres. |
+| [@rawsql-ts/adapter-node-pg](./packages/adapters/adapter-node-pg) | ![npm](https://img.shields.io/npm/v/@rawsql-ts/adapter-node-pg) | Testkit adapter connecting `pg` (node-postgres) to `@rawsql-ts/testkit-postgres`; retained under its legacy name until a non-breaking `testkit-adapter-*` alias exists. |
 | [@rawsql-ts/testkit-sqlite](./packages/testkit-sqlite) | ![npm](https://img.shields.io/npm/v/@rawsql-ts/testkit-sqlite) | SQLite-specific CTE rewriting and fixture validation. In-memory testing with `better-sqlite3`. |
+
+### Adapter Package Spaces
+
+`driver-adapter-*` packages are production runtime driver adapters.
+They handle driver mechanics such as named-parameter compilation, placeholder conversion, and row-result normalization without owning ORM behavior or fixture rewriting.
+
+`testkit-adapter-*` packages are test-only adapters that connect concrete drivers to ZTD/testkit fixture rewriting.
+`@rawsql-ts/adapter-node-pg` currently belongs to that testkit adapter role despite its legacy name.
+The planned rename path is to add a non-breaking alias such as `@rawsql-ts/testkit-adapter-node-postgres`, then document `@rawsql-ts/adapter-node-pg` as the legacy compatibility surface.
 
 ### Evidence
 

--- a/docs/guide/sql-first-end-to-end-tutorial.md
+++ b/docs/guide/sql-first-end-to-end-tutorial.md
@@ -87,13 +87,14 @@ If `docker compose up -d` fails with `all predefined address pools have been ful
 The smoke test proves the starter wiring is sound before you add real feature work.
 It also proves the DB-backed ZTD path is reachable from the starter, not just the DB-free sample path.
 
-If the project was installed with `pnpm install`, keep using pnpm when you add the database adapter for the SQL repair loop:
+If the project was installed with `pnpm install`, keep using pnpm when you add the node-postgres testkit adapter for the SQL repair loop:
 
 ```bash
 pnpm add -D @rawsql-ts/adapter-node-pg
 ```
 
 Avoid mixing `npm install -D` into a pnpm-managed starter project because that can fail before the adapter is added.
+`@rawsql-ts/adapter-node-pg` is the current compatible testkit adapter name; it is not the production driver adapter package space.
 
 ## 3. Add the first real feature
 

--- a/docs/ztd-cli/technology-policy.md
+++ b/docs/ztd-cli/technology-policy.md
@@ -124,7 +124,12 @@ The recommended split is:
 - `@rawsql-ts/ztd-cli`: development-time generator, analyzer, scaffold, and verifier;
 - an optional advanced SQL runtime package: explicit infrastructure for dynamic SQL behavior that cannot be represented as static generated DAO code;
 - an optional advanced SQL runtime package: temporary migration support for dynamic SQL behavior that cannot yet be generated statically.
-- thin driver adapter packages named by concrete driver implementation, such as `@rawsql-ts/driver-adapter-core`, `@rawsql-ts/driver-adapter-node-postgres`, `@rawsql-ts/driver-adapter-postgres-js`, or `@rawsql-ts/driver-adapter-mysql2`.
+- thin production driver adapter packages named by concrete driver implementation, such as `@rawsql-ts/driver-adapter-core`, `@rawsql-ts/driver-adapter-node-postgres`, `@rawsql-ts/driver-adapter-postgres-js`, or `@rawsql-ts/driver-adapter-mysql2`;
+- testkit adapter packages named separately from production driver adapters, such as a future `@rawsql-ts/testkit-adapter-node-postgres`.
+
+The existing `@rawsql-ts/adapter-node-pg` package is a testkit adapter for connecting node-postgres to `@rawsql-ts/testkit-postgres`.
+It should not be treated as the production node-postgres driver adapter.
+The non-breaking rename direction is to introduce a `testkit-adapter-*` alias first, keep the existing package for compatibility, and only then mark the legacy name as deprecated in docs or package metadata.
 
 The optional runtime package should be opt-in and visible.
 `ztd-cli` may provide commands that wire it into a generated project, but the default scaffold should not install it or import it.

--- a/packages/adapters/adapter-node-pg/README.md
+++ b/packages/adapters/adapter-node-pg/README.md
@@ -3,12 +3,17 @@
 ![npm version](https://img.shields.io/npm/v/@rawsql-ts/adapter-node-pg)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 
-Adapter connecting `pg` (node-postgres) Client/Pool APIs to `@rawsql-ts/testkit-postgres`. All rewriting and fixture logic is delegated to the driver-agnostic package.
+Testkit adapter connecting `pg` (node-postgres) Client/Pool APIs to `@rawsql-ts/testkit-postgres`.
+It is for fixture-backed ZTD tests, not the production SQL driver adapter layer.
+All rewriting and fixture logic is delegated to `@rawsql-ts/testkit-postgres`.
+
+The current package name is retained for existing users.
+The intended future naming direction is a non-breaking alias such as `@rawsql-ts/testkit-adapter-node-postgres`, with `@rawsql-ts/adapter-node-pg` kept as the compatible legacy surface during migration.
 
 ## Features
 
-- Drop-in helpers for `pg.Client` and `pg.Pool`
-- Named parameter support (`:user_id` compiled to `$1`)
+- Drop-in testkit helpers for `pg.Client` and `pg.Pool`
+- Named parameter support for test fixtures (`:user_id` compiled to `$1`)
 - Reuses fixture validation and schema snapshot from `@rawsql-ts/testkit-postgres`
 
 ## Installation
@@ -18,6 +23,9 @@ npm install @rawsql-ts/adapter-node-pg pg
 ```
 
 `@rawsql-ts/testkit-postgres` is installed automatically as a dependency.
+
+For production runtime SQL execution, use the `driver-adapter-*` package space such as `@rawsql-ts/driver-adapter-core`.
+This package intentionally stays in the testkit adapter role so a future production `@rawsql-ts/driver-adapter-node-postgres` package can coexist without name confusion.
 
 ## Quick Start
 
@@ -52,6 +60,19 @@ const result = await client.query('SELECT id, email FROM users WHERE id = $1', [
 | `wrapPgClient(client, options)` | Wraps an existing `pg.Client` or `pg.Pool` so queries flow through fixtures without touching your schema. |
 
 All helpers accept the same fixture configuration (`tableDefinitions`, `tableRows`, `ddl`, `missingFixtureStrategy`, etc.) and pass `onExecute` hooks through to `@rawsql-ts/testkit-postgres`.
+
+## Package Naming
+
+`@rawsql-ts/adapter-node-pg` is a testkit adapter package.
+It adapts node-postgres to the ZTD/testkit fixture rewriting path.
+
+The production driver adapter package space is separate:
+
+- `driver-adapter-*` packages are for production SQL driver mechanics such as named-parameter compilation, placeholder conversion, and row-result normalization.
+- `testkit-adapter-*` packages are for ZTD/testkit fixture rewriting adapters that connect concrete drivers to `@rawsql-ts/testkit-*`.
+
+The preferred future name for this package is `@rawsql-ts/testkit-adapter-node-postgres`.
+That rename should be introduced through a non-breaking alias package before this legacy name is deprecated in docs or package metadata.
 
 ## License
 

--- a/packages/adapters/adapter-node-pg/package.json
+++ b/packages/adapters/adapter-node-pg/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rawsql-ts/adapter-node-pg",
   "version": "0.15.8",
-  "description": "Node pg adapter that connects PostgreSQL fixtures to @rawsql-ts/testkit-postgres.",
+  "description": "Testkit adapter that connects node-postgres pg clients and pools to @rawsql-ts/testkit-postgres fixture rewriting.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
@@ -14,6 +14,7 @@
   },
   "keywords": [
     "postgres",
+    "testkit-adapter",
     "adapter",
     "fixtures",
     "rawsql"

--- a/packages/testkit-postgres/README.md
+++ b/packages/testkit-postgres/README.md
@@ -61,7 +61,7 @@ const client = createPostgresTestkitClient({
 });
 ```
 
-The package does not close connections or hold onto drivers — the executor you provide manages pooling and resources. For drop-in `pg` helpers (`createPgTestkitClient`, `createPgTestkitPool`, `wrapPgClient`), see `@rawsql-ts/adapter-node-pg`.
+The package does not close connections or hold onto drivers — the executor you provide manages pooling and resources. For drop-in node-postgres testkit adapter helpers (`createPgTestkitClient`, `createPgTestkitPool`, `wrapPgClient`), see `@rawsql-ts/adapter-node-pg`.
 
 > **Note:** Transaction commands (`BEGIN` / `COMMIT` / `ROLLBACK`) used within testkit are for **test isolation only**. In production code, transaction boundaries and connection lifecycle are the caller's responsibility — not a concern of the query catalog or fixture layer. See the [Execution Scope guide](../../docs/guide/execution-scope.md) for details.
 


### PR DESCRIPTION
## Summary

- Closes #834.
- Clarifies that @rawsql-ts/adapter-node-pg is the node-postgres testkit adapter, not the production driver adapter surface.
- Documents the package-space split between production driver-adapter-* packages and future testkit-adapter-* aliases, with a non-breaking rename path.
- Adds a patch changeset for the compatible legacy package name.

## Verification

- pnpm --filter @rawsql-ts/adapter-node-pg lint
- pnpm --filter @rawsql-ts/adapter-node-pg test
- pnpm --filter @rawsql-ts/adapter-node-pg build
- pnpm changeset status --since origin/main --output=tmp/changeset-status.json
- git diff --cached --check
- pre-commit: workspace typecheck, workspace tests, workspace build, workspace lint

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: not needed; no baseline exception requested.
Scoped checks run: not needed; no baseline exception requested.
Why full baseline is not required: full baseline exception path not used for this PR.

## Self Review

Self-review workflow: Manual self-review skill, two cycles after verification.
Self-review result: No unresolved blockers; wording constrained to a non-breaking rename path, not an implemented rename.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: Documentation and package metadata clarify naming only; no CLI commands, options, generated files, or user migration steps change.
Upgrade note: not selected for this PR.
Deprecation/removal plan or issue: not selected for this PR.
Docs/help/examples updated: not selected for this PR.
Release/changeset wording: not selected for this PR.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: Only the tutorial wording changed; no scaffold templates, init output, generated files, or scaffold behavior changed.
Non-edit assertion: not selected for this PR.
Fail-fast input-contract proof: not selected for this PR.
Generated-output viability proof: not selected for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified distinction between production driver adapters and testkit adapters across repository documentation.
  * Updated adapter naming taxonomy to properly categorize `@rawsql-ts/adapter-node-pg` as a testkit adapter for test environments.
  * Improved package descriptions and guidance to prevent confusion between production and test-only adapter packages.
  * Added clarification on package naming conventions and planned future naming updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mk3008/rawsql-ts/pull/837?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->