### PR TITLE
Fix publish plan for new scaffold runtime packages

### DIFF
--- a/packages/ztd-cli/package.json
+++ b/packages/ztd-cli/package.json
@@ -46,7 +46,8 @@
     "fast-glob": "^3.3.3",
     "rawsql-ts": "^0.21.0",
     "yaml": "^2.8.3",
-    "@rawsql-ts/sql-grep-core": "^0.1.10"
+    "@rawsql-ts/sql-grep-core": "^0.1.10",
+    "@rawsql-ts/driver-adapter-core": "^0.2.0"
   },
   "peerDependencies": {
     "@rawsql-ts/adapter-node-pg": "^0.15.9"
@@ -58,7 +59,6 @@
   },
   "devDependencies": {
     "@rawsql-ts/adapter-node-pg": "^0.15.9",
-    "@rawsql-ts/driver-adapter-core": "^0.2.0",
     "@rawsql-ts/testkit-core": "^0.17.0",
     "@rawsql-ts/testkit-postgres": "^0.16.0",
     "@testcontainers/postgresql": "^10.28.0",

--- a/packages/ztd-cli/tests/publishWorkflow.unit.test.ts
+++ b/packages/ztd-cli/tests/publishWorkflow.unit.test.ts
@@ -10,8 +10,15 @@ const releasePrWorkflowPath = path.resolve(__dirname, '../../../.github/workflow
 const releasePrWorkflow = fs.readFileSync(releasePrWorkflowPath, 'utf8');
 const publishedPackageModePath = path.resolve(__dirname, '../../../scripts/verify-published-package-mode.mjs');
 const publishedPackageModeScript = fs.readFileSync(publishedPackageModePath, 'utf8');
+const publishPlanPath = path.resolve(__dirname, '../../../scripts/publish-plan.mjs');
+const publishPlanScript = fs.readFileSync(publishPlanPath, 'utf8');
 const generatedProjectModePath = path.resolve(__dirname, '../../../scripts/verify-generated-project-mode.mjs');
 const generatedProjectModeScript = fs.readFileSync(generatedProjectModePath, 'utf8');
+const ztdCliPackageJsonPath = path.resolve(__dirname, '../package.json');
+const ztdCliPackageJson = JSON.parse(fs.readFileSync(ztdCliPackageJsonPath, 'utf8')) as {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+};
 
 test('publish workflow verifies built artifacts before actual publish', () => {
   expect(publishWorkflow).toContain('verify_publish_artifacts:');
@@ -127,4 +134,12 @@ test('published-package smoke rebinds scaffold runtime dependencies to packed ta
   expect(publishedPackageModeScript).toContain('for (const sectionName of ["dependencies", "optionalDependencies", "peerDependencies"])');
   expect(publishedPackageModeScript).toContain('section[dependencyName] = tarballDependencies[dependencyName];');
   expect(publishedPackageModeScript).toContain('restoreTarballDependencies(appDir, tarballDependencies);');
+});
+
+test('publish plan can include unpublished workspace dependencies required by published scaffolds', () => {
+  expect(ztdCliPackageJson.dependencies).toHaveProperty('@rawsql-ts/driver-adapter-core');
+  expect(ztdCliPackageJson.devDependencies).not.toHaveProperty('@rawsql-ts/driver-adapter-core');
+  expect(publishPlanScript).toContain('for (let index = 0; index < publishCandidates.length; index += 1)');
+  expect(publishPlanScript).toContain('for (const dependencyName of candidate.workspaceDependencies)');
+  expect(publishPlanScript).toContain('addPublishCandidate(dependencyPkg);');
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -509,6 +509,9 @@ importers:
 
   packages/ztd-cli:
     dependencies:
+      '@rawsql-ts/driver-adapter-core':
+        specifier: ^0.2.0
+        version: link:../drivers/driver-adapter-core
       '@rawsql-ts/sql-grep-core':
         specifier: ^0.1.10
         version: link:../sql-grep-core
@@ -540,9 +543,6 @@ importers:
       '@rawsql-ts/adapter-node-pg':
         specifier: ^0.15.9
         version: link:../adapters/adapter-node-pg
-      '@rawsql-ts/driver-adapter-core':
-        specifier: ^0.2.0
-        version: link:../drivers/driver-adapter-core
       '@rawsql-ts/testkit-core':
         specifier: ^0.17.0
         version: link:../testkit-core

--- a/scripts/publish-plan.mjs
+++ b/scripts/publish-plan.mjs
@@ -61,6 +61,39 @@ function main() {
   const blockers = [];
   const notices = [];
   const publishCandidates = [];
+  const candidateNames = new Set();
+  const packageRegistryState = new Map();
+
+  function getRegistryState(pkg) {
+    const cached = packageRegistryState.get(pkg.name);
+    if (cached) {
+      return cached;
+    }
+
+    const existsOnRegistry = npmPackageExists(pkg.name);
+    const versionPublished = existsOnRegistry ? npmPackageVersionExists(pkg.name, pkg.version) : false;
+    const state = {
+      existsOnRegistry,
+      versionPublished,
+    };
+    packageRegistryState.set(pkg.name, state);
+    return state;
+  }
+
+  function addPublishCandidate(pkg) {
+    if (candidateNames.has(pkg.name)) {
+      return;
+    }
+
+    candidateNames.add(pkg.name);
+    publishCandidates.push({
+      name: pkg.name,
+      version: pkg.version,
+      dir: pkg.dir,
+      changelogPath: pkg.changelogPath,
+      workspaceDependencies: collectWorkspaceDependencyNames(pkg, workspaceNames),
+    });
+  }
 
   if (pendingChangesets.length > 0) {
     blockers.push({
@@ -76,8 +109,38 @@ function main() {
       continue;
     }
 
-    const existsOnRegistry = npmPackageExists(pkg.name);
-    if (!existsOnRegistry) {
+    const registryState = getRegistryState(pkg);
+    if (!registryState.existsOnRegistry || registryState.versionPublished) {
+      continue;
+    }
+
+    addPublishCandidate(pkg);
+  }
+
+  for (let index = 0; index < publishCandidates.length; index += 1) {
+    const candidate = publishCandidates[index];
+    for (const dependencyName of candidate.workspaceDependencies) {
+      const dependencyPkg = workspacePackages.get(dependencyName);
+      if (!dependencyPkg || dependencyPkg.private || candidateNames.has(dependencyName)) {
+        continue;
+      }
+
+      const dependencyRegistryState = getRegistryState(dependencyPkg);
+      if (dependencyRegistryState.versionPublished) {
+        continue;
+      }
+
+      addPublishCandidate(dependencyPkg);
+    }
+  }
+
+  for (const pkg of Array.from(workspacePackages.values()).sort((left, right) => left.name.localeCompare(right.name))) {
+    if (pkg.private || candidateNames.has(pkg.name)) {
+      continue;
+    }
+
+    const registryState = getRegistryState(pkg);
+    if (!registryState.existsOnRegistry) {
       notices.push({
         classification: "quality-issue",
         code: "unregistered-package",
@@ -85,21 +148,7 @@ function main() {
         packageName: pkg.name,
         version: pkg.version,
       });
-      continue;
     }
-
-    const alreadyPublished = npmPackageVersionExists(pkg.name, pkg.version);
-    if (alreadyPublished) {
-      continue;
-    }
-
-    publishCandidates.push({
-      name: pkg.name,
-      version: pkg.version,
-      dir: pkg.dir,
-      changelogPath: pkg.changelogPath,
-      workspaceDependencies: collectWorkspaceDependencyNames(pkg, workspaceNames),
-    });
   }
 
   const buildOrder = topoSortWorkspaceDependencies(


### PR DESCRIPTION
## Summary

- include unpublished workspace dependencies required by publish candidates in the manual publish plan
- move @rawsql-ts/driver-adapter-core into ztd-cli dependencies so scaffold runtime packages are part of the publish dependency closure
- keep unrelated unregistered packages such as @rawsql-ts/advanced-runtime skipped when they are not required by the publish closure

## Verification

- node scripts/publish-plan.mjs --output-dir tmp\\local-publish-plan-after-install
- pnpm --filter @rawsql-ts/ztd-cli test -- publishWorkflow
- pnpm --filter @rawsql-ts/driver-adapter-core run build
- pnpm --filter @rawsql-ts/ztd-cli exec tsc -p tsconfig.json --noEmit
- git diff --check

## Notes

This fixes the manual Publish workflow failure where ztd init generated a consumer dependency on @rawsql-ts/driver-adapter-core, but the publish artifact manifest did not include a driver-adapter-core tarball because the package was still unregistered on npm.

This PR intentionally uses the `no-release` path because it repairs the unpublished 0.27.0 / 0.2.0 publish pipeline before those versions are published.

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: N/A
Scoped checks run: node scripts/publish-plan.mjs --output-dir tmp\\local-publish-plan-after-install; pnpm --filter @rawsql-ts/ztd-cli test -- publishWorkflow; pnpm --filter @rawsql-ts/driver-adapter-core run build; pnpm --filter @rawsql-ts/ztd-cli exec tsc -p tsconfig.json --noEmit; git diff --check
Why full baseline is not required: N/A

## Self Review

Self-review workflow: local focused review of publish plan dependency closure, ztd-cli package metadata, and publish workflow test coverage
Self-review result: no blockers found for the targeted manual Publish fix; full local artifact build was attempted but stopped at an existing Windows-local ddl-docs-cli prepack path, while the failing CI build_publish_artifacts lane had already passed on Ubuntu

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: This does not change command syntax, flags, help text, or generated source shape; it only ensures the existing generated runtime dependency is available during publish verification and actual publish.
Upgrade note: N/A
Deprecation/removal plan or issue: N/A
Docs/help/examples updated: N/A
Release/changeset wording: N/A; PR is labeled no-release because it repairs pre-publish verification.

## Scaffold Contract Proof

- [ ] No scaffold contract proof required for this PR.
- [x] Scaffold contract proof completed.

No-proof rationale: N/A
Non-edit assertion: The scaffold template and generated files are unchanged; only package dependency publication metadata and publish planning changed.
Fail-fast input-contract proof: publishWorkflow unit coverage now asserts driver-adapter-core is a ztd-cli dependency and the publish plan follows workspace dependency closure.
Generated-output viability proof: Local publish plan output includes @rawsql-ts/driver-adapter-core as a publish candidate and ztd-cli workspace dependency, so publish artifact verification can rebind generated consumer dependencies to packed tarballs.