### PR TITLE
fix: skip ztd smoke when CLI artifact is absent

### DIFF
--- a/packages/ztd-cli/tests/publishWorkflow.unit.test.ts
+++ b/packages/ztd-cli/tests/publishWorkflow.unit.test.ts
@@ -51,6 +51,7 @@ test('standalone pnpm proof apps use the installed ztd bin helper instead of pnp
   expect(publishedPackageModeScript).toContain('function getInstalledBinPath(directory, binName) {');
   expect(publishedPackageModeScript).toContain('function runInstalledZtdCli(directory, args) {');
   expect(publishedPackageModeScript).toContain('pnpm-workspace.yaml');
+  expect(publishedPackageModeScript).toContain('const result = runInstalledZtdCli(directory, ["init", "--dry-run", "--yes", ...args]);');
 
   const starterSection = publishedPackageModeScript.slice(
     publishedPackageModeScript.indexOf('function verifyPnpmStarterPath(packages) {'),
@@ -156,6 +157,55 @@ test('published-package smoke rebinds scaffold runtime dependencies to packed ta
   expect(publishedPackageModeScript).toContain('fs.rmSync(path.join(directory, "package-lock.json"), { force: true });');
   expect(publishedPackageModeScript).toContain('fs.rmSync(path.join(directory, "node_modules"), { force: true, recursive: true });');
   expect(publishedPackageModeScript).toContain('restorePublishedDependencyRanges(appDir, packages);');
+});
+
+test('published-package mode only runs ztd CLI smoke paths when its tarball is present', () => {
+  const npmSection = publishedPackageModeScript.slice(
+    publishedPackageModeScript.indexOf('function verifyNpmPrimaryPath(packages) {'),
+    publishedPackageModeScript.indexOf('function verifyNpmConsumerSmoke(phaseAResult) {'),
+  );
+  expect(npmSection).toContain('if (!hasTarballDependency(tarballDependencies, "@rawsql-ts/ztd-cli")) {');
+  expect(npmSection).toContain('return null;');
+  expect(npmSection).toContain('runInstalledZtdCli(appDir, ["init", "--yes", "--workflow", "demo"])');
+  expect(npmSection).not.toContain('NPM, ["exec", "--", "ztd"');
+
+  const smokeSection = publishedPackageModeScript.slice(
+    publishedPackageModeScript.indexOf('function verifyNpmConsumerSmoke(phaseAResult) {'),
+    publishedPackageModeScript.indexOf('function verifyPnpmStarterPath(packages) {'),
+  );
+  expect(smokeSection).toContain('if (phaseAResult == null) {');
+  expect(smokeSection).toContain('return null;');
+  expect(smokeSection).toContain('runInstalledZtdCli(appDir, ["ztd-config"])');
+  expect(smokeSection).toContain('runInstalledZtdCli(appDir, [');
+  expect(smokeSection).not.toContain('NPM, ["exec", "--", "ztd"');
+
+  const starterSection = publishedPackageModeScript.slice(
+    publishedPackageModeScript.indexOf('function verifyPnpmStarterPath(packages) {'),
+    publishedPackageModeScript.indexOf('function verifyPnpmAdapterInstall(packages) {'),
+  );
+  expect(starterSection).toContain('if (!hasTarballDependency(tarballDependencies, "@rawsql-ts/ztd-cli")) {');
+  expect(starterSection).toContain('return null;');
+
+  const adapterSection = publishedPackageModeScript.slice(
+    publishedPackageModeScript.indexOf('function verifyPnpmAdapterInstall(packages) {'),
+    publishedPackageModeScript.indexOf('function verifyPnpmTutorialModelGen(packages) {'),
+  );
+  expect(adapterSection).toContain('if (!hasTarballDependency(tarballDependencies, "@rawsql-ts/ztd-cli")) {');
+  expect(adapterSection).toContain('return null;');
+
+  const tutorialSection = publishedPackageModeScript.slice(
+    publishedPackageModeScript.indexOf('function verifyPnpmTutorialModelGen(packages) {'),
+    publishedPackageModeScript.indexOf('function verifyOverwriteSafety(packages) {'),
+  );
+  expect(tutorialSection).toContain('if (!hasTarballDependency(tarballDependencies, "@rawsql-ts/ztd-cli")) {');
+  expect(tutorialSection).toContain('return null;');
+
+  const overwriteSection = publishedPackageModeScript.slice(
+    publishedPackageModeScript.indexOf('function verifyOverwriteSafety(packages) {'),
+    publishedPackageModeScript.indexOf('function main() {'),
+  );
+  expect(overwriteSection).toContain('if (!hasTarballDependency(tarballDependencies, "@rawsql-ts/ztd-cli")) {');
+  expect(overwriteSection).toContain('return null;');
 });
 
 test('publish plan can include unpublished workspace dependencies required by published scaffolds', () => {

--- a/scripts/verify-published-package-mode.mjs
+++ b/scripts/verify-published-package-mode.mjs
@@ -341,8 +341,8 @@ function readJsonFile(filePath) {
   return JSON.parse(fs.readFileSync(filePath, "utf8"));
 }
 
-function runInitDryRunPlan(directory, packageManager, args) {
-  const result = runIn(directory, packageManager, ["exec", "--", "ztd", "init", "--dry-run", "--yes", ...args]);
+function runInitDryRunPlan(directory, args) {
+  const result = runInstalledZtdCli(directory, ["init", "--dry-run", "--yes", ...args]);
   const stdout = String(result.stdout ?? "");
   const start = stdout.indexOf("{");
   const end = stdout.lastIndexOf("}");
@@ -539,6 +539,10 @@ function verifyNpmPrimaryPath(packages) {
   ensureCleanDir(appDir);
   const tarballDependencies = createTarballDependencyMap(packages);
 
+  if (!hasTarballDependency(tarballDependencies, "@rawsql-ts/ztd-cli")) {
+    return null;
+  }
+
   writePackageJson(appDir, {
     name: "npm-consumer-smoke",
     private: true,
@@ -547,7 +551,7 @@ function verifyNpmPrimaryPath(packages) {
   });
 
   runIn(appDir, NPM, ["install"]);
-  const dryRunPlan = runInitDryRunPlan(appDir, NPM, ["--workflow", "demo"]);
+  const dryRunPlan = runInitDryRunPlan(appDir, ["--workflow", "demo"]);
   assertScaffoldPlanMetadata(dryRunPlan, {
     dryRun: true,
     schemaVersion: 1,
@@ -555,7 +559,7 @@ function verifyNpmPrimaryPath(packages) {
     validator: "none",
     starter: false,
   }, "phase-a init-dry-run");
-  const initResult = runIn(appDir, NPM, ["exec", "--", "ztd", "init", "--yes", "--workflow", "demo"]);
+  const initResult = runInstalledZtdCli(appDir, ["init", "--yes", "--workflow", "demo"]);
 
   assertIncludes(initResult.stdout, "ztd-config", "phase-a packaging-npm-primary-path-gate");
   assertIncludes(initResult.stdout, "model-gen", "phase-a packaging-npm-primary-path-gate");
@@ -582,21 +586,22 @@ function verifyNpmPrimaryPath(packages) {
 }
 
 function verifyNpmConsumerSmoke(phaseAResult) {
+  if (phaseAResult == null) {
+    return null;
+  }
+
   const { appDir } = phaseAResult;
 
   // Phase B proves the first generated smoke test can pass on the npm-first consumer path.
-  runIn(appDir, NPM, ["exec", "--", "ztd", "ztd-config"]);
+  runInstalledZtdCli(appDir, ["ztd-config"]);
 
   // Keep the published command surface aligned with Further Reading docs by
   // exercising the opt-in join-direction flag from the packed CLI artifact.
   fs.mkdirSync(path.join(appDir, "tmp"), { recursive: true });
   fs.writeFileSync(path.join(appDir, "tmp", "join-direction-smoke.sql"), "select 1;\n", "utf8");
-  const lintHelp = runIn(appDir, NPM, ["exec", "--", "ztd", "query", "lint", "--help"]);
+  const lintHelp = runInstalledZtdCli(appDir, ["query", "lint", "--help"]);
   assertIncludes(lintHelp.stdout, "--rules <list>", "phase-b query-lint-help-surface");
-  runIn(appDir, NPM, [
-    "exec",
-    "--",
-    "ztd",
+  runInstalledZtdCli(appDir, [
     "query",
     "lint",
     "--rules",
@@ -620,6 +625,10 @@ function verifyPnpmStarterPath(packages) {
   ensureCleanDir(appDir);
 
   const tarballDependencies = createTarballDependencyMap(packages);
+  if (!hasTarballDependency(tarballDependencies, "@rawsql-ts/ztd-cli")) {
+    return null;
+  }
+
   syncStandaloneWorkspacePackageJson(tarballDependencies);
   writePackageJson(appDir, {
     name: "pnpm-starter-path-check",
@@ -631,7 +640,7 @@ function verifyPnpmStarterPath(packages) {
   });
 
   runIn(appDir, PNPM, ["install", "--no-frozen-lockfile"]);
-  const dryRunPlan = runInitDryRunPlan(appDir, PNPM, [
+  const dryRunPlan = runInitDryRunPlan(appDir, [
     "--starter",
     "--workflow",
     "demo",
@@ -682,6 +691,10 @@ function verifyPnpmAdapterInstall(packages) {
   ensureCleanDir(appDir);
 
   const tarballDependencies = createTarballDependencyMap(packages);
+  if (!hasTarballDependency(tarballDependencies, "@rawsql-ts/ztd-cli")) {
+    return null;
+  }
+
   syncStandaloneWorkspacePackageJson(tarballDependencies);
   writePackageJson(appDir, {
     name: "pnpm-adapter-path-check",
@@ -720,6 +733,10 @@ function verifyPnpmTutorialModelGen(packages) {
   ensureCleanDir(appDir);
 
   const tarballDependencies = createTarballDependencyMap(packages);
+  if (!hasTarballDependency(tarballDependencies, "@rawsql-ts/ztd-cli")) {
+    return null;
+  }
+
   syncStandaloneWorkspacePackageJson(tarballDependencies);
   writePackageJson(appDir, {
     name: "pnpm-tutorial-model-gen-check",
@@ -817,12 +834,17 @@ function verifyPnpmTutorialModelGen(packages) {
 function verifyOverwriteSafety(packages) {
   const appDir = path.join(packageRoot, "overwrite-safety");
   ensureCleanDir(appDir);
+  const tarballDependencies = createTarballDependencyMap(packages);
+
+  if (!hasTarballDependency(tarballDependencies, "@rawsql-ts/ztd-cli")) {
+    return null;
+  }
 
   writePackageJson(appDir, {
     name: "overwrite-safety-check",
     private: true,
     version: "0.0.0",
-    devDependencies: createTarballDependencyMap(packages),
+    devDependencies: tarballDependencies,
   });
 
   fs.mkdirSync(path.join(appDir, "db", "ddl"), { recursive: true });
@@ -889,7 +911,7 @@ function main() {
     verificationMode: options.publishManifestProvided ? "publish-manifest" : "workspace-pack",
     packedInstallApp,
     coreGettingStartedApp,
-    npmPrimaryPathApp: npmPrimaryPathApp.appDir,
+    npmPrimaryPathApp: npmPrimaryPathApp?.appDir ?? null,
     firstTestGateApp: npmSmokeApp,
     npmSmokeApp,
     pnpmStarterApp,


### PR DESCRIPTION
## Summary

- Skip ztd CLI published-package smoke paths when the publish manifest does not include `@rawsql-ts/ztd-cli`.
- Run ztd CLI smoke commands through the installed `.bin/ztd` helper instead of letting `npm exec` resolve a missing `ztd` package from the public registry.
- Add publish workflow unit coverage for core-only publish manifests and installed-bin ztd execution.

## Verification

- `pnpm --filter @rawsql-ts/ztd-cli exec vitest run --config vitest.config.ts tests/publishWorkflow.unit.test.ts` (16 tests passed)
- `pnpm --filter rawsql-ts run build` (passed)
- `node ./scripts/verify-published-package-mode.mjs --publish-manifest tmp/core-only-artifact/publish-manifest.json` (passed with ztd smoke paths skipped)
- `git diff --check` (passed; CRLF warnings only)
- `pnpm test` (320 files passed, 2959 tests passed, 8 skipped)
- pre-commit hook ran workspace typecheck, tests, build, and lint successfully before the metadata-only amend

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

<!-- Write values on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. -->
<!-- Do not add list markers like "-" before these labels; `Tracking issue:` and `Scoped checks run:` must start at column 0. -->
Tracking issue: Not requested; no baseline exception.
Scoped checks run: Targeted ztd-cli publish workflow unit test, core build, core-only published-package verification, git diff whitespace check, full pnpm test, and pre-commit workspace typecheck/test/build/lint.
Why full baseline is not required: No exception requested; full pre-commit checks completed successfully.

## Self Review

<!-- Fill these fields after running the repo self-review workflow or available self-review skill. -->
Self-review workflow: Local self-review skill, two-cycle review after implementation and verification.
Self-review result: No blockers remain; test coverage was strengthened to include every ztd CLI smoke path skip.
Concept-review workflow: Explicit no-concept-impact rationale; change is limited to publish verification orchestration and tests, with no package behavior, scaffold output, generated runtime code, or concept boundary changes.
Concept-review result: No concept or package-boundary violations identified.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-migration rationale: The PR does not change CLI commands, flags, help text, README CLI guidance, or generated consumer-facing behavior; it only changes release verification when the CLI artifact is absent from a publish manifest.
Upgrade note: Not applicable; no user-facing CLI behavior changes.
Deprecation/removal plan or issue: Not applicable; no CLI deprecation or removal.
Docs/help/examples updated: Not applicable; no docs/help/example surface changes.
Release/changeset wording: Not applicable; no package release note needed for repository-only publish verification logic.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-proof rationale: The PR does not edit scaffold templates, scaffold commands, generated output, or scaffold docs; it skips scaffold smoke checks only when the ztd CLI tarball is not part of the publish manifest.
Non-edit assertion: No scaffold-owned files or generated template outputs were edited.
Fail-fast input-contract proof: Publish verification still validates tarball manifests and entrypoints before smoke checks; ztd CLI smoke paths run when `@rawsql-ts/ztd-cli` is present.
Generated-output viability proof: Existing ztd publish workflow unit test plus core-only publish verification prove the release verifier no longer invokes absent scaffold tooling for core-only artifacts.

