### PR TITLE
Support recent PostgreSQL query syntax

### DIFF
--- a/.changeset/pg16-sql-json-syntax.md
+++ b/.changeset/pg16-sql-json-syntax.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": minor
+---
+
+Add parser and formatter support for PostgreSQL 16 SQL/JSON predicates and constructor argument syntax.

--- a/.changeset/pg17-merge-syntax.md
+++ b/.changeset/pg17-merge-syntax.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": patch
+---
+
+Add regression coverage for PostgreSQL 17 `MERGE` extensions, including `WHEN NOT MATCHED BY SOURCE` with `MERGE RETURNING merge_action()`.

--- a/.changeset/pg18-returning-aliases.md
+++ b/.changeset/pg18-returning-aliases.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": minor
+---
+
+Add parser and formatter support for PostgreSQL 18 `RETURNING WITH (OLD AS ..., NEW AS ...)` aliases.

--- a/.changeset/pg19-query-syntax.md
+++ b/.changeset/pg19-query-syntax.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": minor
+---
+
+Add parser and formatter support for PostgreSQL 19 query syntax, including `INSERT ... ON CONFLICT DO SELECT`, `INSERT ... ON CONFLICT DO UPDATE`, `GROUP BY ALL`, and window function `IGNORE NULLS` / `RESPECT NULLS` clauses.

--- a/packages/core/src/models/Clause.ts
+++ b/packages/core/src/models/Clause.ts
@@ -478,16 +478,31 @@ export class SourceAliasExpression extends SqlComponent {
     }
 }
 
+export type ReturningAliasKind = "old" | "new";
+
+export class ReturningAlias extends SqlComponent {
+    static kind = Symbol("ReturningAlias");
+    kind: ReturningAliasKind;
+    alias: IdentifierString;
+    constructor(kind: ReturningAliasKind, alias: string | IdentifierString) {
+        super();
+        this.kind = kind;
+        this.alias = typeof alias === "string" ? new IdentifierString(alias) : alias;
+    }
+}
+
 export class ReturningClause extends SqlComponent {
     static kind = Symbol("ReturningClause");
     items: SelectItem[];
+    aliases: ReturningAlias[];
     /**
      * Constructs a ReturningClause.
      * @param items Array of SelectItem.
      */
-    constructor(items: SelectItem[]) {
+    constructor(items: SelectItem[], aliases: ReturningAlias[] = []) {
         super();
         this.items = items;
+        this.aliases = aliases;
     }
 
     /**

--- a/packages/core/src/models/Clause.ts
+++ b/packages/core/src/models/Clause.ts
@@ -127,9 +127,11 @@ export class OrderByItem extends SqlComponent {
 
 export class GroupByClause extends SqlComponent {
     static kind = Symbol("GroupByClause");
+    mode: "all" | "distinct" | null;
     grouping: ValueComponent[];
-    constructor(expression: ValueComponent[]) {
+    constructor(expression: ValueComponent[], mode: "all" | "distinct" | null = null) {
         super();
+        this.mode = mode;
         this.grouping = expression;
     }
 }
@@ -499,6 +501,36 @@ export class ReturningClause extends SqlComponent {
             // Fallback for expressions: use alias if available, otherwise empty
             return new IdentifierString(item.identifier?.name ?? "");
         });
+    }
+}
+
+export type OnConflictAction = "nothing" | "select" | "update";
+export type OnConflictTargetKind = "columns" | "constraint";
+
+export class OnConflictClause extends SqlComponent {
+    static kind = Symbol("OnConflictClause");
+    target: RawString | null;
+    targetKind: OnConflictTargetKind | null;
+    action: OnConflictAction;
+    setClause: SetClause | null;
+    forClause: ForClause | null;
+    whereClause: WhereClause | null;
+
+    constructor(params: {
+        target?: RawString | string | null;
+        targetKind?: OnConflictTargetKind | null;
+        action: OnConflictAction;
+        setClause?: SetClause | null;
+        forClause?: ForClause | null;
+        whereClause?: WhereClause | null;
+    }) {
+        super();
+        this.target = typeof params.target === "string" ? new RawString(params.target) : params.target ?? null;
+        this.targetKind = params.targetKind ?? null;
+        this.action = params.action;
+        this.setClause = params.setClause ?? null;
+        this.forClause = params.forClause ?? null;
+        this.whereClause = params.whereClause ?? null;
     }
 }
 

--- a/packages/core/src/models/InsertQuery.ts
+++ b/packages/core/src/models/InsertQuery.ts
@@ -2,12 +2,13 @@
 // Supports single/multi-row VALUES and INSERT ... SELECT.
 import { SqlComponent } from "./SqlComponent";
 import { SelectQuery } from "./SelectQuery";
-import { InsertClause, ReturningClause } from "./Clause";
+import { InsertClause, OnConflictClause, ReturningClause } from "./Clause";
 
 export class InsertQuery extends SqlComponent {
     static kind = Symbol("InsertQuery");
     insertClause: InsertClause;
     selectQuery: SelectQuery | null;
+    onConflictClause: OnConflictClause | null;
     returningClause: ReturningClause | null;
 
     /**
@@ -18,11 +19,13 @@ export class InsertQuery extends SqlComponent {
     constructor(params: {
         insertClause: InsertClause;
         selectQuery?: SelectQuery | null;
+        onConflict?: OnConflictClause | null;
         returning?: ReturningClause | null;
     }) {
         super();
         this.insertClause = params.insertClause;
         this.selectQuery = params.selectQuery ?? null;
+        this.onConflictClause = params.onConflict ?? null;
         this.returningClause = params.returning ?? null;
     }
 }

--- a/packages/core/src/models/SqlPrintToken.ts
+++ b/packages/core/src/models/SqlPrintToken.ts
@@ -76,6 +76,7 @@ export enum SqlPrintTokenContainerType {
     FetchExpression = "FetchExpression",
     InsertQuery = "InsertQuery",
     InsertClause = "InsertClause",
+    OnConflictClause = "OnConflictClause",
     UpdateQuery = "UpdateQuery",
     UpdateClause = "UpdateClause",
     DeleteQuery = "DeleteQuery",

--- a/packages/core/src/models/ValueComponent.ts
+++ b/packages/core/src/models/ValueComponent.ts
@@ -21,6 +21,7 @@ export type ValueComponent = ValueList |
     ArraySliceExpression |
     ArrayIndexExpression |
     BetweenExpression |
+    JsonPredicateExpression |
     InlineQuery |
     StringSpecifierExpression |
     TypeValue |
@@ -351,6 +352,29 @@ export class BetweenExpression extends SqlComponent {
         this.lower = lower;
         this.upper = upper;
         this.negated = negated;
+    }
+}
+
+export type JsonPredicateType = "value" | "scalar" | "array" | "object";
+export type JsonPredicateUniqueKeys = "with" | "without";
+
+export class JsonPredicateExpression extends SqlComponent {
+    static kind = Symbol("JsonPredicateExpression");
+    expression: ValueComponent;
+    negated: boolean;
+    jsonType: JsonPredicateType | null;
+    uniqueKeys: JsonPredicateUniqueKeys | null;
+    constructor(
+        expression: ValueComponent,
+        negated: boolean,
+        jsonType: JsonPredicateType | null = null,
+        uniqueKeys: JsonPredicateUniqueKeys | null = null
+    ) {
+        super();
+        this.expression = expression;
+        this.negated = negated;
+        this.jsonType = jsonType;
+        this.uniqueKeys = uniqueKeys;
     }
 }
 

--- a/packages/core/src/models/ValueComponent.ts
+++ b/packages/core/src/models/ValueComponent.ts
@@ -86,6 +86,7 @@ export class FunctionCall extends SqlComponent {
     qualifiedName: QualifiedName;
     argument: ValueComponent | null;
     over: OverExpression | null;
+    nullsTreatment: "ignore nulls" | "respect nulls" | null;
     withinGroup: OrderByClause | null;
     withOrdinality: boolean;
     internalOrderBy: OrderByClause | null;
@@ -99,12 +100,14 @@ export class FunctionCall extends SqlComponent {
         withinGroup: OrderByClause | null = null,
         withOrdinality: boolean = false,
         internalOrderBy: OrderByClause | null = null,
-        filterCondition: ValueComponent | null = null
+        filterCondition: ValueComponent | null = null,
+        nullsTreatment: "ignore nulls" | "respect nulls" | null = null
     ) {
         super();
         this.qualifiedName = new QualifiedName(namespaces, name);
         this.argument = argument;
         this.over = over;
+        this.nullsTreatment = nullsTreatment;
         this.withinGroup = withinGroup;
         this.withOrdinality = withOrdinality;
         this.internalOrderBy = internalOrderBy;

--- a/packages/core/src/parsers/FunctionExpressionParser.ts
+++ b/packages/core/src/parsers/FunctionExpressionParser.ts
@@ -199,17 +199,20 @@ export class FunctionExpressionParser {
                 idx++; // Skip single "with ordinality" token
             }
 
+            const nullsTreatment = this.parseNullsTreatment(lexemes, idx);
+            idx = nullsTreatment.newIndex;
+
             if (idx < lexemes.length && lexemes[idx].value === "over") {
                 const over = OverExpressionParser.parseFromLexeme(lexemes, idx);
                 idx = over.newIndex;
-                const value = new FunctionCall(namespaces, name.name, arg.value, over.value, withinGroup, withOrdinality, internalOrderBy, filterCondition);
+                const value = new FunctionCall(namespaces, name.name, arg.value, over.value, withinGroup, withOrdinality, internalOrderBy, filterCondition, nullsTreatment.value);
                 // Set closing comments if available
                 if (closingComments && closingComments.length > 0) {
                     value.addPositionedComments("after", closingComments);
                 }
                 return { value, newIndex: idx };
             } else {
-                const value = new FunctionCall(namespaces, name.name, arg.value, null, withinGroup, withOrdinality, internalOrderBy, filterCondition);
+                const value = new FunctionCall(namespaces, name.name, arg.value, null, withinGroup, withOrdinality, internalOrderBy, filterCondition, nullsTreatment.value);
                 // Set closing comments if available
                 if (closingComments && closingComments.length > 0) {
                     value.addPositionedComments("after", closingComments);
@@ -283,15 +286,18 @@ export class FunctionExpressionParser {
                     idx++; // Skip single "with ordinality" token
                 }
                 
+                const nullsTreatment = this.parseNullsTreatment(lexemes, idx);
+                idx = nullsTreatment.newIndex;
+
                 // Use the previously parsed namespaces and function name for consistency
                 if (idx < lexemes.length && lexemes[idx].value === "over") {
                     idx++;
                     const over = OverExpressionParser.parseFromLexeme(lexemes, idx);
                     idx = over.newIndex;
-                    const value = new FunctionCall(namespaces, name.name, arg, over.value, withinGroup, withOrdinality, null);
+                    const value = new FunctionCall(namespaces, name.name, arg, over.value, withinGroup, withOrdinality, null, null, nullsTreatment.value);
                     return { value, newIndex: idx };
                 } else {
-                    const value = new FunctionCall(namespaces, name.name, arg, null, withinGroup, withOrdinality, null);
+                    const value = new FunctionCall(namespaces, name.name, arg, null, withinGroup, withOrdinality, null, null, nullsTreatment.value);
                     return { value, newIndex: idx };
                 }
             } else {
@@ -300,6 +306,14 @@ export class FunctionExpressionParser {
         } else {
             throw ParseError.fromUnparsedLexemes(lexemes, idx, `Missing opening parenthesis for function '${name.name}'.`);
         }
+    }
+
+    private static parseNullsTreatment(lexemes: Lexeme[], index: number): { value: "ignore nulls" | "respect nulls" | null; newIndex: number } {
+        const value = lexemes[index]?.value;
+        if (value === "ignore nulls" || value === "respect nulls") {
+            return { value, newIndex: index + 1 };
+        }
+        return { value: null, newIndex: index };
     }
 
     public static parseTypeValue(lexemes: Lexeme[], index: number): { value: TypeValue; newIndex: number; } {

--- a/packages/core/src/parsers/FunctionExpressionParser.ts
+++ b/packages/core/src/parsers/FunctionExpressionParser.ts
@@ -171,6 +171,9 @@ export class FunctionExpressionParser {
             let internalOrderBy: OrderByClause | null = null;
             
             if (this.SQL_JSON_CONSTRUCTORS.has(functionName)) {
+                // SQL/JSON constructor arguments contain VALUE pairs and ON NULL/RETURNING
+                // clauses that do not fit the current function-argument AST. Preserve the
+                // source fragment until #866 adds structured SQL/JSON constructor nodes.
                 const result = this.parseRawFunctionArguments(lexemes, idx);
                 arg = { value: result.argument, newIndex: result.newIndex };
                 closingComments = result.closingComments;
@@ -236,6 +239,11 @@ export class FunctionExpressionParser {
         }
     }
 
+    /**
+     * Captures SQL/JSON constructor arguments as RawString while preserving closing
+     * comments via getClosingComments. Empty argument lists still use ValueList.
+     * Tracking structured AST support: https://github.com/mk3008/rawsql-ts/issues/866
+     */
     private static parseRawFunctionArguments(lexemes: Lexeme[], index: number): { argument: RawString | ValueList; closingComments: string[] | null; newIndex: number } {
         let idx = index;
         if (idx >= lexemes.length || !(lexemes[idx].type & TokenType.OpenParen)) {

--- a/packages/core/src/parsers/FunctionExpressionParser.ts
+++ b/packages/core/src/parsers/FunctionExpressionParser.ts
@@ -9,6 +9,7 @@ import { SelectQueryParser } from "./SelectQueryParser";
 import { OrderByClauseParser } from "./OrderByClauseParser";
 import { ParseError } from "./ParseError";
 import { extractLexemeComments } from "./utils/LexemeCommentUtils";
+import { joinLexemeValues } from "../utils/ParserStringUtils";
 
 export class FunctionExpressionParser {
     /**
@@ -17,6 +18,13 @@ export class FunctionExpressionParser {
     private static readonly AGGREGATE_FUNCTIONS_WITH_ORDER_BY = new Set([
         'string_agg', 'array_agg', 'json_agg', 'jsonb_agg', 
         'json_object_agg', 'jsonb_object_agg', 'xmlagg'
+    ]);
+
+    private static readonly SQL_JSON_CONSTRUCTORS = new Set([
+        'json_array',
+        'json_object',
+        'json_scalar',
+        'json_serialize'
     ]);
 
     /**
@@ -162,7 +170,11 @@ export class FunctionExpressionParser {
             
             let internalOrderBy: OrderByClause | null = null;
             
-            if (this.AGGREGATE_FUNCTIONS_WITH_ORDER_BY.has(functionName)) {
+            if (this.SQL_JSON_CONSTRUCTORS.has(functionName)) {
+                const result = this.parseRawFunctionArguments(lexemes, idx);
+                arg = { value: result.argument, newIndex: result.newIndex };
+                closingComments = result.closingComments;
+            } else if (this.AGGREGATE_FUNCTIONS_WITH_ORDER_BY.has(functionName)) {
                 // Use special aggregate function argument parser with comment capture
                 const result = this.parseAggregateArguments(lexemes, idx);
                 arg = { value: result.arguments, newIndex: result.newIndex };
@@ -222,6 +234,39 @@ export class FunctionExpressionParser {
         } else {
             throw ParseError.fromUnparsedLexemes(lexemes, idx, `Expected opening parenthesis after function name '${name.name}'.`);
         }
+    }
+
+    private static parseRawFunctionArguments(lexemes: Lexeme[], index: number): { argument: RawString | ValueList; closingComments: string[] | null; newIndex: number } {
+        let idx = index;
+        if (idx >= lexemes.length || !(lexemes[idx].type & TokenType.OpenParen)) {
+            throw ParseError.fromUnparsedLexemes(lexemes, idx, `Expected opening parenthesis.`);
+        }
+
+        const contentStart = idx + 1;
+        let depth = 1;
+        idx++;
+
+        while (idx < lexemes.length && depth > 0) {
+            if (lexemes[idx].type & TokenType.OpenParen) {
+                depth++;
+            } else if (lexemes[idx].type & TokenType.CloseParen) {
+                depth--;
+            }
+
+            if (depth === 0) {
+                const closingComments = this.getClosingComments(lexemes[idx]);
+                const rawText = joinLexemeValues(lexemes, contentStart, idx);
+                idx++;
+                return {
+                    argument: rawText.length > 0 ? new RawString(rawText) : new ValueList([]),
+                    closingComments,
+                    newIndex: idx
+                };
+            }
+            idx++;
+        }
+
+        throw ParseError.fromUnparsedLexemes(lexemes, idx, `Expected closing parenthesis.`);
     }
 
     private static parseKeywordFunction(

--- a/packages/core/src/parsers/GroupByParser.ts
+++ b/packages/core/src/parsers/GroupByParser.ts
@@ -30,28 +30,51 @@ export class GroupByClauseParser {
         }
         idx++;
 
+        let mode: "all" | "distinct" | null = null;
+        if (lexemes[idx]?.value === "all" || lexemes[idx]?.value === "distinct") {
+            mode = lexemes[idx].value as "all" | "distinct";
+            idx++;
+        }
+
         if (idx >= lexemes.length) {
+            if (mode === "all") {
+                return { value: new GroupByClause([], mode), newIndex: idx };
+            }
             throw new Error(`Syntax error: Unexpected end of input after 'GROUP BY' keyword. The GROUP BY clause requires at least one expression to group by.`);
         }
 
         const items: ValueComponent[] = [];
-        const item = this.parseItem(lexemes, idx);
-        items.push(item.value);
-        idx = item.newIndex;
-
-        while (idx < lexemes.length && (lexemes[idx].type & TokenType.Comma)) {
-            idx++;
+        if (!this.isClauseBoundary(lexemes[idx])) {
             const item = this.parseItem(lexemes, idx);
             items.push(item.value);
             idx = item.newIndex;
+
+            while (idx < lexemes.length && (lexemes[idx].type & TokenType.Comma)) {
+                idx++;
+                const item = this.parseItem(lexemes, idx);
+                items.push(item.value);
+                idx = item.newIndex;
+            }
         }
 
-        if (items.length === 0) {
+        if (items.length === 0 && mode !== "all") {
             throw new Error(`Syntax error at position ${index}: No grouping expressions found. The GROUP BY clause requires at least one expression to group by.`);
         } else {
-            const clause = new GroupByClause(items);
+            const clause = new GroupByClause(items, mode);
             return { value: clause, newIndex: idx };
         }
+    }
+
+    private static isClauseBoundary(lexeme: Lexeme): boolean {
+        return [
+            "having",
+            "window",
+            "order by",
+            "limit",
+            "offset",
+            "fetch",
+            "for",
+        ].includes(lexeme.value);
     }
 
     private static parseItem(lexemes: Lexeme[], index: number): { value: ValueComponent; newIndex: number } {

--- a/packages/core/src/parsers/GroupByParser.ts
+++ b/packages/core/src/parsers/GroupByParser.ts
@@ -31,8 +31,9 @@ export class GroupByClauseParser {
         idx++;
 
         let mode: "all" | "distinct" | null = null;
-        if (lexemes[idx]?.value === "all" || lexemes[idx]?.value === "distinct") {
-            mode = lexemes[idx].value as "all" | "distinct";
+        const modeCandidate = lexemes[idx]?.value.toLowerCase();
+        if (modeCandidate === "all" || modeCandidate === "distinct") {
+            mode = modeCandidate;
             idx++;
         }
 

--- a/packages/core/src/parsers/InsertQueryParser.ts
+++ b/packages/core/src/parsers/InsertQueryParser.ts
@@ -214,11 +214,11 @@ export class InsertQueryParser {
             target = joinLexemeValues(lexemes, targetStart, idx);
             targetKind = "columns";
         } else if (lexemes[idx]?.value === "on" && lexemes[idx + 1]?.value === "constraint") {
-            const targetStart = idx;
             idx += 2;
             if (idx >= lexemes.length || lexemes[idx].value === "do select" || lexemes[idx].value === "do update" || lexemes[idx].value === "do nothing") {
                 throw new Error(`Syntax error at position ${idx}: Expected constraint name after ON CONSTRAINT.`);
             }
+            const targetStart = idx;
             idx++;
             target = joinLexemeValues(lexemes, targetStart, idx);
             targetKind = "constraint";

--- a/packages/core/src/parsers/InsertQueryParser.ts
+++ b/packages/core/src/parsers/InsertQueryParser.ts
@@ -5,7 +5,7 @@ import { Lexeme, TokenType } from "../models/Lexeme";
 import { SqlTokenizer } from "./SqlTokenizer";
 import { SelectQuery } from "../models/SelectQuery";
 import { SelectQueryParser } from "./SelectQueryParser";
-import { InsertClause, ReturningClause, WithClause } from "../models/Clause";
+import { InsertClause, OnConflictClause, OnConflictTargetKind, ReturningClause, WithClause } from "../models/Clause";
 import { SelectQueryWithClauseHelper } from "../utils/SelectQueryWithClauseHelper";
 import { WithClauseParser } from "./WithClauseParser";
 import { SourceExpressionParser } from "./SourceExpressionParser";
@@ -13,6 +13,10 @@ import { ValuesQueryParser } from "./ValuesQueryParser";
 import { ReturningClauseParser } from "./ReturningClauseParser";
 import { IdentifierString } from "../models/ValueComponent";
 import { extractLexemeComments } from "./utils/LexemeCommentUtils";
+import { joinLexemeValues } from "../utils/ParserStringUtils";
+import { ForClauseParser } from "./ForClauseParser";
+import { WhereClauseParser } from "./WhereClauseParser";
+import { SetClauseParser } from "./SetClauseParser";
 
 export class InsertQueryParser {
     /**
@@ -152,11 +156,22 @@ export class InsertQueryParser {
             idx = selectResult.newIndex;
         }
 
+        let onConflictClause: OnConflictClause | null = null;
+        if (lexemes[idx]?.value === "on conflict") {
+            const onConflictResult = this.parseOnConflictClause(lexemes, idx);
+            onConflictClause = onConflictResult.value;
+            idx = onConflictResult.newIndex;
+        }
+
         let returningClause: ReturningClause | null = null;
         if (lexemes[idx]?.value === "returning") {
             const returningResult = ReturningClauseParser.parseFromLexeme(lexemes, idx);
             returningClause = returningResult.value;
             idx = returningResult.newIndex;
+        }
+
+        if (onConflictClause?.action === "select" && !returningClause) {
+            throw new Error(`Syntax error: ON CONFLICT DO SELECT requires a RETURNING clause.`);
         }
 
         const insertClause = new InsertClause(targetSource, columnIdentifiers ?? null);
@@ -175,10 +190,124 @@ export class InsertQueryParser {
             value: new InsertQuery({
                 insertClause,
                 selectQuery: dataQuery,
+                onConflict: onConflictClause,
                 returning: returningClause
             }),
             newIndex: idx
         };
+    }
+
+    private static parseOnConflictClause(lexemes: Lexeme[], index: number): { value: OnConflictClause; newIndex: number } {
+        let idx = index;
+
+        if (lexemes[idx]?.value !== "on conflict") {
+            throw new Error(`Syntax error at position ${idx}: Expected 'ON CONFLICT'.`);
+        }
+        idx++;
+
+        let target: string | null = null;
+        let targetKind: OnConflictTargetKind | null = null;
+
+        if (lexemes[idx]?.type === TokenType.OpenParen) {
+            const targetStart = idx;
+            idx = this.consumeBalancedParentheses(lexemes, idx);
+            target = joinLexemeValues(lexemes, targetStart, idx);
+            targetKind = "columns";
+        } else if (lexemes[idx]?.value === "on" && lexemes[idx + 1]?.value === "constraint") {
+            const targetStart = idx;
+            idx += 2;
+            if (idx >= lexemes.length || lexemes[idx].value === "do select" || lexemes[idx].value === "do update" || lexemes[idx].value === "do nothing") {
+                throw new Error(`Syntax error at position ${idx}: Expected constraint name after ON CONSTRAINT.`);
+            }
+            idx++;
+            target = joinLexemeValues(lexemes, targetStart, idx);
+            targetKind = "constraint";
+        }
+
+        const actionToken = lexemes[idx]?.value;
+        if (actionToken === "do nothing") {
+            idx++;
+            return {
+                value: new OnConflictClause({
+                    target,
+                    targetKind,
+                    action: "nothing",
+                }),
+                newIndex: idx
+            };
+        }
+
+        if (actionToken === "do update") {
+            idx++;
+            const setResult = SetClauseParser.parseFromLexeme(lexemes, idx);
+            idx = setResult.newIndex;
+
+            let whereClause = null;
+            if (lexemes[idx]?.value === "where") {
+                const whereResult = WhereClauseParser.parseFromLexeme(lexemes, idx);
+                whereClause = whereResult.value;
+                idx = whereResult.newIndex;
+            }
+
+            return {
+                value: new OnConflictClause({
+                    target,
+                    targetKind,
+                    action: "update",
+                    setClause: setResult.setClause,
+                    whereClause,
+                }),
+                newIndex: idx
+            };
+        }
+
+        if (actionToken !== "do select") {
+            const found = lexemes[idx]?.value ?? "end of input";
+            throw new Error(`Syntax error at position ${idx}: Expected 'DO SELECT', 'DO UPDATE', or 'DO NOTHING' after ON CONFLICT but found '${found}'.`);
+        }
+        idx++;
+
+        let forClause = null;
+        if (lexemes[idx]?.value === "for") {
+            const forResult = ForClauseParser.parseFromLexeme(lexemes, idx);
+            forClause = forResult.value;
+            idx = forResult.newIndex;
+        }
+
+        let whereClause = null;
+        if (lexemes[idx]?.value === "where") {
+            const whereResult = WhereClauseParser.parseFromLexeme(lexemes, idx);
+            whereClause = whereResult.value;
+            idx = whereResult.newIndex;
+        }
+
+        return {
+            value: new OnConflictClause({
+                target,
+                targetKind,
+                action: "select",
+                forClause,
+                whereClause,
+            }),
+            newIndex: idx
+        };
+    }
+
+    private static consumeBalancedParentheses(lexemes: Lexeme[], index: number): number {
+        let idx = index;
+        let depth = 0;
+        while (idx < lexemes.length) {
+            if (lexemes[idx].type === TokenType.OpenParen) {
+                depth++;
+            } else if (lexemes[idx].type === TokenType.CloseParen) {
+                depth--;
+                if (depth === 0) {
+                    return idx + 1;
+                }
+            }
+            idx++;
+        }
+        throw new Error(`Syntax error at position ${index}: Expected ')' after ON CONFLICT target.`);
     }
 }
 

--- a/packages/core/src/parsers/ReturningClauseParser.ts
+++ b/packages/core/src/parsers/ReturningClauseParser.ts
@@ -1,8 +1,9 @@
 // Provides parsing for RETURNING clauses in SQL (used in UPDATE, INSERT, DELETE, etc.)
 import { Lexeme, TokenType } from "../models/Lexeme";
-import { ReturningClause, SelectItem } from "../models/Clause";
+import { ReturningAlias, ReturningAliasKind, ReturningClause, SelectItem } from "../models/Clause";
 import { extractLexemeComments } from "./utils/LexemeCommentUtils";
 import { SelectItemParser } from "./SelectClauseParser";
+import { FullNameParser } from "./FullNameParser";
 
 export class ReturningClauseParser {
     /**
@@ -18,6 +19,10 @@ export class ReturningClauseParser {
         const returningLexeme = lexemes[idx];
         const returningComments = extractLexemeComments(returningLexeme);
         idx++;
+
+        const aliasResult = this.parseReturningAliases(lexemes, idx);
+        const aliases = aliasResult.aliases;
+        idx = aliasResult.newIndex;
 
         const items: SelectItem[] = [];
 
@@ -48,7 +53,7 @@ export class ReturningClauseParser {
             throw new Error(`[ReturningClauseParser] Expected a column or '*' after RETURNING at position ${position}.`);
         }
 
-        const clause = new ReturningClause(items);
+        const clause = new ReturningClause(items, aliases);
         if (returningComments.before.length > 0) {
             clause.addPositionedComments("before", returningComments.before);
         }
@@ -64,5 +69,53 @@ export class ReturningClauseParser {
         }
 
         return { value: clause, newIndex: idx };
+    }
+
+    private static parseReturningAliases(lexemes: Lexeme[], index: number): { aliases: ReturningAlias[]; newIndex: number } {
+        let idx = index;
+        const aliases: ReturningAlias[] = [];
+        if (lexemes[idx]?.value !== "with") {
+            return { aliases, newIndex: idx };
+        }
+        idx++;
+
+        if (idx >= lexemes.length || !(lexemes[idx].type & TokenType.OpenParen)) {
+            throw new Error(`[ReturningClauseParser] Expected '(' after RETURNING WITH at position ${idx}.`);
+        }
+        idx++;
+
+        while (idx < lexemes.length) {
+            const kind = lexemes[idx]?.value?.toLowerCase();
+            if (kind !== "old" && kind !== "new") {
+                throw new Error(`[ReturningClauseParser] Expected OLD or NEW in RETURNING WITH alias list at position ${idx}.`);
+            }
+            idx++;
+
+            if (lexemes[idx]?.value !== "as") {
+                throw new Error(`[ReturningClauseParser] Expected AS after ${kind.toUpperCase()} in RETURNING WITH alias list at position ${idx}.`);
+            }
+            idx++;
+
+            const aliasResult = FullNameParser.parseFromLexeme(lexemes, idx);
+            if (aliasResult.namespaces && aliasResult.namespaces.length > 0) {
+                throw new Error(`[ReturningClauseParser] RETURNING WITH alias must be an unqualified identifier at position ${idx}.`);
+            }
+            aliases.push(new ReturningAlias(kind as ReturningAliasKind, aliasResult.name));
+            idx = aliasResult.newIndex;
+
+            if (idx < lexemes.length && (lexemes[idx].type & TokenType.Comma)) {
+                idx++;
+                continue;
+            }
+
+            if (idx < lexemes.length && (lexemes[idx].type & TokenType.CloseParen)) {
+                idx++;
+                return { aliases, newIndex: idx };
+            }
+
+            throw new Error(`[ReturningClauseParser] Expected ',' or ')' in RETURNING WITH alias list at position ${idx}.`);
+        }
+
+        throw new Error(`[ReturningClauseParser] Missing closing ')' in RETURNING WITH alias list.`);
     }
 }

--- a/packages/core/src/parsers/SqlPrintTokenParser.ts
+++ b/packages/core/src/parsers/SqlPrintTokenParser.ts
@@ -1,4 +1,4 @@
-import { PartitionByClause, OrderByClause, OrderByItem, SelectClause, SelectItem, Distinct, DistinctOn, SortDirection, NullsSortDirection, TableSource, SourceExpression, FromClause, JoinClause, JoinOnClause, JoinUsingClause, FunctionSource, SourceAliasExpression, WhereClause, GroupByClause, HavingClause, SubQuerySource, WindowFrameClause, LimitClause, ForClause, OffsetClause, WindowsClause as WindowClause, CommonTable, WithClause, FetchClause, FetchExpression, InsertClause, UpdateClause, DeleteClause, UsingClause, SetClause, ReturningClause, SetClauseItem } from "../models/Clause";
+import { PartitionByClause, OrderByClause, OrderByItem, SelectClause, SelectItem, Distinct, DistinctOn, SortDirection, NullsSortDirection, TableSource, SourceExpression, FromClause, JoinClause, JoinOnClause, JoinUsingClause, FunctionSource, SourceAliasExpression, WhereClause, GroupByClause, HavingClause, SubQuerySource, WindowFrameClause, LimitClause, ForClause, OffsetClause, WindowsClause as WindowClause, CommonTable, WithClause, FetchClause, FetchExpression, InsertClause, OnConflictClause, UpdateClause, DeleteClause, UsingClause, SetClause, ReturningClause, SetClauseItem } from "../models/Clause";
 import { HintClause } from "../models/HintClause";
 import { BinarySelectQuery, SimpleSelectQuery, ValuesQuery } from "../models/SelectQuery";
 import { SqlComponent, SqlComponentVisitor, PositionedComment } from "../models/SqlComponent";
@@ -364,6 +364,7 @@ export class SqlPrintTokenParser implements SqlComponentVisitor<SqlPrintToken> {
 
         this.handlers.set(InsertQuery.kind, (expr) => this.visitInsertQuery(expr as InsertQuery));
         this.handlers.set(InsertClause.kind, (expr) => this.visitInsertClause(expr as InsertClause));
+        this.handlers.set(OnConflictClause.kind, (expr) => this.visitOnConflictClause(expr as OnConflictClause));
         this.handlers.set(UpdateQuery.kind, (expr) => this.visitUpdateQuery(expr as UpdateQuery));
         this.handlers.set(UpdateClause.kind, (expr) => this.visitUpdateClause(expr as UpdateClause));
         this.handlers.set(DeleteQuery.kind, (expr) => this.visitDeleteQuery(expr as DeleteQuery));
@@ -1145,6 +1146,11 @@ export class SqlPrintTokenParser implements SqlComponentVisitor<SqlPrintToken> {
         if (arg.withOrdinality) {
             token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
             token.innerTokens.push(new SqlPrintToken(SqlPrintTokenType.keyword, 'with ordinality'));
+        }
+
+        if (arg.nullsTreatment) {
+            token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
+            token.innerTokens.push(new SqlPrintToken(SqlPrintTokenType.keyword, arg.nullsTreatment));
         }
 
         if (arg.over) {
@@ -2490,6 +2496,15 @@ export class SqlPrintTokenParser implements SqlComponentVisitor<SqlPrintToken> {
     public visitGroupByClause(arg: GroupByClause): SqlPrintToken {
         const token = new SqlPrintToken(SqlPrintTokenType.keyword, 'group by', SqlPrintTokenContainerType.GroupByClause);
 
+        if (arg.mode) {
+            token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
+            token.innerTokens.push(new SqlPrintToken(SqlPrintTokenType.keyword, arg.mode));
+        }
+
+        if (arg.grouping.length === 0) {
+            return token;
+        }
+
         token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
         for (let i = 0; i < arg.grouping.length; i++) {
             if (i > 0) {
@@ -2837,6 +2852,11 @@ export class SqlPrintTokenParser implements SqlComponentVisitor<SqlPrintToken> {
             token.innerTokens.push(this.visit(arg.selectQuery));
         }
 
+        if (arg.onConflictClause) {
+            token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
+            token.innerTokens.push(arg.onConflictClause.accept(this));
+        }
+
         if (arg.returningClause) {
             token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
             token.innerTokens.push(arg.returningClause.accept(this));
@@ -2845,6 +2865,46 @@ export class SqlPrintTokenParser implements SqlComponentVisitor<SqlPrintToken> {
             SelectQueryWithClauseHelper.setWithClause(selectQuery, extractedWithClause);
         }
         return token;
+    }
+
+    private visitOnConflictClause(arg: OnConflictClause): SqlPrintToken {
+        const token = new SqlPrintToken(SqlPrintTokenType.keyword, 'on conflict', SqlPrintTokenContainerType.OnConflictClause);
+
+        if (arg.target) {
+            token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
+            token.innerTokens.push(arg.target.accept(this));
+        }
+
+        token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
+        token.innerTokens.push(new SqlPrintToken(SqlPrintTokenType.keyword, this.formatOnConflictAction(arg)));
+
+        if (arg.setClause) {
+            token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
+            token.innerTokens.push(arg.setClause.accept(this));
+        }
+
+        if (arg.forClause) {
+            token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
+            token.innerTokens.push(arg.forClause.accept(this));
+        }
+
+        if (arg.whereClause) {
+            token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
+            token.innerTokens.push(arg.whereClause.accept(this));
+        }
+
+        return token;
+    }
+
+    private formatOnConflictAction(arg: OnConflictClause): string {
+        switch (arg.action) {
+            case "nothing":
+                return "do nothing";
+            case "select":
+                return "do select";
+            case "update":
+                return "do update";
+        }
     }
 
     private visitInsertClause(arg: InsertClause): SqlPrintToken {

--- a/packages/core/src/parsers/SqlPrintTokenParser.ts
+++ b/packages/core/src/parsers/SqlPrintTokenParser.ts
@@ -3231,6 +3231,23 @@ export class SqlPrintTokenParser implements SqlComponentVisitor<SqlPrintToken> {
         const token = new SqlPrintToken(SqlPrintTokenType.keyword, 'returning', SqlPrintTokenContainerType.ReturningClause);
 
         token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
+        if (arg.aliases.length > 0) {
+            token.innerTokens.push(new SqlPrintToken(SqlPrintTokenType.keyword, 'with'));
+            token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
+            token.innerTokens.push(SqlPrintTokenParser.PAREN_OPEN_TOKEN);
+            for (let i = 0; i < arg.aliases.length; i++) {
+                if (i > 0) {
+                    token.innerTokens.push(...SqlPrintTokenParser.commaSpaceTokens());
+                }
+                token.innerTokens.push(new SqlPrintToken(SqlPrintTokenType.keyword, arg.aliases[i].kind));
+                token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
+                token.innerTokens.push(new SqlPrintToken(SqlPrintTokenType.keyword, 'as'));
+                token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
+                token.innerTokens.push(this.visit(arg.aliases[i].alias));
+            }
+            token.innerTokens.push(SqlPrintTokenParser.PAREN_CLOSE_TOKEN);
+            token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
+        }
         for (let i = 0; i < arg.items.length; i++) {
             if (i > 0) {
                 token.innerTokens.push(...SqlPrintTokenParser.commaSpaceTokens());

--- a/packages/core/src/parsers/SqlPrintTokenParser.ts
+++ b/packages/core/src/parsers/SqlPrintTokenParser.ts
@@ -25,6 +25,7 @@ import {
     ArraySliceExpression,
     ArrayIndexExpression,
     BetweenExpression,
+    JsonPredicateExpression,
     StringSpecifierExpression,
     TypeValue,
     TupleExpression,
@@ -306,6 +307,7 @@ export class SqlPrintTokenParser implements SqlComponentVisitor<SqlPrintToken> {
         this.handlers.set(ArraySliceExpression.kind, (expr) => this.visitArraySliceExpression(expr as ArraySliceExpression));
         this.handlers.set(ArrayIndexExpression.kind, (expr) => this.visitArrayIndexExpression(expr as ArrayIndexExpression));
         this.handlers.set(BetweenExpression.kind, (expr) => this.visitBetweenExpression(expr as BetweenExpression));
+        this.handlers.set(JsonPredicateExpression.kind, (expr) => this.visitJsonPredicateExpression(expr as JsonPredicateExpression));
         this.handlers.set(StringSpecifierExpression.kind, (expr) => this.visitStringSpecifierExpression(expr as StringSpecifierExpression));
         this.handlers.set(TypeValue.kind, (expr) => this.visitTypeValue(expr as TypeValue));
         this.handlers.set(TupleExpression.kind, (expr) => this.visitTupleExpression(expr as TupleExpression));
@@ -2864,6 +2866,28 @@ export class SqlPrintTokenParser implements SqlComponentVisitor<SqlPrintToken> {
         if (selectQuery && extractedWithClause) {
             SelectQueryWithClauseHelper.setWithClause(selectQuery, extractedWithClause);
         }
+        return token;
+    }
+
+    private visitJsonPredicateExpression(arg: JsonPredicateExpression): SqlPrintToken {
+        const token = new SqlPrintToken(SqlPrintTokenType.container, '', SqlPrintTokenContainerType.BinaryExpression);
+
+        token.innerTokens.push(this.visit(arg.expression));
+        token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
+        token.innerTokens.push(new SqlPrintToken(SqlPrintTokenType.operator, arg.negated ? 'is not' : 'is'));
+        token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
+        token.innerTokens.push(new SqlPrintToken(SqlPrintTokenType.keyword, 'json'));
+
+        if (arg.jsonType) {
+            token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
+            token.innerTokens.push(new SqlPrintToken(SqlPrintTokenType.keyword, arg.jsonType));
+        }
+
+        if (arg.uniqueKeys) {
+            token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
+            token.innerTokens.push(new SqlPrintToken(SqlPrintTokenType.keyword, `${arg.uniqueKeys} unique keys`));
+        }
+
         return token;
     }
 

--- a/packages/core/src/parsers/SqlPrintTokenParser.ts
+++ b/packages/core/src/parsers/SqlPrintTokenParser.ts
@@ -2896,6 +2896,10 @@ export class SqlPrintTokenParser implements SqlComponentVisitor<SqlPrintToken> {
 
         if (arg.target) {
             token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
+            if (arg.targetKind === "constraint") {
+                token.innerTokens.push(new SqlPrintToken(SqlPrintTokenType.keyword, 'on constraint'));
+                token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
+            }
             token.innerTokens.push(arg.target.accept(this));
         }
 

--- a/packages/core/src/parsers/ValueParser.ts
+++ b/packages/core/src/parsers/ValueParser.ts
@@ -1,5 +1,5 @@
 import { Lexeme, TokenType } from "../models/Lexeme";
-import { ColumnReference, TypeValue, UnaryExpression, ValueComponent, ValueList, BinaryExpression, CastExpression, ArraySliceExpression, ArrayIndexExpression } from "../models/ValueComponent";
+import { ColumnReference, TypeValue, UnaryExpression, ValueComponent, ValueList, BinaryExpression, CastExpression, ArraySliceExpression, ArrayIndexExpression, JsonPredicateExpression, JsonPredicateType, JsonPredicateUniqueKeys } from "../models/ValueComponent";
 import { SqlTokenizer } from "./SqlTokenizer";
 import { IdentifierParser } from "./IdentifierParser";
 import { LiteralParser } from "./LiteralParser";
@@ -90,6 +90,13 @@ export class ValueParser {
                 break;
             }
 
+            const jsonPredicate = this.tryParseJsonPredicate(lexemes, idx, result);
+            if (jsonPredicate) {
+                result = jsonPredicate.value;
+                idx = jsonPredicate.newIndex;
+                continue;
+            }
+
             // Get operator precedence
             const precedence = OperatorPrecedence.getPrecedence(operator);
 
@@ -138,6 +145,42 @@ export class ValueParser {
         }
 
         return { value: result, newIndex: idx };
+    }
+
+    private static tryParseJsonPredicate(lexemes: Lexeme[], index: number, expression: ValueComponent): { value: JsonPredicateExpression; newIndex: number } | null {
+        const operator = lexemes[index]?.value?.toLowerCase();
+        if (operator !== "is" && operator !== "is not") {
+            return null;
+        }
+
+        let idx = index + 1;
+        if (idx >= lexemes.length || lexemes[idx].value.toLowerCase() !== "json") {
+            return null;
+        }
+        idx++;
+
+        let jsonType: JsonPredicateType | null = null;
+        const typeCandidate = lexemes[idx]?.value?.toLowerCase();
+        if (typeCandidate === "value" || typeCandidate === "scalar" || typeCandidate === "array" || typeCandidate === "object") {
+            jsonType = typeCandidate;
+            idx++;
+        }
+
+        let uniqueKeys: JsonPredicateUniqueKeys | null = null;
+        const uniqueCandidate = lexemes[idx]?.value?.toLowerCase();
+        if (uniqueCandidate === "with" || uniqueCandidate === "without") {
+            const uniqueToken = lexemes[idx + 1]?.value?.toLowerCase();
+            const keysToken = lexemes[idx + 2]?.value?.toLowerCase();
+            if (uniqueToken === "unique" && keysToken === "keys") {
+                uniqueKeys = uniqueCandidate;
+                idx += 3;
+            }
+        }
+
+        return {
+            value: new JsonPredicateExpression(expression, operator === "is not", jsonType, uniqueKeys),
+            newIndex: idx,
+        };
     }
 
     /**

--- a/packages/core/src/tokenReaders/CommandTokenReader.ts
+++ b/packages/core/src/tokenReaders/CommandTokenReader.ts
@@ -78,6 +78,8 @@ const keywordTrie = new KeywordTrie([
     ["groups"],
     // aggregate functions with WITHIN GROUP
     ["within", "group"],
+    ["ignore", "nulls"],
+    ["respect", "nulls"],
     // table functions with WITH ORDINALITY  
     ["with", "ordinality"],
     // window frame
@@ -107,9 +109,12 @@ const keywordTrie = new KeywordTrie([
     ["not", "matched", "by", "source"],
     ["not", "matched", "by", "target"],
     ["update", "set"],
+    ["on", "conflict"],
     ["if", "not", "exists"],
     ["if", "exists"],
     ["do", "nothing"],
+    ["do", "select"],
+    ["do", "update"],
     ["insert", "default", "values"],
     ["values"],
     ["set"],

--- a/packages/core/src/transformers/CTECollector.ts
+++ b/packages/core/src/transformers/CTECollector.ts
@@ -7,7 +7,7 @@ import { MergeDeleteAction, MergeInsertAction, MergeQuery, MergeUpdateAction } f
 import { SqlComponent, SqlComponentVisitor } from "../models/SqlComponent";
 import {
     ArrayExpression, ArrayQueryExpression, BetweenExpression, BinaryExpression, CaseExpression, CaseKeyValuePair,
-    CastExpression, ColumnReference, FunctionCall, InlineQuery, ParenExpression,
+    CastExpression, ColumnReference, FunctionCall, InlineQuery, JsonPredicateExpression, ParenExpression,
     ParameterExpression, SwitchCaseArgument, TupleExpression, UnaryExpression, ValueComponent,
     OverExpression, WindowFrameExpression, IdentifierString, RawString,
     WindowFrameSpec,
@@ -84,6 +84,7 @@ export class CTECollector implements SqlComponentVisitor<void> {
         // Value components that might contain subqueries
         this.handlers.set(ParenExpression.kind, (expr) => this.visitParenExpression(expr as ParenExpression));
         this.handlers.set(BinaryExpression.kind, (expr) => this.visitBinaryExpression(expr as BinaryExpression));
+        this.handlers.set(JsonPredicateExpression.kind, (expr) => this.visitJsonPredicateExpression(expr as JsonPredicateExpression));
         this.handlers.set(UnaryExpression.kind, (expr) => this.visitUnaryExpression(expr as UnaryExpression));
         this.handlers.set(CaseExpression.kind, (expr) => this.visitCaseExpression(expr as CaseExpression));
         this.handlers.set(CaseKeyValuePair.kind, (expr) => this.visitCaseKeyValuePair(expr as CaseKeyValuePair));
@@ -465,6 +466,10 @@ export class CTECollector implements SqlComponentVisitor<void> {
     private visitBinaryExpression(expr: BinaryExpression): void {
         expr.left.accept(this);
         expr.right.accept(this);
+    }
+
+    private visitJsonPredicateExpression(expr: JsonPredicateExpression): void {
+        expr.expression.accept(this);
     }
 
     private visitUnaryExpression(expr: UnaryExpression): void {

--- a/packages/core/src/transformers/CTEDisabler.ts
+++ b/packages/core/src/transformers/CTEDisabler.ts
@@ -274,7 +274,7 @@ export class CTEDisabler implements SqlComponentVisitor<SqlComponent> {
 
     visitGroupByClause(clause: GroupByClause): SqlComponent {
         const newGrouping = clause.grouping.map(item => this.visit(item) as ValueComponent);
-        return new GroupByClause(newGrouping);
+        return new GroupByClause(newGrouping, clause.mode);
     }
 
     visitHavingClause(clause: HavingClause): SqlComponent {

--- a/packages/core/src/transformers/CTEDisabler.ts
+++ b/packages/core/src/transformers/CTEDisabler.ts
@@ -6,7 +6,7 @@ import { DeleteQuery } from "../models/DeleteQuery";
 import { SqlComponent, SqlComponentVisitor } from "../models/SqlComponent";
 import {
     ArrayExpression, ArrayQueryExpression, ArraySliceExpression, ArrayIndexExpression, BetweenExpression, BinaryExpression, CaseExpression, CaseKeyValuePair,
-    CastExpression, ColumnReference, FunctionCall, InlineQuery, ParenExpression,
+    CastExpression, ColumnReference, FunctionCall, InlineQuery, JsonPredicateExpression, ParenExpression,
     ParameterExpression, SwitchCaseArgument, TupleExpression, UnaryExpression, ValueComponent, ValueList,
     OverExpression, WindowFrameExpression, IdentifierString, RawString, StringSpecifierExpression,
     WindowFrameSpec,
@@ -76,6 +76,7 @@ export class CTEDisabler implements SqlComponentVisitor<SqlComponent> {
         // Value components that might contain subqueries
         this.handlers.set(ParenExpression.kind, (expr) => this.visitParenExpression(expr as ParenExpression));
         this.handlers.set(BinaryExpression.kind, (expr) => this.visitBinaryExpression(expr as BinaryExpression));
+        this.handlers.set(JsonPredicateExpression.kind, (expr) => this.visitJsonPredicateExpression(expr as JsonPredicateExpression));
         this.handlers.set(UnaryExpression.kind, (expr) => this.visitUnaryExpression(expr as UnaryExpression));
         this.handlers.set(CaseExpression.kind, (expr) => this.visitCaseExpression(expr as CaseExpression));
         this.handlers.set(CaseKeyValuePair.kind, (expr) => this.visitCaseKeyValuePair(expr as CaseKeyValuePair));
@@ -309,6 +310,11 @@ export class CTEDisabler implements SqlComponentVisitor<SqlComponent> {
         const newLeft = this.visit(expr.left) as ValueComponent;
         const newRight = this.visit(expr.right) as ValueComponent;
         return new BinaryExpression(newLeft, expr.operator.value, newRight);
+    }
+
+    visitJsonPredicateExpression(expr: JsonPredicateExpression): SqlComponent {
+        const expression = this.visit(expr.expression) as ValueComponent;
+        return new JsonPredicateExpression(expression, expr.negated, expr.jsonType, expr.uniqueKeys);
     }
 
     visitUnaryExpression(expr: UnaryExpression): SqlComponent {

--- a/packages/core/src/transformers/CTETableReferenceCollector.ts
+++ b/packages/core/src/transformers/CTETableReferenceCollector.ts
@@ -3,7 +3,7 @@ import { BinarySelectQuery, SelectQuery, SimpleSelectQuery, ValuesQuery } from "
 import { SqlComponent, SqlComponentVisitor } from "../models/SqlComponent";
 import {
     ArrayExpression, ArrayQueryExpression, BetweenExpression, BinaryExpression, CaseExpression, CaseKeyValuePair,
-    CastExpression, ColumnReference, FunctionCall, InlineQuery, ParenExpression,
+    CastExpression, ColumnReference, FunctionCall, InlineQuery, JsonPredicateExpression, ParenExpression,
     ParameterExpression, SwitchCaseArgument, TupleExpression, UnaryExpression, ValueComponent, ValueList,
     OverExpression, WindowFrameExpression, IdentifierString, RawString,
     WindowFrameSpec,
@@ -72,6 +72,7 @@ export class CTETableReferenceCollector implements SqlComponentVisitor<void> {
         // Value components that might contain table references
         this.handlers.set(ParenExpression.kind, (expr) => this.visitParenExpression(expr as ParenExpression));
         this.handlers.set(BinaryExpression.kind, (expr) => this.visitBinaryExpression(expr as BinaryExpression));
+        this.handlers.set(JsonPredicateExpression.kind, (expr) => this.visitJsonPredicateExpression(expr as JsonPredicateExpression));
         this.handlers.set(UnaryExpression.kind, (expr) => this.visitUnaryExpression(expr as UnaryExpression));
         this.handlers.set(CaseExpression.kind, (expr) => this.visitCaseExpression(expr as CaseExpression));
         this.handlers.set(CaseKeyValuePair.kind, (expr) => this.visitCaseKeyValuePair(expr as CaseKeyValuePair));
@@ -364,6 +365,10 @@ export class CTETableReferenceCollector implements SqlComponentVisitor<void> {
     private visitBinaryExpression(expr: BinaryExpression): void {
         expr.left.accept(this);
         expr.right.accept(this);
+    }
+
+    private visitJsonPredicateExpression(expr: JsonPredicateExpression): void {
+        expr.expression.accept(this);
     }
 
     private visitUnaryExpression(expr: UnaryExpression): void {

--- a/packages/core/src/transformers/ColumnReferenceCollector.ts
+++ b/packages/core/src/transformers/ColumnReferenceCollector.ts
@@ -263,6 +263,8 @@ export class ColumnReferenceCollector implements SqlComponentVisitor<void> {
     private collectFromValueComponent(value: ValueComponent): void {
         if (value instanceof ColumnReference) {
             this.columnReferences.push(value);
+        } else if (value instanceof JsonPredicateExpression) {
+            this.collectFromValueComponent(value.expression);
         } else if (value instanceof BinaryExpression) {
             this.collectFromValueComponent(value.left);
             this.collectFromValueComponent(value.right);

--- a/packages/core/src/transformers/ColumnReferenceCollector.ts
+++ b/packages/core/src/transformers/ColumnReferenceCollector.ts
@@ -5,7 +5,7 @@ import { UpdateQuery } from "../models/UpdateQuery";
 import { DeleteQuery } from "../models/DeleteQuery";
 import { MergeDeleteAction, MergeInsertAction, MergeQuery, MergeUpdateAction } from "../models/MergeQuery";
 import { SqlComponent, SqlComponentVisitor } from "../models/SqlComponent";
-import { ArrayExpression, ArrayQueryExpression, BetweenExpression, BinaryExpression, CaseExpression, CastExpression, ColumnReference, FunctionCall, InlineQuery, ParenExpression, UnaryExpression, ValueComponent, ValueList, WindowFrameExpression } from "../models/ValueComponent";
+import { ArrayExpression, ArrayQueryExpression, BetweenExpression, BinaryExpression, CaseExpression, CastExpression, ColumnReference, FunctionCall, InlineQuery, JsonPredicateExpression, ParenExpression, UnaryExpression, ValueComponent, ValueList, WindowFrameExpression } from "../models/ValueComponent";
 
 /**
  * A comprehensive collector for all ColumnReference instances in SQL query structures.
@@ -122,6 +122,7 @@ export class ColumnReferenceCollector implements SqlComponentVisitor<void> {
         // Value component handlers
         this.handlers.set(ColumnReference.kind, (ref) => this.visitColumnReference(ref as ColumnReference));
         this.handlers.set(BinaryExpression.kind, (expr) => this.visitBinaryExpression(expr as BinaryExpression));
+        this.handlers.set(JsonPredicateExpression.kind, (expr) => this.visitJsonPredicateExpression(expr as JsonPredicateExpression));
         this.handlers.set(UnaryExpression.kind, (expr) => this.visitUnaryExpression(expr as UnaryExpression));
         this.handlers.set(FunctionCall.kind, (func) => this.visitFunctionCall(func as FunctionCall));
         this.handlers.set(CaseExpression.kind, (expr) => this.visitCaseExpression(expr as CaseExpression));
@@ -530,6 +531,10 @@ export class ColumnReferenceCollector implements SqlComponentVisitor<void> {
     private visitBinaryExpression(expr: BinaryExpression): void {
         expr.left.accept(this);
         expr.right.accept(this);
+    }
+
+    private visitJsonPredicateExpression(expr: JsonPredicateExpression): void {
+        expr.expression.accept(this);
     }
 
     private visitUnaryExpression(expr: UnaryExpression): void {

--- a/packages/core/src/transformers/SelectableColumnCollector.ts
+++ b/packages/core/src/transformers/SelectableColumnCollector.ts
@@ -19,7 +19,7 @@ export enum DuplicateDetectionMode {
 import { CommonTable, ForClause, FromClause, GroupByClause, HavingClause, LimitClause, OrderByClause, SelectClause, WhereClause, WindowFrameClause, WindowsClause, JoinClause, JoinOnClause, JoinUsingClause, TableSource, SubQuerySource, SourceExpression, SelectItem, PartitionByClause, FetchClause, OffsetClause, ParenSource } from "../models/Clause";
 import { SimpleSelectQuery, BinarySelectQuery } from "../models/SelectQuery";
 import { SqlComponent, SqlComponentVisitor } from "../models/SqlComponent";
-import { ArrayExpression, ArrayQueryExpression, BetweenExpression, BinaryExpression, CaseExpression, CastExpression, ColumnReference, FunctionCall, InlineQuery, ParenExpression, UnaryExpression, ValueComponent, ValueList, WindowFrameExpression, IdentifierString, ArraySliceExpression, ArrayIndexExpression } from "../models/ValueComponent";
+import { ArrayExpression, ArrayQueryExpression, BetweenExpression, BinaryExpression, CaseExpression, CastExpression, ColumnReference, FunctionCall, InlineQuery, JsonPredicateExpression, ParenExpression, UnaryExpression, ValueComponent, ValueList, WindowFrameExpression, IdentifierString, ArraySliceExpression, ArrayIndexExpression } from "../models/ValueComponent";
 import { CTECollector } from "./CTECollector";
 import { SelectValueCollector } from "./SelectValueCollector";
 import { TableColumnResolver } from "./TableColumnResolver";
@@ -166,6 +166,7 @@ export class SelectableColumnCollector implements SqlComponentVisitor<void> {
     private initializeValueComponentHandlers(): void {
         this.handlers.set(ColumnReference.kind, (expr) => this.visitColumnReference(expr as ColumnReference));
         this.handlers.set(BinaryExpression.kind, (expr) => this.visitBinaryExpression(expr as BinaryExpression));
+        this.handlers.set(JsonPredicateExpression.kind, (expr) => this.visitJsonPredicateExpression(expr as JsonPredicateExpression));
         this.handlers.set(UnaryExpression.kind, (expr) => this.visitUnaryExpression(expr as UnaryExpression));
         this.handlers.set(FunctionCall.kind, (expr) => this.visitFunctionCall(expr as FunctionCall));
         this.handlers.set(InlineQuery.kind, (expr) => this.visitInlineQuery(expr as InlineQuery));
@@ -520,6 +521,10 @@ export class SelectableColumnCollector implements SqlComponentVisitor<void> {
         if (expr.right) {
             expr.right.accept(this);
         }
+    }
+
+    private visitJsonPredicateExpression(expr: JsonPredicateExpression): void {
+        expr.expression.accept(this);
     }
 
     private visitUnaryExpression(expr: UnaryExpression): void {

--- a/packages/core/src/transformers/TableSourceCollector.ts
+++ b/packages/core/src/transformers/TableSourceCollector.ts
@@ -7,7 +7,7 @@ import { DeleteQuery } from "../models/DeleteQuery";
 import { MergeDeleteAction, MergeInsertAction, MergeQuery, MergeUpdateAction } from "../models/MergeQuery";
 import {
     ArrayExpression, ArrayQueryExpression, BetweenExpression, BinaryExpression, CaseExpression, CaseKeyValuePair,
-    CastExpression, ColumnReference, FunctionCall, InlineQuery, ParenExpression,
+    CastExpression, ColumnReference, FunctionCall, InlineQuery, JsonPredicateExpression, ParenExpression,
     ParameterExpression, SwitchCaseArgument, TupleExpression, UnaryExpression, ValueComponent, ValueList,
     OverExpression, WindowFrameExpression, IdentifierString, RawString,
     WindowFrameSpec,
@@ -97,6 +97,7 @@ export class TableSourceCollector implements SqlComponentVisitor<void> {
             // Value components that might contain table references
             this.handlers.set(ParenExpression.kind, (expr) => this.visitParenExpression(expr as ParenExpression));
             this.handlers.set(BinaryExpression.kind, (expr) => this.visitBinaryExpression(expr as BinaryExpression));
+            this.handlers.set(JsonPredicateExpression.kind, (expr) => this.visitJsonPredicateExpression(expr as JsonPredicateExpression));
             this.handlers.set(UnaryExpression.kind, (expr) => this.visitUnaryExpression(expr as UnaryExpression));
             this.handlers.set(CaseExpression.kind, (expr) => this.visitCaseExpression(expr as CaseExpression));
             this.handlers.set(CaseKeyValuePair.kind, (expr) => this.visitCaseKeyValuePair(expr as CaseKeyValuePair));
@@ -575,6 +576,10 @@ export class TableSourceCollector implements SqlComponentVisitor<void> {
     private visitBinaryExpression(expr: BinaryExpression): void {
         expr.left.accept(this);
         expr.right.accept(this);
+    }
+
+    private visitJsonPredicateExpression(expr: JsonPredicateExpression): void {
+        expr.expression.accept(this);
     }
 
     private visitUnaryExpression(expr: UnaryExpression): void {

--- a/packages/core/src/utils/ParameterRemover.ts
+++ b/packages/core/src/utils/ParameterRemover.ts
@@ -870,6 +870,9 @@ export class ParameterRemover implements SqlComponentVisitor<SqlComponent | null
      */
     private visitGroupByClause(clause: GroupByClause): GroupByClause | null {
         if (!clause.grouping || clause.grouping.length === 0) {
+            if (clause.mode === "all") {
+                return new GroupByClause([], clause.mode);
+            }
             return null;
         }
 
@@ -881,7 +884,7 @@ export class ParameterRemover implements SqlComponentVisitor<SqlComponent | null
             return null;
         }
 
-        return new GroupByClause(grouping);
+        return new GroupByClause(grouping, clause.mode);
     }
 
     /**

--- a/packages/core/src/utils/ParameterRemover.ts
+++ b/packages/core/src/utils/ParameterRemover.ts
@@ -6,7 +6,7 @@ import { DeleteQuery } from "../models/DeleteQuery";
 import { SqlComponent, SqlComponentVisitor } from "../models/SqlComponent";
 import {
     ArrayExpression, BetweenExpression, BinaryExpression, CaseExpression, CaseKeyValuePair,
-    CastExpression, ColumnReference, FunctionCall, InlineQuery, ParenExpression,
+    CastExpression, ColumnReference, FunctionCall, InlineQuery, JsonPredicateExpression, ParenExpression,
     ParameterExpression, SwitchCaseArgument, TupleExpression, UnaryExpression, ValueComponent,
     OverExpression, WindowFrameExpression, IdentifierString, RawString,
     WindowFrameSpec,
@@ -30,6 +30,8 @@ class ParameterDetector implements SqlComponentVisitor<boolean> {
         // Binary expressions check both sides
         this.handlers.set(BinaryExpression.kind, (expr: BinaryExpression) =>
             this.visit(expr.left) || this.visit(expr.right));
+        this.handlers.set(JsonPredicateExpression.kind, (expr: JsonPredicateExpression) =>
+            this.visit(expr.expression));
 
         // Parenthesized expressions check inner expression
         this.handlers.set(ParenExpression.kind, (expr: ParenExpression) =>
@@ -165,6 +167,7 @@ export class ParameterRemover implements SqlComponentVisitor<SqlComponent | null
         // Value components that might contain subqueries or parameters
         this.handlers.set(ParenExpression.kind, (expr) => this.visitParenExpression(expr as ParenExpression));
         this.handlers.set(BinaryExpression.kind, (expr) => this.visitBinaryExpression(expr as BinaryExpression));
+        this.handlers.set(JsonPredicateExpression.kind, (expr) => this.visitJsonPredicateExpression(expr as JsonPredicateExpression));
         this.handlers.set(UnaryExpression.kind, (expr) => this.visitUnaryExpression(expr as UnaryExpression));
         this.handlers.set(CaseExpression.kind, (expr) => this.visitCaseExpression(expr as CaseExpression));
         this.handlers.set(CaseKeyValuePair.kind, (expr) => this.visitCaseKeyValuePair(expr as CaseKeyValuePair));
@@ -601,6 +604,14 @@ export class ParameterRemover implements SqlComponentVisitor<SqlComponent | null
             // For comparison operators, handle right-associative parser structure
             return this.handleComparisonExpression(expr);
         }
+    }
+
+    private visitJsonPredicateExpression(expr: JsonPredicateExpression): ValueComponent | null {
+        const expression = this.visit(expr.expression) as ValueComponent | null;
+        if (!expression) {
+            return null;
+        }
+        return new JsonPredicateExpression(expression, expr.negated, expr.jsonType, expr.uniqueKeys);
     }
 
     /**

--- a/packages/core/src/utils/ValueComponentRewriter.ts
+++ b/packages/core/src/utils/ValueComponentRewriter.ts
@@ -13,6 +13,7 @@ import {
     FrameBoundaryComponent,
     IdentifierString,
     InlineQuery,
+    JsonPredicateExpression,
     LiteralValue,
     OverExpression,
     ParameterExpression,
@@ -79,6 +80,11 @@ export function rewriteValueComponentWithColumnResolver(
         const left = rewriteValueComponentWithColumnResolver(value.left, resolver);
         const right = rewriteValueComponentWithColumnResolver(value.right, resolver);
         return new BinaryExpression(left, value.operator.value, right);
+    }
+
+    if (value instanceof JsonPredicateExpression) {
+        const expression = rewriteValueComponentWithColumnResolver(value.expression, resolver);
+        return new JsonPredicateExpression(expression, value.negated, value.jsonType, value.uniqueKeys);
     }
 
     if (value instanceof CaseExpression) {

--- a/packages/core/tests/parsers/FunctionExpressionParser.test.ts
+++ b/packages/core/tests/parsers/FunctionExpressionParser.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest';
 import { FunctionExpressionParser } from '../../src/parsers/FunctionExpressionParser';
 import { SqlTokenizer } from '../../src/parsers/SqlTokenizer';
 import { BinaryExpression, ColumnReference, FunctionCall, LiteralValue } from '../../src/models/ValueComponent';
+import { SqlFormatter } from '../../src/transformers/SqlFormatter';
 
 describe('FunctionExpressionParser', () => {
     describe('standard function calls', () => {
@@ -104,6 +105,39 @@ describe('FunctionExpressionParser', () => {
             const functionCall = result.value as FunctionCall;
             expect(functionCall.filterCondition).not.toBeNull();
             expect(functionCall.over).not.toBeNull();
+        });
+    });
+
+    describe('PostgreSQL 19 null treatment for window functions', () => {
+        test('parses IGNORE NULLS before OVER', () => {
+            const tokenizer = new SqlTokenizer('lead(value) IGNORE NULLS OVER (ORDER BY created_at)');
+            const lexemes = tokenizer.readLexmes();
+
+            const result = FunctionExpressionParser.parseFromLexeme(lexemes, 0);
+
+            expect(result.newIndex).toBe(lexemes.length);
+            expect(result.value).toBeInstanceOf(FunctionCall);
+
+            const functionCall = result.value as FunctionCall;
+            expect(functionCall.nullsTreatment).toBe('ignore nulls');
+            expect(functionCall.over).not.toBeNull();
+
+            const query = new SqlFormatter().format(functionCall).formattedSql;
+            expect(query).toBe('lead("value") ignore nulls over(order by "created_at")');
+        });
+
+        test('parses RESPECT NULLS before OVER', () => {
+            const tokenizer = new SqlTokenizer('first_value(value) RESPECT NULLS OVER (PARTITION BY account_id ORDER BY created_at)');
+            const lexemes = tokenizer.readLexmes();
+
+            const result = FunctionExpressionParser.parseFromLexeme(lexemes, 0);
+
+            expect(result.newIndex).toBe(lexemes.length);
+            const functionCall = result.value as FunctionCall;
+            expect(functionCall.nullsTreatment).toBe('respect nulls');
+
+            const query = new SqlFormatter().format(functionCall).formattedSql;
+            expect(query).toBe('first_value("value") respect nulls over(partition by "account_id" order by "created_at")');
         });
     });
 });

--- a/packages/core/tests/parsers/GroupByParser.test.ts
+++ b/packages/core/tests/parsers/GroupByParser.test.ts
@@ -28,6 +28,33 @@ test('group by multiple columns', () => {
     expect(sql).toEqual(`group by "department_id", "job_id"`);
 });
 
+test('group by all', () => {
+    // Arrange
+    const text = `group by all`;
+
+    // Act
+    const clause = GroupByClauseParser.parse(text);
+    const sql = formatter.format(clause);
+
+    // Assert
+    expect(sql).toEqual(`group by all`);
+    expect(clause.mode).toEqual('all');
+    expect(clause.grouping).toHaveLength(0);
+});
+
+test('group by distinct expression', () => {
+    // Arrange
+    const text = `group by distinct department_id`;
+
+    // Act
+    const clause = GroupByClauseParser.parse(text);
+    const sql = formatter.format(clause);
+
+    // Assert
+    expect(sql).toEqual(`group by distinct "department_id"`);
+    expect(clause.mode).toEqual('distinct');
+});
+
 test('group by with expression', () => {
     // Arrange
     const text = `group by extract(year from hire_date)`;

--- a/packages/core/tests/parsers/InsertQueryParser.test.ts
+++ b/packages/core/tests/parsers/InsertQueryParser.test.ts
@@ -3,7 +3,7 @@ import { InsertQuery } from "../../src/models/InsertQuery";
 import { SelectQuery, SimpleSelectQuery, ValuesQuery } from "../../src/models/SelectQuery";
 import { describe, it, expect } from "vitest";
 import { SqlFormatter } from "../../src/transformers/SqlFormatter";
-import { TableSource, ParenSource, SourceExpression } from "../../src/models/Clause";
+import { OnConflictClause, TableSource, ParenSource, SourceExpression } from "../../src/models/Clause";
 
 describe("InsertQueryParser", () => {
     it("parses INSERT INTO table SELECT ...", () => {
@@ -94,6 +94,18 @@ describe("InsertQueryParser", () => {
 
         expect(query).toBe('insert into "tags"("name") values (\'backend\') on conflict on constraint tags_name_key do select for share returning *');
         expect(insert.onConflictClause?.targetKind).toBe("constraint");
+    });
+
+    it("formats programmatic ON CONFLICT ON CONSTRAINT targets", () => {
+        const clause = new OnConflictClause({
+            target: "tags_name_key",
+            targetKind: "constraint",
+            action: "nothing"
+        });
+
+        const query = new SqlFormatter().format(clause).formattedSql;
+
+        expect(query).toBe("on conflict on constraint tags_name_key do nothing");
     });
 
     it("rejects PostgreSQL 19 ON CONFLICT DO SELECT without RETURNING", () => {

--- a/packages/core/tests/parsers/InsertQueryParser.test.ts
+++ b/packages/core/tests/parsers/InsertQueryParser.test.ts
@@ -65,6 +65,76 @@ describe("InsertQueryParser", () => {
         expect(insert.returningClause).not.toBeNull();
     });
 
+    it("parses PostgreSQL 19 INSERT ... ON CONFLICT DO SELECT ... RETURNING", () => {
+        const sql = "INSERT INTO tags (name) VALUES ('backend') ON CONFLICT (name) DO SELECT RETURNING id";
+
+        const insert = InsertQueryParser.parse(sql);
+        const query = new SqlFormatter().format(insert).formattedSql;
+
+        expect(query).toBe('insert into "tags"("name") values (\'backend\') on conflict (name) do select returning "id"');
+        expect(insert.onConflictClause?.action).toBe("select");
+    });
+
+    it("parses PostgreSQL 19 ON CONFLICT DO SELECT with row lock and WHERE condition", () => {
+        const sql = "INSERT INTO tags (name) VALUES ('backend') ON CONFLICT (name) DO SELECT FOR UPDATE WHERE tags.active RETURNING id, name";
+
+        const insert = InsertQueryParser.parse(sql);
+        const query = new SqlFormatter().format(insert).formattedSql;
+
+        expect(query).toBe('insert into "tags"("name") values (\'backend\') on conflict (name) do select for update where "tags"."active" returning "id", "name"');
+        expect(insert.onConflictClause?.forClause?.lockMode).toBe("update");
+        expect(insert.onConflictClause?.whereClause).not.toBeNull();
+    });
+
+    it("parses PostgreSQL 19 ON CONFLICT ON CONSTRAINT DO SELECT", () => {
+        const sql = "INSERT INTO tags (name) VALUES ('backend') ON CONFLICT ON CONSTRAINT tags_name_key DO SELECT FOR SHARE RETURNING *";
+
+        const insert = InsertQueryParser.parse(sql);
+        const query = new SqlFormatter().format(insert).formattedSql;
+
+        expect(query).toBe('insert into "tags"("name") values (\'backend\') on conflict on constraint tags_name_key do select for share returning *');
+        expect(insert.onConflictClause?.targetKind).toBe("constraint");
+    });
+
+    it("rejects PostgreSQL 19 ON CONFLICT DO SELECT without RETURNING", () => {
+        const sql = "INSERT INTO tags (name) VALUES ('backend') ON CONFLICT (name) DO SELECT";
+
+        expect(() => InsertQueryParser.parse(sql)).toThrow("ON CONFLICT DO SELECT requires a RETURNING clause");
+    });
+
+    it("parses INSERT ... ON CONFLICT DO UPDATE", () => {
+        const sql = "INSERT INTO users (id, name) VALUES (1, 'new') ON CONFLICT (id) DO UPDATE SET name = excluded.name";
+
+        const insert = InsertQueryParser.parse(sql);
+        const query = new SqlFormatter().format(insert).formattedSql;
+
+        expect(query).toBe('insert into "users"("id", "name") values (1, \'new\') on conflict (id) do update set "name" = "excluded"."name"');
+        expect(insert.onConflictClause?.action).toBe("update");
+        expect(insert.onConflictClause?.setClause?.items).toHaveLength(1);
+    });
+
+    it("parses INSERT ... ON CONFLICT DO UPDATE with WHERE and RETURNING", () => {
+        const sql = "INSERT INTO users (id, name, updated_at) VALUES (1, 'new', now()) ON CONFLICT (id) DO UPDATE SET name = excluded.name, updated_at = now() WHERE users.deleted_at IS NULL RETURNING id, name";
+
+        const insert = InsertQueryParser.parse(sql);
+        const query = new SqlFormatter().format(insert).formattedSql;
+
+        expect(query).toBe('insert into "users"("id", "name", "updated_at") values (1, \'new\', now()) on conflict (id) do update set "name" = "excluded"."name", "updated_at" = now() where "users"."deleted_at" is null returning "id", "name"');
+        expect(insert.onConflictClause?.whereClause).not.toBeNull();
+        expect(insert.returningClause?.items).toHaveLength(2);
+    });
+
+    it("parses INSERT ... ON CONFLICT ON CONSTRAINT DO UPDATE", () => {
+        const sql = "INSERT INTO users (email, name) VALUES ('a@example.com', 'new') ON CONFLICT ON CONSTRAINT users_email_key DO UPDATE SET name = excluded.name RETURNING id";
+
+        const insert = InsertQueryParser.parse(sql);
+        const query = new SqlFormatter().format(insert).formattedSql;
+
+        expect(query).toBe('insert into "users"("email", "name") values (\'a@example.com\', \'new\') on conflict on constraint users_email_key do update set "name" = "excluded"."name" returning "id"');
+        expect(insert.onConflictClause?.targetKind).toBe("constraint");
+        expect(insert.onConflictClause?.action).toBe("update");
+    });
+
     it("parses INSERT ... RETURNING *", () => {
         const sql = "INSERT INTO users (id, name) VALUES (1, 'a') RETURNING *";
 

--- a/packages/core/tests/parsers/Postgres16Syntax.test.ts
+++ b/packages/core/tests/parsers/Postgres16Syntax.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { SelectQueryParser } from "../../src/parsers/SelectQueryParser";
+import { SqlFormatter } from "../../src/transformers/SqlFormatter";
+
+describe("PostgreSQL 16 syntax", () => {
+    const formatter = new SqlFormatter();
+
+    it("formats SQL/JSON IS JSON predicates without treating JSON as an identifier", () => {
+        const sql = "SELECT payload IS NOT JSON OBJECT WITH UNIQUE KEYS FROM events";
+
+        const ast = SelectQueryParser.parse(sql);
+        const formatted = formatter.format(ast).formattedSql;
+
+        expect(formatted).toBe('select "payload" is not json object with unique keys from "events"');
+    });
+
+    it("preserves SQL/JSON constructor argument syntax", () => {
+        const sql = "SELECT json_object('id' value id, 'name' value name absent on null returning jsonb) FROM users";
+
+        const ast = SelectQueryParser.parse(sql);
+        const formatted = formatter.format(ast).formattedSql;
+
+        expect(formatted).toBe('select json_object(\'id\' value id, \'name\' value name absent on null returning jsonb) from "users"');
+    });
+});

--- a/packages/core/tests/parsers/Postgres17Syntax.test.ts
+++ b/packages/core/tests/parsers/Postgres17Syntax.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { MergeQueryParser } from "../../src/parsers/MergeQueryParser";
+import { SqlFormatter } from "../../src/transformers/SqlFormatter";
+
+describe("PostgreSQL 17 syntax", () => {
+    it("keeps MERGE RETURNING with merge_action()", () => {
+        const sql = [
+            "MERGE INTO users AS target",
+            "USING incoming_users AS source",
+            "ON target.user_id = source.user_id",
+            "WHEN MATCHED THEN UPDATE SET name = source.name",
+            "WHEN NOT MATCHED BY SOURCE THEN DO NOTHING",
+            "RETURNING merge_action() AS action, target.user_id"
+        ].join(" ");
+
+        const ast = MergeQueryParser.parse(sql);
+        const formatted = new SqlFormatter().format(ast).formattedSql;
+
+        expect(ast.returningClause?.items).toHaveLength(2);
+        expect(formatted).toBe('merge into "users" as "target" using "incoming_users" as "source" on "target"."user_id" = "source"."user_id" when matched then update set "name" = "source"."name" when not matched by source then do nothing returning merge_action() as "action", "target"."user_id"');
+    });
+});

--- a/packages/core/tests/parsers/Postgres18Syntax.test.ts
+++ b/packages/core/tests/parsers/Postgres18Syntax.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { DeleteQueryParser } from "../../src/parsers/DeleteQueryParser";
+import { InsertQueryParser } from "../../src/parsers/InsertQueryParser";
+import { MergeQueryParser } from "../../src/parsers/MergeQueryParser";
+import { UpdateQueryParser } from "../../src/parsers/UpdateQueryParser";
+import { SqlFormatter } from "../../src/transformers/SqlFormatter";
+
+describe("PostgreSQL 18 syntax", () => {
+    const formatter = new SqlFormatter();
+
+    it("formats INSERT RETURNING WITH OLD/NEW aliases", () => {
+        const ast = InsertQueryParser.parse("INSERT INTO users(id) VALUES (1) RETURNING WITH (OLD AS o, NEW AS n) o.id, n.id");
+        const formatted = formatter.format(ast).formattedSql;
+
+        expect(ast.returningClause?.aliases).toHaveLength(2);
+        expect(formatted).toBe('insert into "users"("id") values (1) returning with (old as "o", new as "n") "o"."id", "n"."id"');
+    });
+
+    it("formats UPDATE RETURNING WITH OLD/NEW aliases", () => {
+        const ast = UpdateQueryParser.parse("UPDATE users SET name = 'next' RETURNING WITH (OLD AS o, NEW AS n) o.name, n.name");
+        const formatted = formatter.format(ast).formattedSql;
+
+        expect(ast.returningClause?.aliases.map(alias => alias.kind)).toEqual(["old", "new"]);
+        expect(formatted).toBe('update "users" set "name" = \'next\' returning with (old as "o", new as "n") "o"."name", "n"."name"');
+    });
+
+    it("formats DELETE RETURNING WITH OLD alias", () => {
+        const ast = DeleteQueryParser.parse("DELETE FROM users RETURNING WITH (OLD AS o) o.id");
+        const formatted = formatter.format(ast).formattedSql;
+
+        expect(ast.returningClause?.aliases).toHaveLength(1);
+        expect(formatted).toBe('delete from "users" returning with (old as "o") "o"."id"');
+    });
+
+    it("formats MERGE RETURNING WITH OLD/NEW aliases", () => {
+        const sql = [
+            "MERGE INTO users AS target",
+            "USING incoming_users AS source",
+            "ON target.user_id = source.user_id",
+            "WHEN MATCHED THEN UPDATE SET name = source.name",
+            "WHEN NOT MATCHED THEN INSERT (user_id, name) VALUES (source.user_id, source.name)",
+            "RETURNING WITH (OLD AS o, NEW AS n) o.user_id, n.name"
+        ].join(" ");
+
+        const ast = MergeQueryParser.parse(sql);
+        const formatted = formatter.format(ast).formattedSql;
+
+        expect(ast.returningClause?.aliases.map(alias => alias.kind)).toEqual(["old", "new"]);
+        expect(formatted).toBe('merge into "users" as "target" using "incoming_users" as "source" on "target"."user_id" = "source"."user_id" when matched then update set "name" = "source"."name" when not matched then insert("user_id", "name") values("source"."user_id", "source"."name") returning with (old as "o", new as "n") "o"."user_id", "n"."name"');
+    });
+});

--- a/packages/core/tests/parsers/SelectQueryParser.test.ts
+++ b/packages/core/tests/parsers/SelectQueryParser.test.ts
@@ -47,6 +47,10 @@ const selectFormatCases = [
         "select department, count(*) as employee_count from employees group by department",
         'select "department", count(*) as "employee_count" from "employees" group by "department"'],
 
+    ["SELECT with GROUP BY ALL",
+        "select department, count(*) as employee_count from employees group by all order by department",
+        'select "department", count(*) as "employee_count" from "employees" group by all order by "department"'],
+
     ["SELECT with GROUP BY and HAVING",
         "select department, count(*) as employee_count from employees group by department having count(*) > 5",
         'select "department", count(*) as "employee_count" from "employees" group by "department" having count(*) > 5'],

--- a/packages/core/tests/transformers/CTEDisabler.test.ts
+++ b/packages/core/tests/transformers/CTEDisabler.test.ts
@@ -202,6 +202,17 @@ describe('CTEDisabler', () => {
         expect(result).toBe('select "id", "name", count(*) as "total_count" from "filtered_data" group by "id", "name" having count(*) > 10 order by "total_count" desc limit 5');
     });
 
+    test('preserves GROUP BY ALL mode', () => {
+        const sql = `SELECT id, count(*) FROM users GROUP BY ALL`;
+        const query = SelectQueryParser.parse(sql);
+        const disabler = new CTEDisabler();
+
+        const disabledQuery = disabler.visit(query);
+        const result = formatter.format(disabledQuery);
+
+        expect(result).toBe('select "id", count(*) from "users" group by all');
+    });
+
     test('properly handles circular references', () => {
         // Arrange
         const sql = `

--- a/packages/core/tests/transformers/ColumnReferenceCollector.test.ts
+++ b/packages/core/tests/transformers/ColumnReferenceCollector.test.ts
@@ -24,4 +24,14 @@ describe('ColumnReferenceCollector', () => {
         // Assert: The column mentioned only in the FILTER predicate should still be discovered.
         expect(columnNames).toContain('region');
     });
+
+    test('captures columns referenced inside SQL JSON predicates', () => {
+        const sql = `SELECT payload IS JSON FROM events`;
+        const query = SelectQueryParser.parse(sql);
+        const collector = new ColumnReferenceCollector();
+
+        const columnNames = collector.collect(query).map(getColumnName);
+
+        expect(columnNames).toContain('payload');
+    });
 });


### PR DESCRIPTION
## Summary

- Add parser and formatter support for recent PostgreSQL query syntax in `rawsql-ts` core.
- PostgreSQL 16: SQL/JSON predicates and constructor argument syntax.
- PostgreSQL 17: regression coverage for existing MERGE extensions, including `WHEN NOT MATCHED BY SOURCE` and `MERGE RETURNING merge_action()`.
- PostgreSQL 18: `RETURNING WITH (OLD AS ..., NEW AS ...)` aliases across INSERT, UPDATE, DELETE, and MERGE.
- PostgreSQL 19: `INSERT ... ON CONFLICT DO SELECT`, `INSERT ... ON CONFLICT DO UPDATE`, `GROUP BY ALL/DISTINCT`, and window `IGNORE NULLS` / `RESPECT NULLS` clauses.

## Verification

- `pnpm --filter rawsql-ts test`
- `pnpm --filter rawsql-ts build`
- `pnpm --filter rawsql-ts lint`
- `pnpm --filter rawsql-ts benchmark`
- `pnpm demo:complex-sql`
- Pre-commit hook passed workspace `typecheck`, `test`, `build`, and `lint` on the new commits.

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

<!-- Write values on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. -->
<!-- Do not add list markers like "-" before these labels; `Tracking issue:` and `Scoped checks run:` must start at column 0. -->
Tracking issue: User-requested PostgreSQL 16/17/18/19 syntax support in Codex thread.
Scoped checks run: `pnpm --filter rawsql-ts test`; `pnpm --filter rawsql-ts build`; `pnpm --filter rawsql-ts lint`; `pnpm --filter rawsql-ts benchmark`; `pnpm demo:complex-sql`; pre-commit workspace typecheck/test/build/lint.
Why full baseline is not required: Full required baseline was run; no exception requested.

## Self Review

<!-- Fill these fields after running the repo self-review workflow or available self-review skill. -->
Self-review workflow: `developer-self-review` two-cycle consistency review and human acceptance review.
Self-review result: No blockers found; wording, changesets, tests, and verification evidence are present for reviewer handoff.
Concept-review workflow: `packages/core/DESIGN.md` package-boundary review for dialect-agnostic AST and formatter ownership.
Concept-review result: No package-boundary violation found; changes stay in parser/AST/formatter behavior without driver or runtime semantics.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-migration rationale: Core parser/formatter syntax support only; no CLI command, flag, help, or migration surface changed.
Upgrade note: Not required for CLI; changesets describe parser/formatter behavior.
Deprecation/removal plan or issue: Not required because no CLI behavior was deprecated or removed.
Docs/help/examples updated: Not required because no CLI help or example contract changed.
Release/changeset wording: Version-scoped changesets added for PostgreSQL 16, 17, 18, and 19 syntax support.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-proof rationale: Core parser/formatter syntax support only; no scaffold generation, scaffold-owned files, or scaffold input contract changed.
Non-edit assertion: No scaffold output files or scaffold templates were modified.
Fail-fast input-contract proof: Not applicable because scaffold input handling was not changed.
Generated-output viability proof: Not applicable because scaffold generation was not changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PostgreSQL 16 SQL/JSON predicate parsing and formatting support.
  * Added PostgreSQL 17 `MERGE` syntax extensions including `WHEN NOT MATCHED BY SOURCE` and `MERGE RETURNING merge_action()`.
  * Added PostgreSQL 18 `RETURNING WITH` clause aliases (`OLD AS`, `NEW AS`).
  * Added PostgreSQL 19 query syntax: `INSERT ... ON CONFLICT DO SELECT/UPDATE`, `GROUP BY ALL`, and window function `IGNORE NULLS`/`RESPECT NULLS` support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->