### PR TITLE
Fix SSSQL optional planner scope and cast guards

### DIFF
--- a/.changeset/sssql-planner-scope-and-cast.md
+++ b/.changeset/sssql-planner-scope-and-cast.md
@@ -1,0 +1,7 @@
+---
+"rawsql-ts": patch
+---
+
+Fix SSSQL optional-condition planning for queries with CTE-local WHERE clauses and casted null guards.
+
+The SSSQL planner now inserts new root-query optional filters into the root WHERE clause instead of the first WHERE found inside a CTE. Optional-condition recognition also supports null guards written as `:param::type IS NULL` and `CAST(:param AS type) IS NULL`, including multi-predicate branches that use the same parameter.

--- a/packages/core/src/transformers/PruneOptionalConditionBranches.ts
+++ b/packages/core/src/transformers/PruneOptionalConditionBranches.ts
@@ -3,6 +3,8 @@ import { Lexeme, TokenType } from '../models/Lexeme';
 import { BinarySelectQuery, SelectQuery, SimpleSelectQuery } from '../models/SelectQuery';
 import {
     BinaryExpression,
+    CastExpression,
+    FunctionCall,
     LiteralValue,
     ParameterExpression,
     ParenExpression,
@@ -53,6 +55,25 @@ const unwrapSingleOuterParen = (expression: ValueComponent): ValueComponent => {
     }
 
     return candidate;
+};
+
+const unwrapOptionalGuardParameter = (expression: ValueComponent): ValueComponent => {
+    let candidate = unwrapSingleOuterParen(expression);
+    while (candidate instanceof CastExpression) {
+        candidate = unwrapSingleOuterParen(candidate.input);
+    }
+    if (candidate instanceof FunctionCall && getFunctionCallName(candidate) === 'cast' && candidate.argument) {
+        const argument = unwrapSingleOuterParen(candidate.argument);
+        if (isBinaryOperator(argument, 'as')) {
+            return unwrapOptionalGuardParameter(argument.left);
+        }
+    }
+    return candidate;
+};
+
+const getFunctionCallName = (expression: FunctionCall): string => {
+    const name = expression.qualifiedName.name;
+    return 'value' in name ? name.value.toLowerCase() : name.name.toLowerCase();
 };
 
 const collectTopLevelAndTerms = (expression: ValueComponent): ValueComponent[] => {
@@ -110,11 +131,12 @@ const getGuardedParameterName = (expression: ValueComponent): string | null => {
         return null;
     }
 
-    if (!(candidate.left instanceof ParameterExpression) || !isNullLiteral(candidate.right)) {
+    const left = unwrapOptionalGuardParameter(candidate.left);
+    if (!(left instanceof ParameterExpression) || !isNullLiteral(candidate.right)) {
         return null;
     }
 
-    return candidate.left.name.value;
+    return left.name.value;
 };
 
 const getUniqueParameterNames = (expression: ValueComponent): Set<string> => {
@@ -606,13 +628,30 @@ const splitTopLevelTermsByKeyword = (lexemes: Lexeme[], keyword: string): Lexeme
 
 const getGuardedParameterNameFromLexemes = (lexemes: Lexeme[]): string | null => {
     const compact = lexemes.filter(lexeme => !isWrappingParen(lexeme));
-    if (compact.length !== 3) {
-        return null;
+    const isIndexKeyword = (index: number, keyword: string): boolean => {
+        const lexeme = compact[index];
+        return lexeme !== undefined && isKeyword(lexeme, keyword);
+    };
+
+    if (compact.length === 3) {
+        if (!isParameter(compact[0]) || !isIndexKeyword(1, 'is') || !isIndexKeyword(2, 'null')) {
+            return null;
+        }
+        return normalizeParameterName(compact[0].value);
     }
-    if (!isParameter(compact[0]) || !isKeyword(compact[1], 'is') || !isKeyword(compact[2], 'null')) {
-        return null;
+
+    if (compact.length === 5 && isParameter(compact[0]) && compact[1]?.value === '::' && isIndexKeyword(3, 'is') && isIndexKeyword(4, 'null')) {
+        return normalizeParameterName(compact[0].value);
     }
-    return normalizeParameterName(compact[0].value);
+
+    if (compact.length >= 6 && isIndexKeyword(0, 'cast') && isParameter(compact[1]) && isIndexKeyword(2, 'as')) {
+        const isIndex = compact.findIndex((lexeme, index) => index > 2 && isKeyword(lexeme, 'is'));
+        if (isIndex >= 0 && isIndexKeyword(isIndex + 1, 'null')) {
+            return normalizeParameterName(compact[1]!.value);
+        }
+    }
+
+    return null;
 };
 
 const isSupportedMeaningfulBranchFromLexemes = (lexemes: Lexeme[], parameterName: string): boolean => {

--- a/packages/core/src/transformers/SSSQLFilterBuilder.ts
+++ b/packages/core/src/transformers/SSSQLFilterBuilder.ts
@@ -2,7 +2,9 @@ import { WhereClause, type SourceExpression, SubQuerySource, TableSource } from 
 import { SelectQuery, SimpleSelectQuery } from "../models/SelectQuery";
 import {
     BinaryExpression,
+    CastExpression,
     ColumnReference,
+    FunctionCall,
     IdentifierString,
     InlineQuery,
     LiteralValue,
@@ -264,20 +266,39 @@ const isClauseBoundary = (lexeme: Lexeme): boolean => {
 
 const findMinimalWhereInsertPosition = (sql: string): { position: number; hasWhere: boolean } => {
     const lexemes = new SqlTokenizer(sql).tokenize();
-    const whereIndex = lexemes.findIndex(lexeme =>
-        (lexeme.type & TokenType.Command) !== 0 && lexeme.value.toLowerCase() === "where"
-    );
     const statementEnd = getStatementEndPosition(sql);
+    const topLevelLexemes: Array<{ lexeme: Lexeme; index: number }> = [];
+    let depth = 0;
 
-    if (whereIndex >= 0) {
-        const tail = lexemes.slice(whereIndex + 1).find(isClauseBoundary);
+    for (let index = 0; index < lexemes.length; index += 1) {
+        const lexeme = lexemes[index]!;
+        if ((lexeme.type & TokenType.CloseParen) !== 0) {
+            depth = Math.max(0, depth - 1);
+        }
+        if (depth === 0) {
+            topLevelLexemes.push({ lexeme, index });
+        }
+        if ((lexeme.type & TokenType.OpenParen) !== 0) {
+            depth += 1;
+        }
+    }
+
+    const where = topLevelLexemes.find(entry =>
+        (entry.lexeme.type & TokenType.Command) !== 0 && entry.lexeme.value.toLowerCase() === "where"
+    );
+
+    if (where) {
+        const tail = topLevelLexemes
+            .filter(entry => entry.index > where.index)
+            .map(entry => entry.lexeme)
+            .find(isClauseBoundary);
         return {
             position: tail?.position?.startPosition ?? statementEnd,
             hasWhere: true
         };
     }
 
-    const tail = lexemes.find(isClauseBoundary);
+    const tail = topLevelLexemes.map(entry => entry.lexeme).find(isClauseBoundary);
     return {
         position: tail?.position?.startPosition ?? statementEnd,
         hasWhere: false
@@ -524,7 +545,9 @@ const getGuardedParameterName = (expression: ValueComponent): string | null => {
         return null;
     }
 
-    if (!(candidate.left instanceof ParameterExpression)) {
+    const left = unwrapOptionalGuardParameter(candidate.left);
+
+    if (!(left instanceof ParameterExpression)) {
         return null;
     }
 
@@ -535,7 +558,26 @@ const getGuardedParameterName = (expression: ValueComponent): string | null => {
         return null;
     }
 
-    return candidate.left.name.value;
+    return left.name.value;
+};
+
+const unwrapOptionalGuardParameter = (expression: ValueComponent): ValueComponent => {
+    let candidate = unwrapParens(expression);
+    while (candidate instanceof CastExpression) {
+        candidate = unwrapParens(candidate.input);
+    }
+    if (candidate instanceof FunctionCall && getFunctionCallName(candidate) === "cast" && candidate.argument) {
+        const argument = unwrapParens(candidate.argument);
+        if (isBinaryOperator(argument, "as")) {
+            return unwrapOptionalGuardParameter(argument.left);
+        }
+    }
+    return candidate;
+};
+
+const getFunctionCallName = (expression: FunctionCall): string => {
+    const name = expression.qualifiedName.name;
+    return "value" in name ? name.value.toLowerCase() : name.name.toLowerCase();
 };
 
 const buildOptionalScalarBranch = (

--- a/packages/core/src/utils/OperatorPrecedence.ts
+++ b/packages/core/src/utils/OperatorPrecedence.ts
@@ -52,6 +52,7 @@ export class OperatorPrecedence {
         // Arithmetic operators
         '+': 20,
         '-': 20,
+        '||': 20,
         '*': 30,
         '/': 30,
         '%': 30,

--- a/packages/core/tests/transformers/PruneOptionalConditionBranches.test.ts
+++ b/packages/core/tests/transformers/PruneOptionalConditionBranches.test.ts
@@ -146,6 +146,21 @@ describe('pruneOptionalConditionBranches', () => {
         expect(spans[0].sourceRange.text).toBe('(:status IS NULL OR p.status = :status)');
     });
 
+    it('collects source ranges for casted null guards and multi-predicate branches', () => {
+        const sql = [
+            'SELECT u.id, u.email',
+            'FROM users u',
+            "WHERE (CAST(:keyword AS text) IS NULL OR u.email ILIKE '%' || :keyword || '%' OR u.name ILIKE '%' || :keyword || '%')",
+            '  AND (:status::text IS NULL OR u.status = :status)'
+        ].join('\n');
+
+        const spans = collectSupportedOptionalConditionBranchSpans(sql);
+
+        expect(spans.map(span => span.parameterName)).toEqual(['keyword', 'status']);
+        expect(spans[0].sourceRange.text).toBe("(CAST(:keyword AS text) IS NULL OR u.email ILIKE '%' || :keyword || '%' OR u.name ILIKE '%' || :keyword || '%')");
+        expect(spans[1].sourceRange.text).toBe('(:status::text IS NULL OR u.status = :status)');
+    });
+
     it('prunes a top-level optional scalar predicate when the targeted parameter is null', () => {
         const sql = `
             SELECT p.product_id
@@ -354,6 +369,25 @@ describe('pruneOptionalConditionBranches', () => {
         const formattedSql = formatSql(sql, { brand_name: null });
 
         expect(formattedSql).toBe('select "p"."product_id" from "products" as "p"');
+    });
+
+    it('prunes casted null guard branches with multiple meaningful predicates', () => {
+        const sql = `
+            SELECT u.id, u.email
+            FROM users u
+            WHERE (
+                cast(:keyword as text) is null
+                OR u.email ilike '%' || :keyword || '%'
+                OR u.name ilike '%' || :keyword || '%'
+            )
+              AND (:status::text is null OR u.status = :status)
+        `;
+
+        const formattedSql = formatSql(sql, { keyword: null });
+
+        expect(formattedSql).toBe(
+            'select "u"."id", "u"."email" from "users" as "u" where (cast(:status as text) is null or "u"."status" = :status)'
+        );
     });
 
     it('leaves non-top-level optional branches untouched', () => {

--- a/packages/core/tests/transformers/SSSQLFilterBuilder.test.ts
+++ b/packages/core/tests/transformers/SSSQLFilterBuilder.test.ts
@@ -66,6 +66,38 @@ describe('SSSQLFilterBuilder', () => {
         ]));
     });
 
+    it('plans scalar scaffold into the root query when earlier CTEs already contain WHERE clauses', () => {
+        const builder = new SSSQLFilterBuilder();
+        const sql = `
+            with latest_customer_reply as (
+                select tm.ticket_id, max(tm.created_at) as last_customer_reply_at
+                from ticket_messages tm
+                where tm.sender_role = 'customer'
+                group by tm.ticket_id
+            )
+            select t.ticket_id, t.status
+            from tickets t
+            left join latest_customer_reply lcr on lcr.ticket_id = t.ticket_id
+            order by t.ticket_id
+        `;
+
+        const plan = builder.planScaffoldBranch(sql, {
+            target: 'tickets.status',
+            parameterName: 'status',
+            operator: '='
+        });
+
+        expect(plan.ok).toBe(true);
+        expect(plan.requiresFullReformat).toBe(false);
+        expect(plan.sql).toBe(applyPlan(sql, plan.edits));
+        expect(normalizeSql(plan.sql ?? '')).toContain(
+            "where tm.sender_role = 'customer' group by tm.ticket_id"
+        );
+        expect(normalizeSql(plan.sql ?? '')).toContain(
+            'from tickets t left join latest_customer_reply lcr on lcr.ticket_id = t.ticket_id where (:status is null or t.status = :status) order by t.ticket_id'
+        );
+    });
+
     it('plans scalar scaffold for AS aliases and quoted identifiers without full reformat', () => {
         const builder = new SSSQLFilterBuilder();
         const sql = 'select "u"."id", "u"."name" from "users" as "u" where "u"."active" = true';
@@ -606,6 +638,31 @@ describe('SSSQLFilterBuilder', () => {
 
         const removedAgain = builder.remove(removed, { parameterName: 'category_name', kind: 'exists' });
         expect(normalizeSql(new SqlFormatter().format(removedAgain).formattedSql)).toBe(normalized);
+    });
+
+    it('lists casted null-guard optional expression branches', () => {
+        const builder = new SSSQLFilterBuilder();
+        const sql = `
+            select u.id, u.email
+            from users u
+            where (cast(:keyword as text) is null
+                or u.email ilike '%' || :keyword || '%'
+                or u.name ilike '%' || :keyword || '%')
+              and (:status::text is null or u.status = :status)
+        `;
+
+        expect(builder.list(sql)).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                parameterName: 'keyword',
+                kind: 'expression'
+            }),
+            expect.objectContaining({
+                parameterName: 'status',
+                kind: 'scalar',
+                operator: '=',
+                target: 'u.status'
+            })
+        ]));
     });
 
     it('removes not-exists branches idempotently', () => {


### PR DESCRIPTION
## Summary

- Fix SSSQL scalar scaffold planning so root-query filters are inserted into the root query, not into the first CTE-local `WHERE`.
- Recognize SSSQL optional null guards written as `:param::type IS NULL` and `CAST(:param AS type) IS NULL`, including multi-predicate same-parameter branches.
- Add `||` operator precedence so SQL such as `column ILIKE '%' || :keyword || '%' OR ...` is parsed as the SQL engine would read it.

## Verification

- `pnpm --filter rawsql-ts test -- SSSQLFilterBuilder.test.ts PruneOptionalConditionBranches.test.ts`
- `pnpm --filter rawsql-ts test`
- `pnpm --filter rawsql-ts build`
- `pnpm --filter rawsql-ts lint`
- `pnpm --filter rawsql-ts benchmark`
- `pnpm demo:complex-sql`
- Pre-commit hook: workspace `typecheck`, `test`, `build`, and `lint`

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: Not required; no baseline exception requested.
Scoped checks run: Focused core tests, full core test/build/lint, core benchmark, complex SQL demo, and pre-commit workspace typecheck/test/build/lint.
Why full baseline is not required: Full baseline exception is not requested; the pre-commit workspace checks also passed.

## Self Review

Self-review workflow: developer-self-review skill, two-cycle consistency and human-acceptance review.
Self-review result: No blockers remain. Focused tests cover the Ashiba dogfooding failure shapes and full core/workspace hooks passed.
Concept-review workflow: packages/core AGENTS scope and repository review minimums checked for parser/analyzer ownership and driver boundary leakage.
Concept-review result: No package-boundary violation found. The fix stays in core AST/planner logic; no driver adapter parsing or regex-based adapter behavior was added.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: This PR changes core parser/planner behavior only and does not add, rename, or remove CLI commands or flags.
Upgrade note: Users receive improved SSSQL optional-condition recognition after upgrading `rawsql-ts`.
Deprecation/removal plan or issue: No deprecation or removal.
Docs/help/examples updated: No CLI docs or examples changed; release wording is covered by the changeset.
Release/changeset wording: `.changeset/sssql-planner-scope-and-cast.md`

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: This PR does not change scaffold templates or generated application contracts.
Non-edit assertion: No scaffold-owned generated output is changed.
Fail-fast input-contract proof: Not applicable to this parser/planner fix.
Generated-output viability proof: Not applicable; no scaffold output was generated or changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query planning for CTEs with WHERE clauses
  * Extended support for additional SQL null-guard syntax patterns

* **Tests**
  * Added coverage for cast-based null-guard and CTE query scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->