### PR TITLE
Add formatter JOIN condition layout controls

### DIFF
--- a/.changeset/calm-oneline-guards.md
+++ b/.changeset/calm-oneline-guards.md
@@ -3,3 +3,5 @@
 ---
 
 Add the `oneLineMaxLength` formatter option. When enabled, opt-in one-line constructs such as parentheses, CASE expressions, JOIN conditions, subqueries, and `cte-oneline` CTE entries stay compact only while their rendered candidate fits within the configured width; longer candidates fall back to the normal multiline formatter.
+
+Also add JOIN condition layout controls: `joinOnBreak: "before"` can place `ON` on its own indented line, and `joinConditionContinuationIndent` can indent wrapped `AND` / `OR` predicates inside `JOIN ... ON` conditions.

--- a/docs/guide/formatting-recipes.md
+++ b/docs/guide/formatting-recipes.md
@@ -31,6 +31,8 @@ const { formattedSql, params } = formatter.format(query);
 | `valuesCommaBreak` | Same as `commaBreak` | Mirrors `commaBreak` | Comma handling within `VALUES` tuples. |
 | `andBreak` | `'none'`, `'before'`, `'after'` | `'none'` | Controls whether logical `AND` operators move to their own lines. |
 | `orBreak` | `'none'`, `'before'`, `'after'` | `'none'` | Same idea for logical `OR` operators. |
+| `joinOnBreak` | `'none'`, `'before'` | `'none'` | Controls whether `JOIN ... ON` keeps `ON` inline or starts it on an indented continuation line. |
+| `joinConditionContinuationIndent` | `true` / `false` | `false` | Indents wrapped `AND` / `OR` predicates inside `JOIN ... ON` conditions so they read as join-condition continuations instead of sibling joins. |
 | `insertColumnsOneLine` | `true` / `false` | `false` | Keeps column lists inside `INSERT INTO` statements on a single line when `true`. |
 | `indentNestedParentheses` | `true` / `false` | `false` | Adds an extra indent when boolean groups introduce parentheses inside `WHERE` or `HAVING` clauses. |
 | `commentStyle` | `'block'`, `'smart'` | `'block'` | Normalises how comments are emitted (see below). |
@@ -86,6 +88,50 @@ const formatter = new SqlFormatter({
 - `'none'` leaves the logical operators inline.
 
 Choose `'before'` when you want to scan down logical branches quickly, or `'after'` to keep complex conditions aligned underneath their keywords.
+
+### JOIN condition layouts
+
+JOIN predicates can become hard to scan when a long `ON` condition wraps and the continuation `AND` / `OR` lines align with the JOIN itself:
+
+```sql
+left join last_customer_reply lcr on lcr.ticket_id = st.ticket_id
+and lcr.tenant_id = st.tenant_id
+```
+
+Use `joinConditionContinuationIndent: true` when you want to keep the first `ON` predicate inline but indent continuation predicates:
+
+```typescript
+const formatter = new SqlFormatter({
+    newline: 'lf',
+    andBreak: 'before',
+    joinConditionContinuationIndent: true
+});
+```
+
+```sql
+left join last_customer_reply lcr on lcr.ticket_id = st.ticket_id
+    and lcr.tenant_id = st.tenant_id
+    and lcr.source_id = st.source_id
+```
+
+Use `joinOnBreak: 'before'` when your style separates the JOIN target from the condition itself:
+
+```typescript
+const formatter = new SqlFormatter({
+    newline: 'lf',
+    andBreak: 'before',
+    joinOnBreak: 'before'
+});
+```
+
+```sql
+left join last_customer_reply lcr
+    on lcr.ticket_id = st.ticket_id
+    and lcr.tenant_id = st.tenant_id
+    and lcr.source_id = st.source_id
+```
+
+The JOIN-specific options only change predicates inside `JOIN ... ON`. `WHERE`, `HAVING`, and other boolean expressions continue to follow `andBreak` / `orBreak` directly.
 
 ### MERGE `WHEN` predicate layout
 
@@ -245,6 +291,8 @@ Pair this option with your target engine: presets such as `'mysql'` enable it au
   "valuesCommaBreak": "after",
   "andBreak": "before",
   "orBreak": "before",
+  "joinOnBreak": "none",
+  "joinConditionContinuationIndent": false,
   "withClauseStyle": "cte-oneline",
   "insertColumnsOneLine": true,
   "oneLineMaxLength": 100,

--- a/docs/public/demo/style-config.js
+++ b/docs/public/demo/style-config.js
@@ -14,6 +14,8 @@ const DEFAULT_STYLE_BASE = {
     "valuesCommaBreak": "before",
     "andBreak": "before",
     "orBreak": "before",
+    "joinOnBreak": "none",
+    "joinConditionContinuationIndent": false,
     "exportComment": "full",
     "commentStyle": "block",
     "withClauseStyle": "standard",
@@ -147,6 +149,8 @@ function inferStyleDefaults(name, style) {
         "insertColumnsOneLine": true,
         "whenOneLine": false,
         "oneLineMaxLength": 100,
+        "joinOnBreak": "none",
+        "joinConditionContinuationIndent": false,
         ...dialectDefaults
     };
 }

--- a/packages/core/src/transformers/SqlFormatter.ts
+++ b/packages/core/src/transformers/SqlFormatter.ts
@@ -1,5 +1,5 @@
 import { SqlPrintTokenParser, FormatterConfig, PRESETS, CastStyle, ConstraintStyle, SourceAliasStyle, OrderByDefaultDirectionStyle } from '../parsers/SqlPrintTokenParser';
-import { SqlPrinter, CommaBreakStyle, AndBreakStyle, OrBreakStyle } from './SqlPrinter';
+import { SqlPrinter, CommaBreakStyle, AndBreakStyle, OrBreakStyle, JoinOnBreakStyle } from './SqlPrinter';
 import { CommentExportMode } from '../types/Formatting';
 import { IndentCharOption, NewlineOption } from './LinePrinter'; // Import types for compatibility
 import { IdentifierEscapeOption, IdentifierEscapeTarget, resolveIdentifierEscapeOption } from './FormatOptionResolver';
@@ -55,6 +55,8 @@ export interface BaseFormattingOptions {
     andBreak?: AndBreakStyle;
     /** Style for OR line breaks */
     orBreak?: OrBreakStyle;
+    /** Style for JOIN ON line breaks */
+    joinOnBreak?: JoinOnBreakStyle;
     /** Whether to export comments in formatted output */
     exportComment?: boolean | CommentExportMode;
     /** Comment formatting style */
@@ -81,6 +83,8 @@ export interface BaseFormattingOptions {
     whenOneLine?: boolean;
     /** Maximum rendered width for opt-in one-line constructs. Omit to keep legacy unlimited one-line behavior. */
     oneLineMaxLength?: number;
+    /** Indent AND/OR continuation lines inside JOIN ON predicates */
+    joinConditionContinuationIndent?: boolean;
     /** Reorder JOIN ON column comparisons to follow table declaration order */
     joinConditionOrderByDeclaration?: boolean;
 }

--- a/packages/core/src/transformers/SqlPrinter.ts
+++ b/packages/core/src/transformers/SqlPrinter.ts
@@ -37,6 +37,13 @@ export type AndBreakStyle = 'none' | 'before' | 'after';
  */
 export type OrBreakStyle = 'none' | 'before' | 'after';
 
+/**
+ * JoinOnBreakStyle determines whether JOIN ON starts on the JOIN line or its own indented line.
+ * - 'none': Keep ON inline with the JOIN target
+ * - 'before': Break before ON and indent the join condition
+ */
+export type JoinOnBreakStyle = 'none' | 'before';
+
 interface CommentRenderContext {
     position: 'leading' | 'inline';
     isTopLevelContainer: boolean;
@@ -88,6 +95,8 @@ export class SqlPrinter {
     andBreak: AndBreakStyle;
     /** OR break style: 'none', 'before', or 'after' */
     orBreak: OrBreakStyle;
+    /** JOIN ON break style: 'none' or 'before' */
+    joinOnBreak: JoinOnBreakStyle;
 
     /** Keyword case style: 'none', 'upper' | 'lower' */
     keywordCase: 'none' | 'upper' | 'lower';
@@ -127,8 +136,12 @@ export class SqlPrinter {
     private whenOneLine: boolean;
     /** Optional maximum width for opt-in one-line constructs */
     private oneLineMaxLength?: number;
+    /** Whether to indent AND/OR continuation lines inside JOIN ON predicates */
+    private joinConditionContinuationIndent: boolean;
     /** Tracks nesting depth while formatting MERGE WHEN predicate segments */
     private mergeWhenPredicateDepth = 0;
+    /** Tracks nesting depth while formatting JOIN ON condition segments */
+    private joinOnClauseDepth = 0;
     /** Shared helper for oneline-specific formatting decisions */
     private onelineHelper: OnelineFormattingHelper;
     /** Containers whose one-line rendering was rejected by oneLineMaxLength */
@@ -158,6 +171,7 @@ export class SqlPrinter {
         this.valuesCommaBreak = options?.valuesCommaBreak ?? this.commaBreak;
         this.andBreak = options?.andBreak ?? 'none';
         this.orBreak = options?.orBreak ?? 'none';
+        this.joinOnBreak = options?.joinOnBreak ?? 'none';
         this.keywordCase = options?.keywordCase ?? 'none';
         this.commentExportMode = this.resolveCommentExportMode(options?.exportComment);
         this.withClauseStyle = options?.withClauseStyle ?? 'standard';
@@ -172,6 +186,7 @@ export class SqlPrinter {
         this.insertColumnsOneLine = options?.insertColumnsOneLine ?? false;
         this.whenOneLine = options?.whenOneLine ?? false;
         this.oneLineMaxLength = this.normalizeOneLineMaxLength(options?.oneLineMaxLength);
+        this.joinConditionContinuationIndent = options?.joinConditionContinuationIndent ?? false;
         const onelineOptions: OnelineFormattingOptions = {
             parenthesesOneLine: this.parenthesesOneLine,
             betweenOneLine: this.betweenOneLine,
@@ -235,6 +250,7 @@ export class SqlPrinter {
         // initialize
         this.linePrinter = new LinePrinter(this.indentChar, this.indentSize, this.newline, this.commaBreak);
         this.insideWithClause = false; // Reset WITH clause context
+        this.joinOnClauseDepth = 0;
         this.pendingLineCommentBreak = null;
         this.smartCommentBlockBuilder = null;
         this.expandedOneLineFallbackTokens = new WeakSet<SqlPrintToken>();
@@ -430,6 +446,15 @@ export class SqlPrinter {
             this.linePrinter.appendText(token.text);
         }
 
+        if (
+            token.containerType === SqlPrintTokenContainerType.JoinOnClause &&
+            this.joinOnBreak === 'before' &&
+            !this.isOnelineMode() &&
+            this.linePrinter.getCurrentLine().text.trim().length > 0
+        ) {
+            this.linePrinter.appendNewline(level + 1);
+        }
+
         if (this.expandedOneLineFallbackTokens.has(token)) {
             shouldIndentNested = true;
         }
@@ -456,6 +481,9 @@ export class SqlPrinter {
         const delayIndentNewline = shouldIndentNested && token.containerType === SqlPrintTokenContainerType.ParenExpression;
         const isAlterTableStatement = token.containerType === SqlPrintTokenContainerType.AlterTableStatement;
         let deferAlterTableIndent = false;
+        if (token.containerType === SqlPrintTokenContainerType.JoinOnClause && this.joinOnBreak === 'before' && !this.isOnelineMode()) {
+            innerLevel = level + 1;
+        }
 
         const alignExplainChild = this.shouldAlignExplainStatementChild(parentContainerType, token.containerType);
 
@@ -507,6 +535,10 @@ export class SqlPrinter {
         let mergePredicateActive = isMergeWhenClause;
         let alterTableTableRendered = false;
         let alterTableIndentInserted = false;
+        const enteredJoinOnClause = token.containerType === SqlPrintTokenContainerType.JoinOnClause;
+        if (enteredJoinOnClause) {
+            this.joinOnClauseDepth++;
+        }
 
         for (let i = leadingCommentCount; i < token.innerTokens.length; i++) {
             const child = token.innerTokens[i];
@@ -580,6 +612,9 @@ export class SqlPrinter {
 
         if (this.smartCommentBlockBuilder && this.smartCommentBlockBuilder.mode === 'line') {
             this.flushSmartCommentBlockBuilder();
+        }
+        if (enteredJoinOnClause) {
+            this.joinOnClauseDepth--;
         }
 
         // Exit WITH clause context when we finish processing WithClause container
@@ -812,14 +847,14 @@ export class SqlPrinter {
         if (this.andBreak === 'before') {
             // Skip newline when inside WITH clause with full-oneline style
             if (!(this.insideWithClause && this.withClauseStyle === 'full-oneline')) {
-                this.linePrinter.appendNewline(level);
+                this.linePrinter.appendNewline(this.getJoinConditionContinuationLevel(level));
             }
             this.linePrinter.appendText(text);
         } else if (this.andBreak === 'after') {
             this.linePrinter.appendText(text);
             // Skip newline when inside WITH clause with full-oneline style
             if (!(this.insideWithClause && this.withClauseStyle === 'full-oneline')) {
-                this.linePrinter.appendNewline(level);
+                this.linePrinter.appendNewline(this.getJoinConditionContinuationLevel(level));
             }
         } else {
             this.linePrinter.appendText(text);
@@ -888,18 +923,28 @@ export class SqlPrinter {
         if (this.orBreak === 'before') {
             // Insert a newline before OR unless WITH full-oneline mode suppresses breaks.
             if (!(this.insideWithClause && this.withClauseStyle === 'full-oneline')) {
-                this.linePrinter.appendNewline(level);
+                this.linePrinter.appendNewline(this.getJoinConditionContinuationLevel(level));
             }
             this.linePrinter.appendText(text);
         } else if (this.orBreak === 'after') {
             this.linePrinter.appendText(text);
             // Break after OR when multi-line formatting is active.
             if (!(this.insideWithClause && this.withClauseStyle === 'full-oneline')) {
-                this.linePrinter.appendNewline(level);
+                this.linePrinter.appendNewline(this.getJoinConditionContinuationLevel(level));
             }
         } else {
             this.linePrinter.appendText(text);
         }
+    }
+
+    private getJoinConditionContinuationLevel(level: number): number {
+        if (this.joinOnClauseDepth === 0) {
+            return level;
+        }
+        if (this.joinOnBreak === 'before') {
+            return level;
+        }
+        return this.joinConditionContinuationIndent ? level + 1 : level;
     }
 
     /**

--- a/packages/core/tests/transformers/SqlFormatter.join-condition-layout.test.ts
+++ b/packages/core/tests/transformers/SqlFormatter.join-condition-layout.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from 'vitest';
+import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
+import { SqlFormatter } from '../../src/transformers/SqlFormatter';
+
+const sql = `
+    select *
+    from searchable_tickets st
+    left join last_customer_reply lcr on lcr.ticket_id = st.ticket_id
+        and lcr.tenant_id = st.tenant_id
+        and lcr.source_id = st.source_id
+`;
+
+const baseOptions = {
+    newline: 'lf',
+    indentChar: 'space',
+    indentSize: 4,
+    keywordCase: 'lower',
+    identifierEscape: 'none',
+    sourceAliasStyle: 'implicit',
+    andBreak: 'before',
+} as const;
+
+describe('SqlFormatter - JOIN condition layout options', () => {
+    test('keeps existing JOIN condition indentation by default', () => {
+        const formatter = new SqlFormatter(baseOptions);
+        const { formattedSql } = formatter.format(SelectQueryParser.parse(sql));
+
+        expect(formattedSql).toContain(
+            [
+                '    left join last_customer_reply lcr on lcr.ticket_id = st.ticket_id',
+                '    and lcr.tenant_id = st.tenant_id',
+                '    and lcr.source_id = st.source_id',
+            ].join('\n'),
+        );
+    });
+
+    test('breaks before ON and indents the JOIN condition when joinOnBreak is before', () => {
+        const formatter = new SqlFormatter({
+            ...baseOptions,
+            joinOnBreak: 'before',
+        });
+        const { formattedSql } = formatter.format(SelectQueryParser.parse(sql));
+
+        expect(formattedSql).toContain(
+            [
+                '    left join last_customer_reply lcr',
+                '        on lcr.ticket_id = st.ticket_id',
+                '        and lcr.tenant_id = st.tenant_id',
+                '        and lcr.source_id = st.source_id',
+            ].join('\n'),
+        );
+    });
+
+    test('keeps ON inline while indenting continuation predicates', () => {
+        const formatter = new SqlFormatter({
+            ...baseOptions,
+            joinConditionContinuationIndent: true,
+        });
+        const { formattedSql } = formatter.format(SelectQueryParser.parse(sql));
+
+        expect(formattedSql).toContain(
+            [
+                '    left join last_customer_reply lcr on lcr.ticket_id = st.ticket_id',
+                '        and lcr.tenant_id = st.tenant_id',
+                '        and lcr.source_id = st.source_id',
+            ].join('\n'),
+        );
+    });
+
+    test('composes ON break with continuation indentation without double indenting', () => {
+        const formatter = new SqlFormatter({
+            ...baseOptions,
+            joinOnBreak: 'before',
+            joinConditionContinuationIndent: true,
+        });
+        const { formattedSql } = formatter.format(SelectQueryParser.parse(sql));
+
+        expect(formattedSql).toContain(
+            [
+                '    left join last_customer_reply lcr',
+                '        on lcr.ticket_id = st.ticket_id',
+                '        and lcr.tenant_id = st.tenant_id',
+                '        and lcr.source_id = st.source_id',
+            ].join('\n'),
+        );
+    });
+
+    test('indents OR continuation predicates inside JOIN ON conditions', () => {
+        const formatter = new SqlFormatter({
+            ...baseOptions,
+            orBreak: 'before',
+            joinConditionContinuationIndent: true,
+        });
+        const { formattedSql } = formatter.format(SelectQueryParser.parse(`
+            select *
+            from searchable_tickets st
+            left join last_customer_reply lcr on lcr.ticket_id = st.ticket_id
+                or lcr.parent_ticket_id = st.ticket_id
+        `));
+
+        expect(formattedSql).toContain(
+            [
+                '    left join last_customer_reply lcr on lcr.ticket_id = st.ticket_id',
+                '        or lcr.parent_ticket_id = st.ticket_id',
+            ].join('\n'),
+        );
+    });
+});


### PR DESCRIPTION
## Summary

- Add formatter options for JOIN condition layout without changing the default output:
  - `joinOnBreak: "before"` moves `ON` to an indented continuation line.
  - `joinConditionContinuationIndent: true` indents wrapped `AND` / `OR` predicates inside `JOIN ... ON`.
- Document the new options in the formatting recipes guide and expose them in the public style demo defaults.
- Cover default, ON-before, continuation-indent, combined, and OR-continuation cases with formatter tests.

## Verification

- `pnpm vitest run packages/core/tests/transformers/SqlFormatter.join-condition-layout.test.ts packages/core/tests/transformers/SqlFormatter.new-oneline.test.ts packages/core/tests/transformers/SqlFormatter.oneline-max-length.test.ts`
- `node --check docs/public/demo/style-config.js`
- `git diff --check`
- `pnpm typecheck`
- `pnpm --filter rawsql-ts build`
- `pnpm --filter rawsql-ts test`
- `pnpm docs:build`
- pre-commit hook: workspace typecheck, workspace tests, workspace build, workspace lint

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: not needed; no baseline exception requested.
Scoped checks run: focused formatter tests, rawsql-ts package test/build, workspace typecheck/build/test/lint via pre-commit, docs build.
Why full baseline is not required: full baseline exception path not used for this PR.

## Self Review

Self-review workflow: developer-self-review skill, two-cycle consistency and human-acceptance review before PR authoring.
Self-review result: no unresolved blockers; defaults remain backward compatible and tests cover the new JOIN-only branches.
Concept-review workflow: formatter package-boundary review; this is a formatting API option only, with no parser AST, CLI, scaffold, or runtime adapter responsibility changes.
Concept-review result: no unresolved concept or package-boundary violations.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: no CLI command, flag, scaffold, or generated output contract changed; the change is an opt-in formatter API/style-demo option.
Upgrade note: no migration required; defaults preserve existing JOIN formatting.
Deprecation/removal plan or issue: no deprecation or removal.
Docs/help/examples updated: formatting recipes and public style demo defaults updated.
Release/changeset wording: changeset notes the JOIN layout controls.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: no scaffold input contract or generated scaffold output changed.
Non-edit assertion: not applicable; no scaffold output is generated or edited by this PR.
Fail-fast input-contract proof: not applicable; no scaffold input contract changed.
Generated-output viability proof: not applicable; formatter tests and package build cover this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `joinOnBreak` option to control JOIN ON clause line-breaking style
  * Added `joinConditionContinuationIndent` option to indent continuation predicates within JOIN conditions
  * Added `oneLineMaxLength` formatter option for compact one-line construct handling

* **Documentation**
  * Updated formatting guides and demo configuration with new JOIN layout control options

* **Tests**
  * Added comprehensive test coverage for JOIN condition formatting scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->