### PR TITLE
fix: tighten ztd starter prepublish UX proof

### DIFF
--- a/.changeset/quiet-starter-proof.md
+++ b/.changeset/quiet-starter-proof.md
@@ -1,0 +1,5 @@
+---
+"@rawsql-ts/ztd-cli": patch
+---
+
+Tighten the starter first-run experience by keeping the generated smoke QuerySpec typecheckable, wrapping aggregate Postgres connection failures with concise recovery steps, and extending publish artifact verification to run starter typecheck, DB-free smoke tests, and ztd-config before release.

--- a/packages/ztd-cli/templates/src/features/smoke/queries/smoke/boundary.ts
+++ b/packages/ztd-cli/templates/src/features/smoke/queries/smoke/boundary.ts
@@ -6,7 +6,7 @@ import { loadSqlResource } from '#features/_shared/loadSqlResource.js';
 
 const smokeSqlResource = loadSqlResource(dirname(fileURLToPath(import.meta.url)), 'smoke.sql');
 
-export interface SmokeQueryParams {
+export interface SmokeQueryParams extends Record<string, unknown> {
   user_id: number;
 }
 

--- a/packages/ztd-cli/templates/tests/support/ztd/verifier.ts
+++ b/packages/ztd-cli/templates/tests/support/ztd/verifier.ts
@@ -111,8 +111,8 @@ export async function verifyQuerySpecZtdCase<BeforeDb extends FixtureTree, Input
       }
     });
 
-    const result = execute(createQuerySpecExecutor(testkitClient, trace), querySpecCase.input);
-    await expect(result).resolves.toEqual(querySpecCase.output);
+    const result = await execute(createQuerySpecExecutor(testkitClient, trace), querySpecCase.input);
+    expect(result).toEqual(querySpecCase.output);
     if (trace.length === 0) {
       throw new Error(
         `ZTD verifier did not execute any SQL for case "${querySpecCase.name}". Check the query boundary and fixture setup before accepting the case.`
@@ -165,8 +165,8 @@ export async function verifyQuerySpecTraditionalCase<BeforeDb extends FixtureTre
 
   try {
     client = await createPhysicalQuerySpecExecutor(pool, defaults, querySpecCase.beforeDb, trace);
-    const result = execute(client, querySpecCase.input);
-    await expect(result).resolves.toEqual(querySpecCase.output);
+    const result = await execute(client, querySpecCase.input);
+    expect(result).toEqual(querySpecCase.output);
     if (querySpecCase.afterDb) {
       await client.assertAfterDb(querySpecCase.afterDb);
     }
@@ -224,7 +224,7 @@ function wrapStarterDbFailureIfHelpful(error: unknown, context: string, connecti
     return error;
   }
 
-  const originalMessage = error instanceof Error ? error.message : String(error);
+  const originalMessage = describeStarterDbOriginalError(error);
   const wrapped = new Error(
     [
       `The starter Postgres database was not reachable while running ${context}.`,
@@ -234,19 +234,53 @@ function wrapStarterDbFailureIfHelpful(error: unknown, context: string, connecti
       '',
       'Next steps:',
       '1. Start the bundled database with `docker compose up -d`.',
-      '2. If port 5432 is already in use, set another `ZTD_DB_PORT` in `.env` and rerun `docker compose up -d`.',
+      '2. If the configured host port is already in use, set another `ZTD_DB_PORT` in `.env` and rerun `docker compose up -d`.',
       '3. Wait until Postgres is ready, then rerun `npx vitest run`.',
       '',
       'If Docker reports `all predefined address pools have been fully subnetted`, fix Docker networking first; changing `ZTD_DB_PORT` alone will not recover that error.'
     ].join('\n')
   );
-  (wrapped as Error & { cause?: unknown }).cause = error;
   return wrapped;
+}
+
+function describeStarterDbOriginalError(error: unknown): string {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'errors' in error &&
+    Array.isArray((error as { errors?: unknown }).errors)
+  ) {
+    const messages = (error as { errors: unknown[] }).errors
+      .map((innerError) => (innerError instanceof Error ? innerError.message : String(innerError)))
+      .filter((message) => message.trim().length > 0);
+
+    if (messages.length > 0) {
+      return messages.join('; ');
+    }
+  }
+
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+
+  return String(error);
 }
 
 function isStarterDbConnectionFailure(error: unknown): boolean {
   if (typeof error !== 'object' || error === null) {
     return false;
+  }
+
+  if (
+    'errors' in error &&
+    Array.isArray((error as { errors?: unknown }).errors) &&
+    (error as { errors: unknown[] }).errors.some((innerError) => isStarterDbConnectionFailure(innerError))
+  ) {
+    return true;
+  }
+
+  if ('cause' in error && isStarterDbConnectionFailure((error as { cause?: unknown }).cause)) {
+    return true;
   }
 
   const code = 'code' in error ? String((error as { code?: unknown }).code) : '';

--- a/packages/ztd-cli/tests/init.command.test.ts
+++ b/packages/ztd-cli/tests/init.command.test.ts
@@ -264,6 +264,9 @@ test('init starter bootstraps compose, starter DDL, and smoke tests without visi
   expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'smoke', 'queries', 'smoke', 'smoke.sql'))).toContain('where user_id = :user_id::integer');
   expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'smoke', 'boundary.ts'))).toContain('executeSmokeQuerySpec');
   expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'smoke', 'queries', 'smoke', 'boundary.ts'))).toContain('loadSqlResource');
+  expect(readNormalizedFile(path.join(workspace, 'src', 'features', 'smoke', 'queries', 'smoke', 'boundary.ts'))).toContain(
+    'export interface SmokeQueryParams extends Record<string, unknown>'
+  );
   expect(readNormalizedFile(path.join(workspace, '.ztd', 'support', 'setup-env.ts'))).toContain('ZTD_DB_PORT');
   expect(readNormalizedFile(path.join(workspace, '.ztd', 'support', 'setup-env.ts'))).toContain('ZTD_DB_URL');
   expect(readNormalizedFile(path.join(workspace, '.ztd', 'support', 'postgres-testkit.ts'))).toContain('createPostgresTestkitClient');

--- a/packages/ztd-cli/tests/publishWorkflow.unit.test.ts
+++ b/packages/ztd-cli/tests/publishWorkflow.unit.test.ts
@@ -57,7 +57,11 @@ test('standalone pnpm proof apps use the installed ztd bin helper instead of pnp
     publishedPackageModeScript.indexOf('function verifyPnpmAdapterInstall(packages) {'),
   );
   expect(starterSection).toContain('runInstalledZtdCli(appDir,');
-  expect(starterSection).not.toContain('"exec"');
+  expect(starterSection).not.toContain('"exec",\n    "ztd"');
+  expect(starterSection).toContain('"tsc", "--noEmit", "-p", "tsconfig.json"');
+  expect(starterSection).toContain('"src/features/smoke/tests/smoke.boundary.test.ts"');
+  expect(starterSection).toContain('"src/features/smoke/tests/smoke.validation.test.ts"');
+  expect(starterSection).toContain('runInstalledZtdCli(appDir, ["ztd-config"])');
 
   const adapterSection = publishedPackageModeScript.slice(
     publishedPackageModeScript.indexOf('function verifyPnpmAdapterInstall(packages) {'),

--- a/packages/ztd-cli/tests/ztdVerifier.unit.test.ts
+++ b/packages/ztd-cli/tests/ztdVerifier.unit.test.ts
@@ -108,6 +108,43 @@ test('verifyQuerySpecTraditionalCase adds starter recovery steps when Postgres i
   ).rejects.toThrow(/localhost:55433[\s\S]*docker compose up -d/);
 });
 
+test('verifyQuerySpecZtdCase wraps AggregateError connection failures with starter recovery steps', async () => {
+  process.env.ZTD_DB_URL = 'postgres://ztd:ztd@localhost:15432/ztd';
+  const aggregateError = new AggregateError(
+    [
+      Object.assign(new Error('connect ECONNREFUSED ::1:15432'), {
+        code: 'ECONNREFUSED',
+        address: '::1',
+        port: 15432
+      }),
+      Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:15432'), {
+        code: 'ECONNREFUSED',
+        address: '127.0.0.1',
+        port: 15432
+      })
+    ],
+    ''
+  );
+  createPostgresTestkitClientMock.mockReturnValue({
+    query: vi.fn().mockRejectedValue(aggregateError),
+    close: closeMock
+  });
+
+  const { verifyQuerySpecZtdCase } = await import('../templates/tests/support/ztd/verifier');
+
+  await expect(
+    verifyQuerySpecZtdCase(
+      {
+        name: 'aggregate-db-down',
+        beforeDb: {},
+        input: {},
+        output: { ok: true }
+      },
+      (client) => client.query('select 1', {})
+    )
+  ).rejects.toThrow(/localhost:15432[\s\S]*docker compose up -d[\s\S]*ZTD_DB_PORT/);
+});
+
 test('verifyQuerySpecTraditionalCase physically prepares fixtures and returns traditional evidence', async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), 'ztd-verifier-project-'));
   tempDirs.push(rootDir);

--- a/scripts/verify-published-package-mode.mjs
+++ b/scripts/verify-published-package-mode.mjs
@@ -663,6 +663,15 @@ function verifyPnpmStarterPath(packages) {
   // Rebind workspace packages to the freshly packed tarballs so the scaffold install exercises the published manifests.
   fs.writeFileSync(path.join(appDir, "package.json"), `${JSON.stringify(scaffoldPackageJson, null, 2)}\n`, "utf8");
   runIn(appDir, PNPM, ["install", "--no-frozen-lockfile"]);
+  runIn(appDir, PNPM, ["exec", "tsc", "--noEmit", "-p", "tsconfig.json"]);
+  runIn(appDir, PNPM, [
+    "exec",
+    "vitest",
+    "run",
+    "src/features/smoke/tests/smoke.boundary.test.ts",
+    "src/features/smoke/tests/smoke.validation.test.ts",
+  ]);
+  runInstalledZtdCli(appDir, ["ztd-config"]);
 
   return appDir;
 }


### PR DESCRIPTION
## Summary

- Fix the generated ztd starter smoke boundary so the scaffold typechecks without hand edits.
- Wrap starter Postgres connection failures, including AggregateError cases, with concise recovery steps that name Docker, `.env`, and `ZTD_DB_PORT`.
- Extend the published-package verification script so the pre-release tarball proof runs starter typecheck, DB-free smoke tests, and `ztd-config` before npm publication.

## Verification

- `pnpm --filter @rawsql-ts/ztd-cli test -- ztdVerifier.unit.test.ts init.command.test.ts publishWorkflow.unit.test.ts`
- `pnpm --filter @rawsql-ts/ztd-cli test -- ztdVerifier.unit.test.ts publishWorkflow.unit.test.ts`
- `pnpm --filter @rawsql-ts/ztd-cli exec tsc -p tsconfig.json --noEmit`
- `git diff --check`
- `node scripts/verify-published-package-mode.mjs`
- Manual generated tarball starter DB-missing UX check: `pnpm exec vitest run src/features/smoke/queries/smoke/tests/smoke.boundary.ztd.test.ts` now reports the target URL and recovery steps instead of a raw AggregateError. DB-backed success was not run locally because Docker reports `all predefined address pools have been fully subnetted` in this environment.

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: 
Scoped checks run: 
Why full baseline is not required: 

## Self Review

Self-review workflow: Ran the `self-review` skill over starter first-run UX, prepublish proof coverage, error recovery, and claim wording.
Self-review result: No merge blockers remain; the only unconfirmed path is DB-backed success in this local Docker environment due Docker network pool exhaustion, and the generated error text now points at that recovery case.
Concept-review workflow: Checked the ztd-cli package concept/runtime-free boundary in `docs/ztd-cli-docs.md` against the changed starter templates and publish verification flow.
Concept-review result: No concept or package-boundary violation found; generated production code remains runtime-free and the DB/testkit pieces stay in dev/test verification paths.

## CLI Surface Migration

- [ ] No migration packet required for this CLI change.
- [x] CLI/user-facing surface change and migration packet completed.

No-migration rationale: 
Upgrade note: Newly generated starters now typecheck without editing the smoke query params, and DB connection failures include direct recovery steps for Docker and `ZTD_DB_PORT`.
Deprecation/removal plan or issue: No deprecation or removal is introduced.
Docs/help/examples updated: Starter template behavior and published-package verification were updated; the existing starter README remains the user-facing setup guide.
Release/changeset wording: `.changeset/quiet-starter-proof.md` describes the ztd-cli patch release.

## Scaffold Contract Proof

- [ ] No scaffold contract proof required for this PR.
- [x] Scaffold contract proof completed.

No-proof rationale: 
Non-edit assertion: Newly generated starter smoke params are valid TypeScript without hand edits; this is asserted by `init.command.test.ts` and the tarball starter typecheck in `verify-published-package-mode.mjs`.
Fail-fast input-contract proof: `ztdVerifier.unit.test.ts` covers AggregateError-style Postgres connection failures and asserts the starter recovery message includes the target and next steps.
Generated-output viability proof: `node scripts/verify-published-package-mode.mjs` now proves the generated tarball starter by running `pnpm exec tsc --noEmit -p tsconfig.json`, DB-free smoke tests, and `ztd-config` after dependency rebinding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for Postgres aggregate connection failures with concise recovery instructions.
  * Better error message aggregation from nested error structures.

* **New Features**
  * Extended publish-time artifact verification to include starter type-checking, smoke tests, and configuration validation before release.

* **Tests**
  * Added comprehensive test coverage for database connection failure scenarios.
  * Enhanced test assertions for starter initialization flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mk3008/rawsql-ts/pull/848?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->