### PR TITLE
Fix release PR changeset validation

### DIFF
--- a/.changeset/fresh-vitest-scaffold.md
+++ b/.changeset/fresh-vitest-scaffold.md
@@ -1,5 +1,0 @@
----
-"@rawsql-ts/ztd-cli": patch
----
-
-Align the generated project Vitest devDependency with the workspace-supported Vitest version.


### PR DESCRIPTION
## Summary
- Remove the stale changeset that references the deleted `@rawsql-ts/ztd-cli` workspace package.
- Keep the current release PR changesets scoped to existing packages only.

## Verification
- `pnpm changeset status`
- `GITHUB_TOKEN=$(gh auth token) pnpm changeset version` equivalent on Windows via PowerShell env assignment; confirmed the changeset version step succeeds after the stale changeset is removed, then restored generated version files so this PR only removes the stale changeset.

## Merge Readiness
- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

## Self Review
Self-review workflow: verification
Self-review result: No blockers remain for this stale changeset removal.
Concept-review workflow: No concept-impact; this only removes a changeset that targets a deleted workspace package.
Concept-review result: No concept or package-boundary violations remain.

## Notes
The failed Release PR run stopped because Changesets could not assemble a release plan for `@rawsql-ts/ztd-cli`, which was removed from the workspace in #860.