### PR TITLE
Expose optional condition branch source ranges

### DIFF
--- a/.changeset/seven-terms-locate.md
+++ b/.changeset/seven-terms-locate.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": patch
+---
+
+Expose source range metadata for supported optional condition branches so downstream tools can generate runtime pruning metadata without reparsing SQL.

--- a/packages/core/src/transformers/PruneOptionalConditionBranches.ts
+++ b/packages/core/src/transformers/PruneOptionalConditionBranches.ts
@@ -1,4 +1,5 @@
 import { WhereClause } from '../models/Clause';
+import { Lexeme, TokenType } from '../models/Lexeme';
 import { BinarySelectQuery, SelectQuery, SimpleSelectQuery } from '../models/SelectQuery';
 import {
     BinaryExpression,
@@ -9,6 +10,9 @@ import {
     SqlParameterValue,
     ValueComponent
 } from '../models/ValueComponent';
+import { SelectQueryParser } from '../parsers/SelectQueryParser';
+import { SqlTokenizer } from '../parsers/SqlTokenizer';
+import { ValueParser } from '../parsers/ValueParser';
 import { ParameterCollector } from './ParameterCollector';
 
 export type OptionalConditionPruningParameters = Record<string, SqlParameterValue>;
@@ -21,6 +25,19 @@ export interface SupportedOptionalConditionBranch {
     parameterName: string;
     expression: ValueComponent;
     kind: SupportedOptionalConditionBranchKind;
+}
+
+export interface OptionalConditionSourceRange {
+    start: number;
+    end: number;
+    text: string;
+}
+
+export interface SupportedOptionalConditionBranchSpan {
+    parameterName: string;
+    kind: SupportedOptionalConditionBranchKind;
+    sourceRange: OptionalConditionSourceRange;
+    removalRange: OptionalConditionSourceRange;
 }
 
 const isBinaryOperator = (expression: ValueComponent, operator: string): expression is BinaryExpression => {
@@ -383,4 +400,275 @@ export const collectSupportedOptionalConditionBranches = (
     const branches: SupportedOptionalConditionBranch[] = [];
     collectSupportedBranchesFromSelectQuery(query, branches);
     return branches;
+};
+
+/**
+ * Collects supported optional condition branches with source-text ranges.
+ *
+ * The AST collector remains the authority for whether a branch is supported. The range metadata
+ * is derived from tokenizer positions so development tools can generate runtime metadata without
+ * reparsing SQL in production.
+ */
+export const collectSupportedOptionalConditionBranchSpans = (
+    sql: string
+): SupportedOptionalConditionBranchSpan[] => {
+    const parsed = SelectQueryParser.parse(sql);
+    const supportedBranches = collectSupportedOptionalConditionBranches(parsed);
+    if (supportedBranches.length === 0) {
+        return [];
+    }
+
+    const candidates = collectOptionalConditionSpanCandidates(sql);
+    const remainingSupportedCounts = countSupportedBranchesByKey(supportedBranches);
+    assertUnambiguousCandidateCounts(candidates, remainingSupportedCounts);
+    const spans: SupportedOptionalConditionBranchSpan[] = [];
+
+    for (const candidate of candidates) {
+        const key = getSupportedBranchKey(candidate);
+        const remainingCount = remainingSupportedCounts.get(key) ?? 0;
+        if (remainingCount <= 0) {
+            continue;
+        }
+        spans.push(candidate);
+        remainingSupportedCounts.set(key, remainingCount - 1);
+    }
+
+    assertNoMissingSupportedBranches(remainingSupportedCounts);
+    return spans;
+};
+
+interface OptionalConditionSpanCandidate extends SupportedOptionalConditionBranchSpan {
+    openParenIndex: number;
+    closeParenIndex: number;
+}
+
+const getSupportedBranchKey = (
+    branch: Pick<SupportedOptionalConditionBranch, 'parameterName' | 'kind'>
+): string => `${branch.kind}:${branch.parameterName}`;
+
+const countSupportedBranchesByKey = (
+    branches: Pick<SupportedOptionalConditionBranch, 'parameterName' | 'kind'>[]
+): Map<string, number> => {
+    const counts = new Map<string, number>();
+    for (const branch of branches) {
+        const key = getSupportedBranchKey(branch);
+        counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+    return counts;
+};
+
+const assertUnambiguousCandidateCounts = (
+    candidates: OptionalConditionSpanCandidate[],
+    supportedCounts: Map<string, number>
+): void => {
+    const candidateCounts = countSupportedBranchesByKey(candidates);
+    for (const [key, supportedCount] of supportedCounts) {
+        const candidateCount = candidateCounts.get(key) ?? 0;
+        if (candidateCount < supportedCount) {
+            throw new Error(`Could not locate source range for supported optional condition branch '${key}'.`);
+        }
+        if (candidateCount > supportedCount) {
+            throw new Error(`Ambiguous source ranges for supported optional condition branch '${key}'.`);
+        }
+    }
+};
+
+const assertNoMissingSupportedBranches = (supportedCounts: Map<string, number>): void => {
+    const missingKeys = [...supportedCounts.entries()]
+        .filter(([, count]) => count > 0)
+        .map(([key]) => key);
+    if (missingKeys.length > 0) {
+        throw new Error(`Could not locate source ranges for supported optional condition branches: ${missingKeys.join(', ')}.`);
+    }
+};
+
+const collectOptionalConditionSpanCandidates = (sql: string): OptionalConditionSpanCandidate[] => {
+    const lexemes = new SqlTokenizer(sql).readLexemes();
+    const candidates: OptionalConditionSpanCandidate[] = [];
+    const stack: number[] = [];
+
+    for (let index = 0; index < lexemes.length; index += 1) {
+        const lexeme = lexemes[index];
+        if (isOpenParen(lexeme)) {
+            stack.push(index);
+            continue;
+        }
+        if (!isCloseParen(lexeme)) {
+            continue;
+        }
+        const openParenIndex = stack.pop();
+        if (openParenIndex === undefined) {
+            continue;
+        }
+        const candidate = buildOptionalConditionSpanCandidate(sql, lexemes, openParenIndex, index);
+        if (candidate) {
+            candidates.push(candidate);
+        }
+    }
+
+    return candidates.sort((left, right) => left.sourceRange.start - right.sourceRange.start);
+};
+
+const buildOptionalConditionSpanCandidate = (
+    sql: string,
+    lexemes: Lexeme[],
+    openParenIndex: number,
+    closeParenIndex: number
+): OptionalConditionSpanCandidate | null => {
+    const inside = lexemes.slice(openParenIndex + 1, closeParenIndex);
+    const orTermRanges = splitTopLevelTermsByKeyword(inside, 'or');
+    if (orTermRanges.length < 2) {
+        return null;
+    }
+
+    const guardTerms = orTermRanges
+        .map(range => ({ range, parameterName: getGuardedParameterNameFromLexemes(inside.slice(range.start, range.end)) }))
+        .filter((candidate): candidate is { range: LexemeRange; parameterName: string } => candidate.parameterName !== null);
+    if (guardTerms.length !== 1) {
+        return null;
+    }
+
+    const [{ range: guardRange, parameterName }] = guardTerms;
+    const meaningfulTerms = orTermRanges.filter(range => range !== guardRange);
+    if (meaningfulTerms.length === 0) {
+        return null;
+    }
+    if (!meaningfulTerms.every(range => isSupportedMeaningfulBranchFromLexemes(inside.slice(range.start, range.end), parameterName))) {
+        return null;
+    }
+
+    const expandedRange = expandWrappingParenRange(lexemes, openParenIndex, closeParenIndex);
+    const sourceStart = requiredPosition(lexemes[expandedRange.openParenIndex]).startPosition;
+    const sourceEnd = requiredPosition(lexemes[expandedRange.closeParenIndex]).endPosition;
+    const removalRange = getRemovalRange(sql, lexemes, expandedRange.openParenIndex, expandedRange.closeParenIndex);
+
+    return {
+        parameterName,
+        kind: 'expression',
+        sourceRange: {
+            start: sourceStart,
+            end: sourceEnd,
+            text: sql.slice(sourceStart, sourceEnd)
+        },
+        removalRange,
+        openParenIndex: expandedRange.openParenIndex,
+        closeParenIndex: expandedRange.closeParenIndex
+    };
+};
+
+const expandWrappingParenRange = (
+    lexemes: Lexeme[],
+    openParenIndex: number,
+    closeParenIndex: number
+): { openParenIndex: number; closeParenIndex: number } => {
+    let expandedOpenParenIndex = openParenIndex;
+    let expandedCloseParenIndex = closeParenIndex;
+    while (
+        isOpenParen(lexemes[expandedOpenParenIndex - 1]) &&
+        isCloseParen(lexemes[expandedCloseParenIndex + 1])
+    ) {
+        expandedOpenParenIndex -= 1;
+        expandedCloseParenIndex += 1;
+    }
+    return {
+        openParenIndex: expandedOpenParenIndex,
+        closeParenIndex: expandedCloseParenIndex
+    };
+};
+
+interface LexemeRange {
+    start: number;
+    end: number;
+}
+
+const splitTopLevelTermsByKeyword = (lexemes: Lexeme[], keyword: string): LexemeRange[] => {
+    const ranges: LexemeRange[] = [];
+    let depth = 0;
+    let start = 0;
+    for (let index = 0; index < lexemes.length; index += 1) {
+        const lexeme = lexemes[index];
+        if (isOpenParen(lexeme)) {
+            depth += 1;
+            continue;
+        }
+        if (isCloseParen(lexeme)) {
+            depth -= 1;
+            continue;
+        }
+        if (depth === 0 && isKeyword(lexeme, keyword)) {
+            ranges.push({ start, end: index });
+            start = index + 1;
+        }
+    }
+    ranges.push({ start, end: lexemes.length });
+    return ranges;
+};
+
+const getGuardedParameterNameFromLexemes = (lexemes: Lexeme[]): string | null => {
+    const compact = lexemes.filter(lexeme => !isWrappingParen(lexeme));
+    if (compact.length !== 3) {
+        return null;
+    }
+    if (!isParameter(compact[0]) || !isKeyword(compact[1], 'is') || !isKeyword(compact[2], 'null')) {
+        return null;
+    }
+    return normalizeParameterName(compact[0].value);
+};
+
+const isSupportedMeaningfulBranchFromLexemes = (lexemes: Lexeme[], parameterName: string): boolean => {
+    try {
+        const parsed = ValueParser.parseFromLexeme(lexemes, 0);
+        if (parsed.newIndex !== lexemes.length) {
+            return false;
+        }
+        return isSupportedMeaningfulBranch(parsed.value, parameterName);
+    } catch {
+        return false;
+    }
+};
+
+const getRemovalRange = (
+    sql: string,
+    lexemes: Lexeme[],
+    openParenIndex: number,
+    closeParenIndex: number
+): OptionalConditionSourceRange => {
+    const previous = lexemes[openParenIndex - 1];
+    const next = lexemes[closeParenIndex + 1];
+    let start = requiredPosition(lexemes[openParenIndex]).startPosition;
+    let end = requiredPosition(lexemes[closeParenIndex]).endPosition;
+
+    if (previous && isKeyword(previous, 'and')) {
+        start = requiredPosition(previous).startPosition;
+    } else if (next && isKeyword(next, 'and')) {
+        end = requiredPosition(next).endPosition;
+    } else if (previous && isKeyword(previous, 'where')) {
+        start = requiredPosition(previous).startPosition;
+    }
+
+    return {
+        start,
+        end,
+        text: sql.slice(start, end)
+    };
+};
+
+const isParameter = (lexeme: Lexeme): boolean => (lexeme.type & TokenType.Parameter) !== 0;
+const isOpenParen = (lexeme: Lexeme): boolean => (lexeme.type & TokenType.OpenParen) !== 0;
+const isCloseParen = (lexeme: Lexeme): boolean => (lexeme.type & TokenType.CloseParen) !== 0;
+const isKeyword = (lexeme: Lexeme, keyword: string): boolean => lexeme.value.toLowerCase() === keyword;
+const isWrappingParen = (lexeme: Lexeme): boolean => isOpenParen(lexeme) || isCloseParen(lexeme);
+
+const normalizeParameterName = (value: string): string => {
+    if (value.startsWith('${') && value.endsWith('}')) {
+        return value.slice(2, -1);
+    }
+    return value.replace(/^[:@$]/, '');
+};
+
+const requiredPosition = (lexeme: Lexeme): NonNullable<Lexeme['position']> => {
+    if (!lexeme.position) {
+        throw new Error(`Lexeme '${lexeme.value}' is missing source position metadata.`);
+    }
+    return lexeme.position;
 };

--- a/packages/core/tests/transformers/PruneOptionalConditionBranches.test.ts
+++ b/packages/core/tests/transformers/PruneOptionalConditionBranches.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { DynamicQueryBuilder } from '../../src/transformers/DynamicQueryBuilder';
 import {
+    collectSupportedOptionalConditionBranchSpans,
     OptionalConditionPruningParameters,
     pruneOptionalConditionBranches
 } from '../../src/transformers/PruneOptionalConditionBranches';
@@ -16,6 +17,135 @@ const formatSql = (sql: string, pruningParameters?: OptionalConditionPruningPara
 };
 
 describe('pruneOptionalConditionBranches', () => {
+    it('collects source and removal ranges for supported optional branches', () => {
+        const sql = [
+            'SELECT p.product_id',
+            'FROM products p',
+            'WHERE p.deleted_at IS NULL',
+            '  AND (:brand_name IS NULL OR p.brand_name = :brand_name)',
+            '  AND (:status IS NULL OR p.status = :status)',
+            'ORDER BY p.product_id'
+        ].join('\n');
+
+        const spans = collectSupportedOptionalConditionBranchSpans(sql);
+
+        expect(spans).toHaveLength(2);
+        expect(spans.map(span => span.parameterName)).toEqual(['brand_name', 'status']);
+        expect(spans[0].sourceRange.text).toBe('(:brand_name IS NULL OR p.brand_name = :brand_name)');
+        expect(spans[0].removalRange.text).toBe('AND (:brand_name IS NULL OR p.brand_name = :brand_name)');
+        expect(sql.slice(spans[1].sourceRange.start, spans[1].sourceRange.end)).toBe(spans[1].sourceRange.text);
+        expect(sql.slice(spans[1].removalRange.start, spans[1].removalRange.end)).toBe(spans[1].removalRange.text);
+    });
+
+    it('collects a whole-WHERE removal range when the optional branch is the only predicate', () => {
+        const sql = [
+            'SELECT p.product_id',
+            'FROM products p',
+            'WHERE (:brand_name IS NULL OR p.brand_name = :brand_name)'
+        ].join('\n');
+
+        const [span] = collectSupportedOptionalConditionBranchSpans(sql);
+
+        expect(span.parameterName).toBe('brand_name');
+        expect(span.sourceRange.text).toBe('(:brand_name IS NULL OR p.brand_name = :brand_name)');
+        expect(span.removalRange.text).toBe('WHERE (:brand_name IS NULL OR p.brand_name = :brand_name)');
+    });
+
+    it('collects range metadata for nested supported optional branches', () => {
+        const sql = `
+            WITH filtered_products AS (
+                SELECT p.product_id
+                FROM products p
+                WHERE 1 = 1
+                  AND (:brand_name IS NULL OR p.brand_name = :brand_name)
+            )
+            SELECT * FROM filtered_products
+        `;
+
+        const [span] = collectSupportedOptionalConditionBranchSpans(sql);
+
+        expect(span.parameterName).toBe('brand_name');
+        expect(span.sourceRange.text).toBe('(:brand_name IS NULL OR p.brand_name = :brand_name)');
+        expect(span.removalRange.text).toBe('AND (:brand_name IS NULL OR p.brand_name = :brand_name)');
+    });
+
+    it('collects spans in source order when nested and outer queries both contain supported branches', () => {
+        const sql = [
+            'WITH filtered_products AS (',
+            '  SELECT p.product_id',
+            '  FROM products p',
+            '  WHERE 1 = 1',
+            '    AND (:brand_name IS NULL OR p.brand_name = :brand_name)',
+            ')',
+            'SELECT *',
+            'FROM filtered_products fp',
+            'WHERE 1 = 1',
+            '  AND (:status IS NULL OR fp.status = :status)'
+        ].join('\n');
+
+        const spans = collectSupportedOptionalConditionBranchSpans(sql);
+
+        expect(spans.map(span => span.parameterName)).toEqual(['brand_name', 'status']);
+        expect(spans[0].sourceRange.start).toBeLessThan(spans[1].sourceRange.start);
+    });
+
+    it('collects wrapper parentheses in removal ranges for supported optional branches', () => {
+        const sql = [
+            'SELECT p.product_id',
+            'FROM products p',
+            'WHERE p.deleted_at IS NULL',
+            '  AND ((:brand_name IS NULL OR p.brand_name = :brand_name))'
+        ].join('\n');
+
+        const [span] = collectSupportedOptionalConditionBranchSpans(sql);
+
+        expect(span.parameterName).toBe('brand_name');
+        expect(span.sourceRange.text).toBe('((:brand_name IS NULL OR p.brand_name = :brand_name))');
+        expect(span.removalRange.text).toBe('AND ((:brand_name IS NULL OR p.brand_name = :brand_name))');
+    });
+
+    it('does not expose source ranges for unsupported optional-looking branches', () => {
+        const sql = `
+            SELECT p.product_id
+            FROM products p
+            WHERE p.active = true
+               OR (:brand_name IS NULL OR p.brand_name = :brand_name)
+        `;
+
+        expect(collectSupportedOptionalConditionBranchSpans(sql)).toEqual([]);
+    });
+
+    it('rejects ambiguous same-parameter optional-looking ranges that are not all AST-supported pruning branches', () => {
+        const sql = [
+            'WITH filtered_products AS (',
+            '  SELECT p.product_id',
+            '  FROM products p',
+            '  WHERE 1 = 1',
+            '    AND (:brand_name IS NULL OR p.brand_name = :brand_name)',
+            ')',
+            'SELECT p.product_id',
+            'FROM products p',
+            'WHERE p.active = true',
+            '   OR (:brand_name IS NULL OR p.brand_name = :brand_name)'
+        ].join('\n');
+
+        expect(() => collectSupportedOptionalConditionBranchSpans(sql)).toThrow(/Ambiguous source ranges/);
+    });
+
+    it('does not treat a bare guarded parameter as a supported meaningful branch candidate', () => {
+        const sql = [
+            'SELECT p.product_id',
+            'FROM products p',
+            'WHERE (:brand_name IS NULL OR :brand_name)',
+            '  AND (:status IS NULL OR p.status = :status)'
+        ].join('\n');
+
+        const spans = collectSupportedOptionalConditionBranchSpans(sql);
+
+        expect(spans.map(span => span.parameterName)).toEqual(['status']);
+        expect(spans[0].sourceRange.text).toBe('(:status IS NULL OR p.status = :status)');
+    });
+
     it('prunes a top-level optional scalar predicate when the targeted parameter is null', () => {
         const sql = `
             SELECT p.product_id


### PR DESCRIPTION
## Summary

- Add `collectSupportedOptionalConditionBranchSpans` to expose source and removal ranges for supported optional condition branches.
- Keep the existing AST collector as the authority for supportability, using tokenizer positions only to produce development-time runtime metadata.
- Cover normal branches, whole-`WHERE` removals, nested queries, wrapper parentheses, and unsupported optional-looking branches.

## Verification

- `corepack pnpm --filter rawsql-ts test -- packages/core/tests/transformers/PruneOptionalConditionBranches.test.ts`
- `corepack pnpm --filter rawsql-ts build`
- `corepack pnpm --filter rawsql-ts pack --pack-destination C:\Users\mssgm\CodexApp\tmp\rawsql-pack`
- `node verify-sssql-span.cjs` in `C:\Users\mssgm\CodexApp\tmp\rawsql-tarball-consumer` against the packed tarball
- Pre-commit hook: workspace typecheck, workspace tests, workspace build, and workspace lint all passed

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: 
Scoped checks run: 
Why full baseline is not required: 

## Self Review

Self-review workflow: Codex self-review skill, two-cycle pass after implementation and verification.
Self-review result: No merge blockers remain; wrapper-parentheses removal risk was identified and covered before PR.
Concept-review workflow: Package-boundary check for rawsql-ts core plus Ashiba downstream runtime-metadata use case.
Concept-review result: No concept or package-boundary violations remain; this is an additive core API for development-time metadata generation.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: This change does not touch ztd-cli commands, docs, or CLI user-facing behavior.
Upgrade note: No CLI upgrade note required.
Deprecation/removal plan or issue: No deprecation or removal.
Docs/help/examples updated: Not applicable; no CLI docs or help changed.
Release/changeset wording: Added a patch changeset for rawsql-ts.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: This change does not touch scaffold commands, templates, or generated project output.
Non-edit assertion: Not applicable.
Fail-fast input-contract proof: Not applicable.
Generated-output viability proof: Not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed source range and removal range metadata for supported optional condition branches, enabling downstream tools to access branch information for runtime pruning without reparsing the original SQL.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mk3008/rawsql-ts/pull/850?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->