### PR TITLE
fix(core): preserve duplicate wildcard select values

### DIFF
--- a/.changeset/quiet-wildcards-collect.md
+++ b/.changeset/quiet-wildcards-collect.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": patch
+---
+
+Preserve duplicate output column names when `SelectValueCollector` expands wildcard select items across sources.

--- a/packages/core/src/transformers/SelectValueCollector.ts
+++ b/packages/core/src/transformers/SelectValueCollector.ts
@@ -189,13 +189,13 @@ export class SelectValueCollector implements SqlComponentVisitor<void> {
 
             const innerSelected = this.collectValuesFromCteQuery(commonTable.query, innerCommonTables);
             innerSelected.forEach(item => {
-                this.addSelectValueAsUnique(item.name, new ColumnReference(sourceName ? [sourceName] : null, item.name));
+                this.addSelectValue(item.name, new ColumnReference(sourceName ? [sourceName] : null, item.name));
             });
         } else {
             const innerCollector = new SelectValueCollector(this.tableColumnResolver, this.commonTables);
             const innerSelected = innerCollector.collect(source);
             innerSelected.forEach(item => {
-                this.addSelectValueAsUnique(item.name, new ColumnReference(sourceName ? [sourceName] : null, item.name));
+                this.addSelectValue(item.name, new ColumnReference(sourceName ? [sourceName] : null, item.name));
             });
         }
     }
@@ -268,6 +268,10 @@ export class SelectValueCollector implements SqlComponentVisitor<void> {
         if (!this.selectValues.some(item => item.name === name)) {
             this.selectValues.push({ name, value });
         }
+    }
+
+    private addSelectValue(name: string, value: ValueComponent): void {
+        this.selectValues.push({ name, value });
     }
 
     private collectValuesFromCteQuery(query: CTEQuery, commonTables: CommonTable[]): { name: string, value: ValueComponent }[] {

--- a/packages/core/tests/transformers/SelectValueCollectorWildcard.test.ts
+++ b/packages/core/tests/transformers/SelectValueCollectorWildcard.test.ts
@@ -104,22 +104,49 @@ describe('SelectValueCollectorWildcard', () => {
         const expressions = items.map(item => formatter.format(item.value).formattedSql);
 
         // Assert
-        expect(items.length).toBe(5); // posts(2) + users(4) - duplicate id is excluded(1)
+        expect(items.length).toBe(6); // posts(2) + users(4), including duplicate output name id
 
         // Specific columns from posts table
         expect(columnNames).toContain('id');
         expect(columnNames).toContain('title');
 
-        // All columns from users table, however duplicate id is excluded.
-        // This differs from actual DB behavior, but due to the SQL processing library's characteristics, column name duplications are not allowed.
+        // All columns from users table are preserved. Duplicate output names are valid SELECT output positions.
+        expect(columnNames.filter(name => name === 'id')).toHaveLength(2);
         expect(columnNames).toContain('name');
         expect(columnNames).toContain('email');
-        expect(columnNames).toContain('created_at');        // Verify expression content
+        expect(columnNames).toContain('created_at');
+
+        // Verify expression content
         expect(expressions).toContain('"p"."id"');
         expect(expressions).toContain('"p"."title"');
+        expect(expressions).toContain('"u"."id"');
         expect(expressions).toContain('"u"."name"');
         expect(expressions).toContain('"u"."email"');
         expect(expressions).toContain('"u"."created_at"');
+    });
+
+    test('Full wildcard expansion preserves duplicate output names from joined tables', () => {
+        const sql = `SELECT * FROM users u INNER JOIN posts p ON p.user_id = u.id`;
+        const query = SelectQueryParser.parse(sql);
+        const collector = new SelectValueCollector(mockTableResolver);
+
+        const items = collector.collect(query);
+        const namesAndExpressions = items.map(item => ({
+            name: item.name,
+            sql: formatter.format(item.value).formattedSql
+        }));
+
+        expect(namesAndExpressions).toEqual([
+            { name: 'id', sql: '"u"."id"' },
+            { name: 'name', sql: '"u"."name"' },
+            { name: 'email', sql: '"u"."email"' },
+            { name: 'created_at', sql: '"u"."created_at"' },
+            { name: 'id', sql: '"p"."id"' },
+            { name: 'title', sql: '"p"."title"' },
+            { name: 'content', sql: '"p"."content"' },
+            { name: 'user_id', sql: '"p"."user_id"' },
+            { name: 'created_at', sql: '"p"."created_at"' }
+        ]);
     });
 
     test('Wildcard expansion with column aliases', () => {


### PR DESCRIPTION
## Summary

- Preserve duplicate output column names when `SelectValueCollector` expands wildcard select items across joined sources.
- Keep explicit duplicate SELECT items unchanged: the existing explicit duplicate test still deduplicates `SELECT id, id`.
- Add a changeset for the `rawsql-ts` patch release note.

## Verification

- `pnpm --filter rawsql-ts test -- tests/transformers/SelectValueCollectorWildcard.test.ts tests/transformers/SelectValueCollector.test.ts --reporter verbose`
- `pnpm --filter rawsql-ts test`
- `pnpm --filter rawsql-ts build`
- `pnpm --filter rawsql-ts lint`
- Pre-commit hook: workspace `typecheck`, workspace `test`, workspace `build`, workspace `lint`

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: Not requested.
Scoped checks run: Focused SelectValueCollector tests, rawsql-ts package test/build/lint, and pre-commit workspace typecheck/test/build/lint.
Why full baseline is not required: Not applicable; no baseline exception requested.

## Self Review

Self-review workflow: developer-self-review skill applied manually with consistency review and human acceptance review.
Self-review result: No blockers remain; the diff is limited to SelectValueCollector behavior, regression tests, and a changeset.
Concept-review workflow: packages/core/AGENTS.md and packages/core/DESIGN.md package-boundary review.
Concept-review result: No package-boundary violations found; the change stays within DBMS-neutral parser/analyzer behavior and adds no driver, runtime, lineage, UI, or testkit semantics.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: No CLI-facing files, commands, help, or migration surface changed.
Upgrade note: Not applicable.
Deprecation/removal plan or issue: Not applicable.
Docs/help/examples updated: Not applicable.
Release/changeset wording: Added `.changeset/quiet-wildcards-collect.md` for the rawsql-ts patch behavior fix.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: No scaffold-related files or generated project contracts changed.
Non-edit assertion: Not applicable.
Fail-fast input-contract proof: Not applicable.
Generated-output viability proof: Not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed wildcard select queries to correctly preserve duplicate column names when expanding across multiple tables or sources (e.g., in JOIN operations), ensuring all columns are accurately represented in the output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->