### PR TITLE
Fix CUD demo style help and presets

### DIFF
--- a/docs/guide/formatting-recipes.md
+++ b/docs/guide/formatting-recipes.md
@@ -39,6 +39,10 @@ const { formattedSql, params } = formatter.format(query);
 | `joinConditionOrderByDeclaration` | `true` / `false` | `false` | Normalizes `JOIN ... ON` column comparisons so the left operand matches table declaration order. |
 | `whenOneLine` | `true` / `false` | `false` | Forces each `MERGE WHEN` predicate to stay on a single line even if `andBreak` / `orBreak` would normally wrap it. |
 | `exportComment` | `'full'`, `'none'`, `'header-only'`, `'top-header-only'` (legacy `true` / `false` still accepted) | `'none'` | Controls which comments are emitted: `'full'` prints everything, `'none'` drops all comments, `'header-only'` keeps leading comments on every block, and `'top-header-only'` keeps only top-level headers. |
+| `identifierEscape` | `'none'`, `'quote'`, `'backtick'`, `'bracket'`, or `{ "start": string, "end": string }` | From preset or `'quote'` internally | Chooses the identifier delimiter symbol. `'none'` means no delimiter symbol, not "no identifiers targeted". |
+| `identifierEscapeTarget` | `'all'`, `'minimal'` | `'all'` | Chooses whether the formatter escapes every identifier or only identifiers that need escaping to stay valid and semantically safe. Pair it with `identifierEscape`, e.g. `{ "identifierEscape": "quote", "identifierEscapeTarget": "minimal" }`. |
+| `sourceAliasStyle` | `'as'`, `'implicit'` | From preset or `'as'` | Controls whether source aliases render as `from users as u` or `from users u`. |
+| `orderByDefaultDirectionStyle` | `'omit'`, `'explicit'` | From preset or `'omit'` | Controls whether default ascending sort direction is omitted or printed as `ASC`. |
 | `castStyle` | 'standard', 'postgres' | From preset or 'standard' | Chooses how CAST expressions are printed. 'standard' emits ANSI `CAST(expr AS type)` while 'postgres' emits `expr::type`. See "Controlling CAST style" below for usage notes and examples. |
 | `constraintStyle` | `'postgres'`, `'mysql'` | From preset or `'postgres'` | Shapes constraint output in DDL: `'postgres'` prints `constraint ... primary key(...)`, while `'mysql'` emits `unique key name(...)` / `foreign key name(...)`. |
 
@@ -151,6 +155,29 @@ new SqlFormatter({ castStyle: 'postgres' }).format(expr); // "price"::NUMERIC(10
 
 If you are migrating away from PostgreSQL-only syntax, enforce `castStyle: 'standard'` and phase out `::` usage gradually.
 
+### Minimal identifier escaping and alias style
+
+`identifierEscape` selects the delimiter symbol, while `identifierEscapeTarget` selects how many identifiers receive that symbol. They are independent settings:
+
+```json
+{
+  "identifierEscape": "quote",
+  "identifierEscapeTarget": "minimal"
+}
+```
+
+With `minimal`, quoted output is kept only where removing the delimiter would break SQL or change semantics, such as names with spaces, mixed-case identifiers, reserved words, or PostgreSQL special names. Safe lower-case identifiers can print without quotes.
+
+Use `sourceAliasStyle` when you want to preserve alias shorthand:
+
+```json
+{
+  "sourceAliasStyle": "implicit"
+}
+```
+
+This renders `from users u` instead of `from users as u`. Set it to `'as'` when your house style prefers explicit aliases.
+
 ### DDL constraint style
 
 `constraintStyle` controls how table- and column-level constraints appear when formatting `CREATE TABLE` statements.
@@ -172,6 +199,7 @@ Pair this option with your target engine: presets such as `'mysql'` enable it au
 ```json
 {
   "identifierEscape": "none",
+  "identifierEscapeTarget": "all",
   "parameterSymbol": ":",
   "parameterStyle": "named",
   "indentSize": 4,
@@ -194,6 +222,8 @@ Pair this option with your target engine: presets such as `'mysql'` enable it au
   "joinOneLine": true,
   "caseOneLine": true,
   "subqueryOneLine": true,
+  "sourceAliasStyle": "implicit",
+  "orderByDefaultDirectionStyle": "omit",
   "castStyle": "postgres",
   "constraintStyle": "postgres"
 }

--- a/docs/public/cud-demo/index.html
+++ b/docs/public/cud-demo/index.html
@@ -75,7 +75,7 @@
                                 style="background: #2d2d44; color: #e4e4e7; border: 1px solid #3d3d5c; padding: 6px; border-radius: 4px; width: 100%; box-sizing: border-box; margin-top: 5px;">
                         </div>
                         <label for="style-json-editor" style="display: block; margin-top: 10px;">
-                            Style JSON: <a href="../../../guide/formatting-recipes.html" target="_blank"
+                            Style JSON: <a href="/rawsql-ts/guide/formatting-recipes.html" target="_blank"
                                 style="color: #60a5fa; font-size: 0.9em; margin-left: 5px;">(Help)</a>
                         </label>
                         <textarea id="style-json-editor"></textarea>

--- a/docs/public/cud-demo/script.js
+++ b/docs/public/cud-demo/script.js
@@ -1,13 +1,22 @@
 // Default formatting options matching the main demo
 const defaultFormatOptions = {
     "identifierEscape": "none",
+    "identifierEscapeTarget": "all",
     "parameterSymbol": ":",
     "parameterStyle": "named",
     "indentSize": 4,
+    "indentChar": "space",
+    "newline": "lf",
     "keywordCase": "lower",
     "identifierCase": "preserve",
     "expressionWidth": 50,
-    "lineWrapping": false
+    "lineWrapping": false,
+    "sourceAliasStyle": "as",
+    "orderByDefaultDirectionStyle": "omit",
+    "castStyle": "standard",
+    "constraintStyle": "postgres",
+    "insertColumnsOneLine": true,
+    "whenOneLine": false
 };
 
 // Initialize CodeMirror editors immediately

--- a/docs/public/demo/style-config.js
+++ b/docs/public/demo/style-config.js
@@ -4,6 +4,179 @@
 const DEFAULT_STYLE_KEY = 'rawsql-formatter-styles-v2';
 let currentStyles = {};
 
+const DEFAULT_STYLE_BASE = {
+    "indentSize": 4,
+    "indentChar": "space",
+    "newline": "lf",
+    "keywordCase": "lower",
+    "commaBreak": "before",
+    "cteCommaBreak": "before",
+    "valuesCommaBreak": "before",
+    "andBreak": "before",
+    "orBreak": "before",
+    "exportComment": "full",
+    "commentStyle": "block",
+    "withClauseStyle": "standard",
+    "parenthesesOneLine": true,
+    "indentNestedParentheses": true,
+    "betweenOneLine": true,
+    "valuesOneLine": false,
+    "joinOneLine": true,
+    "caseOneLine": false,
+    "subqueryOneLine": false,
+    "insertColumnsOneLine": true,
+    "whenOneLine": false,
+    "joinConditionOrderByDeclaration": false,
+    "orderByDefaultDirectionStyle": "omit",
+    "constraintStyle": "postgres"
+};
+
+const DEFAULT_STYLES = {
+    "Default": {
+        ...DEFAULT_STYLE_BASE,
+        "identifierEscape": "none",
+        "identifierEscapeTarget": "all",
+        "parameterSymbol": ":",
+        "parameterStyle": "named",
+        "sourceAliasStyle": "as",
+        "castStyle": "standard"
+    },
+    "OneLiner": {
+        "identifierEscape": "none",
+        "identifierEscapeTarget": "all",
+        "parameterSymbol": ":",
+        "parameterStyle": "named",
+        "keywordCase": "lower",
+        "sourceAliasStyle": "as",
+        "castStyle": "standard",
+        "constraintStyle": "postgres",
+        "orderByDefaultDirectionStyle": "omit"
+    },
+    "Postgres": {
+        ...DEFAULT_STYLE_BASE,
+        "identifierEscape": "quote",
+        "identifierEscapeTarget": "all",
+        "parameterSymbol": "$",
+        "parameterStyle": "indexed",
+        "keywordCase": "upper",
+        "sourceAliasStyle": "as",
+        "castStyle": "postgres",
+        "constraintStyle": "postgres"
+    },
+    "Postgres Minimal": {
+        ...DEFAULT_STYLE_BASE,
+        "identifierEscape": "quote",
+        "identifierEscapeTarget": "minimal",
+        "parameterSymbol": "$",
+        "parameterStyle": "indexed",
+        "keywordCase": "lower",
+        "sourceAliasStyle": "implicit",
+        "castStyle": "postgres",
+        "constraintStyle": "postgres"
+    },
+    "MySQL": {
+        ...DEFAULT_STYLE_BASE,
+        "identifierEscape": "backtick",
+        "identifierEscapeTarget": "all",
+        "parameterSymbol": "?",
+        "parameterStyle": "anonymous",
+        "keywordCase": "upper",
+        "sourceAliasStyle": "as",
+        "castStyle": "standard",
+        "constraintStyle": "mysql"
+    },
+    "MySQL Minimal": {
+        ...DEFAULT_STYLE_BASE,
+        "identifierEscape": "backtick",
+        "identifierEscapeTarget": "minimal",
+        "parameterSymbol": "?",
+        "parameterStyle": "anonymous",
+        "keywordCase": "lower",
+        "sourceAliasStyle": "implicit",
+        "castStyle": "standard",
+        "constraintStyle": "mysql"
+    },
+    "SQLServer": {
+        ...DEFAULT_STYLE_BASE,
+        "identifierEscape": "bracket",
+        "identifierEscapeTarget": "all",
+        "parameterSymbol": "@",
+        "parameterStyle": "named",
+        "keywordCase": "upper",
+        "sourceAliasStyle": "as",
+        "castStyle": "standard",
+        "constraintStyle": "postgres"
+    },
+    "SQLServer Minimal": {
+        ...DEFAULT_STYLE_BASE,
+        "identifierEscape": "bracket",
+        "identifierEscapeTarget": "minimal",
+        "parameterSymbol": "@",
+        "parameterStyle": "named",
+        "keywordCase": "lower",
+        "sourceAliasStyle": "implicit",
+        "castStyle": "standard",
+        "constraintStyle": "postgres"
+    }
+};
+
+function cloneStyle(style) {
+    return JSON.parse(JSON.stringify(style));
+}
+
+function inferStyleDefaults(name, style) {
+    if (DEFAULT_STYLES[name]) {
+        return DEFAULT_STYLES[name];
+    }
+
+    const identifierEscape = style?.identifierEscape ?? "none";
+    const dialectDefaults =
+        identifierEscape === "backtick"
+            ? { constraintStyle: "mysql" }
+            : identifierEscape === "quote" && style?.parameterSymbol === "$"
+              ? { castStyle: "postgres", constraintStyle: "postgres" }
+              : {};
+
+    return {
+        "identifierEscapeTarget": "all",
+        "sourceAliasStyle": "as",
+        "castStyle": "standard",
+        "constraintStyle": "postgres",
+        "orderByDefaultDirectionStyle": "omit",
+        "insertColumnsOneLine": true,
+        "whenOneLine": false,
+        ...dialectDefaults
+    };
+}
+
+function normalizeStyle(name, style) {
+    return {
+        ...cloneStyle(inferStyleDefaults(name, style)),
+        ...style
+    };
+}
+
+function createDefaultStyles() {
+    return Object.fromEntries(
+        Object.entries(DEFAULT_STYLES).map(([name, style]) => [name, cloneStyle(style)])
+    );
+}
+
+function normalizeStyles(styles) {
+    const normalized = {};
+    for (const [name, style] of Object.entries(styles || {})) {
+        normalized[name] = normalizeStyle(name, style);
+    }
+
+    for (const [name, style] of Object.entries(DEFAULT_STYLES)) {
+        if (!normalized[name]) {
+            normalized[name] = cloneStyle(style);
+        }
+    }
+
+    return normalized;
+}
+
 // DOM elements and external functions - these will be initialized via initStyleConfig
 let styleSelect, styleNameInput, addNewStyleBtn, deleteStyleBtn, saveStyleBtn, resetAllSettingsBtn, revertStyleBtn;
 let styleJsonEditor;
@@ -46,112 +219,10 @@ function initStyleConfig(elements, editorInstance, formatterFunc, statusBarUpdat
 function loadStylesData() {
     const storedStyles = localStorage.getItem(DEFAULT_STYLE_KEY);
     if (storedStyles) {
-        currentStyles = JSON.parse(storedStyles);
+        currentStyles = normalizeStyles(JSON.parse(storedStyles));
+        localStorage.setItem(DEFAULT_STYLE_KEY, JSON.stringify(currentStyles));
     } else {
-        currentStyles = {
-            "Default": {
-                "identifierEscape": "none",
-                "parameterSymbol": ":",
-                "parameterStyle": "named",
-                "indentSize": 4,
-                "indentChar": "space",
-                "newline": "lf",
-                "keywordCase": "lower",
-                "commaBreak": "before",
-                "valuesCommaBreak": "before",
-                "andBreak": "before",
-                "orBreak": "before",
-                "exportComment": true,
-                "commentStyle": "block",
-                "withClauseStyle": "standard",
-                "parenthesesOneLine": true,
-                "indentNestedParentheses": true,
-                "betweenOneLine": true,
-                "valuesOneLine": false,
-                "joinOneLine": true,
-                "caseOneLine": false,
-                "subqueryOneLine": false,
-                "joinConditionOrderByDeclaration": false
-            },
-            "OneLiner": {
-                "identifierEscape": "none",
-                "parameterSymbol": ":",
-                "parameterStyle": "named",
-                "keywordCase": "lower"
-            },
-            "Postgres": {
-                "identifierEscape": "quote",
-                "parameterSymbol": "$",
-                "parameterStyle": "indexed",
-                "indentSize": 4,
-                "indentChar": "space",
-                "newline": "lf",
-                "keywordCase": "upper",
-                "commaBreak": "before",
-                "valuesCommaBreak": "before",
-                "andBreak": "before",
-                "orBreak": "before",
-                "exportComment": true,
-                "commentStyle": "block",
-                "withClauseStyle": "standard",
-                "parenthesesOneLine": true,
-                "indentNestedParentheses": true,
-                "betweenOneLine": true,
-                "valuesOneLine": false,
-                "joinOneLine": true,
-                "caseOneLine": false,
-                "subqueryOneLine": false,
-                "joinConditionOrderByDeclaration": false
-            },
-            "MySQL": {
-                "identifierEscape": "backtick",
-                "parameterSymbol": "?",
-                "parameterStyle": "anonymous",
-                "indentSize": 4,
-                "indentChar": "space",
-                "newline": "lf",
-                "keywordCase": "upper",
-                "commaBreak": "before",
-                "valuesCommaBreak": "before",
-                "andBreak": "before",
-                "orBreak": "before",
-                "exportComment": true,
-                "commentStyle": "block",
-                "withClauseStyle": "standard",
-                "parenthesesOneLine": true,
-                "indentNestedParentheses": true,
-                "betweenOneLine": true,
-                "valuesOneLine": false,
-                "joinOneLine": true,
-                "caseOneLine": false,
-                "subqueryOneLine": false,
-                "joinConditionOrderByDeclaration": false
-            },
-            "SQLServer": {
-                "identifierEscape": "bracket",
-                "parameterSymbol": "@",
-                "parameterStyle": "named",
-                "indentSize": 4,
-                "indentChar": "space",
-                "newline": "lf",
-                "keywordCase": "upper",
-                "commaBreak": "before",
-                "valuesCommaBreak": "before",
-                "andBreak": "before",
-                "orBreak": "before",
-                "exportComment": true,
-                "commentStyle": "block",
-                "withClauseStyle": "standard",
-                "parenthesesOneLine": true,
-                "indentNestedParentheses": true,
-                "betweenOneLine": true,
-                "valuesOneLine": false,
-                "joinOneLine": true,
-                "caseOneLine": false,
-                "subqueryOneLine": false,
-                "joinConditionOrderByDeclaration": false
-            }
-        };
+        currentStyles = createDefaultStyles();
         localStorage.setItem(DEFAULT_STYLE_KEY, JSON.stringify(currentStyles));
     }
 }

--- a/docs/public/migration-demo/script.js
+++ b/docs/public/migration-demo/script.js
@@ -1,13 +1,22 @@
 // Default formatting options
 const defaultFormatOptions = {
     "identifierEscape": "none",
+    "identifierEscapeTarget": "all",
     "parameterSymbol": ":",
     "parameterStyle": "named",
     "indentSize": 4,
+    "indentChar": "space",
+    "newline": "lf",
     "keywordCase": "lower",
     "identifierCase": "preserve",
     "expressionWidth": 50,
-    "lineWrapping": false
+    "lineWrapping": false,
+    "sourceAliasStyle": "as",
+    "orderByDefaultDirectionStyle": "omit",
+    "castStyle": "standard",
+    "constraintStyle": "postgres",
+    "insertColumnsOneLine": true,
+    "whenOneLine": false
 };
 
 // Initialize Editors


### PR DESCRIPTION
## Summary

- Fix the CUD demo `Style JSON` help link so GitHub Pages opens the rawsql-ts formatting recipes page.
- Refresh shared demo style presets with newer formatter options, including minimal identifier escaping targets and source alias style.
- Document the newer formatter style options in the formatting recipes guide.

## Verification

- `node --check docs\public\demo\style-config.js`
- `node --check docs\public\cud-demo\script.js`
- `node --check docs\public\migration-demo\script.js`
- `node --input-type=module -e "... style-config smoke ..."`
- `pnpm --filter rawsql-ts test -- SqlFormatter.identifier-minimal.test.ts SqlFormatter.source-alias-style.test.ts`
- `pnpm --filter rawsql-ts build`
- `pnpm run docs:build`
- `pnpm test`
- Pre-commit hook: staged-file policy, `pnpm typecheck`, `pnpm test`, `pnpm build`, and `pnpm lint`

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

<!-- Write values on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. -->
<!-- Do not add list markers like "-" before these labels; `Tracking issue:` and `Scoped checks run:` must start at column 0. -->
Tracking issue:
Scoped checks run:
Why full baseline is not required:

## Self Review

<!-- Fill these fields after running the repo self-review workflow or available self-review skill. -->
Self-review workflow: developer-self-review skill, consistency review, and human acceptance review.
Self-review result: No blockers remain; the diff is limited to docs/demo files and the generated docs side effects were restored.
Concept-review workflow: Explicit no-concept-impact review; this PR changes demo presets, a demo help link, and formatting guide wording only.
Concept-review result: No package behavior, scaffold contract, or concept-boundary violation found.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-migration rationale: This is a docs/browser demo preset update, not a CLI behavior or option migration.
Upgrade note: No upgrade action required.
Deprecation/removal plan or issue: No deprecation or removal.
Docs/help/examples updated: Formatting recipes and demo presets were updated.
Release/changeset wording: No package release changeset; docs/demo only.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-proof rationale: This PR does not change scaffold generation, scaffold inputs, or generated scaffold output.
Non-edit assertion: Not applicable; no scaffold files are edited.
Fail-fast input-contract proof: Not applicable; no scaffold input contract changes.
Generated-output viability proof: Not applicable; no scaffold output changes.
