### PR TITLE
fix: preserve order by direction comments

### DIFF
--- a/.changeset/order-by-direction-comments.md
+++ b/.changeset/order-by-direction-comments.md
@@ -3,3 +3,4 @@
 ---
 
 Preserve comments attached to ORDER BY direction and NULLS modifiers next to the rendered order expression.
+Keep comments between CASE and the first WHEN inside the CASE expression instead of moving them outside the CASE item.

--- a/.changeset/order-by-direction-comments.md
+++ b/.changeset/order-by-direction-comments.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": patch
+---
+
+Preserve comments attached to ORDER BY direction and NULLS modifiers next to the rendered order expression.

--- a/packages/core/src/parsers/CommandExpressionParser.ts
+++ b/packages/core/src/parsers/CommandExpressionParser.ts
@@ -3,6 +3,11 @@ import { ArrayExpression, CaseExpression, CaseKeyValuePair, SwitchCaseArgument, 
 import { ValueParser } from "./ValueParser";
 
 type KeywordCommentPayload = { legacy: string[] | null; positioned: LexemePositionedComment[] | undefined };
+type CaseWhenKeywordCommentPayload = {
+    caseExpressionPositioned: LexemePositionedComment[] | null;
+    firstWhenPositioned: LexemePositionedComment[] | null;
+    legacyCaseExpression: string[] | null;
+};
 
 export class CommandExpressionParser {
     public static parseFromLexeme(lexemes: Lexeme[], index: number): { value: ValueComponent; newIndex: number } {
@@ -61,10 +66,12 @@ export class CommandExpressionParser {
 
     private static parseCaseWhenExpression(lexemes: Lexeme[], index: number, caseWhenKeywordComments?: string[] | null, caseWhenKeywordPositionedComments?: any): { value: ValueComponent; newIndex: number; } {
         let idx = index;
+        const commentPayload = this.splitCaseWhenKeywordComments(caseWhenKeywordComments, caseWhenKeywordPositionedComments);
 
         // Parse the first WHEN clause
         const casewhenResult = this.parseCaseConditionValuePair(lexemes, idx);
         idx = casewhenResult.newIndex;
+        this.addPositionedComments(casewhenResult.value, commentPayload.firstWhenPositioned);
 
         // Add the initial WHEN-THEN pair to the list
         const caseWhenList = [casewhenResult.value];
@@ -77,14 +84,48 @@ export class CommandExpressionParser {
         const result = new CaseExpression(null, switchCaseResult.value);
         
         // Assign CASE WHEN keyword comments to the CaseExpression (positioned comments only for unified spec)
-        if (caseWhenKeywordPositionedComments && caseWhenKeywordPositionedComments.length > 0) {
-            result.positionedComments = caseWhenKeywordPositionedComments;
-        } else if (caseWhenKeywordComments && caseWhenKeywordComments.length > 0) {
+        if (commentPayload.caseExpressionPositioned && commentPayload.caseExpressionPositioned.length > 0) {
+            result.positionedComments = commentPayload.caseExpressionPositioned;
+        } else if (commentPayload.firstWhenPositioned && commentPayload.firstWhenPositioned.length > 0) {
+            result.positionedComments = [];
+        } else if (commentPayload.legacyCaseExpression && commentPayload.legacyCaseExpression.length > 0) {
             // Convert legacy comments to positioned comments for unified spec
-            result.positionedComments = [CommandExpressionParser.convertLegacyToPositioned(caseWhenKeywordComments, 'before')];
+            result.positionedComments = [CommandExpressionParser.convertLegacyToPositioned(commentPayload.legacyCaseExpression, 'before')];
         }
         
         return { value: result, newIndex: idx };
+    }
+
+    private static splitCaseWhenKeywordComments(caseWhenKeywordComments?: string[] | null, caseWhenKeywordPositionedComments?: LexemePositionedComment[]): CaseWhenKeywordCommentPayload {
+        if (!caseWhenKeywordPositionedComments || caseWhenKeywordPositionedComments.length === 0) {
+            return {
+                caseExpressionPositioned: null,
+                firstWhenPositioned: null,
+                legacyCaseExpression: caseWhenKeywordComments ?? null,
+            };
+        }
+
+        const caseExpressionPositioned: LexemePositionedComment[] = [];
+        const firstWhenPositioned: LexemePositionedComment[] = [];
+        for (const comment of caseWhenKeywordPositionedComments) {
+            if (comment.position === 'after') {
+                firstWhenPositioned.push({
+                    position: 'before',
+                    comments: [...comment.comments],
+                });
+            } else {
+                caseExpressionPositioned.push({
+                    position: comment.position,
+                    comments: [...comment.comments],
+                });
+            }
+        }
+
+        return {
+            caseExpressionPositioned: caseExpressionPositioned.length > 0 ? caseExpressionPositioned : null,
+            firstWhenPositioned: firstWhenPositioned.length > 0 ? firstWhenPositioned : null,
+            legacyCaseExpression: null,
+        };
     }
 
     // parseSwitchCaseArgument method processes the WHEN, ELSE, and END clauses of a CASE expression.
@@ -204,6 +245,16 @@ export class CommandExpressionParser {
     // Helper method: Check if a lexeme is a Command token with the specified value
     private static isCommandWithValue(lexeme: Lexeme, value: string): boolean {
         return ((lexeme.type & TokenType.Command) !== 0) && lexeme.value === value;
+    }
+
+    private static addPositionedComments(target: CaseKeyValuePair, comments: LexemePositionedComment[] | null): void {
+        if (!comments || comments.length === 0) {
+            return;
+        }
+        target.positionedComments = [
+            ...(target.positionedComments ?? []),
+            ...comments,
+        ];
     }
 
     private static parseCaseConditionValuePair(lexemes: Lexeme[], index: number): { value: CaseKeyValuePair; newIndex: number; } {

--- a/packages/core/src/parsers/OrderByClauseParser.ts
+++ b/packages/core/src/parsers/OrderByClauseParser.ts
@@ -4,6 +4,31 @@ import { SqlTokenizer } from "./SqlTokenizer";
 import { ValueParser } from "./ValueParser";
 
 export class OrderByClauseParser {
+    private static appendUniqueComments(target: string[] | null, comments: string[] | null | undefined): string[] | null {
+        if (!comments || comments.length === 0) {
+            return target;
+        }
+
+        const merged = target ? [...target] : [];
+        for (const comment of comments) {
+            if (!merged.includes(comment)) {
+                merged.push(comment);
+            }
+        }
+        return merged;
+    }
+
+    private static collectLexemeComments(token: Lexeme): string[] | null {
+        let comments: string[] | null = null;
+        if (token.positionedComments && token.positionedComments.length > 0) {
+            for (const posComment of token.positionedComments) {
+                comments = this.appendUniqueComments(comments, posComment.comments);
+            }
+        }
+        comments = this.appendUniqueComments(comments, token.comments);
+        return comments;
+    }
+
     // Parse SQL string to AST (was: parse)
     public static parse(query: string): OrderByClause {
         const tokenizer = new SqlTokenizer(query); // Initialize tokenizer
@@ -58,8 +83,8 @@ export class OrderByClauseParser {
             return { value: value, newIndex: idx };
         }
 
-        // Capture comments from ASC/DESC tokens (both legacy comments and positioned comments)
-        let sortDirectionComments: string[] | null = null;
+        // Capture comments from ASC/DESC/NULLS tokens so they stay adjacent to the full ORDER BY item.
+        let orderByItemComments: string[] | null = null;
         let sortDirection: SortDirection | null = null;
 
         if (idx < lexemes.length) {
@@ -74,36 +99,24 @@ export class OrderByClauseParser {
 
             // Capture comments from the ASC/DESC token
             if (sortDirection !== null) {
-                if (token.positionedComments && token.positionedComments.length > 0) {
-                    sortDirectionComments = [];
-                    for (const posComment of token.positionedComments) {
-                        if (posComment.comments && posComment.comments.length > 0) {
-                            sortDirectionComments.push(...posComment.comments);
-                        }
-                    }
-                }
-                if (token.comments && token.comments.length > 0) {
-                    if (!sortDirectionComments) sortDirectionComments = [];
-                    sortDirectionComments.push(...token.comments);
-                }
+                orderByItemComments = this.appendUniqueComments(orderByItemComments, this.collectLexemeComments(token));
             }
         }
 
         // nulls first, nulls last
-        const nullsSortDirection = idx >= lexemes.length
-            ? null
-            : lexemes[idx].value === 'nulls first'
-                ? (idx++, NullsSortDirection.First)
-                : lexemes[idx].value === 'nulls last'
-                    ? (idx++, NullsSortDirection.Last)
-                    : null;
+        let nullsSortDirection: NullsSortDirection | null = null;
+        if (idx < lexemes.length) {
+            const token = lexemes[idx];
+            if (token.value === 'nulls first') {
+                nullsSortDirection = NullsSortDirection.First;
+                idx++;
+            } else if (token.value === 'nulls last') {
+                nullsSortDirection = NullsSortDirection.Last;
+                idx++;
+            }
 
-        // Apply sort direction comments to the value if captured
-        if (sortDirectionComments && sortDirectionComments.length > 0) {
-            if (value.comments) {
-                value.comments.push(...sortDirectionComments);
-            } else {
-                value.comments = sortDirectionComments;
+            if (nullsSortDirection !== null) {
+                orderByItemComments = this.appendUniqueComments(orderByItemComments, this.collectLexemeComments(token));
             }
         }
 
@@ -111,6 +124,10 @@ export class OrderByClauseParser {
             return { value: value, newIndex: idx };
         }
 
-        return { value: new OrderByItem(value, sortDirection, nullsSortDirection), newIndex: idx };
+        const item = new OrderByItem(value, sortDirection, nullsSortDirection);
+        if (orderByItemComments && orderByItemComments.length > 0) {
+            item.comments = orderByItemComments;
+        }
+        return { value: item, newIndex: idx };
     }
 }

--- a/packages/core/src/parsers/SqlPrintTokenParser.ts
+++ b/packages/core/src/parsers/SqlPrintTokenParser.ts
@@ -1590,7 +1590,6 @@ export class SqlPrintTokenParser implements SqlComponentVisitor<SqlPrintToken> {
         }
 
         const switchToken = this.visit(arg.switchCase);
-        promotedComments.push(...this.collectCaseLeadingCommentsFromSwitch(switchToken));
 
         if (promotedComments.length > 0) {
             token.innerTokens.push(...promotedComments);
@@ -2004,6 +2003,9 @@ export class SqlPrintTokenParser implements SqlComponentVisitor<SqlPrintToken> {
         // Add positioned comments in recorded order
         const beforeComments = arg.getPositionedComments('before');
         const afterComments = arg.getPositionedComments('after');
+        const duplicateCaseAfterComments = arg.value instanceof CaseExpression
+            ? this.collectCaseSelectItemDuplicateAfterComments(arg.value)
+            : new Set<string>();
 
         if (beforeComments.length > 0) {
             if (arg.value instanceof CaseExpression || this.listContinuationCommentComponents.has(arg)) {
@@ -2019,7 +2021,7 @@ export class SqlPrintTokenParser implements SqlComponentVisitor<SqlPrintToken> {
         token.innerTokens.push(this.visit(arg.value));
 
         const visibleAfterComments = arg.value instanceof CaseExpression
-            ? this.filterCaseSelectItemDuplicateAfterComments(arg.value, afterComments)
+            ? this.filterCaseSelectItemDuplicateAfterComments(afterComments, duplicateCaseAfterComments)
             : afterComments;
 
         if (visibleAfterComments.length > 0 && !isParenExpression) {
@@ -2112,14 +2114,33 @@ export class SqlPrintTokenParser implements SqlComponentVisitor<SqlPrintToken> {
         return token;
     }
 
-    private filterCaseSelectItemDuplicateAfterComments(value: CaseExpression, afterComments: string[]): string[] {
+    private collectCaseSelectItemDuplicateAfterComments(value: CaseExpression): Set<string> {
+        const promoted = new Set<string>();
+        if (value.comments) {
+            for (const comment of value.comments) {
+                promoted.add(comment);
+            }
+        }
+        const firstCase = value.switchCase.cases[0];
+        if (firstCase?.positionedComments) {
+            for (const positionedComment of firstCase.positionedComments) {
+                if (positionedComment.position === 'before') {
+                    for (const comment of positionedComment.comments) {
+                        promoted.add(comment);
+                    }
+                }
+            }
+        }
+        return promoted;
+    }
+
+    private filterCaseSelectItemDuplicateAfterComments(afterComments: string[], promoted: Set<string>): string[] {
         if (afterComments.length === 0) {
             return afterComments;
         }
-        if (!value.comments || value.comments.length === 0) {
+        if (promoted.size === 0) {
             return afterComments;
         }
-        const promoted = new Set(value.comments);
         return afterComments.filter(comment => !promoted.has(comment));
     }
 

--- a/packages/core/src/parsers/SqlPrintTokenParser.ts
+++ b/packages/core/src/parsers/SqlPrintTokenParser.ts
@@ -240,6 +240,7 @@ export class SqlPrintTokenParser implements SqlComponentVisitor<SqlPrintToken> {
             this._selfHandlingComponentTypes = new Set([
                 SimpleSelectQuery.kind,
                 SelectItem.kind,
+                OrderByItem.kind,
                 CaseKeyValuePair.kind,
                 SwitchCaseArgument.kind,
                 ColumnReference.kind,
@@ -572,6 +573,11 @@ export class SqlPrintTokenParser implements SqlComponentVisitor<SqlPrintToken> {
                 token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
                 token.innerTokens.push(new SqlPrintToken(SqlPrintTokenType.keyword, 'nulls last'));
             }
+        }
+
+        if (arg.comments && arg.comments.length > 0) {
+            token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
+            token.innerTokens.push(...this.createInlineCommentSequence(arg.comments));
         }
         return token;
     }
@@ -2012,9 +2018,13 @@ export class SqlPrintTokenParser implements SqlComponentVisitor<SqlPrintToken> {
 
         token.innerTokens.push(this.visit(arg.value));
 
-        if (afterComments.length > 0 && !isParenExpression) {
+        const visibleAfterComments = arg.value instanceof CaseExpression
+            ? this.filterCaseSelectItemDuplicateAfterComments(arg.value, afterComments)
+            : afterComments;
+
+        if (visibleAfterComments.length > 0 && !isParenExpression) {
             token.innerTokens.push(SqlPrintTokenParser.SPACE_TOKEN);
-            const commentTokens = this.createInlineCommentSequence(afterComments);
+            const commentTokens = this.createInlineCommentSequence(visibleAfterComments);
             token.innerTokens.push(...commentTokens);
         }
 
@@ -2100,6 +2110,17 @@ export class SqlPrintTokenParser implements SqlComponentVisitor<SqlPrintToken> {
         }
 
         return token;
+    }
+
+    private filterCaseSelectItemDuplicateAfterComments(value: CaseExpression, afterComments: string[]): string[] {
+        if (afterComments.length === 0) {
+            return afterComments;
+        }
+        if (!value.comments || value.comments.length === 0) {
+            return afterComments;
+        }
+        const promoted = new Set(value.comments);
+        return afterComments.filter(comment => !promoted.has(comment));
     }
 
     private visitSelectClause(arg: SelectClause): SqlPrintToken {

--- a/packages/core/src/parsers/ValueParser.ts
+++ b/packages/core/src/parsers/ValueParser.ts
@@ -61,10 +61,12 @@ export class ValueParser {
         const left = this.parseItem(lexemes, idx);
         
         // Transfer positioned comments if they exist and the component doesn't handle its own comments
-        if (positionedComments && positionedComments.length > 0 && !left.value.positionedComments) {
-            left.value.positionedComments = positionedComments;
+        if (positionedComments && positionedComments.length > 0) {
+            if (!left.value.positionedComments) {
+                left.value.positionedComments = positionedComments;
+            }
         }
-        // Fall back to legacy comments if positioned comments aren't available
+        // Fall back to legacy comments only when positioned comments aren't available.
         else if (left.value.comments === null && comment && comment.length > 0) {
             left.value.comments = comment;
         }

--- a/packages/core/tests/transformers/CommentStyle.comprehensive.test.ts
+++ b/packages/core/tests/transformers/CommentStyle.comprehensive.test.ts
@@ -289,6 +289,71 @@ describe('CommentStyle - Comprehensive TDD Test', () => {
             expect(result.formattedSql).not.toContain('/* secondary sort item */ "b"');
         });
 
+        test('should keep ORDER BY direction comments adjacent to the ordered expression', () => {
+            const formatter = new SqlFormatter({
+                exportComment: true,
+                commentStyle: 'block',
+                commaBreak: 'before',
+                indentSize: 4,
+                indentChar: ' ',
+                keywordCase: 'lower',
+                newline: '\n'
+            });
+            const sql = `
+                select *
+                from t
+                order by
+                    /* demo fixed order */
+                    customer_rank desc
+                    , last_ordered_at desc nulls last -- recent buyer first
+                    , created_at asc
+            `;
+
+            const query = SelectQueryParser.parse(sql).toSimpleQuery();
+            const result = formatter.format(query);
+
+            expect(result.formattedSql.match(/recent buyer first/g)).toHaveLength(1);
+            expect(result.formattedSql.match(/demo fixed order/g)).toHaveLength(1);
+            expect(result.formattedSql).toContain('    /* demo fixed order */');
+            expect(result.formattedSql).toContain('    , "last_ordered_at" desc nulls last /* recent buyer first */');
+        });
+
+        test('should keep window ORDER BY direction comments consistent with PARTITION BY comments', () => {
+            const formatter = new SqlFormatter({
+                exportComment: true,
+                commentStyle: 'block',
+                commaBreak: 'before',
+                indentSize: 4,
+                indentChar: ' ',
+                keywordCase: 'lower',
+                newline: '\n'
+            });
+            const sql = `
+                select
+                    row_number() over (
+                        partition by l.user_id -- user scope
+                        order by l.logged_in_at desc /* latest first */
+                    ) as rn
+                from login_logs l
+            `;
+
+            const query = SelectQueryParser.parse(sql).toSimpleQuery();
+            const result = formatter.format(query);
+
+            expect(result.formattedSql.match(/latest first/g)).toHaveLength(1);
+            expect(result.formattedSql).toContain([
+                '        partition by',
+                '            "l"."user_id" /* user scope */',
+                '        order by',
+                '            "l"."logged_in_at" desc /* latest first */',
+            ].join('\n'));
+            expect(result.formattedSql).not.toContain([
+                '        order by',
+                '            /* latest first */',
+                '            "l"."logged_in_at" desc',
+            ].join('\n'));
+        });
+
         test('should not move or duplicate comments inside parenthesized WHERE predicates', () => {
             const formatter = new SqlFormatter({
                 exportComment: true,
@@ -437,6 +502,39 @@ describe('CommentStyle - Comprehensive TDD Test', () => {
                 '    or /* urgent */',
                 '        "priority" = \'high\'',
             ].join('\n'));
+        });
+
+        test('should not duplicate comments before CASE select items', () => {
+            const formatter = new SqlFormatter({
+                exportComment: true,
+                commentStyle: 'block',
+                commaBreak: 'before',
+                indentSize: 4,
+                indentChar: ' ',
+                keywordCase: 'lower',
+                newline: '\n',
+                caseOneLine: false
+            });
+            const sql = `
+                select
+                    case
+                        /* rank */
+                        when a = 1 then 'x'
+                        else 'y'
+                    end as rank
+                from t
+            `;
+
+            const query = SelectQueryParser.parse(sql).toSimpleQuery();
+            const result = formatter.format(query);
+
+            expect(result.formattedSql.match(/rank/g)).toHaveLength(2);
+            expect(result.formattedSql).toContain([
+                '    /* rank */',
+                '    case',
+                '        when "a" = 1 then',
+            ].join('\n'));
+            expect(result.formattedSql).not.toContain('end /* rank */ as "rank"');
         });
     });
 

--- a/packages/core/tests/transformers/CommentStyle.comprehensive.test.ts
+++ b/packages/core/tests/transformers/CommentStyle.comprehensive.test.ts
@@ -530,10 +530,11 @@ describe('CommentStyle - Comprehensive TDD Test', () => {
 
             expect(result.formattedSql.match(/rank/g)).toHaveLength(2);
             expect(result.formattedSql).toContain([
-                '    /* rank */',
                 '    case',
+                '        /* rank */',
                 '        when "a" = 1 then',
             ].join('\n'));
+            expect(result.formattedSql).not.toContain('    /* rank */\n    case');
             expect(result.formattedSql).not.toContain('end /* rank */ as "rank"');
         });
     });

--- a/packages/core/tests/transformers/SqlFormatter.case-comment-regression.test.ts
+++ b/packages/core/tests/transformers/SqlFormatter.case-comment-regression.test.ts
@@ -69,4 +69,27 @@ describe('SqlFormatter CASE comment positioning', () => {
 
         expect(result).toBe(expected);
     });
+
+    it('keeps comments between CASE and the first WHEN inside the CASE expression', () => {
+        const formatter = createFormatter();
+        const sql = `select
+    case
+        /* rank judgement */
+        when amount >= 100000 then 'vip'
+        else 'normal'
+    end as customer_rank`;
+        const parsed = SelectQueryParser.parse(sql);
+        const result = formatter.format(parsed).formattedSql;
+
+        const expected = `select
+    case
+        /* rank judgement */
+        when "amount" >= 100000 then
+            'vip'
+        else
+            'normal'
+    end as "customer_rank"`;
+
+        expect(result).toBe(expected);
+    });
 });


### PR DESCRIPTION
## Summary

- Preserve comments attached to ORDER BY direction and NULLS modifiers on the rendered `OrderByItem`.
- Keep window `ORDER BY` direction comments consistent with `PARTITION BY` and select-item trailing comments.
- Keep comments written between `CASE` and the first `WHEN` inside the CASE expression instead of promoting them outside the select item.
- Add regression coverage for comment loss, duplication, misplaced pre-expression rendering, and CASE first-WHEN comments.
- Add a patch changeset for `rawsql-ts`.

## Verification

- `pnpm vitest run packages/core/tests/transformers/SqlFormatter.case-comment-regression.test.ts`
- `pnpm vitest run packages/core/tests/transformers/CommentStyle.comprehensive.test.ts packages/core/tests/transformers/SqlFormatter.case-comment-regression.test.ts`
- `pnpm --filter rawsql-ts test`
- `pnpm typecheck`
- pre-commit gate: workspace typecheck, workspace tests, workspace build, workspace lint
- `git diff --check`

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: none
Scoped checks run: focused CASE formatter regression test, focused comprehensive comment formatter tests, rawsql-ts package tests, workspace typecheck, pre-commit full workspace test/build/lint, diff whitespace check
Why full baseline is not required: full workspace test/build/lint ran through the pre-commit gate

## Self Review

Self-review workflow: two-cycle self-review over parser/formatter diff, tests, changeset, and verification evidence
Self-review result: ready; no merge blockers found
Concept-review workflow: not applicable; this is formatter behavior preservation, not a concept-spec change
Concept-review result: not applicable

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: no CLI option, command, or user-facing surface is changed
Upgrade note: ORDER BY direction/NULLS comments are preserved next to the rendered order expression; comments between CASE and the first WHEN stay inside the CASE expression
Deprecation/removal plan or issue: none
Docs/help/examples updated: changeset added
Release/changeset wording: `.changeset/order-by-direction-comments.md`

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: formatter comment preservation only; no scaffold templates or generated contract changed
Non-edit assertion: no scaffold-generated files changed
Fail-fast input-contract proof: not applicable
Generated-output viability proof: not applicable