### PR TITLE
Fix PostgreSQL token-stable SQL formatting

### DIFF
--- a/.changeset/quiet-arrays-walk.md
+++ b/.changeset/quiet-arrays-walk.md
@@ -1,0 +1,9 @@
+---
+"rawsql-ts": patch
+---
+
+Fix PostgreSQL empty array constructor parsing inside function arguments so `array[]::text[]` formats as an array cast instead of a quoted identifier cast.
+
+Add `sourceAliasStyle: "implicit"` formatting support so callers can avoid inserting optional `AS` keywords for `FROM`/`JOIN` source aliases when they need token-stable formatting.
+
+Add `orderByDefaultDirectionStyle: "explicit"` formatting support so callers can preserve explicit `ASC` directions during token-stable formatting.

--- a/packages/core/src/parsers/SqlPrintTokenParser.ts
+++ b/packages/core/src/parsers/SqlPrintTokenParser.ts
@@ -83,6 +83,10 @@ export type CastStyle = 'postgres' | 'standard';
 
 export type ConstraintStyle = 'postgres' | 'mysql';
 
+export type SourceAliasStyle = 'as' | 'implicit';
+
+export type OrderByDefaultDirectionStyle = 'omit' | 'explicit';
+
 export interface FormatterConfig {
     identifierEscape?: {
         start: string;
@@ -98,6 +102,10 @@ export interface FormatterConfig {
     castStyle?: CastStyle;
     /** Controls how table/column constraints are rendered */
     constraintStyle?: ConstraintStyle;
+    /** Controls whether source aliases are rendered with an explicit AS keyword */
+    sourceAliasStyle?: SourceAliasStyle;
+    /** Controls whether the default ASC direction is omitted or rendered explicitly */
+    orderByDefaultDirectionStyle?: OrderByDefaultDirectionStyle;
 }
 
 export const PRESETS: Record<string, FormatterConfig> = {
@@ -254,6 +262,8 @@ export class SqlPrintTokenParser implements SqlComponentVisitor<SqlPrintToken> {
     index: number = 1;
     private castStyle: CastStyle;
     private constraintStyle: ConstraintStyle;
+    private sourceAliasStyle: SourceAliasStyle;
+    private orderByDefaultDirectionStyle: OrderByDefaultDirectionStyle;
     private readonly normalizeJoinConditionOrder: boolean;
     private joinConditionContexts: Array<{ aliasOrder: Map<string, number> }> = [];
 
@@ -264,6 +274,8 @@ export class SqlPrintTokenParser implements SqlComponentVisitor<SqlPrintToken> {
         parameterStyle?: 'anonymous' | 'indexed' | 'named',
         castStyle?: CastStyle,
         constraintStyle?: ConstraintStyle,
+        sourceAliasStyle?: SourceAliasStyle,
+        orderByDefaultDirectionStyle?: OrderByDefaultDirectionStyle,
         joinConditionOrderByDeclaration?: boolean,
     }) {
         if (options?.preset) {
@@ -285,6 +297,8 @@ export class SqlPrintTokenParser implements SqlComponentVisitor<SqlPrintToken> {
 
         this.castStyle = options?.castStyle ?? 'standard';
         this.constraintStyle = options?.constraintStyle ?? 'postgres';
+        this.sourceAliasStyle = options?.sourceAliasStyle ?? 'as';
+        this.orderByDefaultDirectionStyle = options?.orderByDefaultDirectionStyle ?? 'omit';
         this.normalizeJoinConditionOrder = options?.joinConditionOrderByDeclaration ?? false;
 
         this.handlers.set(ValueList.kind, (expr) => this.visitValueList(expr as ValueList));
@@ -543,6 +557,9 @@ export class SqlPrintTokenParser implements SqlComponentVisitor<SqlPrintToken> {
         if (arg.sortDirection && arg.sortDirection !== SortDirection.Ascending) {
             token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
             token.innerTokens.push(new SqlPrintToken(SqlPrintTokenType.keyword, 'desc'));
+        } else if (this.orderByDefaultDirectionStyle === 'explicit') {
+            token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
+            token.innerTokens.push(new SqlPrintToken(SqlPrintTokenType.keyword, 'asc'));
         }
 
         if (arg.nullsPosition) {
@@ -2182,20 +2199,26 @@ export class SqlPrintTokenParser implements SqlComponentVisitor<SqlPrintToken> {
                 return token;
             }
             token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
-            token.innerTokens.push(new SqlPrintToken(SqlPrintTokenType.keyword, 'as'));
-            token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
+            this.appendSourceAliasKeyword(token);
             // exclude column aliases
             token.innerTokens.push(arg.aliasExpression.accept(this));
             return token;
         } else {
             // For other source types, just print the alias
             token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
-            token.innerTokens.push(new SqlPrintToken(SqlPrintTokenType.keyword, 'as'));
-            token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
+            this.appendSourceAliasKeyword(token);
             // included column aliases
             token.innerTokens.push(arg.aliasExpression.accept(this));
             return token;
         }
+    }
+
+    private appendSourceAliasKeyword(token: SqlPrintToken): void {
+        if (this.sourceAliasStyle === 'implicit') {
+            return;
+        }
+        token.innerTokens.push(new SqlPrintToken(SqlPrintTokenType.keyword, 'as'));
+        token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
     }
 
     public visitFromClause(arg: FromClause): SqlPrintToken {

--- a/packages/core/src/parsers/SqlTokenizer.ts
+++ b/packages/core/src/parsers/SqlTokenizer.ts
@@ -2,11 +2,11 @@ import { FormattingLexeme } from '../models/FormattingLexeme';
 import { Lexeme, LexemePositionedComment, TokenType } from '../models/Lexeme';
 import { CommandTokenReader } from '../tokenReaders/CommandTokenReader';
 import { EscapedIdentifierTokenReader } from '../tokenReaders/EscapedIdentifierTokenReader';
-import { FunctionTokenReader } from '../tokenReaders/FunctionTokenReader';
 import { IdentifierTokenReader } from '../tokenReaders/IdentifierTokenReader';
 import { LiteralTokenReader } from '../tokenReaders/LiteralTokenReader';
 import { OperatorTokenReader } from '../tokenReaders/OperatorTokenReader';
 import { ParameterTokenReader } from '../tokenReaders/ParameterTokenReader';
+import { PostgresFunctionTokenReader } from '../tokenReaders/PostgresFunctionTokenReader';
 import { SpecialSymbolTokenReader } from '../tokenReaders/SymbolTokenReader';
 import { StringSpecifierTokenReader } from '../tokenReaders/StringSpecifierTokenReader';
 import { TokenReaderManager } from '../tokenReaders/TokenReaderManager';
@@ -83,7 +83,7 @@ export class SqlTokenizer {
             // Reason: To prevent types containing parentheses from being misrecognized as functions
             // e.g. `numeric(10, 2)` is a type, not a function
             .register(new TypeTokenReader(input))
-            .register(new FunctionTokenReader(input))
+            .register(new PostgresFunctionTokenReader(input))
             .register(new IdentifierTokenReader(input)) // IdentifierTokenReader should be registered last
             ;
     }

--- a/packages/core/src/tokenReaders/FunctionTokenReader.ts
+++ b/packages/core/src/tokenReaders/FunctionTokenReader.ts
@@ -15,6 +15,10 @@ const keywordParser = new KeywordParser(trie);
  * Reads SQL identifier tokens
  */
 export class FunctionTokenReader extends BaseTokenReader {
+    protected tryReadDialectSpecificToken(_previous: Lexeme | null): Lexeme | null {
+        return null;
+    }
+
     /**
      * Try to read an identifier token
      */
@@ -23,9 +27,9 @@ export class FunctionTokenReader extends BaseTokenReader {
             return null;
         }
 
-        if (this.input.slice(this.position, this.position + 6).toLowerCase() === 'array[') {
-            this.position += 5;
-            return this.createLexeme(TokenType.Function, 'array');
+        const dialectToken = this.tryReadDialectSpecificToken(previous);
+        if (dialectToken) {
+            return dialectToken;
         }
 
         // Check for keyword identifiers

--- a/packages/core/src/tokenReaders/FunctionTokenReader.ts
+++ b/packages/core/src/tokenReaders/FunctionTokenReader.ts
@@ -23,6 +23,11 @@ export class FunctionTokenReader extends BaseTokenReader {
             return null;
         }
 
+        if (this.input.slice(this.position, this.position + 6).toLowerCase() === 'array[') {
+            this.position += 5;
+            return this.createLexeme(TokenType.Function, 'array');
+        }
+
         // Check for keyword identifiers
         const keyword = keywordParser.parse(this.input, this.position);
         if (keyword !== null) {

--- a/packages/core/src/tokenReaders/PostgresFunctionTokenReader.ts
+++ b/packages/core/src/tokenReaders/PostgresFunctionTokenReader.ts
@@ -1,0 +1,13 @@
+import { Lexeme, TokenType } from '../models/Lexeme';
+import { FunctionTokenReader } from './FunctionTokenReader';
+
+export class PostgresFunctionTokenReader extends FunctionTokenReader {
+    protected override tryReadDialectSpecificToken(_previous: Lexeme | null): Lexeme | null {
+        if (this.input.slice(this.position, this.position + 6).toLowerCase() !== 'array[') {
+            return null;
+        }
+
+        this.position += 5;
+        return this.createLexeme(TokenType.Function, 'array');
+    }
+}

--- a/packages/core/src/transformers/SqlFormatter.ts
+++ b/packages/core/src/transformers/SqlFormatter.ts
@@ -1,4 +1,4 @@
-import { SqlPrintTokenParser, FormatterConfig, PRESETS, CastStyle, ConstraintStyle } from '../parsers/SqlPrintTokenParser';
+import { SqlPrintTokenParser, FormatterConfig, PRESETS, CastStyle, ConstraintStyle, SourceAliasStyle, OrderByDefaultDirectionStyle } from '../parsers/SqlPrintTokenParser';
 import { SqlPrinter, CommaBreakStyle, AndBreakStyle, OrBreakStyle } from './SqlPrinter';
 import { CommentExportMode } from '../types/Formatting';
 import { IndentCharOption, NewlineOption } from './LinePrinter'; // Import types for compatibility
@@ -109,6 +109,10 @@ export interface SqlFormatterOptions extends BaseFormattingOptions {
     castStyle?: CastStyle;
     /** Constraint rendering style (affects CREATE TABLE constraint layout) */
     constraintStyle?: ConstraintStyle;
+    /** Source alias rendering style for FROM/JOIN sources */
+    sourceAliasStyle?: SourceAliasStyle;
+    /** Default ORDER BY direction rendering style */
+    orderByDefaultDirectionStyle?: OrderByDefaultDirectionStyle;
 }
 
 /**
@@ -146,6 +150,8 @@ export class SqlFormatter {
             parameterSymbol: options.parameterSymbol ?? presetConfig?.parameterSymbol,
             parameterStyle: options.parameterStyle ?? presetConfig?.parameterStyle,
             castStyle: options.castStyle ?? presetConfig?.castStyle,
+            sourceAliasStyle: options.sourceAliasStyle ?? presetConfig?.sourceAliasStyle,
+            orderByDefaultDirectionStyle: options.orderByDefaultDirectionStyle ?? presetConfig?.orderByDefaultDirectionStyle,
             joinConditionOrderByDeclaration: options.joinConditionOrderByDeclaration,
         };
 

--- a/packages/core/tests/transformers/SqlFormatter.cast-style.test.ts
+++ b/packages/core/tests/transformers/SqlFormatter.cast-style.test.ts
@@ -16,4 +16,32 @@ describe('SqlFormatter cast style', () => {
 
         expect(sql).toBe('select "id"::INTEGER from "users"');
     });
+
+    it('keeps PostgreSQL empty array constructors unquoted when emitting ANSI CAST syntax', () => {
+        const query = SelectQueryParser.parse('SELECT array[]::text[]');
+        const sql = new SqlFormatter().format(query).formattedSql;
+
+        expect(sql).toBe('select cast(array[] as text[])');
+    });
+
+    it('keeps PostgreSQL empty array constructors unquoted inside function arguments', () => {
+        const query = SelectQueryParser.parse('SELECT coalesce(tags.tag_slugs, array[]::text[]) FROM tags');
+        const sql = new SqlFormatter().format(query).formattedSql;
+
+        expect(sql).toBe('select coalesce("tags"."tag_slugs", cast(array[] as text[])) from "tags"');
+    });
+
+    it('keeps PostgreSQL empty array constructor casts in postgres preset function arguments', () => {
+        const query = SelectQueryParser.parse('SELECT coalesce(tags.tag_slugs, array[]::text[]) FROM tags');
+        const sql = new SqlFormatter({ preset: 'postgres' }).format(query).formattedSql;
+
+        expect(sql).toBe('select coalesce("tags"."tag_slugs", array[]::text[]) from "tags"');
+    });
+
+    it('keeps PostgreSQL empty array constructors unquoted inside aggregate arguments', () => {
+        const query = SelectQueryParser.parse('SELECT array_agg(array[]::text[] order by tag) FROM tags');
+        const sql = new SqlFormatter().format(query).formattedSql;
+
+        expect(sql).toBe('select array_agg(cast(array[] as text[]) order by "tag") from "tags"');
+    });
 });

--- a/packages/core/tests/transformers/SqlFormatter.order-by-direction-style.test.ts
+++ b/packages/core/tests/transformers/SqlFormatter.order-by-direction-style.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
+import { SqlFormatter } from '../../src/transformers/SqlFormatter';
+
+describe('SqlFormatter order by default direction style', () => {
+    it('omits ASC by default', () => {
+        const query = SelectQueryParser.parse('select id from users order by created_at asc, id asc');
+        const sql = new SqlFormatter().format(query).formattedSql;
+
+        expect(sql).toBe('select "id" from "users" order by "created_at", "id"');
+    });
+
+    it('can render the default ASC direction explicitly', () => {
+        const query = SelectQueryParser.parse('select id from users order by created_at asc, id asc');
+        const sql = new SqlFormatter({ orderByDefaultDirectionStyle: 'explicit' }).format(query).formattedSql;
+
+        expect(sql).toBe('select "id" from "users" order by "created_at" asc, "id" asc');
+    });
+
+    it('keeps DESC unchanged when ASC is explicit', () => {
+        const query = SelectQueryParser.parse('select id from users order by created_at desc, id asc');
+        const sql = new SqlFormatter({ orderByDefaultDirectionStyle: 'explicit' }).format(query).formattedSql;
+
+        expect(sql).toBe('select "id" from "users" order by "created_at" desc, "id" asc');
+    });
+});

--- a/packages/core/tests/transformers/SqlFormatter.source-alias-style.test.ts
+++ b/packages/core/tests/transformers/SqlFormatter.source-alias-style.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
+import { SqlFormatter } from '../../src/transformers/SqlFormatter';
+
+describe('SqlFormatter source alias style', () => {
+    it('renders source aliases with explicit AS by default', () => {
+        const query = SelectQueryParser.parse('select u.id from users u join accounts a on a.user_id = u.id');
+        const sql = new SqlFormatter().format(query).formattedSql;
+
+        expect(sql).toBe('select "u"."id" from "users" as "u" join "accounts" as "a" on "a"."user_id" = "u"."id"');
+    });
+
+    it('can render source aliases without inserting optional AS keywords', () => {
+        const query = SelectQueryParser.parse('select u.id from users u join accounts a on a.user_id = u.id');
+        const sql = new SqlFormatter({ sourceAliasStyle: 'implicit' }).format(query).formattedSql;
+
+        expect(sql).toBe('select "u"."id" from "users" "u" join "accounts" "a" on "a"."user_id" = "u"."id"');
+    });
+
+    it('keeps column aliases explicit when source aliases are implicit', () => {
+        const query = SelectQueryParser.parse('select u.id as user_id from users u');
+        const sql = new SqlFormatter({ sourceAliasStyle: 'implicit' }).format(query).formattedSql;
+
+        expect(sql).toBe('select "u"."id" as "user_id" from "users" "u"');
+    });
+});


### PR DESCRIPTION
## Summary

- Fix PostgreSQL empty array constructor formatting inside function arguments so `array[]::text[]` remains an array cast instead of becoming a quoted identifier cast.
- Add token-stable formatter controls for callers that need SQL formatting without optional source-alias `AS` insertion or implicit `ASC` removal.
- Cover the formatter behavior with focused regression tests and a changeset.

## Verification

- `pnpm --filter rawsql-ts exec vitest run tests/transformers/SqlFormatter.source-alias-style.test.ts tests/transformers/SqlFormatter.order-by-direction-style.test.ts tests/transformers/SqlFormatter.cast-style.test.ts`
- `pnpm --filter rawsql-ts test`
- `pnpm --filter rawsql-ts build`
- `pnpm --filter rawsql-ts lint`
- `pnpm --filter rawsql-ts benchmark`
- `pnpm demo:complex-sql`
- pre-commit hook during amend: workspace `typecheck`, workspace tests, workspace build, workspace lint
- Tarball smoke in Ashiba support-inbox example: `query format --all --check` reached `Unsafe: 0`; after temporary write, `pnpm check:drift` passed. Ashiba temp changes were restored.

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

<!-- Write values on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. -->
<!-- Do not add list markers like "-" before these labels; `Tracking issue:` and `Scoped checks run:` must start at column 0. -->
Tracking issue: Not applicable; no baseline exception requested.
Scoped checks run: Full rawsql-ts package checks plus workspace pre-commit checks listed in Verification.
Why full baseline is not required: Full baseline exception is not requested; focused and workspace checks completed for the changed formatter/tokenizer surface.

## Self Review

<!-- Fill these fields after running the repo self-review workflow or available self-review skill. -->
Self-review workflow: developer-self-review two-cycle review: consistency review and human acceptance review.
Self-review result: No blockers remain. Verification evidence is explicit; known Ashiba example expectation-string follow-up is outside this rawsql-ts PR and was not left as a repo change.
Concept-review workflow: Package-boundary review for rawsql-ts formatter/token-reader responsibility; no Concept Spec change required because this keeps AST/formatter behavior in rawsql-ts and does not move parsing into adapters.
Concept-review result: No package-boundary violation found. Defaults preserve existing formatter behavior; new behavior is opt-in.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-migration rationale: This PR changes rawsql-ts formatter options and parser/token-reader behavior, not a CLI command surface in this repository.
Upgrade note: New formatter options are opt-in: `sourceAliasStyle: "implicit"` and `orderByDefaultDirectionStyle: "explicit"`; existing defaults remain unchanged.
Deprecation/removal plan or issue: No deprecation or removal.
Docs/help/examples updated: Changeset describes the release-visible behavior; focused tests document usage.
Release/changeset wording: `.changeset/quiet-arrays-walk.md` covers empty array casts and token-stable formatter options.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-proof rationale: No scaffold output or scaffold command behavior is changed.
Non-edit assertion: Not applicable; no generated scaffold contract changed.
Fail-fast input-contract proof: Not applicable; no scaffold input contract changed.
Generated-output viability proof: Not applicable; no scaffold generated output changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `sourceAliasStyle: "implicit"` option to omit optional `AS` keywords for source aliases in `FROM` and `JOIN` clauses.
  * Added `orderByDefaultDirectionStyle: "explicit"` option to preserve explicit `ASC` directions in `ORDER BY` clauses.

* **Bug Fixes**
  * Fixed PostgreSQL parsing for empty array constructors inside function arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->