### PR TITLE
Keep SSSQL refresh idempotent

### DIFF
--- a/.changeset/sssql-refresh-idempotency.md
+++ b/.changeset/sssql-refresh-idempotency.md
@@ -1,0 +1,7 @@
+---
+"rawsql-ts": patch
+---
+
+Keep SSSQL refresh and scaffold planning idempotent when optional branches already use casted null guards.
+
+The SSSQL planner no longer adds a duplicate scalar branch when an equivalent branch already exists with a casted null guard. Refresh planning also keeps existing parameter-named branches in place when the caller does not provide a resolvable physical target name.

--- a/packages/core/src/transformers/SSSQLFilterBuilder.ts
+++ b/packages/core/src/transformers/SSSQLFilterBuilder.ts
@@ -885,6 +885,21 @@ const getBranchInfo = (branch: SupportedOptionalConditionBranch): SssqlBranchInf
     };
 };
 
+const isEquivalentScalarBranch = (
+    branch: SssqlBranchInfo,
+    query: SimpleSelectQuery,
+    parameterName: string,
+    operator: SssqlScalarOperator,
+    targetColumnText: string
+): boolean => {
+    return branch.query === query
+        && branch.kind === "scalar"
+        && branch.parameterName === parameterName
+        && branch.operator === operator
+        && branch.target !== undefined
+        && normalizeIdentifier(branch.target) === normalizeIdentifier(targetColumnText);
+};
+
 /**
  * Builds and refreshes truthful SSSQL optional filter branches.
  * Runtime callers should use pruning, not dynamic predicate injection.
@@ -949,6 +964,17 @@ export class SSSQLFilterBuilder {
     }
 
     planRefresh(query: SelectQuery | string, filters: SSSQLFilterInput): SssqlRewritePlan {
+        if (typeof query === "string") {
+            try {
+                const parsed = SelectQueryParser.parse(query);
+                const result = this.refreshParsed(parsed, filters);
+                if (!result.changed) {
+                    return this.buildPlanFromEdits(query, [], [], []);
+                }
+            } catch {
+                // Fall through to the conservative formatter-backed plan, which reports rewrite errors.
+            }
+        }
         return this.planRewrite(query, parsed => this.refresh(parsed, filters));
     }
 
@@ -1013,7 +1039,12 @@ export class SSSQLFilterBuilder {
 
     refresh(query: SelectQuery | string, filters: SSSQLFilterInput): SelectQuery {
         const parsed = this.parseQuery(query);
+        this.refreshParsed(parsed, filters);
+        return parsed;
+    }
 
+    private refreshParsed(parsed: SelectQuery, filters: SSSQLFilterInput): { query: SelectQuery; changed: boolean } {
+        let changed = false;
         for (const [filterName, filterValue] of Object.entries(filters)) {
             let parameterName = filterName;
             let target: ResolvedFilterTarget | null = null;
@@ -1043,6 +1074,7 @@ export class SSSQLFilterBuilder {
                     parameterName: target.parameterName,
                     operator: "="
                 });
+                changed = true;
                 continue;
             }
 
@@ -1064,20 +1096,25 @@ export class SSSQLFilterBuilder {
                 this.rebaseMovedBranchByAlias(match.expression, correlatedPlan.sourceAlias, correlatedPlan.target.column);
                 rebuildWhereWithoutTerm(match.query, match.expression);
                 correlatedPlan.target.query.appendWhere(match.expression);
+                changed = true;
                 continue;
             }
 
             if (!target) {
-                target = this.resolveTarget(parsed, filterName);
+                target = this.tryResolveTarget(parsed, filterName);
+                if (!target) {
+                    continue;
+                }
             }
             if (match.query !== target.query) {
                 this.rebaseMovedBranch(match.expression, match.query, target.column);
                 rebuildWhereWithoutTerm(match.query, match.expression);
                 target.query.appendWhere(match.expression);
+                changed = true;
             }
         }
 
-        return parsed;
+        return { query: parsed, changed };
     }
 
     remove(query: SelectQuery | string, spec: SssqlRemoveSpec): SelectQuery {
@@ -1128,7 +1165,8 @@ export class SSSQLFilterBuilder {
         const branchSql = `(:${parameterName} is null or ${targetColumnText} ${operator} :${parameterName})`;
         const normalizedBranch = normalizeSql(branchSql);
         const duplicate = this.list(parsed).find(existing =>
-            existing.query === target.query && normalizeSql(existing.sql) === normalizedBranch
+            (existing.query === target.query && normalizeSql(existing.sql) === normalizedBranch)
+            || isEquivalentScalarBranch(existing, target.query, parameterName, operator, targetColumnText)
         );
 
         if (duplicate) {
@@ -1704,6 +1742,14 @@ export class SSSQLFilterBuilder {
             column: matches[0]!.value,
             parameterName: makeParameterName(filterName)
         };
+    }
+
+    private tryResolveTarget(root: SelectQuery, filterName: string): ResolvedFilterTarget | null {
+        try {
+            return this.resolveTarget(root, filterName);
+        } catch {
+            return null;
+        }
     }
 
     private findAliasForTable(query: SimpleSelectQuery, tableName: string): string | null {

--- a/packages/core/tests/transformers/SSSQLFilterBuilder.test.ts
+++ b/packages/core/tests/transformers/SSSQLFilterBuilder.test.ts
@@ -98,6 +98,58 @@ describe('SSSQLFilterBuilder', () => {
         );
     });
 
+    it('does not add a duplicate scalar branch when an equivalent casted null guard already exists', () => {
+        const builder = new SSSQLFilterBuilder();
+        const sql = `
+            select t.ticket_id, t.status
+            from tickets t
+            where (cast(:status as text) is null or t.status = :status)
+            order by t.ticket_id
+        `;
+
+        const plan = builder.planScaffoldBranch(sql, {
+            target: 'tickets.status',
+            parameterName: 'status',
+            operator: '='
+        });
+
+        expect(plan.ok).toBe(true);
+        expect(plan.requiresFullReformat).toBe(false);
+        expect(plan.edits).toHaveLength(0);
+        expect(plan.sql).toBe(sql);
+    });
+
+    it('plans refresh as a no-op when existing casted optional branches do not need moving', () => {
+        const builder = new SSSQLFilterBuilder();
+        const sql = `
+            select t.ticket_id, t.status, c.tier
+            from tickets t
+            join customers c on c.customer_id = t.customer_id
+            where (cast(:status as text) is null or t.status = :status)
+              and (cast(:customerTier as text) is null or c.tier = :customerTier)
+              and (
+                  :keyword is null
+                  or t.subject ilike '%' || :keyword || '%'
+                  or c.name ilike '%' || :keyword || '%'
+              )
+            order by t.ticket_id
+        `;
+
+        const plan = builder.planRefresh(sql, {
+            status: null,
+            customerTier: null,
+            keyword: null
+        });
+
+        expect(plan.ok).toBe(true);
+        expect(plan.requiresFullReformat).toBe(false);
+        expect(plan.edits).toHaveLength(0);
+        expect(plan.sql).toBe(sql);
+        expect(plan.safety.changedOnlyTargetBranches).toBe(true);
+        expect(plan.warnings).toEqual([]);
+        expect(plan.errors).toEqual([]);
+    });
+
     it('plans scalar scaffold for AS aliases and quoted identifiers without full reformat', () => {
         const builder = new SSSQLFilterBuilder();
         const sql = 'select "u"."id", "u"."name" from "users" as "u" where "u"."active" = true';
@@ -663,6 +715,26 @@ describe('SSSQLFilterBuilder', () => {
                 target: 'u.status'
             })
         ]));
+    });
+
+    it('refresh keeps existing scalar branches when the parameter name is not a resolvable target name', () => {
+        const builder = new SSSQLFilterBuilder();
+        const sql = `
+            select t.ticket_id, c.tier as customer_tier
+            from tickets t
+            join customers c on c.customer_id = t.customer_id
+            where (cast(:customerTier as text) is null or c.tier = :customerTier)
+        `;
+
+        const plan = builder.planRefresh(sql, { customerTier: null });
+
+        expect(plan.ok).toBe(true);
+        expect(plan.requiresFullReformat).toBe(false);
+        expect(plan.edits).toHaveLength(0);
+        expect(plan.sql).toBe(sql);
+        expect(plan.sql).toContain('cast(:customerTier as text) is null');
+        expect(plan.sql).toContain('c.tier = :customerTier');
+        expect(plan.errors).toEqual([]);
     });
 
     it('removes not-exists branches idempotently', () => {


### PR DESCRIPTION
## Summary

- Keep SSSQL scalar scaffold planning idempotent when an equivalent branch already exists with a casted null guard.
- Keep `refresh` from failing when callers identify an existing branch by `parameterName` rather than a resolvable physical target name.
- Add regression coverage for the Ashiba tarball dogfooding cases.

## Verification

- `pnpm --filter rawsql-ts test -- SSSQLFilterBuilder.test.ts PruneOptionalConditionBranches.test.ts`
- `pnpm --filter rawsql-ts test`
- `pnpm --filter rawsql-ts build`
- `pnpm --filter rawsql-ts lint`
- Pre-commit hook: workspace `typecheck`, `test`, `build`, and `lint`

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: Not required; no baseline exception requested.
Scoped checks run: Focused core tests, full core test/build/lint, and pre-commit workspace typecheck/test/build/lint.
Why full baseline is not required: Full baseline exception is not requested; the pre-commit workspace checks also passed.

## Self Review

Self-review workflow: developer-self-review skill, two-cycle consistency and human-acceptance review.
Self-review result: No blockers remain. Tests cover duplicate casted-guard scaffold planning and parameter-named refresh no-op behavior.
Concept-review workflow: packages/core AGENTS scope checked for parser/planner ownership and driver boundary leakage.
Concept-review result: No package-boundary violation found. The fix stays in core SSSQL planner logic and does not add driver adapter parsing.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: This PR changes core planner behavior only and does not add, rename, or remove CLI commands or flags.
Upgrade note: Users receive idempotent SSSQL refresh/scaffold behavior after upgrading `rawsql-ts`.
Deprecation/removal plan or issue: No deprecation or removal.
Docs/help/examples updated: No CLI docs or examples changed; release wording is covered by the changeset.
Release/changeset wording: `.changeset/sssql-refresh-idempotency.md`

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: This PR does not change scaffold templates or generated application contracts.
Non-edit assertion: No scaffold-owned generated output is changed.
Fail-fast input-contract proof: Not applicable to this parser/planner fix.
Generated-output viability proof: Not applicable; no scaffold output was generated or changed.
