### PR TITLE
feat(formatter): preserve original parameter style

### DIFF
--- a/.changeset/preserve-original-parameter-style.md
+++ b/.changeset/preserve-original-parameter-style.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": patch
+---
+
+Add `parameterStyle: "original"` so formatting parsed SQL can preserve the input parameter placeholder spelling, including `:name`, `@name`, `$1`, `?`, and `${name}` forms.

--- a/docs/guide/formatting-recipes.md
+++ b/docs/guide/formatting-recipes.md
@@ -45,7 +45,7 @@ const { formattedSql, params } = formatter.format(query);
 | `identifierEscape` | `'none'`, `'quote'`, `'backtick'`, `'bracket'`, or `{ "start": string, "end": string }` | From preset or `'quote'` internally | Chooses the identifier delimiter symbol. `'none'` means no delimiter symbol, not "no identifiers targeted". |
 | `identifierEscapeTarget` | `'all'`, `'minimal'` | `'all'` | Chooses whether the formatter escapes every identifier or only identifiers that need escaping to stay valid and semantically safe. Pair it with `identifierEscape`, e.g. `{ "identifierEscape": "quote", "identifierEscapeTarget": "minimal" }`. |
 | `parameterSymbol` | Any string or `{ "start": string, "end": string }` | From preset or `':'` internally | Chooses the parameter marker. Common values are `':'`, `'$'`, `'@'`, and `'?'`; object form supports paired delimiters. |
-| `parameterStyle` | `'named'`, `'indexed'`, `'anonymous'` | From preset or `'named'` internally | Controls whether parameters print as `:name`, `$1`, or `?` and whether `params` is returned as an object or an ordered array. |
+| `parameterStyle` | `'named'`, `'indexed'`, `'anonymous'`, `'original'` | From preset or `'named'` internally | Controls whether parameters print as `:name`, `$1`, `?`, or the placeholder spelling parsed from the input SQL. It also controls whether `params` is returned as an object or an ordered array. |
 | `sourceAliasStyle` | `'explicit'`, `'omit'` | From preset or `'explicit'` | Controls whether source aliases render as `from users as u` or `from users u`. |
 | `columnAliasStyle` | `'explicit'`, `'omit'` | `'explicit'` | Controls whether select-list column aliases render as `select id as user_id` or `select id user_id`. |
 | `orderByDefaultDirectionStyle` | `'omit'`, `'explicit'` | From preset or `'omit'` | Controls whether default ascending sort direction is omitted or printed as `ASC`. |
@@ -415,6 +415,19 @@ const { formattedSql, params } = formatter.format(query);
 ```
 
 Anonymous style prints bare symbols such as `?` or `%s`. `SqlFormatter` still returns an array so you can hand it to clients that expect positional parameters.
+
+### Original parsed parameters
+
+```typescript
+const query = SelectQueryParser.parse('select * from users where id = @userId and status = :status');
+const formatter = new SqlFormatter({ parameterStyle: 'original' });
+const { formattedSql, params } = formatter.format(query);
+
+// formattedSql keeps @userId and :status
+// params => { userId: null, status: null }
+```
+
+Original style keeps the exact placeholder spelling parsed from the input SQL, including prefixes such as `:`, `@`, `$`, `?`, and `${...}` wrappers. Parameters created programmatically do not have input spelling, so they fall back to the configured `parameterSymbol` as named parameters.
 
 > Tip: You can mix `parameterStyle` with presets like `{ preset: 'postgres' }`. Presets provide sensible defaults that you can override per option when integrating with legacy code.
 

--- a/docs/public/demo/style-config.js
+++ b/docs/public/demo/style-config.js
@@ -230,7 +230,7 @@ const STYLE_CONTROL_GROUPS = [
             { key: 'identifierEscape', label: 'Identifier escape', type: 'select', options: ['none', 'quote', 'backtick', 'bracket'] },
             { key: 'identifierEscapeTarget', label: 'Identifier escape target', type: 'select', options: ['all', 'minimal'] },
             { key: 'parameterSymbol', label: 'Parameter symbol', type: 'select', options: [':', '$', '@', '?'] },
-            { key: 'parameterStyle', label: 'Parameter style', type: 'select', options: ['named', 'indexed', 'anonymous'] },
+            { key: 'parameterStyle', label: 'Parameter style', type: 'select', options: ['named', 'indexed', 'anonymous', 'original'] },
             { key: 'indentSize', label: 'Indent size', type: 'number', min: 0, max: 12, step: 1 },
             { key: 'newline', label: 'Newline', type: 'select', options: ['space', 'lf', 'crlf'] },
             { key: 'sourceAliasStyle', label: 'Source alias keyword', type: 'select', options: ['omit', 'explicit'] },

--- a/packages/core/src/models/ValueComponent.ts
+++ b/packages/core/src/models/ValueComponent.ts
@@ -233,15 +233,17 @@ export class ParameterExpression extends SqlComponent {
     static kind = Symbol("ParameterExpression");
     name: RawString;
     value: SqlParameterValue; // Holds the parameter value; can be provided via second argument.
+    sourceText: string | null;
     /**
      * The index assigned by the formatter when generating parameterized queries.
      * Used for naming parameters like $1, $2, etc.
      */
     index: number | null;
-    constructor(name: string, value: SqlParameterValue = null) {
+    constructor(name: string, value: SqlParameterValue = null, sourceText: string | null = null) {
         super();
         this.name = new RawString(name);
         this.value = value; // Value is now accepted as a second argument (optional)
+        this.sourceText = sourceText;
         this.index = null;
     }
 }

--- a/packages/core/src/parsers/ParameterDecorator.ts
+++ b/packages/core/src/parsers/ParameterDecorator.ts
@@ -5,9 +5,9 @@
 export class ParameterDecorator {
     prefix: string;
     suffix: string;
-    style: 'named' | 'indexed' | 'anonymous';
+    style: 'named' | 'indexed' | 'anonymous' | 'original';
 
-    constructor(options?: { prefix?: string; suffix?: string; style?: 'named' | 'indexed' | 'anonymous' }) {
+    constructor(options?: { prefix?: string; suffix?: string; style?: 'named' | 'indexed' | 'anonymous' | 'original' }) {
         this.prefix = options?.prefix ?? ':';
         this.suffix = options?.suffix ?? '';
         this.style = options?.style ?? 'named';
@@ -26,7 +26,7 @@ export class ParameterDecorator {
         } else if (this.style === 'indexed') {
             // e.g. $1, ?1, :1
             paramText = this.prefix + index;
-        } else if (this.style === 'named') {
+        } else if (this.style === 'named' || this.style === 'original') {
             // e.g. :name, @name, ${name}
             paramText = this.prefix + text + this.suffix;
         }

--- a/packages/core/src/parsers/ParameterExpressionParser.ts
+++ b/packages/core/src/parsers/ParameterExpressionParser.ts
@@ -5,6 +5,7 @@ export class ParameterExpressionParser {
     public static parseFromLexeme(lexemes: Lexeme[], index: number): { value: ValueComponent; newIndex: number } {
         let idx = index;
         let paramName = lexemes[idx].value;
+        const sourceText = paramName;
 
         // Normalize parameter: Remove the parameter symbol and extract the parameter name.
         if (paramName.startsWith('${') && paramName.endsWith('}')) {
@@ -15,7 +16,7 @@ export class ParameterExpressionParser {
             paramName = paramName.slice(1);
         }
 
-        const value = new ParameterExpression(paramName);
+        const value = new ParameterExpression(paramName, null, sourceText);
         idx++;
         return { value, newIndex: idx };
     }

--- a/packages/core/src/parsers/SqlPrintTokenParser.ts
+++ b/packages/core/src/parsers/SqlPrintTokenParser.ts
@@ -76,7 +76,8 @@ import {
 export enum ParameterStyle {
     Anonymous = 'anonymous',
     Indexed = 'indexed',
-    Named = 'named'
+    Named = 'named',
+    Original = 'original'
 }
 
 export type CastStyle = 'postgres' | 'standard';
@@ -99,7 +100,7 @@ export interface FormatterConfig {
     };
     parameterSymbol?: string | { start: string; end: string };
     /**
-     * Parameter style: anonymous (?), indexed ($1), or named (:name)
+     * Parameter style: anonymous (?), indexed ($1), named (:name), or original parsed spelling.
      */
     parameterStyle?: ParameterStyle;
     /** Controls how CAST expressions are rendered */
@@ -280,7 +281,7 @@ export class SqlPrintTokenParser implements SqlComponentVisitor<SqlPrintToken> {
         preset?: FormatterConfig,
         identifierEscape?: { start: string; end: string; target?: 'all' | 'minimal' },
         parameterSymbol?: string | { start: string; end: string },
-        parameterStyle?: 'anonymous' | 'indexed' | 'named',
+        parameterStyle?: 'anonymous' | 'indexed' | 'named' | 'original',
         castStyle?: CastStyle,
         constraintStyle?: ConstraintStyle,
         sourceAliasStyle?: SourceAliasStyle,
@@ -608,7 +609,7 @@ export class SqlPrintTokenParser implements SqlComponentVisitor<SqlPrintToken> {
         const paramsRaw = ParameterCollector.collect(arg).sort((a, b) => (a.index ?? 0) - (b.index ?? 0));
 
         const style = this.parameterDecorator.style;
-        if (style === ParameterStyle.Named) {
+        if (style === ParameterStyle.Named || style === ParameterStyle.Original) {
             // Named: { name: value, ... }
             const paramsObj: Record<string, any> = {};
             for (const p of paramsRaw) {
@@ -1355,7 +1356,9 @@ export class SqlPrintTokenParser implements SqlComponentVisitor<SqlPrintToken> {
     private visitParameterExpression(arg: ParameterExpression): SqlPrintToken {
         // Create a parameter token and decorate it using the parameterDecorator
         arg.index = this.index;
-        const text = this.parameterDecorator.decorate(arg.name.value, arg.index)
+        const text = this.parameterDecorator.style === ParameterStyle.Original && arg.sourceText
+            ? arg.sourceText
+            : this.parameterDecorator.decorate(arg.name.value, arg.index);
         const token = new SqlPrintToken(SqlPrintTokenType.parameter, text);
 
         this.addComponentComments(token, arg);

--- a/packages/core/src/transformers/SqlFormatter.ts
+++ b/packages/core/src/transformers/SqlFormatter.ts
@@ -112,7 +112,7 @@ export interface SqlFormatterOptions extends BaseFormattingOptions {
     /** Parameter symbol configuration for SQL parameters */
     parameterSymbol?: string | { start: string; end: string };
     /** Style for parameter formatting */
-    parameterStyle?: 'anonymous' | 'indexed' | 'named';
+    parameterStyle?: 'anonymous' | 'indexed' | 'named' | 'original';
     /** Preferred CAST rendering style */
     castStyle?: CastStyle;
     /** Constraint rendering style (affects CREATE TABLE constraint layout) */

--- a/packages/core/tests/transformers/SqlFormatter.parameter-original-style.test.ts
+++ b/packages/core/tests/transformers/SqlFormatter.parameter-original-style.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
+import { SqlFormatter } from '../../src/transformers/SqlFormatter';
+import { BinaryExpression, ParameterExpression } from '../../src/models/ValueComponent';
+import { SimpleSelectQuery } from '../../src/models/SelectQuery';
+
+describe('SqlFormatter parameter original style', () => {
+    it('preserves parsed parameter placeholder spelling', () => {
+        const query = SelectQueryParser.parse(
+            'select * from users where tenant_id = :tenant_id and owner_id = @owner_id and rank_id = $1 and state = ${state}'
+        );
+
+        const formatter = new SqlFormatter({
+            parameterStyle: 'original',
+            keywordCase: 'lower',
+            identifierEscape: 'none',
+            newline: 'space'
+        });
+
+        const result = formatter.format(query);
+
+        expect(result.formattedSql).toBe(
+            'select * from users where tenant_id = :tenant_id and owner_id = @owner_id and rank_id = $1 and state = ${state}'
+        );
+        expect(result.params).toEqual({
+            tenant_id: null,
+            owner_id: null,
+            '1': null,
+            state: null
+        });
+    });
+
+    it('preserves anonymous parsed placeholders in output', () => {
+        const query = SelectQueryParser.parse('select * from users where id = ?');
+
+        const formatter = new SqlFormatter({
+            parameterStyle: 'original',
+            identifierEscape: 'none',
+            newline: 'space'
+        });
+
+        const result = formatter.format(query);
+
+        expect(result.formattedSql).toBe('select * from users where id = ?');
+    });
+
+    it('falls back to configured named output for generated parameters without source spelling', () => {
+        const query = SelectQueryParser.parse('select id from users where id = :old_user_id') as SimpleSelectQuery;
+        const condition = query.whereClause!.condition as BinaryExpression;
+        condition.right = new ParameterExpression('user_id', 42);
+
+        const formatter = new SqlFormatter({
+            parameterStyle: 'original',
+            parameterSymbol: '@',
+            identifierEscape: 'none',
+            newline: 'space'
+        });
+
+        const result = formatter.format(query);
+
+        expect(result.formattedSql).toBe('select id from users where id = @user_id');
+        expect(result.params).toEqual({ user_id: 42 });
+    });
+
+    it('still rewrites parsed parameters when a concrete output style is selected', () => {
+        const query = SelectQueryParser.parse('select * from users where id = @user_id');
+
+        const formatter = new SqlFormatter({
+            parameterStyle: 'named',
+            parameterSymbol: ':',
+            identifierEscape: 'none',
+            newline: 'space'
+        });
+
+        const result = formatter.format(query);
+
+        expect(result.formattedSql).toBe('select * from users where id = :user_id');
+        expect(result.params).toEqual({ user_id: null });
+    });
+});


### PR DESCRIPTION
## Summary

- Add `parameterStyle: "original"` so parsed SQL parameters keep their input placeholder spelling when formatted.
- Preserve parsed parameter source text on `ParameterExpression`, while generated parameters without source spelling fall back to configured named output.
- Expose the option in the Style Editor, formatting guide, and patch changeset.

## Verification

- `corepack pnpm --filter rawsql-ts exec vitest run tests/transformers/SqlFormatter.parameter-original-style.test.ts tests/transformers/SqlParameterBinder.test.ts tests/parameter.test.ts`
- `corepack pnpm --filter rawsql-ts test`
- `corepack pnpm --filter rawsql-ts build`
- `corepack pnpm --filter rawsql-ts lint`
- `corepack pnpm --filter rawsql-ts benchmark`
- `corepack pnpm demo:complex-sql`
- `git diff --check`
- Pre-commit hook: workspace typecheck, workspace test, workspace build, workspace lint

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: Not required; no baseline exception requested.
Scoped checks run: Full required core checks, parser benchmark, complex SQL demo, focused parameter formatter regressions, and the pre-commit workspace baseline.
Why full baseline is not required: Full baseline was run by the pre-commit hook.

## Self Review

Self-review workflow: Repo-local developer-self-review skill; two-cycle review covering formatter behavior, parser source preservation, docs/editor consistency, and verification evidence.
Self-review result: No blockers remain; `original` is covered for parsed mixed placeholders, anonymous placeholder output, generated-parameter fallback, and existing named rewrite behavior.
Concept-review workflow: `packages/core/AGENTS.md` and `packages/core/DESIGN.md` package-boundary review.
Concept-review result: No concept or package-boundary violations remain; the change stays DBMS-neutral and limited to parser/formatter AST preservation.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: Formatter API and demo/docs option only; no CLI command, flag, help, or scaffold surface changed.
Upgrade note: Optional new `parameterStyle: "original"` formatter setting; existing parameter styles keep their behavior.
Deprecation/removal plan or issue: Not required; no option is deprecated or removed.
Docs/help/examples updated: Formatting guide and demo Style Editor updated.
Release/changeset wording: Patch changeset added for `rawsql-ts`.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: Formatter/parser option only; no scaffold template, generated scaffold output, or scaffold input contract changed.
Non-edit assertion: Not applicable; no scaffold-owned files changed.
Fail-fast input-contract proof: Not applicable; no scaffold input contract changed.
Generated-output viability proof: Not applicable; no generated scaffold output changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `parameterStyle: "original"` option to SQL formatting to output parameter placeholders using their original form (`:name`, `@name`, `$1`, `?`, `${name}`).
  * Updated demo configuration to include the new parameter style option.

* **Documentation**
  * Updated formatting recipes guide with examples of the new parameter style option.

* **Tests**
  * Added test suite covering the new parameter style option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->