### PR TITLE
feat: add SSSQL rewrite plans

### DIFF
--- a/.changeset/sssql-rewrite-plan.md
+++ b/.changeset/sssql-rewrite-plan.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": minor
+---
+
+Add SSSQL rewrite plan APIs on `SSSQLFilterBuilder` so callers can inspect scaffold, refresh, and remove rewrites before applying them. Plans include rewritten SQL, edit spans, safety metadata, warnings, and errors. Scalar add and remove plans can now return minimal span-based edits when the change can be proven target-local, while unsupported cases fall back to conservative full-reformat warnings.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,6 +56,7 @@
         "eslint-config-prettier": "^10.1.1",
         "eslint-plugin-filenames": "^1.3.2",
         "eslint-plugin-prettier": "^5.2.3",
+        "fast-check": "^4.8.0",
         "microtime": "^3.1.1",
         "mitata": "^1.0.34",
         "node-sql-parser": "^5.4.0",

--- a/packages/core/src/transformers/SSSQLFilterBuilder.ts
+++ b/packages/core/src/transformers/SSSQLFilterBuilder.ts
@@ -13,6 +13,8 @@ import {
     type ValueComponent
 } from "../models/ValueComponent";
 import { SelectQueryParser } from "../parsers/SelectQueryParser";
+import { SqlTokenizer } from "../parsers/SqlTokenizer";
+import { Lexeme, TokenType } from "../models/Lexeme";
 import { UpstreamSelectQueryFinder } from "./UpstreamSelectQueryFinder";
 import { ColumnReferenceCollector } from "./ColumnReferenceCollector";
 import { SelectableColumnCollector, DuplicateDetectionMode } from "./SelectableColumnCollector";
@@ -33,6 +35,71 @@ export type SssqlBranchKind = "scalar" | "exists" | "not-exists" | "expression";
 
 export interface SssqlTransformResult {
     query: SelectQuery;
+}
+
+export type SssqlRewriteEditKind = "insert" | "replace" | "delete";
+
+export interface SssqlRewriteEdit {
+    start: number;
+    end: number;
+    before: string;
+    after: string;
+    kind: SssqlRewriteEditKind;
+    reason?: string;
+    target?: SssqlRewriteEditTarget;
+}
+
+export interface SssqlRewriteEditTarget {
+    branchKind: SssqlBranchKind;
+    parameterName: string;
+    column?: string;
+}
+
+export type SssqlRewriteChangedRegionKind =
+    | "target-branch"
+    | "where-keyword"
+    | "boolean-operator"
+    | "parentheses"
+    | "formatter-rewrite"
+    | "comment"
+    | "unknown";
+
+export interface SssqlRewriteChangedRegion {
+    kind: SssqlRewriteChangedRegionKind;
+    start: number;
+    end: number;
+    message?: string;
+}
+
+export interface SssqlRewritePlanWarning {
+    code: string;
+    message: string;
+    detail?: unknown;
+}
+
+export interface SssqlRewritePlanError {
+    code: string;
+    message: string;
+    detail?: unknown;
+}
+
+export interface SssqlRewriteSafety {
+    tokenCountBefore: number;
+    tokenCountAfter: number;
+    tokenSequencePreserved: boolean;
+    commentsPreserved: boolean;
+    changedOnlyTargetBranches: boolean;
+    changedRegions: readonly SssqlRewriteChangedRegion[];
+}
+
+export interface SssqlRewritePlan {
+    ok: boolean;
+    requiresFullReformat: boolean;
+    edits: readonly SssqlRewriteEdit[];
+    sql?: string;
+    safety: SssqlRewriteSafety;
+    warnings: readonly SssqlRewritePlanWarning[];
+    errors: readonly SssqlRewritePlanError[];
 }
 
 export interface SssqlBranchInfo {
@@ -100,6 +167,253 @@ let formatter: SqlFormatter | null = null;
 const normalizeIdentifier = (value: string): string => value.trim().toLowerCase();
 
 const normalizeSql = (value: string): string => value.replace(/\s+/g, " ").trim().toLowerCase();
+
+interface RewriteTokenSignature {
+    type: number;
+    value: string;
+}
+
+const normalizeRewriteTokenType = (lexeme: Lexeme): number => {
+    if ((lexeme.type & TokenType.Command) !== 0) {
+        return TokenType.Command;
+    }
+    if ((lexeme.type & TokenType.Identifier) !== 0) {
+        return TokenType.Identifier;
+    }
+    return lexeme.type;
+};
+
+const normalizeRewriteTokenValue = (lexeme: Lexeme): string => {
+    if ((lexeme.type & TokenType.Command) !== 0) {
+        return lexeme.value.toLowerCase();
+    }
+    return lexeme.value;
+};
+
+const tokenizeForRewritePlan = (sql: string): RewriteTokenSignature[] => {
+    return new SqlTokenizer(sql).tokenize().map(lexeme => ({
+        type: normalizeRewriteTokenType(lexeme),
+        value: normalizeRewriteTokenValue(lexeme)
+    }));
+};
+
+const tokenSequencesEqual = (left: RewriteTokenSignature[], right: RewriteTokenSignature[]): boolean => {
+    if (left.length !== right.length) {
+        return false;
+    }
+
+    return left.every((token, index) => {
+        const other = right[index];
+        return other !== undefined && token.type === other.type && token.value === other.value;
+    });
+};
+
+const collectCommentFragments = (sql: string): string[] => {
+    return new SqlTokenizer(sql).tokenize().flatMap(lexeme => {
+        if (lexeme.positionedComments) {
+            return lexeme.positionedComments.flatMap(positioned => positioned.comments);
+        }
+        return lexeme.comments ? [...lexeme.comments] : [];
+    });
+};
+
+const commentsPreservedInOrder = (before: string[], after: string[]): boolean => {
+    let cursor = 0;
+    for (const comment of before) {
+        const foundAt = after.indexOf(comment, cursor);
+        if (foundAt < 0) {
+            return false;
+        }
+        cursor = foundAt + 1;
+    }
+    return true;
+};
+
+const countCommandToken = (tokens: RewriteTokenSignature[], value: string): number => {
+    return tokens.filter(token => token.type === TokenType.Command && token.value === value).length;
+};
+
+const applyRewriteEdits = (sql: string, edits: readonly SssqlRewriteEdit[]): string => {
+    return [...edits]
+        .sort((left, right) => right.start - left.start)
+        .reduce((current, edit) => {
+            return current.slice(0, edit.start) + edit.after + current.slice(edit.end);
+        }, sql);
+};
+
+const getStatementEndPosition = (sql: string): number => {
+    let end = sql.length;
+    while (end > 0 && /\s/.test(sql[end - 1]!)) {
+        end--;
+    }
+    if (end > 0 && sql[end - 1] === ";") {
+        end--;
+        while (end > 0 && /\s/.test(sql[end - 1]!)) {
+            end--;
+        }
+    }
+    return end;
+};
+
+const clauseBoundaryCommands = new Set(["group by", "having", "order by", "limit", "offset", "fetch", "for"]);
+
+const isClauseBoundary = (lexeme: Lexeme): boolean => {
+    return (lexeme.type & TokenType.Command) !== 0
+        && clauseBoundaryCommands.has(lexeme.value.toLowerCase());
+};
+
+const findMinimalWhereInsertPosition = (sql: string): { position: number; hasWhere: boolean } => {
+    const lexemes = new SqlTokenizer(sql).tokenize();
+    const whereIndex = lexemes.findIndex(lexeme =>
+        (lexeme.type & TokenType.Command) !== 0 && lexeme.value.toLowerCase() === "where"
+    );
+    const statementEnd = getStatementEndPosition(sql);
+
+    if (whereIndex >= 0) {
+        const tail = lexemes.slice(whereIndex + 1).find(isClauseBoundary);
+        return {
+            position: tail?.position?.startPosition ?? statementEnd,
+            hasWhere: true
+        };
+    }
+
+    const tail = lexemes.find(isClauseBoundary);
+    return {
+        position: tail?.position?.startPosition ?? statementEnd,
+        hasWhere: false
+    };
+};
+
+const findMatchingParenEnd = (sql: string, start: number): number => {
+    let depth = 0;
+    let quote: string | null = null;
+
+    for (let index = start; index < sql.length; index++) {
+        const char = sql[index]!;
+        if (quote) {
+            if (char === quote) {
+                if (quote === "'" && sql[index + 1] === "'") {
+                    index++;
+                    continue;
+                }
+                quote = null;
+            }
+            continue;
+        }
+
+        if (char === "'" || char === "\"") {
+            quote = char;
+            continue;
+        }
+        if (char === "(") {
+            depth++;
+        }
+        if (char === ")") {
+            depth--;
+            if (depth === 0) {
+                return index + 1;
+            }
+        }
+    }
+
+    return -1;
+};
+
+const findOptionalBranchSpans = (sql: string, parameterName: string): Array<{ start: number; end: number; text: string }> => {
+    const spans: Array<{ start: number; end: number; text: string }> = [];
+    const parameterNeedle = `:${parameterName.toLowerCase()}`;
+    const lowerSql = sql.toLowerCase();
+
+    for (let index = 0; index < sql.length; index++) {
+        if (sql[index] !== "(") {
+            continue;
+        }
+
+        const end = findMatchingParenEnd(sql, index);
+        if (end < 0) {
+            break;
+        }
+
+        const text = sql.slice(index, end);
+        const normalized = lowerSql.slice(index, end);
+        if (normalized.includes(parameterNeedle) && normalized.includes(" is null") && normalized.includes(" or ")) {
+            spans.push({ start: index, end, text });
+        }
+        index = end - 1;
+    }
+
+    return spans;
+};
+
+const findBooleanOperatorBefore = (sql: string, start: number): { start: number; end: number; value: string } | null => {
+    const prefix = sql.slice(0, start);
+    const match = /(\s+)(and|or)(\s*)$/i.exec(prefix);
+    if (!match || match.index === undefined) {
+        return null;
+    }
+    return {
+        start: match.index,
+        end: start,
+        value: match[2]!.toLowerCase()
+    };
+};
+
+const findBooleanOperatorAfter = (sql: string, end: number): { start: number; end: number; value: string } | null => {
+    const suffix = sql.slice(end);
+    const match = /^(\s*)(and|or)(\s+)/i.exec(suffix);
+    if (!match) {
+        return null;
+    }
+    return {
+        start: end,
+        end: end + match[0].length,
+        value: match[2]!.toLowerCase()
+    };
+};
+
+const findWhereBefore = (sql: string, position: number): { start: number; end: number } | null => {
+    const lexemes = new SqlTokenizer(sql).tokenize();
+    let found: Lexeme | null = null;
+    for (const lexeme of lexemes) {
+        if ((lexeme.position?.startPosition ?? 0) >= position) {
+            break;
+        }
+        if ((lexeme.type & TokenType.Command) !== 0 && lexeme.value.toLowerCase() === "where") {
+            found = lexeme;
+        }
+    }
+    if (!found?.position) {
+        return null;
+    }
+    return {
+        start: found.position.startPosition,
+        end: found.position.endPosition
+    };
+};
+
+const findSourceColumnReferenceText = (sql: string, reference: ColumnReference): string => {
+    const namespace = normalizeIdentifier(reference.getNamespace());
+    const column = normalizeIdentifier(reference.column.name);
+    const lexemes = new SqlTokenizer(sql).tokenize();
+
+    for (let index = 0; index < lexemes.length - 2; index++) {
+        const first = lexemes[index]!;
+        const dot = lexemes[index + 1]!;
+        const last = lexemes[index + 2]!;
+        if ((first.type & TokenType.Identifier) === 0 || dot.value !== "." || (last.type & TokenType.Identifier) === 0) {
+            continue;
+        }
+        if (normalizeIdentifier(first.value) !== namespace || normalizeIdentifier(last.value) !== column) {
+            continue;
+        }
+        if (!first.position || !last.position) {
+            continue;
+        }
+        return sql.slice(first.position.startPosition, last.position.endPosition);
+    }
+
+    return normalizeColumnReferenceText(reference);
+};
 
 const normalizeColumnReferenceKey = (reference: ColumnReference): string => {
     return `${normalizeIdentifier(reference.getNamespace())}.${normalizeIdentifier(reference.column.name)}`;
@@ -541,6 +855,84 @@ export class SSSQLFilterBuilder {
         return collectSupportedOptionalConditionBranches(parsed).map(getBranchInfo);
     }
 
+    planScaffold(query: SelectQuery | string, filters: SSSQLFilterInput): SssqlRewritePlan {
+        if (typeof query === "string") {
+            const entries = Object.entries(filters);
+            if (entries.length === 1) {
+                const [filterName, filterValue] = entries[0]!;
+                if (isExplicitEqualityScaffoldValue(filterValue)) {
+                    try {
+                        return this.planScalarInsert(query, {
+                            target: filterName,
+                            parameterName: makeParameterName(filterName),
+                            operator: "="
+                        });
+                    } catch {
+                        // Fall through to the conservative formatter-backed plan, which reports rewrite errors.
+                    }
+                }
+            }
+        }
+        return this.planRewrite(query, parsed => this.scaffold(parsed, filters));
+    }
+
+    dryRunScaffold(query: SelectQuery | string, filters: SSSQLFilterInput): SssqlRewritePlan {
+        return this.planScaffold(query, filters);
+    }
+
+    planScaffoldBranch(query: SelectQuery | string, spec: SssqlScaffoldSpec): SssqlRewritePlan {
+        if (typeof query === "string" && (spec.kind === "exists" || spec.kind === "not-exists")) {
+            try {
+                return this.planExistsInsert(query, spec as SssqlExistsScaffoldSpec);
+            } catch {
+                // Fall through to the conservative formatter-backed plan, which reports rewrite errors.
+            }
+        }
+        if (typeof query === "string" && spec.kind !== "exists" && spec.kind !== "not-exists") {
+            try {
+                return this.planScalarInsert(query, spec as SssqlScalarScaffoldSpec);
+            } catch {
+                // Fall through to the conservative formatter-backed plan, which reports rewrite errors.
+            }
+        }
+        return this.planRewrite(query, parsed => this.scaffoldBranch(parsed, spec));
+    }
+
+    dryRunScaffoldBranch(query: SelectQuery | string, spec: SssqlScaffoldSpec): SssqlRewritePlan {
+        return this.planScaffoldBranch(query, spec);
+    }
+
+    planRefresh(query: SelectQuery | string, filters: SSSQLFilterInput): SssqlRewritePlan {
+        return this.planRewrite(query, parsed => this.refresh(parsed, filters));
+    }
+
+    dryRunRefresh(query: SelectQuery | string, filters: SSSQLFilterInput): SssqlRewritePlan {
+        return this.planRefresh(query, filters);
+    }
+
+    planRemove(query: SelectQuery | string, spec: SssqlRemoveSpec): SssqlRewritePlan {
+        if (typeof query === "string") {
+            try {
+                return this.planBranchRemoval(query, spec);
+            } catch {
+                // Fall through to the conservative formatter-backed plan, which reports rewrite errors.
+            }
+        }
+        return this.planRewrite(query, parsed => this.remove(parsed, spec));
+    }
+
+    dryRunRemove(query: SelectQuery | string, spec: SssqlRemoveSpec): SssqlRewritePlan {
+        return this.planRemove(query, spec);
+    }
+
+    planRemoveAll(query: SelectQuery | string): SssqlRewritePlan {
+        return this.planRewrite(query, parsed => this.removeAll(parsed));
+    }
+
+    dryRunRemoveAll(query: SelectQuery | string): SssqlRewritePlan {
+        return this.planRemoveAll(query);
+    }
+
     scaffold(query: SelectQuery | string, filters: SSSQLFilterInput): SelectQuery {
         const parsed = this.parseQuery(query);
 
@@ -676,6 +1068,423 @@ export class SSSQLFilterBuilder {
 
     private parseQuery(query: SelectQuery | string): SelectQuery {
         return typeof query === "string" ? SelectQueryParser.parse(query) : query;
+    }
+
+    private planScalarInsert(sourceSql: string, spec: SssqlScalarScaffoldSpec): SssqlRewritePlan {
+        const parsed = SelectQueryParser.parse(sourceSql);
+        const target = this.resolveTarget(parsed, spec.target);
+        const parameterName = spec.parameterName?.trim() || target.parameterName;
+        const operator = normalizeScalarOperator(spec.operator);
+        const targetColumnText = findSourceColumnReferenceText(sourceSql, target.column);
+        const branchSql = `(:${parameterName} is null or ${targetColumnText} ${operator} :${parameterName})`;
+        const normalizedBranch = normalizeSql(branchSql);
+        const duplicate = this.list(parsed).find(existing =>
+            existing.query === target.query && normalizeSql(existing.sql) === normalizedBranch
+        );
+
+        if (duplicate) {
+            return this.buildPlanFromEdits(sourceSql, [], [], []);
+        }
+
+        return this.buildMinimalInsertPlan(sourceSql, branchSql, {
+            branchKind: "scalar",
+            parameterName,
+            column: targetColumnText
+        });
+    }
+
+    private planExistsInsert(sourceSql: string, spec: SssqlExistsScaffoldSpec): SssqlRewritePlan {
+        const parameterName = spec.parameterName.trim();
+        if (!parameterName) {
+            throw new Error("SSSQL EXISTS/NOT EXISTS scaffold requires parameterName.");
+        }
+        if (spec.anchorColumns.length === 0) {
+            throw new Error("SSSQL EXISTS/NOT EXISTS scaffold requires at least one anchorColumn.");
+        }
+
+        const parsed = SelectQueryParser.parse(sourceSql);
+        const anchorTargets = spec.anchorColumns.map(anchorColumn => this.resolveTarget(parsed, anchorColumn));
+        const targetQueries = [...new Set(anchorTargets.map(target => target.query))];
+        if (targetQueries.length !== 1) {
+            throw new Error("SSSQL EXISTS/NOT EXISTS scaffold anchor columns must resolve within one query scope.");
+        }
+
+        const targetQuery = targetQueries[0]!;
+        const sourceColumns = anchorTargets.map(target => findSourceColumnReferenceText(sourceSql, target.column));
+        const substitutedSql = substituteAnchorPlaceholders(spec.query, sourceColumns).trim();
+        enforceSubqueryConstraints(substitutedSql);
+
+        const subquery = SelectQueryParser.parse(substitutedSql);
+        const parameterNames = new Set(ParameterCollector.collect(subquery).map(parameter => parameter.name.value));
+        if (parameterNames.size !== 1 || !parameterNames.has(parameterName)) {
+            throw new Error(
+                `SSSQL ${spec.kind.toUpperCase()} scaffold query must reference only parameter ':${parameterName}'.`
+            );
+        }
+
+        const branchSql = `(:${parameterName} is null or ${spec.kind === "not-exists" ? "not exists" : "exists"} (${substitutedSql}))`;
+        const duplicate = this.list(parsed).find(existing =>
+            existing.query === targetQuery && normalizeSql(existing.sql) === normalizeSql(branchSql)
+        );
+        if (duplicate) {
+            return this.buildPlanFromEdits(sourceSql, [], [], []);
+        }
+
+        return this.buildMinimalInsertPlan(sourceSql, branchSql, {
+            branchKind: spec.kind,
+            parameterName,
+            column: sourceColumns.join(", ")
+        });
+    }
+
+    private buildMinimalInsertPlan(
+        sourceSql: string,
+        branchSql: string,
+        target: SssqlRewriteEditTarget
+    ): SssqlRewritePlan {
+        const insertPosition = findMinimalWhereInsertPosition(sourceSql);
+        const needsLeadingSpace = insertPosition.position === 0
+            || !/\s/.test(sourceSql[insertPosition.position - 1]!);
+        const prefix = `${needsLeadingSpace ? " " : ""}${insertPosition.hasWhere ? "and" : "where"} `;
+        const suffix = insertPosition.position < getStatementEndPosition(sourceSql) ? " " : "";
+        const branchLabel = target.branchKind === "scalar" ? "scalar" : target.branchKind;
+        const edit: SssqlRewriteEdit = {
+            start: insertPosition.position,
+            end: insertPosition.position,
+            before: "",
+            after: `${prefix}${branchSql}${suffix}`,
+            kind: "insert",
+            reason: insertPosition.hasWhere
+                ? `Append SSSQL ${branchLabel} branch to the existing WHERE clause.`
+                : `Create a WHERE clause for the SSSQL ${branchLabel} branch.`,
+            target
+        };
+        const changedRegions: SssqlRewriteChangedRegion[] = [{
+            kind: "target-branch",
+            start: edit.start + prefix.length,
+            end: edit.start + edit.after.length - suffix.length,
+            message: `Inserted SSSQL ${branchLabel} optional branch.`
+        }];
+        if (insertPosition.hasWhere) {
+            changedRegions.unshift({
+                kind: "boolean-operator",
+                start: edit.start,
+                end: edit.start + prefix.length,
+                message: `Inserted AND before the SSSQL ${branchLabel} branch.`
+            });
+        } else {
+            changedRegions.unshift({
+                kind: "where-keyword",
+                start: edit.start,
+                end: edit.start + prefix.length,
+                message: `Inserted WHERE before the SSSQL ${branchLabel} branch.`
+            });
+        }
+
+        return this.buildPlanFromEdits(sourceSql, [edit], changedRegions, []);
+    }
+
+    private planBranchRemoval(sourceSql: string, spec: SssqlRemoveSpec): SssqlRewritePlan {
+        const parsed = SelectQueryParser.parse(sourceSql);
+        const matches = this.findMatchingBranchInfos(parsed, spec);
+        if (matches.length > 1) {
+            return this.buildPlanFromEdits(sourceSql, [], [], [], [{
+                code: "REWRITE_FAILED",
+                message: "SSSQL remove planning found multiple matching branches.",
+                detail: `Multiple SSSQL branches matched parameter ':${spec.parameterName}'. Remove is ambiguous.`
+            }]);
+        }
+        if (matches.length === 0) {
+            return this.buildPlanFromEdits(sourceSql, [], [], []);
+        }
+
+        const branchSpans = findOptionalBranchSpans(sourceSql, spec.parameterName);
+        if (branchSpans.length > 1) {
+            return this.buildPlanFromEdits(sourceSql, [], [], [], [{
+                code: "AMBIGUOUS_SOURCE_SPAN",
+                message: "SSSQL remove planning found multiple source spans for the target branch.",
+                detail: { parameterName: spec.parameterName, count: branchSpans.length }
+            }]);
+        }
+        const span = branchSpans[0];
+        if (!span) {
+            return this.planRewrite(sourceSql, query => this.remove(query, spec));
+        }
+
+        const beforeOperator = findBooleanOperatorBefore(sourceSql, span.start);
+        const afterOperator = findBooleanOperatorAfter(sourceSql, span.end);
+        const where = findWhereBefore(sourceSql, span.start);
+        let start = span.start;
+        let end = span.end;
+        const changedRegions: SssqlRewriteChangedRegion[] = [{
+            kind: "target-branch",
+            start: span.start,
+            end: span.end,
+            message: "Removed SSSQL optional branch."
+        }];
+
+        if (beforeOperator) {
+            start = beforeOperator.start;
+            changedRegions.unshift({
+                kind: "boolean-operator",
+                start: beforeOperator.start,
+                end: beforeOperator.end,
+                message: `Removed adjacent ${beforeOperator.value.toUpperCase()} before the SSSQL branch.`
+            });
+        } else if (afterOperator) {
+            end = afterOperator.end;
+            changedRegions.push({
+                kind: "boolean-operator",
+                start: afterOperator.start,
+                end: afterOperator.end,
+                message: `Removed adjacent ${afterOperator.value.toUpperCase()} after the SSSQL branch.`
+            });
+        } else if (where) {
+            start = where.start;
+            while (end < sourceSql.length && /\s/.test(sourceSql[end]!)) {
+                end++;
+            }
+            changedRegions.unshift({
+                kind: "where-keyword",
+                start: where.start,
+                end: where.end,
+                message: "Removed WHERE because the SSSQL branch was the only condition."
+            });
+        }
+
+        const edit: SssqlRewriteEdit = {
+            start,
+            end,
+            before: sourceSql.slice(start, end),
+            after: "",
+            kind: "delete",
+            reason: "Remove the targeted SSSQL optional branch from the source SQL.",
+            target: {
+                branchKind: matches[0]!.kind,
+                parameterName: matches[0]!.parameterName,
+                column: matches[0]!.target
+            }
+        };
+
+        return this.buildPlanFromEdits(sourceSql, [edit], changedRegions, []);
+    }
+
+    private buildPlanFromEdits(
+        sourceSql: string,
+        edits: readonly SssqlRewriteEdit[],
+        changedRegions: readonly SssqlRewriteChangedRegion[],
+        warnings: readonly SssqlRewritePlanWarning[],
+        errors: readonly SssqlRewritePlanError[] = []
+    ): SssqlRewritePlan {
+        const plannedSql = errors.length === 0 ? applyRewriteEdits(sourceSql, edits) : undefined;
+        const beforeTokens = tokenizeForRewritePlan(sourceSql);
+        const beforeComments = collectCommentFragments(sourceSql);
+        const afterTokens = plannedSql !== undefined ? tokenizeForRewritePlan(plannedSql) : [];
+        const afterComments = plannedSql !== undefined ? collectCommentFragments(plannedSql) : [];
+        const commentsPreserved = plannedSql !== undefined
+            ? commentsPreservedInOrder(beforeComments, afterComments)
+            : false;
+        const changedOnlyTargetBranches = errors.length === 0
+            && changedRegions.every(region =>
+                region.kind === "target-branch"
+                || region.kind === "where-keyword"
+                || region.kind === "boolean-operator"
+                || region.kind === "parentheses"
+            )
+            && commentsPreserved;
+        const planWarnings = [...warnings];
+
+        if (plannedSql !== undefined && applyRewriteEdits(sourceSql, edits) !== plannedSql) {
+            errors = [...errors, {
+                code: "APPLY_PLAN_MISMATCH",
+                message: "Applying SSSQL rewrite plan edits did not reproduce the planned SQL."
+            }];
+        }
+        if (plannedSql !== undefined) {
+            try {
+                SelectQueryParser.parse(plannedSql);
+            } catch (error) {
+                errors = [...errors, {
+                    code: "PARSE_AFTER_FAILED",
+                    message: "The SQL produced by SSSQL rewrite planning could not be parsed.",
+                    detail: error instanceof Error ? error.message : error
+                }];
+            }
+        }
+        if (plannedSql !== undefined && !commentsPreserved) {
+            planWarnings.push({
+                code: "COMMENTS_NOT_PRESERVED",
+                message: "One or more input SQL comments are missing or reordered after the SSSQL rewrite."
+            });
+        }
+
+        return {
+            ok: errors.length === 0,
+            requiresFullReformat: false,
+            edits,
+            sql: plannedSql,
+            safety: {
+                tokenCountBefore: beforeTokens.length,
+                tokenCountAfter: afterTokens.length,
+                tokenSequencePreserved: plannedSql !== undefined ? tokenSequencesEqual(beforeTokens, afterTokens) : false,
+                commentsPreserved,
+                changedOnlyTargetBranches,
+                changedRegions
+            },
+            warnings: planWarnings,
+            errors
+        };
+    }
+
+    private planRewrite(
+        query: SelectQuery | string,
+        rewrite: (query: SelectQuery) => SelectQuery
+    ): SssqlRewritePlan {
+        const warnings: SssqlRewritePlanWarning[] = [];
+        const errors: SssqlRewritePlanError[] = [];
+        const sourceSql = typeof query === "string"
+            ? query
+            : formatSqlComponent(query);
+
+        if (typeof query !== "string") {
+            warnings.push({
+                code: "SOURCE_SQL_UNAVAILABLE",
+                message: "SSSQL rewrite planning received an AST, so the source SQL had to be formatter-generated before analysis."
+            });
+        }
+
+        let beforeTokens: RewriteTokenSignature[] = [];
+        let beforeComments: string[] = [];
+        try {
+            beforeTokens = tokenizeForRewritePlan(sourceSql);
+            beforeComments = collectCommentFragments(sourceSql);
+        } catch (error) {
+            errors.push({
+                code: "TOKENIZE_BEFORE_FAILED",
+                message: "Could not tokenize the input SQL before SSSQL rewrite planning.",
+                detail: error instanceof Error ? error.message : error
+            });
+        }
+
+        let plannedSql: string | undefined;
+        let afterTokens: RewriteTokenSignature[] = [];
+        let afterComments: string[] = [];
+
+        if (errors.length === 0) {
+            try {
+                const parsed = SelectQueryParser.parse(sourceSql);
+                const rewritten = rewrite(parsed);
+                plannedSql = formatSqlComponent(rewritten);
+            } catch (error) {
+                errors.push({
+                    code: "REWRITE_FAILED",
+                    message: "SSSQL rewrite planning could not produce a rewritten query.",
+                    detail: error instanceof Error ? error.message : error
+                });
+            }
+        }
+
+        if (plannedSql !== undefined) {
+            try {
+                SelectQueryParser.parse(plannedSql);
+            } catch (error) {
+                errors.push({
+                    code: "PARSE_AFTER_FAILED",
+                    message: "The SQL produced by SSSQL rewrite planning could not be parsed.",
+                    detail: error instanceof Error ? error.message : error
+                });
+            }
+
+            try {
+                afterTokens = tokenizeForRewritePlan(plannedSql);
+                afterComments = collectCommentFragments(plannedSql);
+            } catch (error) {
+                errors.push({
+                    code: "TOKENIZE_AFTER_FAILED",
+                    message: "Could not tokenize the SQL produced by SSSQL rewrite planning.",
+                    detail: error instanceof Error ? error.message : error
+                });
+            }
+        }
+
+        const edits = plannedSql !== undefined && plannedSql !== sourceSql
+            ? [{
+                start: 0,
+                end: sourceSql.length,
+                before: sourceSql,
+                after: plannedSql,
+                kind: "replace" as const,
+                reason: "Current SSSQL rewrite planning is backed by AST rewrite plus formatter output."
+            }]
+            : [];
+        const changedRegions: SssqlRewriteChangedRegion[] = edits.length > 0
+            ? [{
+                kind: "formatter-rewrite",
+                start: 0,
+                end: sourceSql.length,
+                message: "The conservative SSSQL rewrite plan requires replacing formatter output for the full SQL text."
+            }]
+            : [];
+        const requiresFullReformat = edits.length > 0;
+        const tokenSequencePreserved = plannedSql !== undefined
+            ? tokenSequencesEqual(beforeTokens, afterTokens)
+            : false;
+        const commentsPreserved = plannedSql !== undefined
+            ? commentsPreservedInOrder(beforeComments, afterComments)
+            : false;
+        const changedOnlyTargetBranches = edits.length === 0;
+
+        if (requiresFullReformat) {
+            warnings.push({
+                code: "FULL_REFORMAT_REQUIRED",
+                message: "The current SSSQL rewrite plan can only represent the change as a full SQL replacement."
+            });
+        }
+        if (plannedSql !== undefined && !tokenSequencePreserved) {
+            warnings.push({
+                code: "TOKEN_SEQUENCE_CHANGED",
+                message: "The SQL token sequence changes after the SSSQL rewrite. The conservative planner cannot prove that only target branches changed.",
+                detail: {
+                    tokenCountBefore: beforeTokens.length,
+                    tokenCountAfter: afterTokens.length
+                }
+            });
+        }
+        if (plannedSql !== undefined && !commentsPreserved) {
+            warnings.push({
+                code: "COMMENTS_NOT_PRESERVED",
+                message: "One or more input SQL comments are missing or reordered after the SSSQL rewrite."
+            });
+        }
+        if (plannedSql !== undefined && countCommandToken(afterTokens, "as") > countCommandToken(beforeTokens, "as")) {
+            warnings.push({
+                code: "OPTIONAL_ALIAS_AS_ADDED",
+                message: "The rewrite output contains more AS tokens than the input, which may indicate formatter-added aliases."
+            });
+        }
+        if (plannedSql !== undefined && !sourceSql.includes("\"") && plannedSql.includes("\"")) {
+            warnings.push({
+                code: "IDENTIFIER_QUOTES_ADDED",
+                message: "The rewrite output contains double-quoted identifiers that were not present in the input SQL."
+            });
+        }
+
+        return {
+            ok: errors.length === 0,
+            requiresFullReformat,
+            edits,
+            sql: plannedSql,
+            safety: {
+                tokenCountBefore: beforeTokens.length,
+                tokenCountAfter: afterTokens.length,
+                tokenSequencePreserved,
+                commentsPreserved,
+                changedOnlyTargetBranches,
+                changedRegions
+            },
+            warnings,
+            errors
+        };
     }
 
     private findMatchingBranchInfos(root: SelectQuery, spec: SssqlRemoveSpec): SssqlBranchInfo[] {

--- a/packages/core/src/transformers/SSSQLFilterBuilder.ts
+++ b/packages/core/src/transformers/SSSQLFilterBuilder.ts
@@ -319,6 +319,10 @@ const findMatchingParenEnd = (sql: string, start: number): number => {
     return -1;
 };
 
+// Fallback for #854: findOptionalBranchSpans, findBooleanOperatorBefore, and
+// findBooleanOperatorAfter recover minimal remove spans until the AST can expose
+// source positions for optional parenthesized OR/IS NULL branches reliably.
+// Keep regex-based rewriting limited to this fallback path.
 const findOptionalBranchSpans = (sql: string, parameterName: string): Array<{ start: number; end: number; text: string }> => {
     const spans: Array<{ start: number; end: number; text: string }> = [];
     const parameterNeedle = `:${parameterName.toLowerCase()}`;
@@ -1073,6 +1077,9 @@ export class SSSQLFilterBuilder {
     private planScalarInsert(sourceSql: string, spec: SssqlScalarScaffoldSpec): SssqlRewritePlan {
         const parsed = SelectQueryParser.parse(sourceSql);
         const target = this.resolveTarget(parsed, spec.target);
+        if (target.query !== parsed) {
+            return this.planRewrite(sourceSql, query => this.scaffoldBranch(query, spec));
+        }
         const parameterName = spec.parameterName?.trim() || target.parameterName;
         const operator = normalizeScalarOperator(spec.operator);
         const targetColumnText = findSourceColumnReferenceText(sourceSql, target.column);
@@ -1110,6 +1117,9 @@ export class SSSQLFilterBuilder {
         }
 
         const targetQuery = targetQueries[0]!;
+        if (targetQuery !== parsed) {
+            return this.planRewrite(sourceSql, query => this.scaffoldBranch(query, spec));
+        }
         const sourceColumns = anchorTargets.map(target => findSourceColumnReferenceText(sourceSql, target.column));
         const substitutedSql = substituteAnchorPlaceholders(spec.query, sourceColumns).trim();
         enforceSubqueryConstraints(substitutedSql);
@@ -1200,11 +1210,7 @@ export class SSSQLFilterBuilder {
 
         const branchSpans = findOptionalBranchSpans(sourceSql, spec.parameterName);
         if (branchSpans.length > 1) {
-            return this.buildPlanFromEdits(sourceSql, [], [], [], [{
-                code: "AMBIGUOUS_SOURCE_SPAN",
-                message: "SSSQL remove planning found multiple source spans for the target branch.",
-                detail: { parameterName: spec.parameterName, count: branchSpans.length }
-            }]);
+            return this.planRewrite(sourceSql, query => this.remove(query, spec));
         }
         const span = branchSpans[0];
         if (!span) {

--- a/packages/core/tests/models/SelectQueryJoin.test.ts
+++ b/packages/core/tests/models/SelectQueryJoin.test.ts
@@ -1,51 +1,143 @@
 import { describe, test, expect } from 'vitest';
+import fc from 'fast-check';
 import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
 import { Formatter } from '../../src/transformers/Formatter';
 import { SimpleSelectQuery } from '../../src/models/SelectQuery';
 
 const formatter = new Formatter();
 
+const joinApiCases = [
+    {
+        name: 'innerJoinRaw basic usage',
+        kind: 'innerJoinRaw',
+        sql: 'SELECT u.id, u.name FROM users u',
+        source: 'orders',
+        alias: 'o',
+        columns: ['id'],
+        expected: 'select "u"."id", "u"."name" from "users" as "u" inner join "orders" as "o" on "u"."id" = "o"."id"',
+    },
+    {
+        name: 'leftJoinRaw multi-column',
+        kind: 'leftJoinRaw',
+        sql: 'SELECT u.id, u.name FROM users u',
+        source: 'orders',
+        alias: 'o',
+        columns: ['id', 'name'],
+        expected: 'select "u"."id", "u"."name" from "users" as "u" left join "orders" as "o" on "u"."id" = "o"."id" and "u"."name" = "o"."name"',
+    },
+    {
+        name: 'rightJoinRaw schema qualified',
+        kind: 'rightJoinRaw',
+        sql: 'SELECT u.id FROM users u',
+        source: 'public.orders',
+        alias: 'o',
+        columns: ['id'],
+        expected: 'select "u"."id" from "users" as "u" right join "public"."orders" as "o" on "u"."id" = "o"."id"',
+    },
+    {
+        name: 'innerJoinRaw subquery',
+        kind: 'innerJoinRaw',
+        sql: 'SELECT u.id, u.name FROM users u',
+        source: "(SELECT id, name FROM orders WHERE status = 'active')",
+        alias: 'o',
+        columns: ['id'],
+        expected: 'select "u"."id", "u"."name" from "users" as "u" inner join (select "id", "name" from "orders" where "status" = \'active\') as "o" on "u"."id" = "o"."id"',
+    },
+    {
+        name: 'innerJoinRaw with merged WITH clauses',
+        kind: 'innerJoinRaw',
+        sql: "WITH sub_users AS (SELECT id, name FROM users WHERE active = true) SELECT u.id, u.name FROM sub_users u",
+        source: "(WITH sub_orders AS (SELECT id, name FROM orders WHERE status = 'active') SELECT id, name FROM sub_orders)",
+        alias: 'o',
+        columns: ['id'],
+        expected: 'with "sub_orders" as (select "id", "name" from "orders" where "status" = \'active\'), "sub_users" as (select "id", "name" from "users" where "active" = true) select "u"."id", "u"."name" from "sub_users" as "u" inner join (select "id", "name" from "sub_orders") as "o" on "u"."id" = "o"."id"',
+    },
+    {
+        name: 'innerJoin toSource',
+        kind: 'innerJoin',
+        sql: 'SELECT u.id, u.name FROM users u',
+        source: 'SELECT id, name FROM orders WHERE status = "active"',
+        alias: 'o',
+        columns: ['id'],
+        expected: 'select "u"."id", "u"."name" from "users" as "u" inner join (select "id", "name" from "orders" where "status" = "active") as "o" on "u"."id" = "o"."id"',
+    },
+    {
+        name: 'leftJoin toSource single string column',
+        kind: 'leftJoin',
+        sql: 'SELECT u.id, u.name FROM users u',
+        source: 'SELECT id, name FROM orders',
+        alias: 'o',
+        columns: 'id',
+        expected: 'select "u"."id", "u"."name" from "users" as "u" left join (select "id", "name" from "orders") as "o" on "u"."id" = "o"."id"',
+    },
+    {
+        name: 'rightJoin toSource single string column',
+        kind: 'rightJoin',
+        sql: 'SELECT u.id FROM users u',
+        source: 'SELECT id FROM orders',
+        alias: 'o',
+        columns: 'id',
+        expected: 'select "u"."id" from "users" as "u" right join (select "id" from "orders") as "o" on "u"."id" = "o"."id"',
+    },
+    {
+        name: 'wildcard select with resolver',
+        kind: 'innerJoinRawWithResolver',
+        sql: 'SELECT * FROM users as u',
+        source: 'posts',
+        alias: 'p',
+        columns: 'user_id',
+        expected: 'select * from "users" as "u" inner join "posts" as "p" on "u"."user_id" = "p"."user_id"',
+    },
+] as const;
+
+type JoinApiCase = typeof joinApiCases[number];
+
+function applyJoinCase(query: SimpleSelectQuery, joinCase: JoinApiCase): void {
+    if (joinCase.kind === 'innerJoinRaw') {
+        query.innerJoinRaw(joinCase.source, joinCase.alias, joinCase.columns);
+        return;
+    }
+    if (joinCase.kind === 'leftJoinRaw') {
+        query.leftJoinRaw(joinCase.source, joinCase.alias, joinCase.columns);
+        return;
+    }
+    if (joinCase.kind === 'rightJoinRaw') {
+        query.rightJoinRaw(joinCase.source, joinCase.alias, joinCase.columns);
+        return;
+    }
+    if (joinCase.kind === 'innerJoinRawWithResolver') {
+        const resolver = (tableName: string) => {
+            if (tableName === 'users') return ['user_id', 'name'];
+            if (tableName === 'posts') return ['post_id', 'user_id', 'title'];
+            return [];
+        };
+        query.innerJoinRaw(joinCase.source, joinCase.alias, joinCase.columns, resolver);
+        return;
+    }
+
+    const subquery = SelectQueryParser.parse(joinCase.source) as SimpleSelectQuery;
+    if (joinCase.kind === 'innerJoin') {
+        query.innerJoin(subquery.toSource(joinCase.alias), joinCase.columns);
+        return;
+    }
+    if (joinCase.kind === 'leftJoin') {
+        query.leftJoin(subquery.toSource(joinCase.alias), joinCase.columns);
+        return;
+    }
+    query.rightJoin(subquery.toSource(joinCase.alias), joinCase.columns);
+}
+
 describe('SimpleSelectQuery JOIN API', () => {
-    test('innerJoin: basic usage', () => {
-        // Arrange
-        const sql = 'SELECT u.id, u.name FROM users u';
-        const query = SelectQueryParser.parse(sql) as SimpleSelectQuery;
-        query.innerJoinRaw('orders', 'o', ['id']);
-
-        // Act
-        const result = formatter.format(query);
-        const expected = 'select "u"."id", "u"."name" from "users" as "u" inner join "orders" as "o" on "u"."id" = "o"."id"';
-
-        // Assert
-        expect(result.replace(/\s+/g, ' ').trim()).toBe(expected);
-    });
-
-    test('leftJoin: multi-column', () => {
-        // Arrange
-        const sql = 'SELECT u.id, u.name FROM users u';
-        const query = SelectQueryParser.parse(sql) as SimpleSelectQuery;
-        query.leftJoinRaw('orders', 'o', ['id', 'name']);
-
-        // Act
-        const result = formatter.format(query);
-        const expected = 'select "u"."id", "u"."name" from "users" as "u" left join "orders" as "o" on "u"."id" = "o"."id" and "u"."name" = "o"."name"';
-
-        // Assert
-        expect(result.replace(/\s+/g, ' ').trim()).toBe(expected);
-    });
-
-    test('rightJoin: schema qualified', () => {
-        // Arrange
-        const sql = 'SELECT u.id FROM users u';
-        const query = SelectQueryParser.parse(sql) as SimpleSelectQuery;
-        query.rightJoinRaw('public.orders', 'o', ['id']);
-
-        // Act
-        const result = formatter.format(query);
-        const expected = 'select "u"."id" from "users" as "u" right join "public"."orders" as "o" on "u"."id" = "o"."id"';
-
-        // Assert
-        expect(result.replace(/\s+/g, ' ').trim()).toBe(expected);
+    test('formats generated JOIN API scenarios as expected', () => {
+        fc.assert(
+            fc.property(fc.constantFrom(...joinApiCases), (joinCase) => {
+                const query = SelectQueryParser.parse(joinCase.sql) as SimpleSelectQuery;
+                applyJoinCase(query, joinCase);
+                const result = formatter.format(query);
+                expect(result.replace(/\s+/g, ' ').trim(), joinCase.name).toBe(joinCase.expected);
+            }),
+            { numRuns: joinApiCases.length * 3 }
+        );
     });
 
     test('throws if join column not found', () => {
@@ -66,130 +158,6 @@ describe('SimpleSelectQuery JOIN API', () => {
         expect(() => query.innerJoinRaw('orders', 'o', ['id'])).toThrow();
     });
 
-    test('innerJoinRaw: can join with a subquery', () => {
-        // Arrange
-        const subquery = 'SELECT id, name FROM orders WHERE status = \'active\'';
-        const sql = 'SELECT u.id, u.name FROM users u';
-        const query = SelectQueryParser.parse(sql) as SimpleSelectQuery;
-
-        // Act
-        query.innerJoinRaw(`(${subquery})`, 'o', ['id']);
-        const result = formatter.format(query);
-
-        // Assert
-        const expected = 'select "u"."id", "u"."name" from "users" as "u" inner join (select "id", "name" from "orders" where "status" = \'active\') as "o" on "u"."id" = "o"."id"';
-        expect(result.replace(/\s+/g, ' ').trim()).toBe(expected);
-    });
-
-    test('innerJoinRaw: join with subquery and both queries have WITH clause', () => {
-        // Arrange
-        const subquery = `WITH sub_orders AS (SELECT id, name FROM orders WHERE status = 'active') SELECT id, name FROM sub_orders`;
-        const sql = `WITH sub_users AS (SELECT id, name FROM users WHERE active = true) SELECT u.id, u.name FROM sub_users u`;
-        const query = SelectQueryParser.parse(sql) as SimpleSelectQuery;
-
-        // Act
-        query.innerJoinRaw(`(${subquery})`, 'o', ['id']);
-        const result = formatter.format(query);
-
-        // Assert
-        const expected = 'with "sub_orders" as (select "id", "name" from "orders" where "status" = \'active\'), "sub_users" as (select "id", "name" from "users" where "active" = true) select "u"."id", "u"."name" from "sub_users" as "u" inner join (select "id", "name" from "sub_orders") as "o" on "u"."id" = "o"."id"';
-        expect(result.replace(/\s+/g, ' ').trim()).toBe(expected);
-    });
-
-    test('innerJoin: join with subquery using toSource', () => {
-        // Arrange
-        const subquery = SelectQueryParser.parse('SELECT id, name FROM orders WHERE status = "active"') as SimpleSelectQuery;
-        const sql = 'SELECT u.id, u.name FROM users u';
-        const query = SelectQueryParser.parse(sql) as SimpleSelectQuery;
-
-        // Use toSource to wrap subquery as a source
-        query.innerJoin(subquery.toSource('o'), ['id']);
-
-        // Act
-        const result = formatter.format(query);
-
-        // Assert
-        const expected = 'select "u"."id", "u"."name" from "users" as "u" inner join (select "id", "name" from "orders" where "status" = "active") as "o" on "u"."id" = "o"."id"';
-        expect(result.replace(/\s+/g, ' ').trim()).toBe(expected);
-    });
-
-    test('innerJoinRaw: single string column', () => {
-        const sql = 'SELECT u.id, u.name FROM users u';
-        const query = SelectQueryParser.parse(sql) as SimpleSelectQuery;
-        query.innerJoinRaw('orders', 'o', 'id');
-        const result = formatter.format(query);
-        const expected = 'select "u"."id", "u"."name" from "users" as "u" inner join "orders" as "o" on "u"."id" = "o"."id"';
-        expect(result.replace(/\s+/g, ' ').trim()).toBe(expected);
-    });
-
-    test('leftJoinRaw: single string column', () => {
-        const sql = 'SELECT u.id, u.name FROM users u';
-        const query = SelectQueryParser.parse(sql) as SimpleSelectQuery;
-        query.leftJoinRaw('orders', 'o', 'id');
-        const result = formatter.format(query);
-        const expected = 'select "u"."id", "u"."name" from "users" as "u" left join "orders" as "o" on "u"."id" = "o"."id"';
-        expect(result.replace(/\s+/g, ' ').trim()).toBe(expected);
-    });
-
-    test('rightJoinRaw: single string column', () => {
-        // Arrange
-        const sql = 'SELECT u.id FROM users u';
-        const query = SelectQueryParser.parse(sql) as SimpleSelectQuery;
-
-        // Act
-        query.rightJoinRaw('public.orders', 'o', 'id');
-        const result = formatter.format(query);
-
-        // Assert
-        const expected = 'select "u"."id" from "users" as "u" right join "public"."orders" as "o" on "u"."id" = "o"."id"';
-        expect(result.replace(/\s+/g, ' ').trim()).toBe(expected);
-    });
-
-    test('innerJoin: single string column', () => {
-        // Arrange
-        const sql = 'SELECT u.id, u.name FROM users u';
-        const query = SelectQueryParser.parse(sql) as SimpleSelectQuery;
-        const subquery = SelectQueryParser.parse('SELECT id, name FROM orders') as SimpleSelectQuery;
-
-        // Act
-        query.innerJoin(subquery.toSource('o'), 'id');
-        const result = formatter.format(query);
-
-        // Assert
-        const expected = 'select "u"."id", "u"."name" from "users" as "u" inner join (select "id", "name" from "orders") as "o" on "u"."id" = "o"."id"';
-        expect(result.replace(/\s+/g, ' ').trim()).toBe(expected);
-    });
-
-    test('leftJoin: single string column', () => {
-        // Arrange
-        const sql = 'SELECT u.id, u.name FROM users u';
-        const query = SelectQueryParser.parse(sql) as SimpleSelectQuery;
-        const subquery = SelectQueryParser.parse('SELECT id, name FROM orders') as SimpleSelectQuery;
-
-        // Act
-        query.leftJoin(subquery.toSource('o'), 'id');
-        const result = formatter.format(query);
-
-        // Assert
-        const expected = 'select "u"."id", "u"."name" from "users" as "u" left join (select "id", "name" from "orders") as "o" on "u"."id" = "o"."id"';
-        expect(result.replace(/\s+/g, ' ').trim()).toBe(expected);
-    });
-
-    test('rightJoin: single string column', () => {
-        // Arrange
-        const sql = 'SELECT u.id FROM users u';
-        const query = SelectQueryParser.parse(sql) as SimpleSelectQuery;
-        const subquery = SelectQueryParser.parse('SELECT id FROM orders') as SimpleSelectQuery;
-
-        // Act
-        query.rightJoin(subquery.toSource('o'), 'id');
-        const result = formatter.format(query);
-
-        // Assert
-        const expected = 'select "u"."id" from "users" as "u" right join (select "id" from "orders") as "o" on "u"."id" = "o"."id"';
-        expect(result.replace(/\s+/g, ' ').trim()).toBe(expected);
-    });
-
     test('innerJoinRaw: throws if join column not found with wildcard select', () => {
         // Arrange
         const sql = 'SELECT * FROM users as u';
@@ -199,23 +167,4 @@ describe('SimpleSelectQuery JOIN API', () => {
         expect(() => query.innerJoinRaw('posts', 'p', 'user_id')).toThrow('Invalid JOIN condition');
     });
 
-    test('innerJoinRaw: resolves join column with wildcard select using TableColumnResolver', () => {
-        // Arrange
-        const sql = 'SELECT * FROM users as u';
-        const query = SelectQueryParser.parse(sql) as SimpleSelectQuery;
-        const resolver = (tableName: string) => {
-            if (tableName === 'users') return ['user_id', 'name'];
-            if (tableName === 'posts') return ['post_id', 'user_id', 'title'];
-            return [];
-        };
-
-        // Act
-        query.innerJoinRaw('posts', 'p', 'user_id', resolver);
-        const formatter = new Formatter();
-        const result = formatter.format(query);
-
-        // Assert
-        const expected = 'select * from "users" as "u" inner join "posts" as "p" on "u"."user_id" = "p"."user_id"';
-        expect(result.replace(/\s+/g, ' ').trim()).toBe(expected);
-    });
 });

--- a/packages/core/tests/parsers/SelectQueryParser.test.ts
+++ b/packages/core/tests/parsers/SelectQueryParser.test.ts
@@ -1,216 +1,218 @@
-// --- FETCH句のテストケースは下のtest.each配列に追加するよ！ ---
 import { describe, test, expect } from 'vitest';
+import fc from 'fast-check';
 import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
 import { Formatter } from '../../src/transformers/Formatter';
 import { ParameterStyle, PRESETS } from '../../src/parsers/SqlPrintTokenParser';
 
 const formatter = new Formatter();
 
+const selectFormatCases = [
+    ["Simple SELECT",
+        "select id, name from users",
+        'select "id", "name" from "users"'],
+
+    ["SELECT with alias",
+        "select u.id as user_id, u.name as user_name from users u",
+        'select "u"."id" as "user_id", "u"."name" as "user_name" from "users" as "u"'],
+
+    ["SELECT ALL fields with wildcard",
+        "select * from products",
+        'select * from "products"'],
+
+    ["SELECT with WHERE condition",
+        "select id, name from users where active = TRUE",
+        'select "id", "name" from "users" where "active" = true'],
+
+    ["SELECT with multiple WHERE conditions",
+        "select id, name from users where age >= 18 and status = 'active'",
+        'select "id", "name" from "users" where "age" >= 18 and "status" = \'active\''],
+
+    ["SELECT with ORDER BY",
+        "select id, name from users order by name",
+        'select "id", "name" from "users" order by "name"'],
+
+    ["SELECT with ORDER BY DESC",
+        "select id, name from users order by name desc",
+        'select "id", "name" from "users" order by "name" desc'],
+
+    ["SELECT with LIMIT",
+        "select id, name from users limit 10",
+        'select "id", "name" from "users" limit 10'],
+
+    ["SELECT with LIMIT and OFFSET",
+        "select id, name from users limit 10 offset 5",
+        'select "id", "name" from "users" limit 10 offset 5'],
+
+    ["SELECT with GROUP BY",
+        "select department, count(*) as employee_count from employees group by department",
+        'select "department", count(*) as "employee_count" from "employees" group by "department"'],
+
+    ["SELECT with GROUP BY and HAVING",
+        "select department, count(*) as employee_count from employees group by department having count(*) > 5",
+        'select "department", count(*) as "employee_count" from "employees" group by "department" having count(*) > 5'],
+
+    ["SELECT with JOIN",
+        "select u.name, o.total from users u join orders o on u.id = o.user_id",
+        'select "u"."name", "o"."total" from "users" as "u" join "orders" as "o" on "u"."id" = "o"."user_id"'],
+
+    ["SELECT with multiple JOINs",
+        "select u.name, o.id, p.name as product_name from users u join orders o on u.id = o.user_id join products p on o.product_id = p.id",
+        'select "u"."name", "o"."id", "p"."name" as "product_name" from "users" as "u" join "orders" as "o" on "u"."id" = "o"."user_id" join "products" as "p" on "o"."product_id" = "p"."id"'],
+
+    ["SELECT with LEFT JOIN",
+        "select u.name, o.total from users u left join orders o on u.id = o.user_id",
+        'select "u"."name", "o"."total" from "users" as "u" left join "orders" as "o" on "u"."id" = "o"."user_id"'],
+
+    ["SELECT with subquery in FROM",
+        "select avg_data.avg_price from (select category, avg(price) as avg_price from products group by category) as avg_data",
+        'select "avg_data"."avg_price" from (select "category", avg("price") as "avg_price" from "products" group by "category") as "avg_data"'],
+
+    ["SELECT with subquery in WHERE",
+        "select id, name from users where id in (select user_id from premium_subscriptions)",
+        'select "id", "name" from "users" where "id" in (select "user_id" from "premium_subscriptions")'],
+
+    ["SELECT with DISTINCT",
+        "select distinct category from products",
+        'select distinct "category" from "products"'],
+
+    ["SELECT with DISTINCT ON",
+        "select distinct on (department) id, name, salary from employees order by department, salary desc",
+        'select distinct on("department") "id", "name", "salary" from "employees" order by "department", "salary" desc'],
+
+    ["SELECT with window functions",
+        "select date, value, avg(value) over(order by date rows between 2 preceding and current row) as moving_avg from stocks",
+        'select "date", "value", avg("value") over(order by "date" rows between 2 preceding and current row) as "moving_avg" from "stocks"'],
+
+    ["SELECT with window clause",
+        "select id, value, avg(value) over w from measurements window w as (order by id rows between 2 preceding and 2 following)",
+        'select "id", "value", avg("value") over "w" from "measurements" window "w" as (order by "id" rows between 2 preceding and 2 following)'],
+
+    ["SELECT with FOR UPDATE clause",
+        "select id, stock from products where id = 123 for update",
+        'select "id", "stock" from "products" where "id" = 123 for update'],
+
+    ["SELECT with FOR SHARE clause",
+        "select id, balance from accounts where user_id = 456 for share",
+        'select "id", "balance" from "accounts" where "user_id" = 456 for share'],
+
+    ["SELECT with all basic clauses combined",
+        "select distinct u.id, u.name, count(o.id) as order_count " +
+        "from users u " +
+        "left join orders o on u.id = o.user_id " +
+        "where u.active = true " +
+        "group by u.id, u.name " +
+        "having count(o.id) > 0 " +
+        "order by order_count desc " +
+        "limit 10",
+        'select distinct "u"."id", "u"."name", count("o"."id") as "order_count" from "users" as "u" left join "orders" as "o" on "u"."id" = "o"."user_id" where "u"."active" = true group by "u"."id", "u"."name" having count("o"."id") > 0 order by "order_count" desc limit 10'],
+
+    ["SELECT with NOT NULL check",
+        "select id, name from users where email is not null",
+        'select "id", "name" from "users" where "email" is not null'],
+
+    ["SELECT with BETWEEN",
+        "select product_name, price from products where price between 10 and 50",
+        'select "product_name", "price" from "products" where "price" between 10 and 50'],
+
+    ["SELECT with EXISTS subquery",
+        "select id, name from customers where exists (select 1 from orders where orders.customer_id = customers.id)",
+        'select "id", "name" from "customers" where exists (select 1 from "orders" where "orders"."customer_id" = "customers"."id")'],
+
+    ["SELECT with WITH clause (CTE)",
+        "WITH monthly_sales AS (SELECT DATE_TRUNC('month', order_date) AS month, SUM(amount) AS total FROM orders GROUP BY month) SELECT month, total FROM monthly_sales ORDER BY month",
+        'with "monthly_sales" as (select date_trunc(\'month\', "order_date") as "month", sum("amount") as "total" from "orders" group by "month") select "month", "total" from "monthly_sales" order by "month"'],
+
+    ["SELECT with multiple CTEs",
+        "WITH customers_2023 AS (SELECT * FROM customers WHERE join_date >= '2023-01-01'), customer_orders AS (SELECT c.id, c.name, COUNT(o.id) AS order_count FROM customers_2023 c LEFT JOIN orders o ON c.id = o.customer_id GROUP BY c.id, c.name) SELECT * FROM customer_orders WHERE order_count > 0 ORDER BY order_count DESC",
+        'with "customers_2023" as (select * from "customers" where "join_date" >= \'2023-01-01\'), "customer_orders" as (select "c"."id", "c"."name", count("o"."id") as "order_count" from "customers_2023" as "c" left join "orders" as "o" on "c"."id" = "o"."customer_id" group by "c"."id", "c"."name") select * from "customer_orders" where "order_count" > 0 order by "order_count" desc'],
+
+    ["SELECT with recursive CTE",
+        "WITH RECURSIVE employee_hierarchy AS (SELECT id, name, manager_id, 1 AS level FROM employees WHERE manager_id IS NULL UNION ALL SELECT e.id, e.name, e.manager_id, eh.level + 1 FROM employees e JOIN employee_hierarchy eh ON e.manager_id = eh.id) SELECT * FROM employee_hierarchy ORDER BY level, name",
+        'with recursive "employee_hierarchy" as (select "id", "name", "manager_id", 1 as "level" from "employees" where "manager_id" is null union all select "e"."id", "e"."name", "e"."manager_id", "eh"."level" + 1 from "employees" as "e" join "employee_hierarchy" as "eh" on "e"."manager_id" = "eh"."id") select * from "employee_hierarchy" order by "level", "name"'],
+
+    ["Simple VALUES query",
+        "values (1, 'test', true)",
+        "values (1, 'test', true)"],
+
+    ["VALUES with multiple tuples",
+        "values (1, 'apple', 0.99), (2, 'banana', 0.59), (3, 'orange', 0.79)",
+        "values (1, 'apple', 0.99), (2, 'banana', 0.59), (3, 'orange', 0.79)"],
+
+    ["VALUES with expressions",
+        "values (1 + 2, concat('hello', ' ', 'world'), 5 * 10)",
+        "values (1 + 2, concat('hello', ' ', 'world'), 5 * 10)"],
+
+    ["SELECT UNION VALUES",
+        "select id, name, price from products union values (100, 'New Product', 29.99)",
+        'select "id", "name", "price" from "products" union values (100, \'New Product\', 29.99)'],
+
+    ["VALUES UNION VALUES",
+        "values (1, 'first'), (2, 'second') union values (3, 'third'), (4, 'fourth')",
+        "values (1, 'first'), (2, 'second') union values (3, 'third'), (4, 'fourth')"],
+
+    ["VALUES UNION SELECT",
+        "values (1, 'test'), (2, 'sample') union select id, name from products where featured = true",
+        'values (1, \'test\'), (2, \'sample\') union select "id", "name" from "products" where "featured" = true'],
+
+    ["WITH clause with VALUES",
+        "with sample_data as (values (1, 'apple'), (2, 'orange'), (3, 'banana')) select * from sample_data order by 2",
+        'with "sample_data" as (values (1, \'apple\'), (2, \'orange\'), (3, \'banana\')) select * from "sample_data" order by 2'],
+
+    ["WITH multiple CTEs with VALUES",
+        "with fruits as (values (1, 'apple'), (2, 'orange')), vegetables as (values (3, 'carrot'), (4, 'potato')) select * from fruits union select * from vegetables",
+        'with "fruits" as (values (1, \'apple\'), (2, \'orange\')), "vegetables" as (values (3, \'carrot\'), (4, \'potato\')) select * from "fruits" union select * from "vegetables"'],
+
+    ["Subquery with VALUES in FROM",
+        "select t.id, t.name from (values (1, 'apple'), (2, 'orange')) as t(id, name) where t.id > 1",
+        'select "t"."id", "t"."name" from (values (1, \'apple\'), (2, \'orange\')) as "t"("id", "name") where "t"."id" > 1'],
+
+    ["Subquery with VALUES in WHERE clause",
+        "select id, name from products where (id, category) in (values (1, 'fruit'), (2, 'vegetable'))",
+        'select "id", "name" from "products" where ("id", "category") in (values (1, \'fruit\'), (2, \'vegetable\'))'],
+
+    ["WITH clause with VALUES and column aliases",
+        "with sample_data(id, name) as (values (1, 'apple'), (2, 'orange'), (3, 'banana')) select * from sample_data order by 2",
+        'with "sample_data"("id", "name") as (values (1, \'apple\'), (2, \'orange\'), (3, \'banana\')) select * from "sample_data" order by 2'],
+
+    ["WITH multiple CTEs with VALUES and column aliases",
+        "with fruits(id, name) as (values (1, 'apple'), (2, 'orange')), vegetables(id, name) as (values (3, 'carrot'), (4, 'potato')) select * from fruits union select * from vegetables",
+        'with "fruits"("id", "name") as (values (1, \'apple\'), (2, \'orange\')), "vegetables"("id", "name") as (values (3, \'carrot\'), (4, \'potato\')) select * from "fruits" union select * from "vegetables"'],
+
+    ["SELECT with template variable",
+        "select ${name}",
+        'select :name'],
+
+    ["SELECT with FETCH FIRST ROW ONLY",
+        "select id, name from users fetch first row only",
+        'select "id", "name" from "users" fetch first 1 rows only'],
+
+    ["SELECT with FETCH NEXT 5 ROWS ONLY",
+        "select * from products fetch next 5 rows only",
+        'select * from "products" fetch next 5 rows only'],
+
+    ["SELECT with ORDER BY and FETCH",
+        "select id, name from users order by id fetch first 10 rows only",
+        'select "id", "name" from "users" order by "id" fetch first 10 rows only'],
+
+    ["SELECT with OFFSET and FETCH",
+        "select * from logs offset 20 rows fetch next 10 rows only",
+        'select * from "logs" offset 20 fetch next 10 rows only'],
+
+    ["SELECT with multiple named WINDOW clauses",
+        "select id, value, avg(value) over w1, sum(value) over w2 from measurements window w1 as (partition by id), w2 as (order by value)",
+        'select "id", "value", avg("value") over "w1", sum("value") over "w2" from "measurements" window "w1" as (partition by "id"), "w2" as (order by "value")'],
+] as const;
+
 describe('SelectQueryParser', () => {
-    test.each([
-        ["Simple SELECT",
-            "select id, name from users",
-            'select "id", "name" from "users"'],
-
-        ["SELECT with alias",
-            "select u.id as user_id, u.name as user_name from users u",
-            'select "u"."id" as "user_id", "u"."name" as "user_name" from "users" as "u"'],
-
-        ["SELECT ALL fields with wildcard",
-            "select * from products",
-            'select * from "products"'],
-
-        ["SELECT with WHERE condition",
-            "select id, name from users where active = TRUE",
-            'select "id", "name" from "users" where "active" = true'],
-
-        ["SELECT with multiple WHERE conditions",
-            "select id, name from users where age >= 18 and status = 'active'",
-            'select "id", "name" from "users" where "age" >= 18 and "status" = \'active\''],
-
-        ["SELECT with ORDER BY",
-            "select id, name from users order by name",
-            'select "id", "name" from "users" order by "name"'],
-
-        ["SELECT with ORDER BY DESC",
-            "select id, name from users order by name desc",
-            'select "id", "name" from "users" order by "name" desc'],
-
-        ["SELECT with LIMIT",
-            "select id, name from users limit 10",
-            'select "id", "name" from "users" limit 10'],
-
-        ["SELECT with LIMIT and OFFSET",
-            "select id, name from users limit 10 offset 5",
-            'select "id", "name" from "users" limit 10 offset 5'],
-
-        ["SELECT with GROUP BY",
-            "select department, count(*) as employee_count from employees group by department",
-            'select "department", count(*) as "employee_count" from "employees" group by "department"'],
-
-        ["SELECT with GROUP BY and HAVING",
-            "select department, count(*) as employee_count from employees group by department having count(*) > 5",
-            'select "department", count(*) as "employee_count" from "employees" group by "department" having count(*) > 5'],
-
-        ["SELECT with JOIN",
-            "select u.name, o.total from users u join orders o on u.id = o.user_id",
-            'select "u"."name", "o"."total" from "users" as "u" join "orders" as "o" on "u"."id" = "o"."user_id"'],
-
-        ["SELECT with multiple JOINs",
-            "select u.name, o.id, p.name as product_name from users u join orders o on u.id = o.user_id join products p on o.product_id = p.id",
-            'select "u"."name", "o"."id", "p"."name" as "product_name" from "users" as "u" join "orders" as "o" on "u"."id" = "o"."user_id" join "products" as "p" on "o"."product_id" = "p"."id"'],
-
-        ["SELECT with LEFT JOIN",
-            "select u.name, o.total from users u left join orders o on u.id = o.user_id",
-            'select "u"."name", "o"."total" from "users" as "u" left join "orders" as "o" on "u"."id" = "o"."user_id"'],
-
-        ["SELECT with subquery in FROM",
-            "select avg_data.avg_price from (select category, avg(price) as avg_price from products group by category) as avg_data",
-            'select "avg_data"."avg_price" from (select "category", avg("price") as "avg_price" from "products" group by "category") as "avg_data"'],
-
-        ["SELECT with subquery in WHERE",
-            "select id, name from users where id in (select user_id from premium_subscriptions)",
-            'select "id", "name" from "users" where "id" in (select "user_id" from "premium_subscriptions")'],
-
-        ["SELECT with DISTINCT",
-            "select distinct category from products",
-            'select distinct "category" from "products"'],
-
-        ["SELECT with DISTINCT ON",
-            "select distinct on (department) id, name, salary from employees order by department, salary desc",
-            'select distinct on("department") "id", "name", "salary" from "employees" order by "department", "salary" desc'],
-
-        ["SELECT with window functions",
-            "select date, value, avg(value) over(order by date rows between 2 preceding and current row) as moving_avg from stocks",
-            'select "date", "value", avg("value") over(order by "date" rows between 2 preceding and current row) as "moving_avg" from "stocks"'],
-
-        ["SELECT with window clause",
-            "select id, value, avg(value) over w from measurements window w as (order by id rows between 2 preceding and 2 following)",
-            'select "id", "value", avg("value") over "w" from "measurements" window "w" as (order by "id" rows between 2 preceding and 2 following)'],
-
-        ["SELECT with FOR UPDATE clause",
-            "select id, stock from products where id = 123 for update",
-            'select "id", "stock" from "products" where "id" = 123 for update'],
-
-        ["SELECT with FOR SHARE clause",
-            "select id, balance from accounts where user_id = 456 for share",
-            'select "id", "balance" from "accounts" where "user_id" = 456 for share'],
-
-        ["SELECT with all basic clauses combined",
-            "select distinct u.id, u.name, count(o.id) as order_count " +
-            "from users u " +
-            "left join orders o on u.id = o.user_id " +
-            "where u.active = true " +
-            "group by u.id, u.name " +
-            "having count(o.id) > 0 " +
-            "order by order_count desc " +
-            "limit 10",
-            'select distinct "u"."id", "u"."name", count("o"."id") as "order_count" from "users" as "u" left join "orders" as "o" on "u"."id" = "o"."user_id" where "u"."active" = true group by "u"."id", "u"."name" having count("o"."id") > 0 order by "order_count" desc limit 10'],
-
-        ["SELECT with NOT NULL check",
-            "select id, name from users where email is not null",
-            'select "id", "name" from "users" where "email" is not null'],
-
-        ["SELECT with BETWEEN",
-            "select product_name, price from products where price between 10 and 50",
-            'select "product_name", "price" from "products" where "price" between 10 and 50'],
-
-        ["SELECT with EXISTS subquery",
-            "select id, name from customers where exists (select 1 from orders where orders.customer_id = customers.id)",
-            'select "id", "name" from "customers" where exists (select 1 from "orders" where "orders"."customer_id" = "customers"."id")'],
-
-        ["SELECT with WITH clause (CTE)",
-            "WITH monthly_sales AS (SELECT DATE_TRUNC('month', order_date) AS month, SUM(amount) AS total FROM orders GROUP BY month) SELECT month, total FROM monthly_sales ORDER BY month",
-            'with "monthly_sales" as (select date_trunc(\'month\', "order_date") as "month", sum("amount") as "total" from "orders" group by "month") select "month", "total" from "monthly_sales" order by "month"'],
-
-        ["SELECT with multiple CTEs",
-            "WITH customers_2023 AS (SELECT * FROM customers WHERE join_date >= '2023-01-01'), customer_orders AS (SELECT c.id, c.name, COUNT(o.id) AS order_count FROM customers_2023 c LEFT JOIN orders o ON c.id = o.customer_id GROUP BY c.id, c.name) SELECT * FROM customer_orders WHERE order_count > 0 ORDER BY order_count DESC",
-            'with "customers_2023" as (select * from "customers" where "join_date" >= \'2023-01-01\'), "customer_orders" as (select "c"."id", "c"."name", count("o"."id") as "order_count" from "customers_2023" as "c" left join "orders" as "o" on "c"."id" = "o"."customer_id" group by "c"."id", "c"."name") select * from "customer_orders" where "order_count" > 0 order by "order_count" desc'],
-
-        ["SELECT with recursive CTE",
-            "WITH RECURSIVE employee_hierarchy AS (SELECT id, name, manager_id, 1 AS level FROM employees WHERE manager_id IS NULL UNION ALL SELECT e.id, e.name, e.manager_id, eh.level + 1 FROM employees e JOIN employee_hierarchy eh ON e.manager_id = eh.id) SELECT * FROM employee_hierarchy ORDER BY level, name",
-            'with recursive "employee_hierarchy" as (select "id", "name", "manager_id", 1 as "level" from "employees" where "manager_id" is null union all select "e"."id", "e"."name", "e"."manager_id", "eh"."level" + 1 from "employees" as "e" join "employee_hierarchy" as "eh" on "e"."manager_id" = "eh"."id") select * from "employee_hierarchy" order by "level", "name"'],
-
-        ["Simple VALUES query",
-            "values (1, 'test', true)",
-            "values (1, 'test', true)"],
-
-        ["VALUES with multiple tuples",
-            "values (1, 'apple', 0.99), (2, 'banana', 0.59), (3, 'orange', 0.79)",
-            "values (1, 'apple', 0.99), (2, 'banana', 0.59), (3, 'orange', 0.79)"],
-
-        ["VALUES with expressions",
-            "values (1 + 2, concat('hello', ' ', 'world'), 5 * 10)",
-            "values (1 + 2, concat('hello', ' ', 'world'), 5 * 10)"],
-
-        ["SELECT UNION VALUES",
-            "select id, name, price from products union values (100, 'New Product', 29.99)",
-            'select "id", "name", "price" from "products" union values (100, \'New Product\', 29.99)'],
-
-        ["VALUES UNION VALUES",
-            "values (1, 'first'), (2, 'second') union values (3, 'third'), (4, 'fourth')",
-            "values (1, 'first'), (2, 'second') union values (3, 'third'), (4, 'fourth')"],
-
-        ["VALUES UNION SELECT",
-            "values (1, 'test'), (2, 'sample') union select id, name from products where featured = true",
-            'values (1, \'test\'), (2, \'sample\') union select "id", "name" from "products" where "featured" = true'],
-
-        ["WITH clause with VALUES",
-            "with sample_data as (values (1, 'apple'), (2, 'orange'), (3, 'banana')) select * from sample_data order by 2",
-            'with "sample_data" as (values (1, \'apple\'), (2, \'orange\'), (3, \'banana\')) select * from "sample_data" order by 2'],
-
-        ["WITH multiple CTEs with VALUES",
-            "with fruits as (values (1, 'apple'), (2, 'orange')), vegetables as (values (3, 'carrot'), (4, 'potato')) select * from fruits union select * from vegetables",
-            'with "fruits" as (values (1, \'apple\'), (2, \'orange\')), "vegetables" as (values (3, \'carrot\'), (4, \'potato\')) select * from "fruits" union select * from "vegetables"'],
-
-        ["Subquery with VALUES in FROM",
-            "select t.id, t.name from (values (1, 'apple'), (2, 'orange')) as t(id, name) where t.id > 1",
-            'select "t"."id", "t"."name" from (values (1, \'apple\'), (2, \'orange\')) as "t"("id", "name") where "t"."id" > 1'],
-
-        ["Subquery with VALUES in WHERE clause",
-            "select id, name from products where (id, category) in (values (1, 'fruit'), (2, 'vegetable'))",
-            'select "id", "name" from "products" where ("id", "category") in (values (1, \'fruit\'), (2, \'vegetable\'))'],
-
-        ["WITH clause with VALUES and column aliases",
-            "with sample_data(id, name) as (values (1, 'apple'), (2, 'orange'), (3, 'banana')) select * from sample_data order by 2",
-            'with "sample_data"("id", "name") as (values (1, \'apple\'), (2, \'orange\'), (3, \'banana\')) select * from "sample_data" order by 2'],
-
-        ["WITH multiple CTEs with VALUES and column aliases",
-            "with fruits(id, name) as (values (1, 'apple'), (2, 'orange')), vegetables(id, name) as (values (3, 'carrot'), (4, 'potato')) select * from fruits union select * from vegetables",
-            'with "fruits"("id", "name") as (values (1, \'apple\'), (2, \'orange\')), "vegetables"("id", "name") as (values (3, \'carrot\'), (4, \'potato\')) select * from "fruits" union select * from "vegetables"'],
-
-        ["SELECT with template variable",
-            "select ${name}",
-            'select :name'],
-
-
-        ["SELECT with FETCH FIRST ROW ONLY",
-            "select id, name from users fetch first row only",
-            'select "id", "name" from "users" fetch first 1 rows only'],
-
-        ["SELECT with FETCH NEXT 5 ROWS ONLY",
-            "select * from products fetch next 5 rows only",
-            'select * from "products" fetch next 5 rows only'],
-
-        ["SELECT with ORDER BY and FETCH",
-            "select id, name from users order by id fetch first 10 rows only",
-            'select "id", "name" from "users" order by "id" fetch first 10 rows only'],
-
-        ["SELECT with OFFSET and FETCH",
-            "select * from logs offset 20 rows fetch next 10 rows only",
-            'select * from "logs" offset 20 fetch next 10 rows only'],
-
-        ["SELECT with multiple named WINDOW clauses",
-            "select id, value, avg(value) over w1, sum(value) over w2 from measurements window w1 as (partition by id), w2 as (order by value)",
-            'select "id", "value", avg("value") over "w1", sum("value") over "w2" from "measurements" window "w1" as (partition by "id"), "w2" as (order by "value")'],
-
-    ])('%s', (_, text, expected) => {
-        // Parse the query
-        const query = SelectQueryParser.parse(text);
-        // Format it back to SQL
-        const sql = formatter.format(query);
-        // Verify it matches our expected output
-        expect(sql).toBe(expected);
+    test('formats known full-query examples as expected', () => {
+        fc.assert(
+            fc.property(fc.constantFrom(...selectFormatCases), ([caseName, text, expected]) => {
+                const query = SelectQueryParser.parse(text);
+                const sql = formatter.format(query);
+                expect(sql, caseName).toBe(expected);
+            }),
+            { numRuns: selectFormatCases.length * 2 }
+        );
     });
 });
 

--- a/packages/core/tests/transformers/SSSQLFilterBuilder.test.ts
+++ b/packages/core/tests/transformers/SSSQLFilterBuilder.test.ts
@@ -4,7 +4,276 @@ import { SqlFormatter } from '../../src/transformers/SqlFormatter';
 
 const normalizeSql = (sql: string): string => sql.replace(/\s+/g, ' ').trim().toLowerCase();
 
+const applyPlan = (sql: string, edits: readonly { start: number; end: number; after: string }[]): string => {
+    return [...edits]
+        .sort((left, right) => right.start - left.start)
+        .reduce((current, edit) => {
+            return current.slice(0, edit.start) + edit.after + current.slice(edit.end);
+        }, sql);
+};
+
 describe('SSSQLFilterBuilder', () => {
+    it('plans scalar scaffold as a minimal insert without reformatting existing SQL', () => {
+        const builder = new SSSQLFilterBuilder();
+        const sql = `
+            -- keep report comment
+            SELECT u.id, u.name
+            FROM users u
+            WHERE u.active = true
+        `;
+
+        const plan = builder.planScaffold(sql, { 'users.name': 'Alice' });
+
+        expect(plan.ok).toBe(true);
+        expect(plan.requiresFullReformat).toBe(false);
+        expect(plan.edits).toHaveLength(1);
+        expect(plan.edits[0]).toEqual(expect.objectContaining({
+            before: '',
+            kind: 'insert',
+            target: {
+                branchKind: 'scalar',
+                parameterName: 'users_name',
+                column: 'u.name'
+            }
+        }));
+        expect(plan.sql).toBe(applyPlan(sql, plan.edits));
+        expect(plan.sql).toContain('and (:users_name is null or u.name = :users_name)');
+        expect(plan.safety.tokenCountAfter).toBeGreaterThan(plan.safety.tokenCountBefore);
+        expect(plan.safety.changedOnlyTargetBranches).toBe(true);
+        expect(plan.safety.commentsPreserved).toBe(true);
+        expect(plan.safety.changedRegions).toEqual(expect.arrayContaining([
+            expect.objectContaining({ kind: 'boolean-operator' }),
+            expect.objectContaining({ kind: 'target-branch' })
+        ]));
+        expect(plan.warnings).toEqual([]);
+        expect(plan.errors).toEqual([]);
+    });
+
+    it('plans scalar scaffold into a query without WHERE as a minimal WHERE insert', () => {
+        const builder = new SSSQLFilterBuilder();
+        const sql = 'select u.id, u.name from users u order by u.id';
+
+        const plan = builder.planScaffold(sql, { 'users.name': 'Alice' });
+
+        expect(plan.ok).toBe(true);
+        expect(plan.requiresFullReformat).toBe(false);
+        expect(plan.sql).toBe('select u.id, u.name from users u where (:users_name is null or u.name = :users_name) order by u.id');
+        expect(plan.sql).toBe(applyPlan(sql, plan.edits));
+        expect(plan.safety.changedOnlyTargetBranches).toBe(true);
+        expect(plan.safety.changedRegions).toEqual(expect.arrayContaining([
+            expect.objectContaining({ kind: 'where-keyword' }),
+            expect.objectContaining({ kind: 'target-branch' })
+        ]));
+    });
+
+    it('plans scalar scaffold for AS aliases and quoted identifiers without full reformat', () => {
+        const builder = new SSSQLFilterBuilder();
+        const sql = 'select "u"."id", "u"."name" from "users" as "u" where "u"."active" = true';
+
+        const plan = builder.planScaffold(sql, { 'users.name': 'Alice' });
+
+        expect(plan.ok).toBe(true);
+        expect(plan.requiresFullReformat).toBe(false);
+        expect(plan.sql).toBe(applyPlan(sql, plan.edits));
+        expect(plan.sql).toContain('and (:users_name is null or "u"."name" = :users_name)');
+        expect(plan.safety.changedOnlyTargetBranches).toBe(true);
+    });
+
+    it('plans exists and not-exists scaffold branches as minimal inserts', () => {
+        const builder = new SSSQLFilterBuilder();
+        const sql = 'select p.product_id, p.product_name from products p where p.active = true order by p.product_id';
+
+        const existsPlan = builder.planScaffoldBranch(sql, {
+            kind: 'exists',
+            parameterName: 'category_name',
+            anchorColumns: ['products.product_id'],
+            query: `
+                select 1
+                from product_categories pc
+                where pc.product_id = $c0
+                  and pc.category_name = :category_name
+            `
+        });
+
+        expect(existsPlan.ok).toBe(true);
+        expect(existsPlan.requiresFullReformat).toBe(false);
+        expect(existsPlan.sql).toBe(applyPlan(sql, existsPlan.edits));
+        expect(existsPlan.sql).toContain('and (:category_name is null or exists');
+        expect(existsPlan.sql).toContain('pc.product_id = p.product_id');
+        expect(existsPlan.safety.changedOnlyTargetBranches).toBe(true);
+
+        const notExistsPlan = builder.planScaffoldBranch(sql, {
+            kind: 'not-exists',
+            parameterName: 'archived_name',
+            anchorColumns: ['products.product_id'],
+            query: `
+                select 1
+                from archived_products ap
+                where ap.product_id = $c0
+                  and ap.product_name = :archived_name
+            `
+        });
+
+        expect(notExistsPlan.ok).toBe(true);
+        expect(notExistsPlan.requiresFullReformat).toBe(false);
+        expect(notExistsPlan.sql).toBe(applyPlan(sql, notExistsPlan.edits));
+        expect(notExistsPlan.sql).toContain('and (:archived_name is null or not exists');
+        expect(notExistsPlan.sql).toContain('ap.product_id = p.product_id');
+        expect(notExistsPlan.safety.changedOnlyTargetBranches).toBe(true);
+    });
+
+    it('plans refresh rewrites and exposes the rewritten SQL without applying it to the input text', () => {
+        const builder = new SSSQLFilterBuilder();
+        const sql = `
+            WITH base_orders AS (
+                SELECT o.order_id, o.status
+                FROM orders o
+            )
+            SELECT b.order_id
+            FROM base_orders b
+            WHERE (:orders_status IS NULL OR lower(b.status) LIKE lower(:orders_status))
+        `;
+
+        const plan = builder.planRefresh(sql, { 'orders.status': { '=': 'paid' } });
+
+        expect(plan.ok).toBe(true);
+        expect(plan.requiresFullReformat).toBe(true);
+        expect(plan.sql).toContain(':orders_status is null');
+        expect(normalizeSql(plan.sql ?? '')).toContain('from "orders" as "o" where (:orders_status is null or lower("o"."status") like lower(:orders_status))');
+        expect(plan.safety.changedOnlyTargetBranches).toBe(false);
+    });
+
+    it('plans scalar remove as a minimal delete', () => {
+        const builder = new SSSQLFilterBuilder();
+        const sql = 'select p.product_id, p.product_name from products p where p.active = true and (:product_name is null or p.product_name ilike :product_name) order by p.product_id';
+
+        const plan = builder.planRemove(sql, { parameterName: 'product_name', kind: 'scalar' });
+
+        expect(plan.ok).toBe(true);
+        expect(plan.requiresFullReformat).toBe(false);
+        expect(plan.edits).toHaveLength(1);
+        expect(plan.edits[0]).toEqual(expect.objectContaining({
+            kind: 'delete',
+            target: expect.objectContaining({
+                branchKind: 'scalar',
+                parameterName: 'product_name'
+            })
+        }));
+        expect(plan.sql).not.toContain(':product_name');
+        expect(plan.sql).toBe(applyPlan(sql, plan.edits));
+        expect(plan.safety.changedOnlyTargetBranches).toBe(true);
+        expect(plan.safety.changedRegions).toEqual(expect.arrayContaining([
+            expect.objectContaining({ kind: 'boolean-operator' }),
+            expect.objectContaining({ kind: 'target-branch' })
+        ]));
+    });
+
+    it('plans scalar remove without leaving an empty WHERE clause', () => {
+        const builder = new SSSQLFilterBuilder();
+        const sql = 'select p.product_id from products p where (:product_name is null or p.product_name = :product_name) order by p.product_id';
+
+        const plan = builder.planRemove(sql, { parameterName: 'product_name', kind: 'scalar' });
+
+        expect(plan.ok).toBe(true);
+        expect(plan.sql).toBe('select p.product_id from products p order by p.product_id');
+        expect(plan.sql).toBe(applyPlan(sql, plan.edits));
+        expect(plan.sql).not.toMatch(/\bwhere\b/i);
+        expect(plan.safety.changedOnlyTargetBranches).toBe(true);
+        expect(plan.safety.changedRegions).toEqual(expect.arrayContaining([
+            expect.objectContaining({ kind: 'where-keyword' }),
+            expect.objectContaining({ kind: 'target-branch' })
+        ]));
+    });
+
+    it('plans scalar remove at the beginning of a compound WHERE clause', () => {
+        const builder = new SSSQLFilterBuilder();
+        const sql = 'select p.product_id from products p where (:product_name is null or p.product_name = :product_name) and p.active = true';
+
+        const plan = builder.planRemove(sql, { parameterName: 'product_name', kind: 'scalar' });
+
+        expect(plan.ok).toBe(true);
+        expect(plan.requiresFullReformat).toBe(false);
+        expect(plan.sql).toBe('select p.product_id from products p where p.active = true');
+        expect(plan.sql).toBe(applyPlan(sql, plan.edits));
+        expect(plan.safety.changedOnlyTargetBranches).toBe(true);
+    });
+
+    it('plans exists branch remove as a minimal delete', () => {
+        const builder = new SSSQLFilterBuilder();
+        const sql = `
+            select p.product_id
+            from products p
+            where p.active = true
+              and (:category_name is null or exists (
+                select 1
+                from product_categories pc
+                where pc.product_id = p.product_id
+                  and pc.category_name = :category_name
+              ))
+        `;
+
+        const plan = builder.planRemove(sql, { parameterName: 'category_name', kind: 'exists' });
+
+        expect(plan.ok).toBe(true);
+        expect(plan.requiresFullReformat).toBe(false);
+        expect(plan.sql).toBe(applyPlan(sql, plan.edits));
+        expect(plan.sql).not.toContain(':category_name');
+        expect(plan.safety.changedOnlyTargetBranches).toBe(true);
+        expect(plan.edits[0]?.target).toEqual(expect.objectContaining({
+            branchKind: 'exists',
+            parameterName: 'category_name'
+        }));
+    });
+
+    it('plans not-exists branch remove as a minimal delete', () => {
+        const builder = new SSSQLFilterBuilder();
+        const sql = `
+            select p.product_id
+            from products p
+            where p.active = true
+              and (:archived_name is null or not exists (
+                select 1
+                from archived_products ap
+                where ap.product_id = p.product_id
+                  and ap.product_name = :archived_name
+              ))
+        `;
+
+        const plan = builder.planRemove(sql, { parameterName: 'archived_name', kind: 'not-exists' });
+
+        expect(plan.ok).toBe(true);
+        expect(plan.requiresFullReformat).toBe(false);
+        expect(plan.sql).toBe(applyPlan(sql, plan.edits));
+        expect(plan.sql).not.toContain(':archived_name');
+        expect(plan.safety.changedOnlyTargetBranches).toBe(true);
+        expect(plan.edits[0]?.target).toEqual(expect.objectContaining({
+            branchKind: 'not-exists',
+            parameterName: 'archived_name'
+        }));
+    });
+
+    it('reports rewrite failures as plan errors instead of throwing', () => {
+        const builder = new SSSQLFilterBuilder();
+
+        const plan = builder.planScaffold(
+            `
+                SELECT u.name, p.name
+                FROM users u
+                JOIN profiles p ON p.user_id = u.id
+            `,
+            { name: 'Alice' }
+        );
+
+        expect(plan.ok).toBe(false);
+        expect(plan.errors).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                code: 'REWRITE_FAILED',
+                detail: expect.stringMatching(/ambiguous/i)
+            })
+        ]));
+        expect(plan.sql).toBeUndefined();
+    });
+
     it('scaffolds an equality-based optional filter into a simple query', () => {
         const builder = new SSSQLFilterBuilder();
         const query = builder.scaffold(

--- a/packages/core/tests/transformers/SSSQLFilterBuilder.test.ts
+++ b/packages/core/tests/transformers/SSSQLFilterBuilder.test.ts
@@ -79,6 +79,26 @@ describe('SSSQLFilterBuilder', () => {
         expect(plan.safety.changedOnlyTargetBranches).toBe(true);
     });
 
+    it('falls back to formatter-backed scaffold planning for nested query targets', () => {
+        const builder = new SSSQLFilterBuilder();
+        const sql = `
+            with base_users as (
+                select u.id, u.name
+                from users u
+            )
+            select b.id
+            from base_users b
+        `;
+
+        const plan = builder.planScaffold(sql, { 'users.name': 'Alice' });
+
+        expect(plan.ok).toBe(true);
+        expect(plan.requiresFullReformat).toBe(true);
+        expect(plan.safety.changedOnlyTargetBranches).toBe(false);
+        expect(normalizeSql(plan.sql ?? '')).toContain('from "users" as "u" where (:users_name is null or "u"."name" = :users_name)');
+        expect(normalizeSql(plan.sql ?? '')).toContain('select "b"."id" from "base_users" as "b"');
+    });
+
     it('plans exists and not-exists scaffold branches as minimal inserts', () => {
         const builder = new SSSQLFilterBuilder();
         const sql = 'select p.product_id, p.product_name from products p where p.active = true order by p.product_id';
@@ -250,6 +270,27 @@ describe('SSSQLFilterBuilder', () => {
             branchKind: 'not-exists',
             parameterName: 'archived_name'
         }));
+    });
+
+    it('falls back to formatter-backed remove planning for ambiguous source spans', () => {
+        const builder = new SSSQLFilterBuilder();
+        const sql = `
+            select p.product_id
+            from products p
+            where p.active = true
+              and (:product_name is null or p.product_name = :product_name)
+              /* archived example: (:product_name is null or old.product_name = :product_name) */
+        `;
+
+        const plan = builder.planRemove(sql, { parameterName: 'product_name', kind: 'scalar' });
+
+        expect(plan.ok).toBe(true);
+        expect(plan.requiresFullReformat).toBe(true);
+        expect(plan.errors).toEqual([]);
+        expect(plan.warnings).toEqual(expect.arrayContaining([
+            expect.objectContaining({ code: 'FULL_REFORMAT_REQUIRED' })
+        ]));
+        expect(normalizeSql(plan.sql ?? '')).toBe('select "p"."product_id" from "products" as "p" where "p"."active" = true');
     });
 
     it('reports rewrite failures as plan errors instead of throwing', () => {

--- a/packages/core/tests/transformers/SqlFormatter.comment-statement-invariance.property.test.ts
+++ b/packages/core/tests/transformers/SqlFormatter.comment-statement-invariance.property.test.ts
@@ -1,0 +1,439 @@
+import { describe, expect, test } from 'vitest';
+import fc from 'fast-check';
+import { Lexeme, TokenType } from '../../src/models/Lexeme';
+import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
+import { SqlTokenizer } from '../../src/parsers/SqlTokenizer';
+import { SqlFormatter } from '../../src/transformers/SqlFormatter';
+
+type CommentStyle = 'block' | 'line';
+
+interface GeneratedComment {
+    style: CommentStyle;
+    text: string;
+}
+
+interface GeneratedQuery {
+    name: string;
+    baseSql: string;
+    commentedSql: string;
+}
+
+const formatter = new SqlFormatter({
+    exportComment: true,
+    keywordCase: 'lower',
+    newline: ' ',
+});
+
+const commentTextArb = fc
+    .array(
+        fc.constantFrom(
+            'header',
+            'field',
+            'source',
+            'filter',
+            'join',
+            'join-keyword',
+            'join-source',
+            'join-alias',
+            'join-on',
+            'cte',
+            'value',
+            'order',
+            'group',
+            'case',
+            'note',
+            'safe'
+        ),
+        { minLength: 1, maxLength: 4 }
+    )
+    .map((words) => words.join(' '));
+
+const commentArb = fc.record({
+    style: fc.constantFrom<CommentStyle>('block', 'line'),
+    text: commentTextArb,
+});
+
+const commentsArb = fc.array(commentArb, { minLength: 24, maxLength: 24 });
+
+function renderComment(comment: GeneratedComment): string {
+    if (comment.style === 'line') {
+        return `\n-- ${comment.text}\n`;
+    }
+    return ` /* ${comment.text} */ `;
+}
+
+interface TokenSignature {
+    type: number;
+    value: string;
+}
+
+function normalizeTokenValue(lexeme: Lexeme): string {
+    if ((lexeme.type & TokenType.Command) !== 0) {
+        return lexeme.value.toLowerCase();
+    }
+    return lexeme.value;
+}
+
+function normalizeTokenType(lexeme: Lexeme): number {
+    if ((lexeme.type & TokenType.Command) !== 0) {
+        return TokenType.Command;
+    }
+    if ((lexeme.type & TokenType.Identifier) !== 0) {
+        return TokenType.Identifier;
+    }
+    return lexeme.type;
+}
+
+function tokenSignatures(sql: string): TokenSignature[] {
+    const signatures = new SqlTokenizer(sql).tokenize().map((lexeme) => ({
+        type: normalizeTokenType(lexeme),
+        value: normalizeTokenValue(lexeme),
+    }));
+    return omitOptionalAliasAs(signatures);
+}
+
+function omitOptionalAliasAs(signatures: TokenSignature[]): TokenSignature[] {
+    return signatures.filter((signature, index) => {
+        if (signature.type !== TokenType.Command || signature.value !== 'as') {
+            return true;
+        }
+
+        const next = signatures[index + 1];
+        return next?.type === TokenType.OpenParen;
+    });
+}
+
+function format(sql: string): string {
+    const query = SelectQueryParser.parse(sql);
+    return formatter.format(query).formattedSql;
+}
+
+function expectSameTokenSequence(actualSql: string, expectedSql: string, name: string): void {
+    const actual = tokenSignatures(actualSql);
+    const expected = tokenSignatures(expectedSql);
+
+    expect(actual.length, `${name}: token count`).toBe(expected.length);
+    expect(actual, `${name}: token sequence`).toEqual(expected);
+}
+
+function expectFormatPreservesTokenSequence(sql: string, name: string): void {
+    const formattedSql = format(sql);
+    expectSameTokenSequence(formattedSql, sql, name);
+}
+
+function selectWithWhere(comments: GeneratedComment[]): GeneratedQuery {
+    const c = comments.map(renderComment);
+    return {
+        name: 'select-with-where',
+        baseSql: 'select u.id, u.name from users u where u.active = true and u.age >= 18 order by u.name',
+        commentedSql: [
+            c[0],
+            'select',
+            c[1],
+            'u.id',
+            c[2],
+            ', u.name',
+            c[3],
+            'from users u',
+            c[4],
+            'where',
+            c[5],
+            'u.active = true',
+            c[6],
+            'and u.age >= 18',
+            c[7],
+            'order by u.name',
+        ].join(' '),
+    };
+}
+
+function selectWithJoin(comments: GeneratedComment[]): GeneratedQuery {
+    const c = comments.map(renderComment);
+    return {
+        name: 'select-with-join',
+        baseSql: 'select u.id, o.total from users u left join orders o on u.id = o.user_id where o.total > 10',
+        commentedSql: [
+            c[0],
+            'select u.id',
+            c[1],
+            ', o.total',
+            c[2],
+            'from users u',
+            c[3],
+            'left join orders o',
+            c[4],
+            'on',
+            c[5],
+            'u.id = o.user_id',
+            c[6],
+            'where o.total > 10',
+        ].join(' '),
+    };
+}
+
+function selectWithJoinKeywordComments(comments: GeneratedComment[]): GeneratedQuery {
+    const c = comments.map(renderComment);
+    return {
+        name: 'select-with-join-keyword-comments',
+        baseSql: [
+            'select u.id, o.total',
+            'from users u',
+            'left join orders o on u.id = o.user_id',
+            'where o.total > 10',
+        ].join(' '),
+        commentedSql: [
+            c[0],
+            'select u.id',
+            c[1],
+            ', o.total',
+            c[2],
+            'from',
+            c[3],
+            'users',
+            c[4],
+            'u',
+            c[5],
+            'left',
+            c[6],
+            'join',
+            c[7],
+            'orders',
+            c[8],
+            'o',
+            c[9],
+            'on',
+            c[10],
+            'u.id = o.user_id',
+            c[11],
+            'where o.total > 10',
+        ].join(' '),
+    };
+}
+
+function selectWithJoinConditionComments(comments: GeneratedComment[]): GeneratedQuery {
+    const c = comments.map(renderComment);
+    return {
+        name: 'select-with-join-condition-comments',
+        baseSql: [
+            'select u.id, o.total',
+            'from users u',
+            'inner join orders o',
+            'on u.id = o.user_id and u.region = o.region',
+            'where u.active = true',
+        ].join(' '),
+        commentedSql: [
+            c[0],
+            'select u.id, o.total',
+            c[1],
+            'from users u',
+            c[2],
+            'inner join orders o',
+            c[3],
+            'on',
+            c[4],
+            'u.id',
+            c[5],
+            '=',
+            c[6],
+            'o.user_id',
+            c[7],
+            'and',
+            c[8],
+            'u.region',
+            c[9],
+            '=',
+            c[10],
+            'o.region',
+            c[11],
+            'where u.active = true',
+        ].join(' '),
+    };
+}
+
+function selectWithMultipleJoinComments(comments: GeneratedComment[]): GeneratedQuery {
+    const c = comments.map(renderComment);
+    return {
+        name: 'select-with-multiple-join-comments',
+        baseSql: [
+            'select u.id, o.total, p.name',
+            'from users u',
+            'join orders o on u.id = o.user_id',
+            'left join products p on o.product_id = p.id',
+            'where p.active = true',
+        ].join(' '),
+        commentedSql: [
+            c[0],
+            'select u.id, o.total, p.name',
+            c[1],
+            'from users u',
+            c[2],
+            'join',
+            c[3],
+            'orders o',
+            c[4],
+            'on u.id = o.user_id',
+            c[5],
+            'left',
+            c[6],
+            'join',
+            c[7],
+            'products',
+            c[8],
+            'p',
+            c[9],
+            'on',
+            c[10],
+            'o.product_id = p.id',
+            c[11],
+            'where p.active = true',
+        ].join(' '),
+    };
+}
+
+function selectWithCte(comments: GeneratedComment[]): GeneratedQuery {
+    const c = comments.map(renderComment);
+    return {
+        name: 'select-with-cte',
+        baseSql: 'with active_users as (select id, name from users where active = true) select id, name from active_users order by name',
+        commentedSql: [
+            c[0],
+            'with',
+            c[1],
+            'active_users as (',
+            c[2],
+            'select id, name',
+            c[3],
+            'from users',
+            c[4],
+            'where active = true',
+            c[5],
+            ')',
+            c[6],
+            'select id, name',
+            c[7],
+            'from active_users order by name',
+        ].join(' '),
+    };
+}
+
+function selectWithExists(comments: GeneratedComment[]): GeneratedQuery {
+    const c = comments.map(renderComment);
+    return {
+        name: 'select-with-exists',
+        baseSql: 'select c.id from customers c where exists (select 1 from orders o where o.customer_id = c.id)',
+        commentedSql: [
+            c[0],
+            'select c.id',
+            c[1],
+            'from customers c',
+            c[2],
+            'where exists (',
+            c[3],
+            'select 1',
+            c[4],
+            'from orders o',
+            c[5],
+            'where o.customer_id = c.id',
+            c[6],
+            ')',
+        ].join(' '),
+    };
+}
+
+function selectWithGroupBy(comments: GeneratedComment[]): GeneratedQuery {
+    const c = comments.map(renderComment);
+    return {
+        name: 'select-with-group-by',
+        baseSql: 'select department, count(*) as employee_count from employees group by department having count(*) > 5',
+        commentedSql: [
+            c[0],
+            'select department',
+            c[1],
+            ', count(*) as employee_count',
+            c[2],
+            'from employees',
+            c[3],
+            'group by department',
+            c[4],
+            'having count(*) > 5',
+        ].join(' '),
+    };
+}
+
+function selectWithCase(comments: GeneratedComment[]): GeneratedQuery {
+    const c = comments.map(renderComment);
+    return {
+        name: 'select-with-case',
+        baseSql: "select case when status = 'active' then 'ACTIVE' else 'INACTIVE' end as status_label from users",
+        commentedSql: [
+            c[0],
+            'select case',
+            c[1],
+            "when status = 'active'",
+            c[2],
+            "then 'ACTIVE'",
+            c[3],
+            "else 'INACTIVE'",
+            c[4],
+            'end as status_label',
+            c[5],
+            'from users',
+        ].join(' '),
+    };
+}
+
+const queryArb = commentsArb.chain((comments) =>
+    fc.constantFrom(
+        selectWithWhere(comments),
+        selectWithJoin(comments),
+        selectWithJoinKeywordComments(comments),
+        selectWithJoinConditionComments(comments),
+        selectWithMultipleJoinComments(comments),
+        selectWithCte(comments),
+        selectWithExists(comments),
+        selectWithGroupBy(comments),
+        selectWithCase(comments)
+    )
+);
+
+describe('SqlFormatter comment statement invariance', () => {
+    test('commented SELECT queries keep the same token sequence after formatting', () => {
+        fc.assert(
+            fc.property(queryArb, ({ name, baseSql, commentedSql }) => {
+                expectSameTokenSequence(commentedSql, baseSql, `${name}: comments do not add SQL tokens`);
+                expectFormatPreservesTokenSequence(commentedSql, `${name}: format preserves tokens`);
+            }),
+            {
+                numRuns: 200,
+            }
+        );
+    });
+
+    test('comments between CASE and WHEN keep token count even when comment text is not exactly recoverable', () => {
+        const sql = [
+            "select case /* aa */ when status = 'active'",
+            "then 'ACTIVE'",
+            "else 'INACTIVE'",
+            'end as status_label',
+            'from users',
+        ].join(' ');
+
+        expectFormatPreservesTokenSequence(sql, 'case-comment-between-case-and-when');
+    });
+
+    test('optional alias AS does not affect token sequence comparison', () => {
+        expectSameTokenSequence(
+            'select u.id from users as u left join orders as o on u.id = o.user_id',
+            'select u.id from users u left join orders o on u.id = o.user_id',
+            'optional-alias-as'
+        );
+    });
+
+    test('optional final semicolon does not affect token sequence comparison', () => {
+        expectSameTokenSequence(
+            'select u.id from users u where u.active = true;',
+            'select u.id from users u where u.active = true',
+            'optional-final-semicolon'
+        );
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,6 +282,9 @@ importers:
       eslint-plugin-prettier:
         specifier: ^5.2.3
         version: 5.5.4(eslint-config-prettier@10.1.8(eslint@9.36.0(jiti@2.6.1)))(eslint@9.36.0(jiti@2.6.1))(prettier@3.7.4)
+      fast-check:
+        specifier: ^4.8.0
+        version: 4.8.0
       microtime:
         specifier: ^3.1.1
         version: 3.1.1
@@ -2566,6 +2569,10 @@ packages:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
     engines: {node: '>=8.0.0'}
 
+  fast-check@4.8.0:
+    resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
+    engines: {node: '>=12.17.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -3472,6 +3479,9 @@ packages:
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
@@ -5648,14 +5658,6 @@ snapshots:
     optionalDependencies:
       vite: 7.3.2(@types/node@22.18.7)(jiti@2.6.1)(yaml@2.8.3)
 
-  '@vitest/mocker@4.0.15(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 4.0.15
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(yaml@2.8.3)
-
   '@vitest/mocker@4.0.7(vite@7.3.2(@types/node@22.18.7)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.0.7
@@ -6586,6 +6588,10 @@ snapshots:
     dependencies:
       pure-rand: 6.1.0
 
+  fast-check@4.8.0:
+    dependencies:
+      pure-rand: 8.4.0
+
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
@@ -7485,6 +7491,8 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
+  pure-rand@8.4.0: {}
+
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
@@ -8241,7 +8249,7 @@ snapshots:
   vitest@4.0.15(@types/node@22.19.17)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 4.0.15
-      '@vitest/mocker': 4.0.15(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(yaml@2.8.3))
+      '@vitest/mocker': 4.0.15(vite@7.3.2(@types/node@22.18.7)(jiti@2.6.1)(yaml@2.8.3))
       '@vitest/pretty-format': 4.0.15
       '@vitest/runner': 4.0.15
       '@vitest/snapshot': 4.0.15


### PR DESCRIPTION
## Summary

- Add SSSQL rewrite plan/dry-run APIs with edit spans, safety metadata, warnings, errors, and apply-plan consistency.
- Return span-based minimal edits for provable scalar and exists/not-exists add/remove rewrites; keep refresh on the conservative formatter-backed plan path.
- Strengthen formatter property tests by comparing token sequences across commented SQL, including JOIN comments and alias/semicolon normalization.

## Verification

- pnpm --filter rawsql-ts build
- pnpm --filter rawsql-ts test -- tests/transformers/SSSQLFilterBuilder.test.ts tests/transformers/DynamicFilterRoutingDogfooding.test.ts tests/transformers/DynamicQueryBuilder.test.ts tests/transformers/SqlFormatter.comment-statement-invariance.property.test.ts
- pnpm --filter rawsql-ts test
- pnpm typecheck
- pnpm test (fails outside this PR scope: ztd/transfer dependency/runner failures in ztdLint, sqlCatalog.ztd.runner, sqlClientAdapterTemplate, transfer pg sql-client)

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: not needed; no baseline exception requested.
Scoped checks run: not needed; no baseline exception requested.
Why full baseline is not required: full baseline exception path not used for this PR.

## Self Review

Self-review workflow: Two-cycle self-review completed: implementation consistency, then human acceptance/readiness review.
Self-review result: No unresolved blocker in core changes. P2 refresh minimal move remains intentionally conservative and is called out for follow-up.
Concept-review workflow: Concept boundary review not required; this is a core API/test change and does not alter Concept Spec-owned domain boundaries.
Concept-review result: No concept or package-boundary violation found.

## CLI Surface Migration

- [ ] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: not selected for this PR.
Upgrade note: not selected for this PR.
Deprecation/removal plan or issue: not selected for this PR.
Docs/help/examples updated: not selected for this PR.
Release/changeset wording: not selected for this PR.

## Scaffold Contract Proof

- [ ] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: not selected for this PR.
Non-edit assertion: not selected for this PR.
Fail-fast input-contract proof: not selected for this PR.
Generated-output viability proof: not selected for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added rewrite planning API to inspect SQL transformation operations (scaffold, refresh, remove) before application
  * Plan results include safety metrics, warnings, and preview of edited SQL

* **Documentation**
  * Expanded API documentation for rewrite planning features

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mk3008/rawsql-ts/pull/853?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->