### PR TITLE
fix(transfer): align pg adapter with runtime-free driver adapter

### DIFF
--- a/packages/transfer/package.json
+++ b/packages/transfer/package.json
@@ -48,6 +48,7 @@
     "pre-commit": "pnpm lint-staged"
   },
   "dependencies": {
+    "@rawsql-ts/driver-adapter-core": "workspace:*",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/transfer/src/adapters/pg/sql-client.ts
+++ b/packages/transfer/src/adapters/pg/sql-client.ts
@@ -1,10 +1,11 @@
+import { createRowsOnlySqlClient } from '@rawsql-ts/driver-adapter-core';
 import type { SqlClient } from '#libraries/sql/sql-client.js';
 
 /**
- * Adapt a `pg`-style queryable (Client or Pool) into a SqlClient.
+ * Adapt a node-postgres `pg`-style queryable (Client or Pool) into a SqlClient.
  *
- * pg's `query()` returns `QueryResult<T>` with a `.rows` property.
- * This helper unwraps the result so it satisfies the shared `SqlClient` contract.
+ * SQL resources can keep `:name` parameters for readability. The adapter compiles
+ * them to node-postgres `$1`, `$2`, ... placeholders immediately before execution.
  *
  * Usage:
  *   // This runtime example uses DATABASE_URL for application code.
@@ -13,17 +14,8 @@ import type { SqlClient } from '#libraries/sql/sql-client.js';
  *   const client = fromPg(pool);
  *   const users = await client.query<{ id: number }>('SELECT id ...', []);
  */
-export function fromPg(
-  queryable: {
-    query(text: string, values?: readonly unknown[]): Promise<{ rows: Record<string, unknown>[] }>;
-  }
-): SqlClient {
-  return {
-    query<T extends Record<string, unknown> = Record<string, unknown>>(
-      text: string,
-      values?: readonly unknown[]
-    ): Promise<T[]> {
-      return queryable.query(text, values).then((result) => result.rows as T[]);
-    }
-  };
+export function fromPg(queryable: {
+  query(text: string, values?: readonly unknown[]): Promise<{ rows: Record<string, unknown>[] }>;
+}): SqlClient {
+  return createRowsOnlySqlClient(queryable, { placeholderStyle: 'pg-indexed' });
 }

--- a/packages/transfer/src/libraries/sql/sql-client.ts
+++ b/packages/transfer/src/libraries/sql/sql-client.ts
@@ -1,15 +1,15 @@
-/**
- * Promise that resolves to the array of rows produced by an SQL query.
- * @template T Shape of each row yielded by the SQL client.
- * @example
- * const rows: SqlQueryRows<{ id: number; name: string }> = client.query('SELECT id, name FROM users');
- */
-export type SqlQueryRows<T> = Promise<T[]>;
+export type {
+  SqlClient,
+  SqlNamedParams,
+  SqlQueryParameters,
+  SqlQueryRows,
+} from '@rawsql-ts/driver-adapter-core';
 
 /**
  * Minimal SQL client contract shared by the app and adapter boundaries.
  *
- * - Production: adapt this contract to your preferred driver (pg, mysql2, etc.) and normalize the results to `T[]`.
+ * - Production: adapt this contract to your preferred driver (node-postgres, mysql2, etc.) and normalize the results to `T[]`.
+ * - SQL files may keep `:name` parameters for readability; driver adapters compile them to the placeholder style required by the driver.
  * - Tests: replace the implementation with a mock, a fixture helper, or an adapter that follows this contract.
  *
  * Connection strategy note:
@@ -17,9 +17,3 @@ export type SqlQueryRows<T> = Promise<T[]>;
  * - Multiple clients can coexist in the same workflow as long as each one owns its own lifecycle.
  * - Do not share a live client across parallel workers without proper synchronization.
  */
-export type SqlClient = {
-  query<T extends Record<string, unknown> = Record<string, unknown>>(
-    text: string,
-    values?: readonly unknown[]
-  ): SqlQueryRows<T>;
-};

--- a/packages/transfer/tests/adapters/pg/sql-client.test.ts
+++ b/packages/transfer/tests/adapters/pg/sql-client.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'vitest';
+
+import { fromPg } from '../../../src/adapters/pg/sql-client.js';
+
+describe('fromPg', () => {
+  test('compiles named parameters to node-postgres placeholders', async () => {
+    const calls: Array<{ text: string; values?: readonly unknown[] }> = [];
+    const client = fromPg({
+      async query(text, values) {
+        calls.push({ text, values });
+        return { rows: [{ destination_definition_id: '1' }] };
+      },
+    });
+
+    const rows = await client.query<{ destination_definition_id: string }>(
+      'select * from transfer_destination_definition where destination_definition_name = any(:names) and is_enabled = :enabled',
+      { names: ['journal', 'ledger'], enabled: true },
+    );
+
+    expect(rows).toEqual([{ destination_definition_id: '1' }]);
+    expect(calls).toEqual([
+      {
+        text: 'select * from transfer_destination_definition where destination_definition_name = any($1) and is_enabled = $2',
+        values: [['journal', 'ledger'], true],
+      },
+    ]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -457,6 +457,9 @@ importers:
 
   packages/transfer:
     dependencies:
+      '@rawsql-ts/driver-adapter-core':
+        specifier: workspace:*
+        version: link:../drivers/driver-adapter-core
       zod:
         specifier: ^4.3.6
         version: 4.3.6


### PR DESCRIPTION
## Summary

- Align `@rawsql-ts/transfer` with the runtime-free ztd-cli path by reusing `@rawsql-ts/driver-adapter-core` for the shared SQL client contract.
- Update the transfer pg adapter so SQL resources can keep named parameters while node-postgres receives `$1`, `$2`, ... placeholders.
- Add a regression test proving `fromPg` compiles named params before execution.

## Verification

- `pnpm --filter @rawsql-ts/transfer typecheck`
- `pnpm --filter @rawsql-ts/transfer test`
- `pnpm --filter @rawsql-ts/transfer build`
- `pnpm --filter @rawsql-ts/transfer lint`
- pre-commit workspace checks passed: `typecheck`, `test`, `build`, `lint`

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

<!-- Write values on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. -->
<!-- Do not add list markers like "-" before these labels; `Tracking issue:` and `Scoped checks run:` must start at column 0. -->
Tracking issue: none
Scoped checks run: transfer scoped checks plus pre-commit workspace typecheck/test/build/lint
Why full baseline is not required: full pre-commit workspace checks passed; no baseline exception is requested

## Self Review

<!-- Fill these fields after running the repo self-review workflow or available self-review skill. -->
Self-review workflow: Codex self-review skill, two-cycle review before PR authoring
Self-review result: no merge blockers found; evidence supports the runtime adapter alignment claim

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-migration rationale: no ztd-cli command, help, docs, or user-facing CLI behavior changed; this only aligns transfer runtime adapter code with the existing driver adapter core.
Upgrade note: not applicable
Deprecation/removal plan or issue: not applicable
Docs/help/examples updated: not applicable
Release/changeset wording: not applicable; transfer is private and no release changeset is required

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-proof rationale: no ztd-cli scaffold command or template files changed.
Non-edit assertion: not applicable
Fail-fast input-contract proof: not applicable
Generated-output viability proof: not applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated SQL client interface across database adapters for consistent parameter handling and behavior.
  * Improved SQL parameter normalization for query execution.

* **Tests**
  * Added test coverage for SQL parameter conversion and query result handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mk3008/rawsql-ts/pull/838?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->