### PR TITLE
fix(ztd-cli): improve starter setup errors

### DIFF
--- a/.agents/skills/pr-readiness/SKILL.md
+++ b/.agents/skills/pr-readiness/SKILL.md
@@ -21,7 +21,7 @@ Use this skill before creating or editing a rawsql-ts pull request.
    - `Merge Readiness`
    - `CLI Surface Migration` when CLI-facing files changed
    - `Scaffold Contract Proof` when scaffold-related files changed
-6. Fill required same-line fields exactly as labels appear in the template, including `Self-review workflow:` and `Self-review result:`.
+6. Fill required same-line fields exactly as labels appear in the template, including `Self-review workflow:`, `Self-review result:`, `Concept-review workflow:`, and `Concept-review result:`.
 7. After implementation verification, run the repo self-review workflow as the finishing review pass before PR authoring.
 8. Before `gh pr create` / `gh pr edit`, validate the prepared PR body by running the readiness script locally.
 9. Do not present the PR as ready while self-review has unresolved blockers or the readiness script fails.
@@ -46,7 +46,9 @@ Use the actual base and head SHAs from the PR or from `git merge-base` / `git re
 - Required gates selected
 - Required fields filled
 - Self-review workflow and result recorded in the PR body
+- Concept-review workflow and result recorded in the PR body
 - Self-review blockers resolved or explicitly surfaced
+- Concept or package-boundary violations resolved or explicitly surfaced
 - Local readiness command
 - Readiness result
 - Remaining blockers

--- a/.agents/skills/self-review/SKILL.md
+++ b/.agents/skills/self-review/SKILL.md
@@ -15,15 +15,17 @@ Use this skill when rawsql-ts developer work is about to be shown to a human. Th
 
 ## Workflow
 1. Run `consistency review`.
-2. Record findings about literal drift, mirror / test / policy mismatch, required fields, GitHub-safe references, per-item final form, and test wording.
-3. Run `human acceptance review`.
-4. Record findings about reviewer cognitive load, issue context, visible value, visible evidence, guarantee limits, gaps, and next human decision.
-5. Triage each finding as `blocker`, `follow-up`, or `nit`.
-6. Resolve blockers or mark the result not ready.
+2. Run `concept boundary review` for changed package behavior, generated scaffold output, docs, and review wording. Read the owning package concept, package scope, technology policy, or Concept Spec when one exists, and check whether the change violates durable boundaries such as runtime-free standard paths, SQL-first visibility, human-owned concept authority, or package responsibility limits.
+3. Record findings about literal drift, mirror / test / policy mismatch, concept / package-policy mismatch, required fields, GitHub-safe references, per-item final form, and test wording.
+4. Run `human acceptance review`.
+5. Record findings about reviewer cognitive load, issue context, visible value, visible evidence, guarantee limits, gaps, and next human decision.
+6. Triage each finding as `blocker`, `follow-up`, or `nit`.
+7. Resolve blockers or mark the result not ready.
 
 ## Output Shape
 - Source request or source issue
 - Review cycle 1 findings
+- Concept boundary review findings
 - Review cycle 2 findings
 - Triage summary
 - Review readiness
@@ -31,6 +33,8 @@ Use this skill when rawsql-ts developer work is about to be shown to a human. Th
 
 ## Constraints
 - Run both review cycles before claiming readiness for human review.
+- Do not claim readiness for package behavior, scaffold output, generated runtime code, docs, or PR text until the concept boundary review has checked the relevant Concept Spec or package concept when one exists.
+- Treat a violation of a durable package concept as a blocker unless the PR explicitly includes a human-approved concept or scope change.
 - Do not treat wording-only issues as blockers by default.
 - Do not bury blockers inside a summary paragraph.
 - If a blocker remains, mark the result not ready.

--- a/.changeset/bright-starter-errors.md
+++ b/.changeset/bright-starter-errors.md
@@ -1,0 +1,5 @@
+---
+'@rawsql-ts/ztd-cli': patch
+---
+
+Improve starter onboarding failures by replacing npm's default test placeholder during init and generating actionable database setup errors for missing or unreachable starter Postgres connections.

--- a/.codex/agents/review.md
+++ b/.codex/agents/review.md
@@ -12,6 +12,7 @@ Use this subagent after verification and reporting but before human review. Its 
 - Run `consistency review` first.
 - Run `human acceptance review` second.
 - Check the pre-PR retro gate before declaring review readiness.
+- Run `concept boundary review` as part of the finishing review for changed package behavior, generated scaffold output, docs, and PR wording. Read the owning package concept, package scope, technology policy, or Concept Spec when one exists, and check whether the change violates durable boundaries such as runtime-free standard paths, SQL-first visibility, human-owned concept authority, or package responsibility limits.
 - Use `.agents/skills/package-spec-review/SKILL.md` when package-level Scope, Test Policy, Authority Model, Technology Policy, review-plan, or generated review views are part of the change.
 - Use `.agents/skills/structured-metadata-migration-review/SKILL.md` when structured Concept Specs, rule registries, AI review JSON, relationship metadata, or generated review views are added or migrated.
 - Use `.agents/skills/broad-generated-diff-review-packet/SKILL.md` when generated docs, API docs, mass removals, or broad derived artifacts make normal review coverage hard to judge.
@@ -33,6 +34,7 @@ Use this subagent after verification and reporting but before human review. Its 
 Check that:
 
 - required sections are present,
+- changed behavior and generated output are consistent with the owning package concept or Concept Spec when one exists,
 - per-item reporting keeps `acceptance item`, `status`, `evidence`, and `gap` visible,
 - unresolved PR-blocking retro items are either closed or explicitly surfaced,
 - failed required checks are not dismissed as out of scope solely because they occur outside touched files,
@@ -41,6 +43,17 @@ Check that:
 - `tests were updated` and `tests passed` are not conflated,
 - GitHub-facing text does not contain local filesystem paths, and
 - the report does not overclaim beyond the stated evidence.
+
+## Concept Boundary Review
+
+Check that:
+
+- package changes do not contradict the package concept, package scope, technology policy, or approved Concept Specs,
+- `@rawsql-ts/ztd-cli` standard generated runtime remains runtime-free: no dependency on `ztd-cli`, `rawsql-ts`, runtime mapper libraries, runtime validator libraries, SQL JSON result shaping, or hidden business SQL rewriting in the standard scaffold path,
+- driver adapter behavior stays limited to driver-facing mechanics such as named-parameter compilation and row-result normalization,
+- test support, examples, and DB-backed starter guidance are not mistaken for production runtime requirements,
+- any deliberate concept or scope change is explicitly human-approved in the issue or PR text, and
+- concept review findings are triaged as blockers when they contradict durable package boundaries without an approved concept/scope change.
 
 ## Review Cycle 2: Human Acceptance Review
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,6 +22,8 @@ Why full baseline is not required:
 <!-- Fill these fields after running the repo self-review workflow or available self-review skill. -->
 Self-review workflow:
 Self-review result:
+Concept-review workflow:
+Concept-review result:
 
 ## CLI Surface Migration
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,8 @@ Deeper `AGENTS.md` files take precedence when they add stricter or narrower rule
 
 - Development has two completion stages: first prove the feature and regression tests, then run a separate finishing review pass before PR handoff.
 - The finishing review pass must use the available self-review workflow or repo-local review skill, and it must look for cross-mode regressions such as direct command versus PR/worktree command behavior.
+- The finishing review pass must include a concept boundary review when the change touches package behavior, generated scaffold output, generated runtime code, docs, or PR wording. Read the owning package concept, package scope, technology policy, or Concept Spec when one exists.
+- For `@rawsql-ts/ztd-cli`, the concept boundary review must check that the standard generated runtime path remains runtime-free: no dependency on `ztd-cli`, `rawsql-ts`, runtime mapper libraries, runtime validator libraries, SQL JSON result shaping, or hidden business SQL rewriting. Test support and driver adapters may exist only within their stated non-ORM, driver/test roles.
 - Final PR text and final implementation reports must pass self-review before human review.
 - Before creating or editing a PR, read `.github/pull_request_template.md` and use `.agents/skills/pr-readiness/SKILL.md` when present.
 - Before claiming a PR is ready, run the repository PR readiness script locally when `scripts/check-pr-readiness.js` exists, or explicitly state why it could not be run.

--- a/packages/ztd-cli/src/commands/init.ts
+++ b/packages/ztd-cli/src/commands/init.ts
@@ -1993,7 +1993,7 @@ function ensurePackageJsonFormatting(
 
   // Ensure the canonical formatting and lint scripts exist without overwriting custom commands.
   for (const [name, value] of Object.entries(requiredScripts)) {
-    if (name in scripts) {
+    if (name in scripts && !shouldReplaceScaffoldScript(name, scripts[name])) {
       continue;
     }
     scripts[name] = value;
@@ -2104,6 +2104,18 @@ function ensurePackageJsonFormatting(
   // Persist the updated manifest so the new scripts and tools are available immediately.
   dependencies.writeFile(packagePath, `${JSON.stringify(parsed, null, 2)}\n`);
   return { relativePath: relative, outcome: packageExists ? 'overwritten' : 'created' };
+}
+
+function shouldReplaceScaffoldScript(name: string, currentValue: string | undefined): boolean {
+  if (name !== 'test' || currentValue === undefined) {
+    return false;
+  }
+
+  const normalized = currentValue.trim().replace(/\s+/g, ' ');
+  return (
+    normalized === 'echo "Error: no test specified" && exit 1' ||
+    normalized === "echo 'Error: no test specified' && exit 1"
+  );
 }
 
 function resolveLintStagedCommand(packageManager: PackageManager): string {

--- a/packages/ztd-cli/templates/tests/support/postgres-testkit.ts
+++ b/packages/ztd-cli/templates/tests/support/postgres-testkit.ts
@@ -96,9 +96,7 @@ export function createStarterPostgresTestkitClient<RowType extends Record<string
 ): PostgresTestkitClient<RowType> {
   const connectionString = options.connectionString ?? process.env.ZTD_DB_URL;
   if (!connectionString) {
-    throw new Error(
-      'Set options.connectionString or ZTD_DB_URL before creating a starter Postgres testkit client.'
-    );
+    throw new Error(buildStarterPostgresSetupMessage());
   }
 
   const defaults = loadStarterPostgresDefaults(options.rootDir);
@@ -106,11 +104,15 @@ export function createStarterPostgresTestkitClient<RowType extends Record<string
 
   return createPostgresTestkitClient({
     queryExecutor: async (sql, params) => {
-      const result = await pool.query(sql, params as unknown[]);
-      return {
-        rows: result.rows,
-        rowCount: result.rowCount ?? undefined
-      };
+      try {
+        const result = await pool.query(sql, params as unknown[]);
+        return {
+          rows: result.rows,
+          rowCount: result.rowCount ?? undefined
+        };
+      } catch (error) {
+        throw wrapStarterPostgresFailureIfHelpful(error, connectionString);
+      }
     },
     defaultSchema: options.defaultSchema ?? defaults.defaultSchema,
     searchPath: options.searchPath ?? defaults.searchPath,
@@ -123,6 +125,69 @@ export function createStarterPostgresTestkitClient<RowType extends Record<string
       await pool.end();
     }
   });
+}
+
+function buildStarterPostgresSetupMessage(): string {
+  return [
+    'ZTD_DB_URL is not set before creating a starter Postgres testkit client.',
+    '',
+    'Next steps:',
+    '1. Copy `.env.example` to `.env`.',
+    '2. Set `ZTD_DB_PORT=5432`, or choose another free host port.',
+    '3. Start the starter Postgres database with `docker compose up -d`.',
+    '4. Rerun `npx vitest run`.',
+    '',
+    'The generated Vitest setup derives `ZTD_DB_URL` from `ZTD_DB_PORT`.',
+    'If Docker reports `all predefined address pools have been fully subnetted`, fix Docker networking first; changing `ZTD_DB_PORT` alone will not recover that error.'
+  ].join('\n');
+}
+
+function wrapStarterPostgresFailureIfHelpful(error: unknown, connectionString: string): unknown {
+  if (!isStarterPostgresConnectionFailure(error)) {
+    return error;
+  }
+
+  const originalMessage = error instanceof Error ? error.message : String(error);
+  const wrapped = new Error(
+    [
+      'The starter Postgres database was not reachable while running a starter Postgres testkit query.',
+      '',
+      `Connection target: ${describeConnectionTarget(connectionString)}`,
+      `Original error: ${originalMessage}`,
+      '',
+      'Next steps:',
+      '1. Start the bundled database with `docker compose up -d`.',
+      '2. If port 5432 is already in use, set another `ZTD_DB_PORT` in `.env` and rerun `docker compose up -d`.',
+      '3. Wait until Postgres is ready, then rerun `npx vitest run`.',
+      '',
+      'If Docker reports `all predefined address pools have been fully subnetted`, fix Docker networking first; changing `ZTD_DB_PORT` alone will not recover that error.'
+    ].join('\n')
+  );
+  (wrapped as Error & { cause?: unknown }).cause = error;
+  return wrapped;
+}
+
+function isStarterPostgresConnectionFailure(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+
+  const code = 'code' in error ? String((error as { code?: unknown }).code) : '';
+  if (['ECONNREFUSED', 'ENOTFOUND', 'ETIMEDOUT', 'ECONNRESET', 'EAI_AGAIN', '28P01', '3D000'].includes(code)) {
+    return true;
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  return /connection terminated|connection timeout|password authentication failed|getaddrinfo|connect econnrefused/i.test(message);
+}
+
+function describeConnectionTarget(connectionString: string): string {
+  try {
+    const url = new URL(connectionString);
+    return `${url.protocol}//${url.hostname}${url.port ? `:${url.port}` : ''}/${url.pathname.replace(/^\/+/, '')}`;
+  } catch {
+    return 'configured ZTD_DB_URL';
+  }
 }
 
 function resolveStarterDdlOptions(ddlDirectories: string[]): DdlFixtureLoaderOptions | undefined {

--- a/packages/ztd-cli/templates/tests/support/ztd/verifier.ts
+++ b/packages/ztd-cli/templates/tests/support/ztd/verifier.ts
@@ -68,7 +68,7 @@ export async function verifyQuerySpecZtdCase<BeforeDb extends FixtureTree, Input
 ): Promise<QuerySpecExecutionEvidence> {
   const connectionString = process.env.ZTD_DB_URL;
   if (!connectionString) {
-    throw new Error('Set ZTD_DB_URL before running query-boundary ZTD cases.');
+    throw new Error(buildStarterDbSetupMessage('query-boundary ZTD cases'));
   }
 
   const tableRows = flattenFixtureTableRows(querySpecCase.beforeDb).map((tableFixture) => ({
@@ -142,7 +142,7 @@ export async function verifyQuerySpecZtdCase<BeforeDb extends FixtureTree, Input
   }
 
   if (failure) {
-    throw failure;
+    throw wrapStarterDbFailureIfHelpful(failure, 'query-boundary ZTD cases', connectionString);
   }
 
   return evidence;
@@ -154,7 +154,7 @@ export async function verifyQuerySpecTraditionalCase<BeforeDb extends FixtureTre
 ): Promise<QuerySpecExecutionEvidence> {
   const connectionString = process.env.ZTD_DB_URL;
   if (!connectionString) {
-    throw new Error('Set ZTD_DB_URL before running query-boundary traditional cases.');
+    throw new Error(buildStarterDbSetupMessage('query-boundary traditional cases'));
   }
 
   const trace: QueryExecutionTrace[] = [];
@@ -198,10 +198,73 @@ export async function verifyQuerySpecTraditionalCase<BeforeDb extends FixtureTre
   }
 
   if (failure) {
-    throw failure;
+    throw wrapStarterDbFailureIfHelpful(failure, 'query-boundary traditional cases', connectionString);
   }
 
   return evidence;
+}
+
+function buildStarterDbSetupMessage(context: string): string {
+  return [
+    `ZTD_DB_URL is not set before running ${context}.`,
+    '',
+    'Next steps:',
+    '1. Copy `.env.example` to `.env`.',
+    '2. Set `ZTD_DB_PORT=5432`, or choose another free host port.',
+    '3. Start the starter Postgres database with `docker compose up -d`.',
+    '4. Rerun `npx vitest run`.',
+    '',
+    'The generated Vitest setup derives `ZTD_DB_URL` from `ZTD_DB_PORT`.',
+    'If Docker reports `all predefined address pools have been fully subnetted`, fix Docker networking first; changing `ZTD_DB_PORT` alone will not recover that error.'
+  ].join('\n');
+}
+
+function wrapStarterDbFailureIfHelpful(error: unknown, context: string, connectionString: string): unknown {
+  if (!isStarterDbConnectionFailure(error)) {
+    return error;
+  }
+
+  const originalMessage = error instanceof Error ? error.message : String(error);
+  const wrapped = new Error(
+    [
+      `The starter Postgres database was not reachable while running ${context}.`,
+      '',
+      `Connection target: ${describeConnectionTarget(connectionString)}`,
+      `Original error: ${originalMessage}`,
+      '',
+      'Next steps:',
+      '1. Start the bundled database with `docker compose up -d`.',
+      '2. If port 5432 is already in use, set another `ZTD_DB_PORT` in `.env` and rerun `docker compose up -d`.',
+      '3. Wait until Postgres is ready, then rerun `npx vitest run`.',
+      '',
+      'If Docker reports `all predefined address pools have been fully subnetted`, fix Docker networking first; changing `ZTD_DB_PORT` alone will not recover that error.'
+    ].join('\n')
+  );
+  (wrapped as Error & { cause?: unknown }).cause = error;
+  return wrapped;
+}
+
+function isStarterDbConnectionFailure(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+
+  const code = 'code' in error ? String((error as { code?: unknown }).code) : '';
+  if (['ECONNREFUSED', 'ENOTFOUND', 'ETIMEDOUT', 'ECONNRESET', 'EAI_AGAIN', '28P01', '3D000'].includes(code)) {
+    return true;
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  return /connection terminated|connection timeout|password authentication failed|getaddrinfo|connect econnrefused/i.test(message);
+}
+
+function describeConnectionTarget(connectionString: string): string {
+  try {
+    const url = new URL(connectionString);
+    return `${url.protocol}//${url.hostname}${url.port ? `:${url.port}` : ''}/${url.pathname.replace(/^\/+/, '')}`;
+  } catch {
+    return 'configured ZTD_DB_URL';
+  }
 }
 
 function flattenFixtureTableRows(

--- a/packages/ztd-cli/tests/init.command.test.ts
+++ b/packages/ztd-cli/tests/init.command.test.ts
@@ -138,12 +138,15 @@ test('init bootstraps a feature-first scaffold', { timeout: 60_000 }, async () =
   expect(readNormalizedFile(path.join(workspace, '.env.example'))).toContain('ZTD_DB_PORT=5432');
   const packageJson = JSON.parse(readNormalizedFile(path.join(workspace, 'package.json'))) as {
     type?: string;
+    scripts?: Record<string, string>;
     dependencies: Record<string, string>;
     devDependencies: Record<string, string>;
     imports?: Record<string, { types: string; default: string }>;
     'lint-staged'?: Record<string, string[]>;
     'simple-git-hooks'?: Record<string, string>;
   };
+  expect(packageJson.scripts?.test).toContain('--passWithNoTests');
+  expect(packageJson.scripts?.test).not.toContain('no test specified');
   expect(packageJson['lint-staged']?.['*.{ts,tsx,js,jsx,json,md,sql}']).toEqual(['prettier --write']);
   expect(packageJson['simple-git-hooks']?.['pre-commit']).toBe('pnpm lint-staged');
   expect(packageJson.devDependencies).toHaveProperty('dotenv');
@@ -263,6 +266,10 @@ test('init starter bootstraps compose, starter DDL, and smoke tests without visi
   expect(readNormalizedFile(path.join(workspace, '.ztd', 'support', 'postgres-testkit.ts'))).toContain('loadStarterPostgresDefaults');
   expect(readNormalizedFile(path.join(workspace, '.ztd', 'support', 'postgres-testkit.ts'))).toContain('ZTD_DB_URL');
   expect(readNormalizedFile(path.join(workspace, '.ztd', 'support', 'postgres-testkit.ts'))).toContain('throw new Error');
+  expect(readNormalizedFile(path.join(workspace, '.ztd', 'support', 'postgres-testkit.ts'))).toContain('Copy `.env.example` to `.env`');
+  expect(readNormalizedFile(path.join(workspace, '.ztd', 'support', 'postgres-testkit.ts'))).toContain('docker compose up -d');
+  expect(readNormalizedFile(path.join(workspace, 'tests', 'support', 'ztd', 'verifier.ts'))).toContain('Copy `.env.example` to `.env`');
+  expect(readNormalizedFile(path.join(workspace, 'tests', 'support', 'ztd', 'verifier.ts'))).toContain('all predefined address pools have been fully subnetted');
   expect(readNormalizedFile(path.join(workspace, 'ztd.config.json'))).toContain('"ztdRootDir": ".ztd"');
   expect(readNormalizedFile(path.join(workspace, 'ztd.config.json'))).toContain('"defaultSchema": "public"');
   expect(readNormalizedFile(path.join(workspace, 'ztd.config.json'))).toContain('"searchPath": [');
@@ -313,10 +320,13 @@ test('init starter bootstraps compose, starter DDL, and smoke tests without visi
   expect(readNormalizedFile(path.join(workspace, 'src', 'adapters', 'console', 'repositoryTelemetry.ts'))).not.toContain('sqlText');
   const packageJson = JSON.parse(readNormalizedFile(path.join(workspace, 'package.json'))) as {
     type?: string;
+    scripts?: Record<string, string>;
     dependencies: Record<string, string>;
     devDependencies: Record<string, string>;
     imports?: Record<string, { types: string; default: string }>;
   };
+  expect(packageJson.scripts?.test).toContain('--passWithNoTests');
+  expect(packageJson.scripts?.test).not.toContain('no test specified');
   expect(packageJson.devDependencies).toHaveProperty('dotenv');
   expect(packageJson.devDependencies).not.toHaveProperty('@rawsql-ts/sql-contract');
   expect(packageJson.dependencies).toHaveProperty('@rawsql-ts/driver-adapter-core');
@@ -461,6 +471,43 @@ test('init derives generated lint-staged hook command from the package manager l
     'simple-git-hooks'?: Record<string, string>;
   };
   expect(packageJson['simple-git-hooks']?.['pre-commit']).toBe('npx lint-staged');
+});
+
+test('init replaces the default npm test placeholder with the runnable scaffold test script', async () => {
+  const workspace = createTempDir('cli-init-npm-test-placeholder');
+  const prompter = new TestPrompter([]);
+  writeFileSync(
+    path.join(workspace, 'package.json'),
+    `${JSON.stringify(
+      {
+        name: 'npm-placeholder-starter',
+        version: '1.0.0',
+        scripts: {
+          test: 'echo "Error: no test specified" && exit 1',
+          custom: 'node custom.js'
+        }
+      },
+      null,
+      2
+    )}\n`,
+    'utf8'
+  );
+
+  await runInitCommand(prompter, {
+    rootDir: workspace,
+    nonInteractive: true,
+    forceOverwrite: true,
+    workflow: 'empty',
+    validator: 'zod',
+    skipInstall: true
+  });
+
+  const packageJson = JSON.parse(readNormalizedFile(path.join(workspace, 'package.json'))) as {
+    scripts?: Record<string, string>;
+  };
+  expect(packageJson.scripts?.test).toContain('--passWithNoTests');
+  expect(packageJson.scripts?.test).not.toContain('no test specified');
+  expect(packageJson.scripts?.custom).toBe('node custom.js');
 });
 
 test('default scaffold omits AI control files', async () => {

--- a/packages/ztd-cli/tests/init.command.test.ts
+++ b/packages/ztd-cli/tests/init.command.test.ts
@@ -152,6 +152,10 @@ test('init bootstraps a feature-first scaffold', { timeout: 60_000 }, async () =
   expect(packageJson.devDependencies).toHaveProperty('dotenv');
   expect(packageJson.devDependencies).not.toHaveProperty('@rawsql-ts/sql-contract');
   expect(packageJson.dependencies).toHaveProperty('@rawsql-ts/driver-adapter-core');
+  expect(packageJson.dependencies).not.toHaveProperty('@rawsql-ts/ztd-cli');
+  expect(packageJson.dependencies).not.toHaveProperty('rawsql-ts');
+  expect(packageJson.dependencies).not.toHaveProperty('@rawsql-ts/testkit-core');
+  expect(packageJson.dependencies).not.toHaveProperty('@rawsql-ts/testkit-postgres');
   expect(packageJson.devDependencies).not.toHaveProperty('@rawsql-ts/driver-adapter-core');
   expect(packageJson.devDependencies).toHaveProperty('@rawsql-ts/testkit-core');
   expect(packageJson.imports?.['#features/*.js']).toEqual({
@@ -330,6 +334,10 @@ test('init starter bootstraps compose, starter DDL, and smoke tests without visi
   expect(packageJson.devDependencies).toHaveProperty('dotenv');
   expect(packageJson.devDependencies).not.toHaveProperty('@rawsql-ts/sql-contract');
   expect(packageJson.dependencies).toHaveProperty('@rawsql-ts/driver-adapter-core');
+  expect(packageJson.dependencies).not.toHaveProperty('@rawsql-ts/ztd-cli');
+  expect(packageJson.dependencies).not.toHaveProperty('rawsql-ts');
+  expect(packageJson.dependencies).not.toHaveProperty('@rawsql-ts/testkit-core');
+  expect(packageJson.dependencies).not.toHaveProperty('@rawsql-ts/testkit-postgres');
   expect(packageJson.devDependencies).not.toHaveProperty('@rawsql-ts/driver-adapter-core');
   expect(packageJson.devDependencies).toHaveProperty('@rawsql-ts/testkit-core');
   expect(packageJson.devDependencies).toHaveProperty('@rawsql-ts/testkit-postgres');

--- a/packages/ztd-cli/tests/postgresTestkitHelper.unit.test.ts
+++ b/packages/ztd-cli/tests/postgresTestkitHelper.unit.test.ts
@@ -63,7 +63,7 @@ test('createStarterPostgresTestkitClient requires an explicit connectionString o
         tableDefinitions: [],
         tableRows: []
       })
-    ).toThrow('Set options.connectionString or ZTD_DB_URL before creating a starter Postgres testkit client.');
+    ).toThrow(/Copy `.env\.example` to `.env`/);
   } finally {
     if (previous === undefined) {
       delete process.env.ZTD_DB_URL;

--- a/packages/ztd-cli/tests/prReadiness.unit.test.ts
+++ b/packages/ztd-cli/tests/prReadiness.unit.test.ts
@@ -57,6 +57,8 @@ const {
     baselineRationale?: string;
     selfReviewWorkflow?: string;
     selfReviewResult?: string;
+    conceptReviewWorkflow?: string;
+    conceptReviewResult?: string;
     cliMode?: 'no-packet' | 'packet' | null;
     cliNoMigrationRationale?: string;
     upgradeNote?: string;
@@ -104,6 +106,8 @@ function createBaseBody(): string {
     '',
     'Self-review workflow: self-review skill two-cycle pass completed.',
     'Self-review result: no unresolved blockers.',
+    'Concept-review workflow: concept boundary review checked the owning package concept.',
+    'Concept-review result: no concept or package-boundary violations remain.',
     '',
     '## CLI Surface Migration',
     '',
@@ -165,6 +169,8 @@ test('pr-readiness accepts a tracked baseline exception plus CLI migration packe
     '',
     'Self-review workflow: self-review skill two-cycle pass completed.',
     'Self-review result: no unresolved blockers.',
+    'Concept-review workflow: concept boundary review checked the owning package concept.',
+    'Concept-review result: no concept or package-boundary violations remain.',
     '',
     '## CLI Surface Migration',
     '',
@@ -212,7 +218,7 @@ test('pr-readiness rejects CLI changes without a migration packet or rationale',
 
 test('pr-readiness rejects PR bodies without self-review evidence', () => {
   const body = createBaseBody()
-    .replace('## Self Review\n\nSelf-review workflow: self-review skill two-cycle pass completed.\nSelf-review result: no unresolved blockers.\n\n', '');
+    .replace('## Self Review\n\nSelf-review workflow: self-review skill two-cycle pass completed.\nSelf-review result: no unresolved blockers.\nConcept-review workflow: concept boundary review checked the owning package concept.\nConcept-review result: no concept or package-boundary violations remain.\n\n', '');
 
   const validation = validatePrReadiness({
     body,
@@ -224,6 +230,25 @@ test('pr-readiness rejects PR bodies without self-review evidence', () => {
     'Missing "## Self Review" section from the PR body.',
     'Self Review must name the self-review workflow or skill that was run. is required: "Self-review workflow:" must be filled in.',
     'Self Review must state whether blockers remain. is required: "Self-review result:" must be filled in.',
+    'Self Review must name the concept review workflow, package concept, Concept Spec, or explicit no-concept-impact rationale that was checked. is required: "Concept-review workflow:" must be filled in.',
+    'Self Review must state whether concept or package-boundary violations remain. is required: "Concept-review result:" must be filled in.',
+  ]));
+});
+
+test('pr-readiness rejects PR bodies without concept review evidence', () => {
+  const body = createBaseBody()
+    .replace('Concept-review workflow: concept boundary review checked the owning package concept.\n', '')
+    .replace('Concept-review result: no concept or package-boundary violations remain.\n', '');
+
+  const validation = validatePrReadiness({
+    body,
+    classification: classifyPrReadiness(['packages/core/src/index.ts']),
+  });
+
+  expect(validation.ok).toBe(false);
+  expect(validation.errors).toEqual(expect.arrayContaining([
+    'Self Review must name the concept review workflow, package concept, Concept Spec, or explicit no-concept-impact rationale that was checked. is required: "Concept-review workflow:" must be filled in.',
+    'Self Review must state whether concept or package-boundary violations remain. is required: "Concept-review result:" must be filled in.',
   ]));
 });
 
@@ -250,6 +275,8 @@ test('pr-readiness rejects scaffold changes without the three proof classes', ()
     '',
     'Self-review workflow: self-review skill two-cycle pass completed.',
     'Self-review result: no unresolved blockers.',
+    'Concept-review workflow: concept boundary review checked the owning package concept.',
+    'Concept-review result: no concept or package-boundary violations remain.',
     '',
     '## CLI Surface Migration',
     '',
@@ -335,6 +362,7 @@ test('pr-readiness preparation renders a validator-compatible CLI packet body', 
   });
 
   expect(prepared.body).toContain('Tracking issue: not needed; no baseline exception requested.');
+  expect(prepared.body).toContain('Concept-review result: no unresolved concept or package-boundary violations.');
   expect(prepared.body).toContain('Upgrade note: Replace `--specs-dir` with `--scope-dir` in command examples.');
 
   const validation = validatePrReadiness({

--- a/packages/ztd-cli/tests/ztdVerifier.unit.test.ts
+++ b/packages/ztd-cli/tests/ztdVerifier.unit.test.ts
@@ -69,6 +69,45 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+test('verifyQuerySpecZtdCase explains how to create ZTD_DB_URL when the starter DB env is missing', async () => {
+  delete process.env.ZTD_DB_URL;
+
+  const { verifyQuerySpecZtdCase } = await import('../templates/tests/support/ztd/verifier');
+
+  await expect(
+    verifyQuerySpecZtdCase(
+      {
+        name: 'missing-db-url',
+        beforeDb: {},
+        input: {},
+        output: { ok: true }
+      },
+      async () => ({ ok: true })
+    )
+  ).rejects.toThrow(/Copy `\.env\.example` to `\.env`/);
+});
+
+test('verifyQuerySpecTraditionalCase adds starter recovery steps when Postgres is unreachable', async () => {
+  process.env.ZTD_DB_URL = 'postgres://ztd:ztd@localhost:55433/ztd';
+  const connectionError = new Error('connect ECONNREFUSED 127.0.0.1:55433') as Error & { code?: string };
+  connectionError.code = 'ECONNREFUSED';
+  poolConnectMock.mockRejectedValue(connectionError);
+
+  const { verifyQuerySpecTraditionalCase } = await import('../templates/tests/support/ztd/verifier');
+
+  await expect(
+    verifyQuerySpecTraditionalCase(
+      {
+        name: 'db-down',
+        beforeDb: {},
+        input: {},
+        output: { ok: true }
+      },
+      async () => ({ ok: true })
+    )
+  ).rejects.toThrow(/localhost:55433[\s\S]*docker compose up -d/);
+});
+
 test('verifyQuerySpecTraditionalCase physically prepares fixtures and returns traditional evidence', async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), 'ztd-verifier-project-'));
   tempDirs.push(rootDir);

--- a/scripts/check-pr-readiness.js
+++ b/scripts/check-pr-readiness.js
@@ -222,6 +222,18 @@ function validatePrReadiness({ body, classification, pullRequestContext = null }
     'Self-review result',
     'Self Review must state whether blockers remain.',
   );
+  requireField(
+    errors,
+    normalizedBody,
+    'Concept-review workflow',
+    'Self Review must name the concept review workflow, package concept, Concept Spec, or explicit no-concept-impact rationale that was checked.',
+  );
+  requireField(
+    errors,
+    normalizedBody,
+    'Concept-review result',
+    'Self Review must state whether concept or package-boundary violations remain.',
+  );
 
   if (classification.requiresCliMigrationPacket) {
     if (!/##\s+CLI Surface Migration/iu.test(normalizedBody)) {

--- a/scripts/prepare-pr-readiness.js
+++ b/scripts/prepare-pr-readiness.js
@@ -26,6 +26,8 @@ function parseArgs(argv) {
     baselineRationale: '',
     selfReviewWorkflow: 'repo self-review workflow completed before PR authoring.',
     selfReviewResult: 'no unresolved self-review blockers.',
+    conceptReviewWorkflow: 'concept boundary review completed against the owning package concept or Concept Spec.',
+    conceptReviewResult: 'no unresolved concept or package-boundary violations.',
     cliMode: null,
     cliNoMigrationRationale: '',
     upgradeNote: '',
@@ -95,6 +97,14 @@ function parseArgs(argv) {
         break;
       case '--self-review-result':
         options.selfReviewResult = requireOperand(arg);
+        index += 1;
+        break;
+      case '--concept-review-workflow':
+        options.conceptReviewWorkflow = requireOperand(arg);
+        index += 1;
+        break;
+      case '--concept-review-result':
+        options.conceptReviewResult = requireOperand(arg);
         index += 1;
         break;
       case '--cli-mode':
@@ -195,6 +205,10 @@ function requireOption(condition, value, message) {
 }
 
 function renderPrReadinessBody({ classification, options }) {
+  const selfReviewWorkflow = options.selfReviewWorkflow ?? 'repo self-review workflow completed before PR authoring.';
+  const selfReviewResult = options.selfReviewResult ?? 'no unresolved self-review blockers.';
+  const conceptReviewWorkflow = options.conceptReviewWorkflow ?? 'concept boundary review completed against the owning package concept or Concept Spec.';
+  const conceptReviewResult = options.conceptReviewResult ?? 'no unresolved concept or package-boundary violations.';
   const lines = [
     '## Summary',
     '',
@@ -215,8 +229,10 @@ function renderPrReadinessBody({ classification, options }) {
     '',
     '## Self Review',
     '',
-    `Self-review workflow: ${options.selfReviewWorkflow}`,
-    `Self-review result: ${options.selfReviewResult}`,
+    `Self-review workflow: ${selfReviewWorkflow}`,
+    `Self-review result: ${selfReviewResult}`,
+    `Concept-review workflow: ${conceptReviewWorkflow}`,
+    `Concept-review result: ${conceptReviewResult}`,
     '',
     '## CLI Surface Migration',
     '',


### PR DESCRIPTION
## Summary

- Replace npm's default failing test placeholder during ztd init while preserving custom scripts.
- Generate starter DB setup errors that explain .env, ZTD_DB_PORT, docker compose, and Docker network-pool recovery steps.
- Require PR readiness bodies to record Concept Review evidence alongside Self Review evidence.
- Add concept boundary review to repo-local self-review/code-review guidance and test the ztd-cli runtime-free dependency boundary.

## Verification

- pnpm --filter @rawsql-ts/ztd-cli test -- init.command postgresTestkitHelper ztdVerifier
- pnpm --filter @rawsql-ts/ztd-cli test -- prReadiness.unit.test.ts
- pnpm --filter @rawsql-ts/ztd-cli exec tsc -p tsconfig.json --noEmit
- git diff --check

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: not needed; no baseline exception requested.
Scoped checks run: not needed; no baseline exception requested.
Why full baseline is not required: full baseline exception path not used for this PR.

## Self Review

Self-review workflow: Two-pass self-review plus concept boundary review against docs/ztd-cli/package-concept.md.
Self-review result: No unresolved blockers; concept review is now required by the PR readiness gate.
Concept-review workflow: Concept boundary review checked docs/ztd-cli/package-concept.md and the ztd-cli runtime-free standard path.
Concept-review result: No ztd-cli runtime-free violation found; generated runtime dependencies exclude ztd-cli/rawsql-ts/testkit packages except allowed driver adapter mechanics.

## CLI Surface Migration

- [ ] No migration packet required for this CLI change.
- [x] CLI/user-facing surface change and migration packet completed.

No-migration rationale: not selected for this PR.
Upgrade note: Existing generated projects are unchanged; newly initialized projects replace npm's default test placeholder and show clearer DB setup failures.
Deprecation/removal plan or issue: No deprecation or removal.
Docs/help/examples updated: Generated starter support templates, repo-local review guidance, PR readiness template/checks, and tests were updated.
Release/changeset wording: Patch changeset added for @rawsql-ts/ztd-cli starter onboarding error improvements.

## Scaffold Contract Proof

- [ ] No scaffold contract proof required for this PR.
- [x] Scaffold contract proof completed.

No-proof rationale: not selected for this PR.
Non-edit assertion: The change only replaces the known npm default test placeholder; custom scripts are preserved by init.command.test.ts.
Fail-fast input-contract proof: ztdVerifier and postgresTestkitHelper unit tests assert missing and unreachable DB failures include actionable recovery steps; prReadiness tests assert missing Concept Review evidence fails.
Generated-output viability proof: init.command tests assert generated starter support files contain .env, ZTD_DB_PORT, docker compose, Docker network-pool guidance, and production dependencies exclude ztd-cli/rawsql-ts/testkit packages.
