### PR TITLE
Fix publish smoke driver adapter tarball binding

### DIFF
--- a/packages/ztd-cli/src/commands/init.ts
+++ b/packages/ztd-cli/src/commands/init.ts
@@ -292,7 +292,7 @@ const STACK_DEV_DEPENDENCIES: Record<string, string> = {
   '@rawsql-ts/ztd-cli': resolveCurrentCliVersion(),
 };
 const STACK_RUNTIME_DEPENDENCIES: Record<string, string> = {
-  '@rawsql-ts/driver-adapter-core': '^0.1.0'
+  '@rawsql-ts/driver-adapter-core': '^0.2.0'
 };
 const STARTER_DEV_DEPENDENCIES: Record<string, string> = {
   pg: '^8.13.1',

--- a/packages/ztd-cli/tests/publishWorkflow.unit.test.ts
+++ b/packages/ztd-cli/tests/publishWorkflow.unit.test.ts
@@ -122,3 +122,9 @@ test('packed tarball install smoke only runs commands for tarballs included in t
   expect(publishedPackageModeScript).toContain('.filter((packageName) => hasTarballDependency(tarballDependencies, packageName));');
   expect(publishedPackageModeScript).toContain('if (smokeImportTargets.length > 0) {');
 });
+
+test('published-package smoke rebinds scaffold runtime dependencies to packed tarballs', () => {
+  expect(publishedPackageModeScript).toContain('for (const sectionName of ["dependencies", "optionalDependencies", "peerDependencies"])');
+  expect(publishedPackageModeScript).toContain('section[dependencyName] = tarballDependencies[dependencyName];');
+  expect(publishedPackageModeScript).toContain('restoreTarballDependencies(appDir, tarballDependencies);');
+});

--- a/scripts/verify-published-package-mode.mjs
+++ b/scripts/verify-published-package-mode.mjs
@@ -251,6 +251,17 @@ function readPackageJson(directory) {
 function restoreTarballDependencies(directory, tarballDependencies) {
   const packageJsonPath = path.join(directory, "package.json");
   const packageJson = readPackageJson(directory);
+  for (const sectionName of ["dependencies", "optionalDependencies", "peerDependencies"]) {
+    const section = packageJson[sectionName];
+    if (!section || typeof section !== "object" || Array.isArray(section)) {
+      continue;
+    }
+    for (const dependencyName of Object.keys(section)) {
+      if (typeof tarballDependencies[dependencyName] === "string") {
+        section[dependencyName] = tarballDependencies[dependencyName];
+      }
+    }
+  }
   packageJson.devDependencies = {
     ...(packageJson.devDependencies ?? {}),
     ...tarballDependencies,


### PR DESCRIPTION
## Summary

- rebind generated consumer runtime dependencies to packed tarballs during published-package smoke verification
- align ztd init's driver adapter dependency floor with the just-released driver-adapter-core version
- add a publish workflow unit check for runtime dependency tarball rebinding

## Verification

- pnpm --filter @rawsql-ts/ztd-cli test -- publishWorkflow
- pnpm --filter @rawsql-ts/ztd-cli exec tsc -p tsconfig.json --noEmit *(fails on existing rawsql-ts SSSQL/tokenizer export drift, unrelated to this publish smoke failure)*

## Notes

This fixes the manual Publish workflow failure where the generated npm consumer could not resolve @rawsql-ts/driver-adapter-core during typecheck.

This PR intentionally uses the `no-release` path because it fixes publish verification before the pending versions are published; adding a changeset would create another release bump for a smoke-test repair.

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: N/A
Scoped checks run: pnpm --filter @rawsql-ts/ztd-cli test -- publishWorkflow; pnpm --filter @rawsql-ts/ztd-cli exec tsc -p tsconfig.json --noEmit
Why full baseline is not required: N/A

## Self Review

Self-review workflow: local focused review of changed publish-smoke script, ztd init dependency floor, and publish workflow unit coverage
Self-review result: no blockers found for the targeted publish-smoke fix; ztd-cli tsc still fails on existing rawsql-ts SSSQL/tokenizer export drift outside this PR

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: This does not change command syntax, flags, help text, or user-facing CLI behavior; it aligns generated dependency metadata and publish-smoke verification.
Upgrade note: N/A
Deprecation/removal plan or issue: N/A
Docs/help/examples updated: N/A
Release/changeset wording: N/A; PR is labeled no-release because it repairs pre-publish verification.

## Scaffold Contract Proof

- [ ] No scaffold contract proof required for this PR.
- [x] Scaffold contract proof completed.

No-proof rationale: N/A
Non-edit assertion: The change only updates the runtime dependency version emitted by ztd init and the publish-smoke tarball rebinding; scaffold file layout and parent files are not rewritten.
Fail-fast input-contract proof: Existing publishWorkflow unit coverage remains green, and this PR adds a guard that publish-smoke dependency rebinding is present before runtime typecheck.
Generated-output viability proof: Packed runtime dependencies are rebound into generated consumer dependencies, optionalDependencies, and peerDependencies so generated output can resolve @rawsql-ts/driver-adapter-core from local tarballs during publish verification.