### PR TITLE
Add formatter oneline width guard

### DIFF
--- a/.changeset/calm-oneline-guards.md
+++ b/.changeset/calm-oneline-guards.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": minor
+---
+
+Add the `oneLineMaxLength` formatter option. When enabled, opt-in one-line constructs such as parentheses, CASE expressions, JOIN conditions, subqueries, and `cte-oneline` CTE entries stay compact only while their rendered candidate fits within the configured width; longer candidates fall back to the normal multiline formatter.

--- a/docs/guide/formatting-recipes.md
+++ b/docs/guide/formatting-recipes.md
@@ -36,6 +36,7 @@ const { formattedSql, params } = formatter.format(query);
 | `commentStyle` | `'block'`, `'smart'` | `'block'` | Normalises how comments are emitted (see below). |
 | `withClauseStyle` | `'standard'`, `'cte-oneline'`, `'full-oneline'` | `'standard'` | Expands or collapses common table expressions. |
 | `parenthesesOneLine`, `betweenOneLine`, `valuesOneLine`, `joinOneLine`, `caseOneLine`, `subqueryOneLine` | `true` / `false` | `false` for each | Opt-in switches that keep the corresponding construct on a single line even if other break settings would expand it. |
+| `oneLineMaxLength` | Positive integer | Unlimited | Optional width guard for opt-in one-line constructs. When a one-line candidate would exceed this length, the formatter falls back to the normal multiline layout for that construct. |
 | `joinConditionOrderByDeclaration` | `true` / `false` | `false` | Normalizes `JOIN ... ON` column comparisons so the left operand matches table declaration order. |
 | `whenOneLine` | `true` / `false` | `false` | Forces each `MERGE WHEN` predicate to stay on a single line even if `andBreak` / `orBreak` would normally wrap it. |
 | `exportComment` | `'full'`, `'none'`, `'header-only'`, `'top-header-only'` (legacy `true` / `false` still accepted) | `'none'` | Controls which comments are emitted: `'full'` prints everything, `'none'` drops all comments, `'header-only'` keeps leading comments on every block, and `'top-header-only'` keeps only top-level headers. |
@@ -101,6 +102,39 @@ const formatter = new SqlFormatter({
 ```
 
 The switch leaves other logical groups untouched, so `WHERE` clauses continue to follow the global `andBreak` / `orBreak` style.
+
+### Keeping short one-line groups without flattening long predicates
+
+The `*OneLine` switches are useful for compact predicates such as SSSQL optional filters:
+
+```sql
+(cast(:status as text) is null or status = :status)
+```
+
+The same switch can become hard to read when the predicate grows into a long keyword search or a `CASE` expression. Set `oneLineMaxLength` to keep short candidates compact while allowing long candidates to fall back to the regular multiline formatter:
+
+```typescript
+const formatter = new SqlFormatter({
+    newline: 'lf',
+    parenthesesOneLine: true,
+    caseOneLine: true,
+    orBreak: 'before',
+    oneLineMaxLength: 100
+});
+```
+
+With the width guard enabled, a short optional predicate can stay on one line, while a longer group expands into the configured logical-operator layout:
+
+```sql
+(
+    :keyword is null
+    or subject ilike '%' || :keyword || '%'
+    or customer_name ilike '%' || :keyword || '%'
+    or latest_message_body ilike '%' || :keyword || '%'
+)
+```
+
+The limit applies to opt-in one-line containers such as parentheses, `BETWEEN`, `VALUES`, `JOIN ... ON`, `CASE`, subqueries, and individual CTE entries formatted by `withClauseStyle: 'cte-oneline'`. The width check includes the current indentation and any text already present on the line. It does not change `withClauseStyle: 'full-oneline'`, which intentionally treats the whole `WITH` block as a single-line mode.
 
 ### INSERT column list layouts
 
@@ -213,6 +247,7 @@ Pair this option with your target engine: presets such as `'mysql'` enable it au
   "orBreak": "before",
   "withClauseStyle": "cte-oneline",
   "insertColumnsOneLine": true,
+  "oneLineMaxLength": 100,
   "indentNestedParentheses": true,
   "exportComment": "full",
   "commentStyle": "smart",

--- a/docs/public/demo/style-config.js
+++ b/docs/public/demo/style-config.js
@@ -26,6 +26,7 @@ const DEFAULT_STYLE_BASE = {
     "subqueryOneLine": false,
     "insertColumnsOneLine": true,
     "whenOneLine": false,
+    "oneLineMaxLength": 100,
     "joinConditionOrderByDeclaration": false,
     "orderByDefaultDirectionStyle": "omit",
     "constraintStyle": "postgres"
@@ -145,6 +146,7 @@ function inferStyleDefaults(name, style) {
         "orderByDefaultDirectionStyle": "omit",
         "insertColumnsOneLine": true,
         "whenOneLine": false,
+        "oneLineMaxLength": 100,
         ...dialectDefaults
     };
 }

--- a/packages/core/src/transformers/SqlFormatter.ts
+++ b/packages/core/src/transformers/SqlFormatter.ts
@@ -79,6 +79,8 @@ export interface BaseFormattingOptions {
     insertColumnsOneLine?: boolean;
     /** Keep MERGE WHEN clause predicates on one line regardless of AND break settings */
     whenOneLine?: boolean;
+    /** Maximum rendered width for opt-in one-line constructs. Omit to keep legacy unlimited one-line behavior. */
+    oneLineMaxLength?: number;
     /** Reorder JOIN ON column comparisons to follow table declaration order */
     joinConditionOrderByDeclaration?: boolean;
 }

--- a/packages/core/src/transformers/SqlPrinter.ts
+++ b/packages/core/src/transformers/SqlPrinter.ts
@@ -1570,7 +1570,8 @@ export class SqlPrinter {
         if (value === undefined || !Number.isFinite(value) || value <= 0) {
             return undefined;
         }
-        return Math.floor(value);
+        const normalized = Math.floor(value);
+        return normalized > 0 ? normalized : undefined;
     }
 
     private fitsOneLineMaxLength(text: string): boolean {

--- a/packages/core/src/transformers/SqlPrinter.ts
+++ b/packages/core/src/transformers/SqlPrinter.ts
@@ -125,10 +125,14 @@ export class SqlPrinter {
     private insertColumnsOneLine: boolean;
     /** Whether to keep MERGE WHEN predicates on a single line */
     private whenOneLine: boolean;
+    /** Optional maximum width for opt-in one-line constructs */
+    private oneLineMaxLength?: number;
     /** Tracks nesting depth while formatting MERGE WHEN predicate segments */
     private mergeWhenPredicateDepth = 0;
     /** Shared helper for oneline-specific formatting decisions */
     private onelineHelper: OnelineFormattingHelper;
+    /** Containers whose one-line rendering was rejected by oneLineMaxLength */
+    private expandedOneLineFallbackTokens = new WeakSet<SqlPrintToken>();
     /** Pending line comment that needs a forced newline before next token */
     private pendingLineCommentBreak: number | null = null;
     /** Accumulates lines when reconstructing multi-line block comments inside CommentBlocks */
@@ -167,6 +171,7 @@ export class SqlPrinter {
         this.indentNestedParentheses = options?.indentNestedParentheses ?? false;
         this.insertColumnsOneLine = options?.insertColumnsOneLine ?? false;
         this.whenOneLine = options?.whenOneLine ?? false;
+        this.oneLineMaxLength = this.normalizeOneLineMaxLength(options?.oneLineMaxLength);
         const onelineOptions: OnelineFormattingOptions = {
             parenthesesOneLine: this.parenthesesOneLine,
             betweenOneLine: this.betweenOneLine,
@@ -232,6 +237,7 @@ export class SqlPrinter {
         this.insideWithClause = false; // Reset WITH clause context
         this.pendingLineCommentBreak = null;
         this.smartCommentBlockBuilder = null;
+        this.expandedOneLineFallbackTokens = new WeakSet<SqlPrintToken>();
         if (this.linePrinter.lines.length > 0 && level !== this.linePrinter.lines[0].level) {
             this.linePrinter.lines[0].level = level;
         }
@@ -386,7 +392,7 @@ export class SqlPrinter {
         const current = this.linePrinter.getCurrentLine();
         const isCaseContext = this.isCaseContext(token.containerType);
         const nextCaseContextDepth = isCaseContext ? caseContextDepth + 1 : caseContextDepth;
-        const shouldIndentNested = this.shouldIndentNestedParentheses(token, previousSiblingWasOpenParen);
+        let shouldIndentNested = this.shouldIndentNestedParentheses(token, previousSiblingWasOpenParen);
 
         // Handle different token types
         if (token.type === SqlPrintTokenType.keyword) {
@@ -415,13 +421,17 @@ export class SqlPrinter {
             const commentLevel = this.getCommentBaseIndentLevel(level, parentContainerType);
             this.handleCommentNewlineToken(token, commentLevel);
         } else if (token.containerType === SqlPrintTokenContainerType.CommonTable && this.withClauseStyle === 'cte-oneline') {
-            this.handleCteOnelineToken(token, level);
-            return; // Return early to avoid processing innerTokens
-        } else if (this.shouldFormatContainerAsOneline(token, shouldIndentNested)) {
-            this.handleOnelineToken(token, level);
+            if (this.tryHandleCteOnelineToken(token, level)) {
+                return; // Return early to avoid processing innerTokens
+            }
+        } else if (this.shouldFormatContainerAsOneline(token, shouldIndentNested) && this.tryHandleOnelineToken(token, level)) {
             return; // Return early to avoid processing innerTokens
         } else if (!this.tryAppendInsertClauseTokenText(token.text, parentContainerType)) {
             this.linePrinter.appendText(token.text);
+        }
+
+        if (this.expandedOneLineFallbackTokens.has(token)) {
+            shouldIndentNested = true;
         }
 
         // append keyword tokens(not indented)
@@ -829,7 +839,11 @@ export class SqlPrinter {
             if (!this.isOnelineMode()) {
                 if (this.shouldBreakAfterOpeningParen(parentContainerType)) {
                     this.linePrinter.appendNewline(level + 1);
-                } else if (indentParentActive && !(this.insideWithClause && this.withClauseStyle === 'full-oneline')) {
+                } else if (
+                    indentParentActive &&
+                    parentContainerType === SqlPrintTokenContainerType.ParenExpression &&
+                    !(this.insideWithClause && this.withClauseStyle === 'full-oneline')
+                ) {
                     this.linePrinter.appendNewline(level);
                 }
             }
@@ -842,7 +856,11 @@ export class SqlPrinter {
                 this.linePrinter.appendText(token.text);
                 return;
             }
-            if (indentParentActive && !(this.insideWithClause && this.withClauseStyle === 'full-oneline')) {
+            if (
+                indentParentActive &&
+                parentContainerType === SqlPrintTokenContainerType.ParenExpression &&
+                !(this.insideWithClause && this.withClauseStyle === 'full-oneline')
+            ) {
                 const closingLevel = Math.max(level - 1, 0);
                 this.linePrinter.appendNewline(closingLevel);
             }
@@ -894,6 +912,9 @@ export class SqlPrinter {
         }
         if (token.containerType !== SqlPrintTokenContainerType.ParenExpression) {
             return false;
+        }
+        if (this.expandedOneLineFallbackTokens.has(token)) {
+            return true;
         }
 
         // Look for nested parentheses containers. If present, indent to highlight grouping.
@@ -1545,16 +1566,38 @@ export class SqlPrinter {
         return this.newline === ' ';
     }
 
+    private normalizeOneLineMaxLength(value?: number): number | undefined {
+        if (value === undefined || !Number.isFinite(value) || value <= 0) {
+            return undefined;
+        }
+        return Math.floor(value);
+    }
+
+    private fitsOneLineMaxLength(text: string): boolean {
+        if (this.oneLineMaxLength === undefined) {
+            return true;
+        }
+
+        const currentLine = this.linePrinter.getCurrentLine();
+        const indentWidth = currentLine.level * this.indentSize * String(this.indentChar).length;
+        return indentWidth + currentLine.text.length + text.length <= this.oneLineMaxLength;
+    }
+
     /**
      * Handles CTE tokens with one-liner formatting.
      * Creates a nested SqlPrinter instance for proper CTE oneline formatting.
      */
-    private handleCteOnelineToken(token: SqlPrintToken, level: number): void {
+    private tryHandleCteOnelineToken(token: SqlPrintToken, level: number): boolean {
         const onelinePrinter = this.createCteOnelinePrinter();
         const onelineResult = onelinePrinter.print(token, level);
         let cleanedResult = this.cleanDuplicateSpaces(onelineResult);
         cleanedResult = cleanedResult.replace(/\(\s+/g, '(').replace(/\s+\)/g, ' )');
-        this.linePrinter.appendText(cleanedResult.trim());
+        const trimmedResult = cleanedResult.trim();
+        if (!this.fitsOneLineMaxLength(trimmedResult)) {
+            return false;
+        }
+        this.linePrinter.appendText(trimmedResult);
+        return true;
     }
 
     /**
@@ -1582,11 +1625,35 @@ export class SqlPrinter {
      * Handles tokens with oneline formatting (parentheses, BETWEEN, VALUES, JOIN, CASE, subqueries).
      * Creates a unified oneline printer that formats everything as one line regardless of content type.
      */
-    private handleOnelineToken(token: SqlPrintToken, level: number): void {
+    private tryHandleOnelineToken(token: SqlPrintToken, level: number): boolean {
         const onelinePrinter = this.createOnelinePrinter();
         const onelineResult = onelinePrinter.print(token, level);
         const cleanedResult = this.cleanDuplicateSpaces(onelineResult);
+        if (!this.fitsOneLineMaxLength(cleanedResult)) {
+            if (this.isBooleanParenExpression(token)) {
+                this.expandedOneLineFallbackTokens.add(token);
+            }
+            return false;
+        }
         this.linePrinter.appendText(cleanedResult);
+        return true;
+    }
+
+    private isBooleanParenExpression(token: SqlPrintToken): boolean {
+        if (token.containerType !== SqlPrintTokenContainerType.ParenExpression) {
+            return false;
+        }
+        return this.containsLogicalOperator(token);
+    }
+
+    private containsLogicalOperator(token: SqlPrintToken): boolean {
+        if (
+            (token.type === SqlPrintTokenType.operator || token.type === SqlPrintTokenType.keyword) &&
+            ['and', 'or'].includes(token.text.toLowerCase())
+        ) {
+            return true;
+        }
+        return token.innerTokens.some((child) => this.containsLogicalOperator(child));
     }
 
     private getClauseBreakIndentLevel(parentType: SqlPrintTokenContainerType | undefined, level: number): number {

--- a/packages/core/tests/transformers/SqlFormatter.oneline-max-length.test.ts
+++ b/packages/core/tests/transformers/SqlFormatter.oneline-max-length.test.ts
@@ -125,4 +125,29 @@ describe('SqlFormatter - oneLineMaxLength option', () => {
         expect(formattedSql).toContain('\n        select');
         expect(formattedSql).toContain('\n        from\n            tickets');
     });
+
+    test('treats sub-unit fractional limits as unset instead of a zero-width guard', () => {
+        const formatter = new SqlFormatter({
+            newline: 'lf',
+            indentChar: 'space',
+            indentSize: 4,
+            keywordCase: 'lower',
+            identifierEscape: 'none',
+            parameterSymbol: ':',
+            parameterStyle: 'named',
+            parenthesesOneLine: true,
+            orBreak: 'before',
+            oneLineMaxLength: 0.5,
+        });
+
+        const query = SelectQueryParser.parse(`
+            select *
+            from tickets
+            where (cast(:status as text) is null or status = :status)
+        `);
+
+        const { formattedSql } = formatter.format(query);
+
+        expect(formattedSql).toContain('(cast(:status as text) is null or status = :status)');
+    });
 });

--- a/packages/core/tests/transformers/SqlFormatter.oneline-max-length.test.ts
+++ b/packages/core/tests/transformers/SqlFormatter.oneline-max-length.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from 'vitest';
+import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
+import { SqlFormatter } from '../../src/transformers/SqlFormatter';
+
+describe('SqlFormatter - oneLineMaxLength option', () => {
+    test('keeps short SSSQL-style optional predicates on one line', () => {
+        const formatter = new SqlFormatter({
+            newline: 'lf',
+            indentChar: 'space',
+            indentSize: 4,
+            keywordCase: 'lower',
+            identifierEscape: 'none',
+            parameterSymbol: ':',
+            parameterStyle: 'named',
+            parenthesesOneLine: true,
+            orBreak: 'before',
+            oneLineMaxLength: 120,
+        });
+
+        const query = SelectQueryParser.parse(`
+            select *
+            from tickets
+            where (cast(:status as text) is null or status = :status)
+        `);
+
+        const { formattedSql } = formatter.format(query);
+
+        expect(formattedSql).toContain('(cast(:status as text) is null or status = :status)');
+    });
+
+    test('expands long optional predicate groups when the one-line candidate is too wide', () => {
+        const formatter = new SqlFormatter({
+            newline: 'lf',
+            indentChar: 'space',
+            indentSize: 4,
+            keywordCase: 'lower',
+            identifierEscape: 'none',
+            parameterSymbol: ':',
+            parameterStyle: 'named',
+            parenthesesOneLine: true,
+            indentNestedParentheses: true,
+            orBreak: 'before',
+            oneLineMaxLength: 80,
+        });
+
+        const query = SelectQueryParser.parse(`
+            select *
+            from tickets
+            where (:keyword is null
+                or subject ilike '%' || :keyword || '%'
+                or customer_name ilike '%' || :keyword || '%'
+                or latest_message_body ilike '%' || :keyword || '%')
+        `);
+
+        const { formattedSql } = formatter.format(query);
+
+        expect(formattedSql).toContain('(\n        :keyword is null');
+        expect(formattedSql).toContain("\n        or subject ilike '%' || :keyword || '%'");
+        expect(formattedSql).toContain("\n        or customer_name ilike '%' || :keyword || '%'");
+        expect(formattedSql).toContain("\n        or latest_message_body ilike '%' || :keyword || '%'");
+    });
+
+    test('expands long CASE optional predicates while retaining readable CASE layout', () => {
+        const formatter = new SqlFormatter({
+            newline: 'lf',
+            indentChar: 'space',
+            indentSize: 4,
+            keywordCase: 'lower',
+            identifierEscape: 'none',
+            parameterSymbol: ':',
+            parameterStyle: 'named',
+            parenthesesOneLine: true,
+            caseOneLine: true,
+            indentNestedParentheses: true,
+            orBreak: 'before',
+            oneLineMaxLength: 90,
+        });
+
+        const query = SelectQueryParser.parse(`
+            select *
+            from tickets t
+            where (cast(:slaState as text) is null
+                or case
+                    when t.sla_due_at is null then 'none'
+                    when t.sla_due_at < now() then 'breached'
+                    when t.sla_due_at < now() + interval '4 hours' then 'warning'
+                    else 'ok'
+                end = :slaState)
+        `);
+
+        const { formattedSql } = formatter.format(query);
+
+        expect(formattedSql).toContain('(\n        cast(:slaState as text) is null');
+        expect(formattedSql).toContain('\n        or case');
+        expect(formattedSql).toContain("\n            when t.sla_due_at is null then");
+        expect(formattedSql).toContain("\n            else");
+    });
+
+    test('falls back from cte-oneline when a CTE entry exceeds the limit', () => {
+        const formatter = new SqlFormatter({
+            newline: 'lf',
+            indentChar: 'space',
+            indentSize: 4,
+            keywordCase: 'lower',
+            identifierEscape: 'none',
+            withClauseStyle: 'cte-oneline',
+            commaBreak: 'after',
+            cteCommaBreak: 'after',
+            oneLineMaxLength: 60,
+        });
+
+        const query = SelectQueryParser.parse(`
+            with long_filtered_tickets as (
+                select ticket_id, subject, customer_name
+                from tickets
+                where subject is not null
+            )
+            select *
+            from long_filtered_tickets
+        `);
+
+        const { formattedSql } = formatter.format(query);
+
+        expect(formattedSql).toContain('long_filtered_tickets as (');
+        expect(formattedSql).toContain('\n        select');
+        expect(formattedSql).toContain('\n        from\n            tickets');
+    });
+});


### PR DESCRIPTION
## Summary

- Add a formatter width guard for opt-in one-line constructs via oneLineMaxLength.
- Keep compact SSSQL-style predicates on one line while letting long boolean or CASE predicates fall back to multiline formatting.
- Document the option and add it to the public formatter demo defaults.

## Verification

- pnpm vitest run packages/core/tests/transformers/SqlFormatter.oneline-max-length.test.ts
- pnpm vitest run packages/core/tests/transformers/SqlFormatter.parentheses-oneline.test.ts packages/core/tests/transformers/SqlFormatter.new-oneline.test.ts packages/core/tests/transformers/SqlFormatter.indent-nested-parentheses.test.ts packages/core/tests/transformers/SqlFormatter.cteCommaStyle.test.ts
- pnpm typecheck
- node --check docs/public/demo/style-config.js
- pnpm --filter rawsql-ts test
- pnpm --filter rawsql-ts build
- pnpm docs:build
- git diff --check
- pre-commit hook: workspace typecheck, workspace test, workspace build, workspace lint

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: not needed; no baseline exception requested.
Scoped checks run: not needed; no baseline exception requested.
Why full baseline is not required: full baseline exception path not used for this PR.

## Self Review

Self-review workflow: self-review skill, two-cycle review before PR authoring.
Self-review result: no unresolved blockers; full-oneline remains intentionally outside this option and is documented.
Concept-review workflow: formatter API/package-boundary review; no CLI or scaffold contract surface changed.
Concept-review result: no unresolved concept or package-boundary violations.

## CLI Surface Migration

- [ ] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: not selected for this PR.
Upgrade note: not selected for this PR.
Deprecation/removal plan or issue: not selected for this PR.
Docs/help/examples updated: not selected for this PR.
Release/changeset wording: not selected for this PR.

## Scaffold Contract Proof

- [ ] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: not selected for this PR.
Non-edit assertion: not selected for this PR.
Fail-fast input-contract proof: not selected for this PR.
Generated-output viability proof: not selected for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `oneLineMaxLength` formatting option to control the maximum width for optional one-line SQL constructs (parentheses, CASE expressions, JOIN conditions, subqueries, and CTEs). Short constructs remain compact; longer ones automatically expand to multiline format for improved readability. Default value: 100 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->