### PR TITLE
docs(demo): preserve parameter style by default

### DIFF
--- a/docs/public/cud-demo/script.js
+++ b/docs/public/cud-demo/script.js
@@ -35,7 +35,7 @@ const defaultFormatOptions = {
     "identifierEscape": "none",
     "identifierEscapeTarget": "all",
     "parameterSymbol": ":",
-    "parameterStyle": "named",
+    "parameterStyle": "original",
     "sourceAliasStyle": "explicit",
     "castStyle": "standard"
 };

--- a/docs/public/demo/style-config.js
+++ b/docs/public/demo/style-config.js
@@ -44,7 +44,7 @@ const DEFAULT_STYLE_BASE = {
     "identifierEscape": "none",
     "identifierEscapeTarget": "all",
     "parameterSymbol": ":",
-    "parameterStyle": "named",
+    "parameterStyle": "original",
     "sourceAliasStyle": "explicit",
     "castStyle": "standard"
 };


### PR DESCRIPTION
## Summary

- Change the CUD demo default formatter options so `parameterStyle` starts as `original`.
- Align the shared demo Default style preset with the same `parameterStyle: "original"` value used by the CUD demo Style tab.

## Verification

- `rg -n '"parameterStyle": "original"' docs/public/cud-demo/script.js docs/public/demo/style-config.js`
- `git diff --check`
- pre-commit: workspace typecheck, workspace test, workspace build, workspace lint

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

<!-- Write values on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. -->
<!-- Do not add list markers like "-" before these labels; `Tracking issue:` and `Scoped checks run:` must start at column 0. -->
Tracking issue: Not applicable; no baseline exception requested.
Scoped checks run: Static demo value check, diff whitespace check, and pre-commit workspace checks.
Why full baseline is not required: Not applicable; no baseline exception requested.

## Self Review

<!-- Fill these fields after running the repo self-review workflow or available self-review skill. -->
Self-review workflow: Repo-local developer-self-review skill, consistency and human-acceptance review.
Self-review result: No blockers remain; the CUD demo initial formatter options and shared Default style preset now agree.
Concept-review workflow: No package concept impact; docs/public static demo configuration only.
Concept-review result: No concept or package-boundary violations.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-migration rationale: Static demo default style change only; no CLI surface changed.
Upgrade note: Not applicable; no CLI behavior changed.
Deprecation/removal plan or issue: Not applicable; no deprecation or removal.
Docs/help/examples updated: Demo configuration updated directly.
Release/changeset wording: No changeset needed because this is a docs/public demo default change with no package API or runtime package behavior change.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-proof rationale: Static demo default style change only; no scaffold templates or generated output changed.
Non-edit assertion: Not applicable; no scaffold files changed.
Fail-fast input-contract proof: Not applicable; no scaffold input contract changed.
Generated-output viability proof: Not applicable; no generated scaffold output changed.
