### PR TITLE
test(parser): cover postgres grouping operations

### DIFF
--- a/packages/core/tests/parsers/GroupByParser.test.ts
+++ b/packages/core/tests/parsers/GroupByParser.test.ts
@@ -127,6 +127,18 @@ test('group by with grouping set', () => {
     expect(sql).toEqual(`group by grouping sets(("department_id"), ("job_id"), ("department_id", "job_id"))`);
 });
 
+test('group by with empty grouping set', () => {
+    // Arrange
+    const text = `group by grouping sets ((brand), (size), ())`;
+
+    // Act
+    const clause = GroupByClauseParser.parse(text);
+    const sql = formatter.format(clause);
+
+    // Assert
+    expect(sql).toEqual(`group by grouping sets(("brand"), ("size"), ())`);
+});
+
 test('group by with cube', () => {
     // Arrange
     const text = `group by cube (department_id, job_id)`;
@@ -139,6 +151,18 @@ test('group by with cube', () => {
     expect(sql).toEqual(`group by cube("department_id", "job_id")`);
 });
 
+test('group by with cube nested grouping elements', () => {
+    // Arrange
+    const text = `group by cube ((a, b), c)`;
+
+    // Act
+    const clause = GroupByClauseParser.parse(text);
+    const sql = formatter.format(clause);
+
+    // Assert
+    expect(sql).toEqual(`group by cube(("a", "b"), "c")`);
+});
+
 test('group by with rollup', () => {
     // Arrange
     const text = `group by rollup (department_id, job_id)`;
@@ -149,6 +173,18 @@ test('group by with rollup', () => {
 
     // Assert
     expect(sql).toEqual(`group by rollup("department_id", "job_id")`);
+});
+
+test('group by distinct rollup', () => {
+    // Arrange
+    const text = `group by distinct rollup (a, b), rollup (a, c)`;
+
+    // Act
+    const clause = GroupByClauseParser.parse(text);
+    const sql = formatter.format(clause);
+
+    // Assert
+    expect(sql).toEqual(`group by distinct rollup("a", "b"), rollup("a", "c")`);
 });
 
 test('group by with mix of columns and aggregations', () => {

--- a/packages/core/tests/parsers/SelectQueryParser.test.ts
+++ b/packages/core/tests/parsers/SelectQueryParser.test.ts
@@ -51,6 +51,26 @@ const selectFormatCases = [
         "select department, count(*) as employee_count from employees group by all order by department",
         'select "department", count(*) as "employee_count" from "employees" group by all order by "department"'],
 
+    ["SELECT with GROUPING SETS empty set",
+        "select brand, size, sum(sales) from items_sold group by grouping sets ((brand), (size), ())",
+        'select "brand", "size", sum("sales") from "items_sold" group by grouping sets(("brand"), ("size"), ())'],
+
+    ["SELECT with GROUPING function and ROLLUP",
+        "select make, model, grouping(make, model), sum(sales) from items_sold group by rollup(make, model)",
+        'select "make", "model", grouping("make", "model"), sum("sales") from "items_sold" group by rollup("make", "model")'],
+
+    ["SELECT with nested CUBE grouping elements",
+        "select a, b, c, sum(v) from t group by cube ((a, b), c)",
+        'select "a", "b", "c", sum("v") from "t" group by cube(("a", "b"), "c")'],
+
+    ["SELECT with multiple grouping items",
+        "select a, b, c, d, e, sum(v) from t group by a, cube (b, c), grouping sets ((d), (e))",
+        'select "a", "b", "c", "d", "e", sum("v") from "t" group by "a", cube("b", "c"), grouping sets(("d"), ("e"))'],
+
+    ["SELECT with GROUP BY DISTINCT ROLLUP",
+        "select a, b, sum(v) from t group by distinct rollup (a, b), rollup (a, c)",
+        'select "a", "b", sum("v") from "t" group by distinct rollup("a", "b"), rollup("a", "c")'],
+
     ["SELECT with GROUP BY and HAVING",
         "select department, count(*) as employee_count from employees group by department having count(*) > 5",
         'select "department", count(*) as "employee_count" from "employees" group by "department" having count(*) > 5'],


### PR DESCRIPTION
## Summary

- Add PostgreSQL official-syntax coverage for GROUPING SETS, ROLLUP, CUBE, and GROUPING(...) parser/formatter behavior.
- Confirm existing parser support for empty grouping sets, nested grouping elements, multiple grouping items, and GROUP BY DISTINCT with grouping operations.
- No parser implementation change was needed because the newly added TDD coverage already passes on the current implementation.

## Verification

- `corepack pnpm --filter rawsql-ts exec vitest run tests/parsers/GroupByParser.test.ts tests/parsers/SelectQueryParser.test.ts`
- `corepack pnpm --filter rawsql-ts test`
- `corepack pnpm --filter rawsql-ts build`
- `corepack pnpm --filter rawsql-ts lint`
- pre-commit: workspace typecheck, workspace test, workspace build, workspace lint

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

<!-- Write values on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. -->
<!-- Do not add list markers like "-" before these labels; `Tracking issue:` and `Scoped checks run:` must start at column 0. -->
Tracking issue: Not applicable; no baseline exception requested.
Scoped checks run: Focused parser tests, core test/build/lint, and pre-commit workspace checks.
Why full baseline is not required: Not applicable; no baseline exception requested.

## Self Review

<!-- Fill these fields after running the repo self-review workflow or available self-review skill. -->
Self-review workflow: Repo-local developer-self-review skill, two-cycle review.
Self-review result: No blockers remain; change is test-only and scoped to parser coverage.
Concept-review workflow: packages/core/AGENTS.md and packages/core/DESIGN.md package-boundary review.
Concept-review result: No package-boundary violations; tests specify DBMS-neutral parser/formatter syntax preservation.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-migration rationale: Test-only parser coverage; no CLI surface changed.
Upgrade note: Not applicable; no CLI or runtime behavior changed.
Deprecation/removal plan or issue: Not applicable; no deprecated CLI behavior.
Docs/help/examples updated: Not applicable; no CLI docs or examples changed.
Release/changeset wording: No changeset needed because this is test-only coverage with no package API or behavior change.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-proof rationale: Test-only parser coverage; no scaffold templates or generated output changed.
Non-edit assertion: Not applicable; no scaffold files changed.
Fail-fast input-contract proof: Not applicable; no scaffold input contract changed.
Generated-output viability proof: Not applicable; no generated scaffold output changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for `GROUP BY` clause parsing and formatting, including support for `GROUPING SETS`, `CUBE`, and `ROLLUP` constructs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->