### PR TITLE
ci: guard publish artifact verification for partial manifests

### DIFF
--- a/packages/ztd-cli/tests/publishWorkflow.unit.test.ts
+++ b/packages/ztd-cli/tests/publishWorkflow.unit.test.ts
@@ -82,6 +82,18 @@ test('published-package mode includes the rawsql-ts getting-started smoke path',
   expect(publishedPackageModeScript).toContain('const formatter = new SqlFormatter();');
 });
 
+test('published-package mode only runs the rawsql-ts getting-started smoke when its tarball is present', () => {
+  const coreSection = publishedPackageModeScript.slice(
+    publishedPackageModeScript.indexOf('function verifyCoreGettingStarted(packages) {'),
+    publishedPackageModeScript.indexOf('function verifyNpmPrimaryPath(packages) {'),
+  );
+
+  expect(coreSection).toContain('const tarballDependencies = createTarballDependencyMap(packages);');
+  expect(coreSection).toContain('if (!hasTarballDependency(tarballDependencies, "rawsql-ts")) {');
+  expect(coreSection).toContain('return null;');
+  expect(coreSection).toContain('"rawsql-ts": tarballDependencies["rawsql-ts"],');
+});
+
 test('published-package mode expects local-source guard scripts from npm consumer scaffolds', () => {
   const npmSection = publishedPackageModeScript.slice(
     publishedPackageModeScript.indexOf('function verifyNpmPrimaryPath(packages) {'),
@@ -131,9 +143,15 @@ test('packed tarball install smoke only runs commands for tarballs included in t
 });
 
 test('published-package smoke rebinds scaffold runtime dependencies to packed tarballs', () => {
-  expect(publishedPackageModeScript).toContain('for (const sectionName of ["dependencies", "optionalDependencies", "peerDependencies"])');
+  expect(publishedPackageModeScript).toContain('function createPublishedDependencyRangeMap(packages) {');
+  expect(publishedPackageModeScript).toContain('dependencyName === "rawsql-ts" || dependencyName.startsWith("@rawsql-ts/")');
+  expect(publishedPackageModeScript).toContain('for (const sectionName of ["dependencies", "optionalDependencies", "peerDependencies", "devDependencies"])');
   expect(publishedPackageModeScript).toContain('section[dependencyName] = tarballDependencies[dependencyName];');
-  expect(publishedPackageModeScript).toContain('restoreTarballDependencies(appDir, tarballDependencies);');
+  expect(publishedPackageModeScript).toContain('currentRange.startsWith("file:")');
+  expect(publishedPackageModeScript).toContain('section[dependencyName] = publishedDependencyRanges.get(dependencyName);');
+  expect(publishedPackageModeScript).toContain('fs.rmSync(path.join(directory, "package-lock.json"), { force: true });');
+  expect(publishedPackageModeScript).toContain('fs.rmSync(path.join(directory, "node_modules"), { force: true, recursive: true });');
+  expect(publishedPackageModeScript).toContain('restorePublishedDependencyRanges(appDir, packages);');
 });
 
 test('publish plan can include unpublished workspace dependencies required by published scaffolds', () => {

--- a/scripts/verify-published-package-mode.mjs
+++ b/scripts/verify-published-package-mode.mjs
@@ -237,6 +237,30 @@ function hasTarballDependency(tarballDependencies, packageName) {
   return typeof tarballDependencies[packageName] === "string";
 }
 
+function createPublishedDependencyRangeMap(packages) {
+  const dependencyRanges = new Map();
+
+  for (const pkg of packages) {
+    for (const sectionName of ["dependencies", "optionalDependencies", "peerDependencies", "devDependencies"]) {
+      const section = pkg.manifest[sectionName];
+      if (!section || typeof section !== "object" || Array.isArray(section)) {
+        continue;
+      }
+
+      for (const [dependencyName, dependencyRange] of Object.entries(section)) {
+        if (
+          typeof dependencyRange === "string"
+          && (dependencyName === "rawsql-ts" || dependencyName.startsWith("@rawsql-ts/"))
+        ) {
+          dependencyRanges.set(dependencyName, dependencyRange);
+        }
+      }
+    }
+  }
+
+  return dependencyRanges;
+}
+
 function setPackageTypeModule(directory) {
   const packageJsonPath = path.join(directory, "package.json");
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
@@ -248,25 +272,45 @@ function readPackageJson(directory) {
   return JSON.parse(fs.readFileSync(path.join(directory, "package.json"), "utf8"));
 }
 
-function restoreTarballDependencies(directory, tarballDependencies) {
+function restorePublishedDependencyRanges(directory, packages) {
   const packageJsonPath = path.join(directory, "package.json");
   const packageJson = readPackageJson(directory);
-  for (const sectionName of ["dependencies", "optionalDependencies", "peerDependencies"]) {
+  const tarballDependencies = createTarballDependencyMap(packages);
+  const publishedDependencyRanges = createPublishedDependencyRangeMap(packages);
+  let changed = false;
+
+  for (const sectionName of ["dependencies", "optionalDependencies", "peerDependencies", "devDependencies"]) {
     const section = packageJson[sectionName];
     if (!section || typeof section !== "object" || Array.isArray(section)) {
       continue;
     }
-    for (const dependencyName of Object.keys(section)) {
+
+    for (const [dependencyName, currentRange] of Object.entries(section)) {
       if (typeof tarballDependencies[dependencyName] === "string") {
-        section[dependencyName] = tarballDependencies[dependencyName];
+        if (section[dependencyName] !== tarballDependencies[dependencyName]) {
+          section[dependencyName] = tarballDependencies[dependencyName];
+          changed = true;
+        }
+        continue;
+      }
+
+      if (
+        typeof currentRange === "string"
+        && currentRange.startsWith("file:")
+        && publishedDependencyRanges.has(dependencyName)
+      ) {
+        section[dependencyName] = publishedDependencyRanges.get(dependencyName);
+        changed = true;
       }
     }
   }
-  packageJson.devDependencies = {
-    ...(packageJson.devDependencies ?? {}),
-    ...tarballDependencies,
-  };
+
   fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
+
+  if (changed) {
+    fs.rmSync(path.join(directory, "package-lock.json"), { force: true });
+    fs.rmSync(path.join(directory, "node_modules"), { force: true, recursive: true });
+  }
 }
 
 function writeNode16Tsconfig(directory) {
@@ -443,6 +487,12 @@ function verifyPackedTarballInstall(packages) {
 
 function verifyCoreGettingStarted(packages) {
   const appDir = path.join(packageRoot, "rawsql-ts-getting-started");
+  const tarballDependencies = createTarballDependencyMap(packages);
+
+  if (!hasTarballDependency(tarballDependencies, "rawsql-ts")) {
+    return null;
+  }
+
   ensureCleanDir(appDir);
 
   writePackageJson(appDir, {
@@ -451,7 +501,7 @@ function verifyCoreGettingStarted(packages) {
     version: "0.0.0",
     type: "module",
     devDependencies: {
-      "rawsql-ts": createTarballDependencyMap(packages)["rawsql-ts"],
+      "rawsql-ts": tarballDependencies["rawsql-ts"],
     },
   });
 
@@ -525,7 +575,7 @@ function verifyNpmPrimaryPath(packages) {
   assertFileMissing(appDir, path.join("src", "features", "smoke", "queries", "smoke", "tests", "smoke.boundary.ztd.test.ts"), "phase-a default-scaffold-shape");
   assertFileMissing(appDir, path.join(".ztd", "agents", "manifest.json"), "phase-a default-scaffold-shape");
 
-  restoreTarballDependencies(appDir, tarballDependencies);
+  restorePublishedDependencyRanges(appDir, packages);
   runIn(appDir, NPM, ["install"]);
 
   return { appDir };


### PR DESCRIPTION
## Summary

- Skip the rawsql-ts getting-started smoke when the publish manifest does not include a rawsql-ts tarball.
- Rebind generated scaffold local file dependencies to packed tarballs or published npm ranges before publish artifact smoke installs.
- Reset npm lock/install state after dependency rebinding so verification does not keep stale local file links.

## Verification

- pnpm --filter @rawsql-ts/ztd-cli test -- publishWorkflow.unit.test.ts
- node --check scripts/verify-published-package-mode.mjs
- git diff --check
- node ./scripts/verify-published-package-mode.mjs --publish-manifest tmp/ci-artifacts-26295661007/publish-manifest.json

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: not needed; no baseline exception requested.
Scoped checks run: publish artifact verification failure was reproduced with the downloaded run artifact and targeted script/test checks were run.
Why full baseline is not required: CI fix is limited to publish artifact verification script behavior and its publishWorkflow unit coverage.

## Self Review

Self-review workflow: Focused self-review of the CI failure path, manifest-gated smoke behavior, and dependency rebinding behavior.
Self-review result: No unresolved blockers; downloaded failing artifact now verifies successfully with the updated script.
Concept-review workflow: Concept boundary check classified this as technical-support CI verification work with no business-bearing artifact changes.
Concept-review result: No ConceptSpec or ztd-cli runtime-free boundary violation; change only affects publish artifact verification mechanics.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: No CLI command, generated user surface, or documented workflow changes.
Upgrade note: No user action required.
Deprecation/removal plan or issue: No deprecation or removal.
Docs/help/examples updated: Not needed; internal CI verification script only.
Release/changeset wording: No changeset needed; publish CI verification fix only.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: This does not change scaffold generation contracts; it only makes publish artifact verification avoid local-source dependency leakage.
Non-edit assertion: No generated scaffold templates were edited.
Fail-fast input-contract proof: publishWorkflow unit test asserts manifest-gated rawsql-ts smoke and dependency rebinding behavior.
Generated-output viability proof: Downloaded failed publish artifact manifest was re-run through verify-published-package-mode successfully.