### PR TITLE
fix(core): expand syntax-derived wildcard outputs

### DIFF
--- a/.changeset/syntax-derived-wildcards.md
+++ b/.changeset/syntax-derived-wildcards.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": patch
+---
+
+Expand CTE and derived-table wildcard SELECT outputs from SQL syntax when the selected source exposes explicit columns. This preserves wildcard output order, keeps duplicate output names as separate SELECT positions, and avoids requiring a table resolver for syntax-derived CTE or subquery columns.

--- a/packages/core/src/transformers/SelectValueCollector.ts
+++ b/packages/core/src/transformers/SelectValueCollector.ts
@@ -23,12 +23,14 @@ export class SelectValueCollector implements SqlComponentVisitor<void> {
     private commonTableCollector: CTECollector;
     private commonTables: CommonTable[];
     public initialCommonTables: CommonTable[] | null;
+    private preserveDuplicateSelectItems: boolean;
 
-    constructor(tableColumnResolver: TableColumnResolver | null = null, initialCommonTables: CommonTable[] | null = null) {
+    constructor(tableColumnResolver: TableColumnResolver | null = null, initialCommonTables: CommonTable[] | null = null, preserveDuplicateSelectItems: boolean = false) {
         this.tableColumnResolver = tableColumnResolver ?? null;
         this.commonTableCollector = new CTECollector();
         this.commonTables = [];
         this.initialCommonTables = initialCommonTables;
+        this.preserveDuplicateSelectItems = preserveDuplicateSelectItems;
 
         this.handlers = new Map<symbol, (arg: any) => void>();
 
@@ -128,76 +130,104 @@ export class SelectValueCollector implements SqlComponentVisitor<void> {
             return;
         }
 
-        // full wildcard
-        if (this.selectValues.some(item => item.value instanceof ColumnReference && item.value.namespaces === null)) {
-            if (query.fromClause) {
-                this.processFromClause(query.fromClause, true);
+        const expandedValues: { name: string, value: ValueComponent }[] = [];
+        for (const item of this.selectValues) {
+            if (item.name !== '*' || !(item.value instanceof ColumnReference)) {
+                expandedValues.push(item);
+                continue;
             }
-            // remove wildcard
-            this.selectValues = this.selectValues.filter(item => item.name !== '*');
-            return;
-        };
 
-        // table wildcard
-        const wildSourceNames = wildcards.filter(item => item.value instanceof ColumnReference && item.value.namespaces)
-            .map(item => (item.value as ColumnReference).getNamespace());
-
-        if (query.fromClause) {
-            const fromSourceName = query.fromClause.getSourceAliasName();
-            if (fromSourceName && wildSourceNames.includes(fromSourceName)) {
-                this.processFromClause(query.fromClause, false);
-            }
-            if (query.fromClause.joins) {
-                for (const join of query.fromClause.joins) {
-                    const joinSourceName = join.getSourceAliasName();
-                    if (joinSourceName && wildSourceNames.includes(joinSourceName)) {
-                        this.processJoinClause(join);
-                    }
-                }
-            }
+            expandedValues.push(...this.expandWildcardValue(item.value, query.fromClause));
         }
-        // remove wildcard
-        this.selectValues = this.selectValues.filter(item => item.name !== '*');
-        return;
+
+        this.selectValues = expandedValues;
     }
 
     private processFromClause(clause: FromClause, joinCascade: boolean): void {
-        if (clause) {
-            const fromSourceName = clause.getSourceAliasName();
-            this.processSourceExpression(fromSourceName, clause.source);
-
-            if (clause.joins && joinCascade) {
-                for (const join of clause.joins) {
-                    this.processJoinClause(join);
-                }
-            }
+        for (const item of this.collectFromClauseValues(clause, joinCascade)) {
+            this.addSelectValue(item.name, item.value);
         }
         return;
     }
 
     private processJoinClause(clause: JoinClause): void {
-        const sourceName = clause.getSourceAliasName();
-        this.processSourceExpression(sourceName, clause.source);
+        for (const item of this.collectJoinClauseValues(clause)) {
+            this.addSelectValue(item.name, item.value);
+        }
     }
 
     private processSourceExpression(sourceName: string | null, source: SourceExpression) {
+        for (const item of this.collectSourceExpressionValues(sourceName, source)) {
+            this.addSelectValue(item.name, item.value);
+        }
+    }
+
+    private expandWildcardValue(value: ColumnReference, fromClause: FromClause | null): { name: string, value: ValueComponent }[] {
+        if (!fromClause) {
+            return [];
+        }
+
+        if (value.namespaces === null) {
+            return this.collectFromClauseValues(fromClause, true);
+        }
+
+        const sourceName = value.getNamespace();
+        if (fromClause.getSourceAliasName() === sourceName) {
+            return this.collectFromClauseValues(fromClause, false);
+        }
+
+        if (!fromClause.joins) {
+            return [];
+        }
+
+        const join = fromClause.joins.find(item => this.getJoinSourceName(item) === sourceName);
+        return join ? this.collectJoinClauseValues(join) : [];
+    }
+
+    private collectFromClauseValues(clause: FromClause, joinCascade: boolean): { name: string, value: ValueComponent }[] {
+        const values = this.collectSourceExpressionValues(clause.getSourceAliasName(), clause.source);
+
+        if (clause.joins && joinCascade) {
+            for (const join of clause.joins) {
+                values.push(...this.collectJoinClauseValues(join));
+            }
+        }
+
+        return values;
+    }
+
+    private collectJoinClauseValues(clause: JoinClause): { name: string, value: ValueComponent }[] {
+        return this.collectSourceExpressionValues(this.getJoinSourceName(clause), clause.source);
+    }
+
+    private getJoinSourceName(clause: JoinClause): string | null {
+        return clause.source.getAliasName();
+    }
+
+    private collectSourceExpressionValues(sourceName: string | null, source: SourceExpression): { name: string, value: ValueComponent }[] {
         // check common table
-        const commonTable = this.commonTables.find(item => item.aliasExpression.table.name === sourceName);
+        const tableSourceName = source.datasource instanceof TableSource ? source.datasource.getSourceName() : null;
+        const commonTable = tableSourceName
+            ? this.commonTables.find(item => item.aliasExpression.table.name === tableSourceName)
+            : null;
+
         if (commonTable) {
             // Exclude this CTE from consideration to prevent self-reference
-            const innerCommonTables = this.commonTables.filter(item => item.aliasExpression.table.name !== sourceName);
+            const innerCommonTables = this.commonTables.filter(item => item.aliasExpression.table.name !== commonTable.aliasExpression.table.name);
 
             const innerSelected = this.collectValuesFromCteQuery(commonTable.query, innerCommonTables);
-            innerSelected.forEach(item => {
-                this.addSelectValue(item.name, new ColumnReference(sourceName ? [sourceName] : null, item.name));
-            });
-        } else {
-            const innerCollector = new SelectValueCollector(this.tableColumnResolver, this.commonTables);
-            const innerSelected = innerCollector.collect(source);
-            innerSelected.forEach(item => {
-                this.addSelectValue(item.name, new ColumnReference(sourceName ? [sourceName] : null, item.name));
-            });
+            return innerSelected.map(item => ({
+                name: item.name,
+                value: new ColumnReference(sourceName ? [sourceName] : null, item.name)
+            }));
         }
+
+        const innerCollector = new SelectValueCollector(this.tableColumnResolver, this.commonTables, true);
+        const innerSelected = innerCollector.collect(source);
+        return innerSelected.map(item => ({
+            name: item.name,
+            value: new ColumnReference(sourceName ? [sourceName] : null, item.name)
+        }));
     }
 
     private visitSelectClause(clause: SelectClause): void {
@@ -208,7 +238,7 @@ export class SelectValueCollector implements SqlComponentVisitor<void> {
 
     private processSelectItem(item: SelectItem): void {
         if (item.identifier) {
-            this.addSelectValueAsUnique(item.identifier.name, item.value);
+            this.addSelectValueFromSelectItem(item.identifier.name, item.value);
         }
         else if (item.value instanceof ColumnReference) {            // Handle column reference
             // columnName can be '*'
@@ -219,7 +249,7 @@ export class SelectValueCollector implements SqlComponentVisitor<void> {
             }
             else {
                 // Add with duplicate checking
-                this.addSelectValueAsUnique(columnName, item.value);
+                this.addSelectValueFromSelectItem(columnName, item.value);
             }
         }
     }
@@ -233,23 +263,23 @@ export class SelectValueCollector implements SqlComponentVisitor<void> {
         if (source.aliasExpression && source.aliasExpression.columns) {
             const sourceName = source.getAliasName();
             source.aliasExpression.columns.forEach(column => {
-                this.addSelectValueAsUnique(column.name, new ColumnReference(sourceName ? [sourceName] : null, column.name));
+                this.addSelectValueFromSelectItem(column.name, new ColumnReference(sourceName ? [sourceName] : null, column.name));
             });
             return;
         } else if (source.datasource instanceof TableSource) {
             if (this.tableColumnResolver) {
                 const sourceName = source.datasource.getSourceName();
                 this.tableColumnResolver(sourceName).forEach(column => {
-                    this.addSelectValueAsUnique(column, new ColumnReference([sourceName], column));
+                    this.addSelectValueFromSelectItem(column, new ColumnReference([sourceName], column));
                 });
             }
             return;
         } else if (source.datasource instanceof SubQuerySource) {
             const sourceName = source.getAliasName();
-            const innerCollector = new SelectValueCollector(this.tableColumnResolver, this.commonTables);
+            const innerCollector = new SelectValueCollector(this.tableColumnResolver, this.commonTables, true);
             const innerSelected = innerCollector.collect(source.datasource.query);
             innerSelected.forEach(item => {
-                this.addSelectValueAsUnique(item.name, new ColumnReference(sourceName ? [sourceName] : null, item.name));
+                this.addSelectValueFromSelectItem(item.name, new ColumnReference(sourceName ? [sourceName] : null, item.name));
             });
             return;
         } else if (source.datasource instanceof ParenSource) {
@@ -274,9 +304,18 @@ export class SelectValueCollector implements SqlComponentVisitor<void> {
         this.selectValues.push({ name, value });
     }
 
+    private addSelectValueFromSelectItem(name: string, value: ValueComponent): void {
+        if (this.preserveDuplicateSelectItems) {
+            this.addSelectValue(name, value);
+            return;
+        }
+
+        this.addSelectValueAsUnique(name, value);
+    }
+
     private collectValuesFromCteQuery(query: CTEQuery, commonTables: CommonTable[]): { name: string, value: ValueComponent }[] {
         if (this.isSelectQuery(query)) {
-            const innerCollector = new SelectValueCollector(this.tableColumnResolver, commonTables);
+            const innerCollector = new SelectValueCollector(this.tableColumnResolver, commonTables, true);
             return innerCollector.collect(query);
         }
 

--- a/packages/core/tests/transformers/SelectValueCollectorWildcard.test.ts
+++ b/packages/core/tests/transformers/SelectValueCollectorWildcard.test.ts
@@ -226,6 +226,114 @@ describe('SelectValueCollectorWildcard', () => {
         expect(expressions).toContain('"cte"."created_at"');
     });
 
+    test('Wildcard expansion from CTE output without resolver', () => {
+        const sql = `
+            WITH scored AS (
+                SELECT
+                    customer_id,
+                    amount,
+                    amount * 2 AS score
+                FROM orders
+            )
+            SELECT
+                s.*
+            FROM scored AS s
+        `;
+        const query = SelectQueryParser.parse(sql);
+        const collector = new SelectValueCollector();
+
+        const items = collector.collect(query);
+        const namesAndExpressions = items.map(item => ({
+            name: item.name,
+            sql: formatter.format(item.value).formattedSql
+        }));
+
+        expect(namesAndExpressions).toEqual([
+            { name: 'customer_id', sql: '"s"."customer_id"' },
+            { name: 'amount', sql: '"s"."amount"' },
+            { name: 'score', sql: '"s"."score"' }
+        ]);
+    });
+
+    test('Wildcard expansion from derived table output without resolver', () => {
+        const sql = `
+            SELECT
+                d.*
+            FROM (
+                SELECT
+                    a,
+                    b
+                FROM t
+            ) AS d
+        `;
+        const query = SelectQueryParser.parse(sql);
+        const collector = new SelectValueCollector();
+
+        const items = collector.collect(query);
+        const namesAndExpressions = items.map(item => ({
+            name: item.name,
+            sql: formatter.format(item.value).formattedSql
+        }));
+
+        expect(namesAndExpressions).toEqual([
+            { name: 'a', sql: '"d"."a"' },
+            { name: 'b', sql: '"d"."b"' }
+        ]);
+    });
+
+    test('Wildcard expansion keeps mixed SELECT output order', () => {
+        const sql = `
+            WITH scored AS (
+                SELECT
+                    customer_id,
+                    amount
+                FROM orders
+            )
+            SELECT
+                s.*,
+                s.amount * 2 AS score
+            FROM scored AS s
+        `;
+        const query = SelectQueryParser.parse(sql);
+        const collector = new SelectValueCollector();
+
+        const items = collector.collect(query);
+        const namesAndExpressions = items.map(item => ({
+            name: item.name,
+            sql: formatter.format(item.value).formattedSql
+        }));
+
+        expect(namesAndExpressions).toEqual([
+            { name: 'customer_id', sql: '"s"."customer_id"' },
+            { name: 'amount', sql: '"s"."amount"' },
+            { name: 'score', sql: '"s"."amount" * 2' }
+        ]);
+    });
+
+    test('Wildcard expansion preserves duplicate derived output names', () => {
+        const sql = `
+            SELECT
+                d.*
+            FROM (
+                SELECT
+                    c.id,
+                    o.id
+                FROM customers AS c
+                JOIN orders AS o ON o.customer_id = c.id
+            ) AS d
+        `;
+        const query = SelectQueryParser.parse(sql);
+        const collector = new SelectValueCollector();
+
+        const items = collector.collect(query);
+
+        expect(items.map(item => item.name)).toEqual(['id', 'id']);
+        expect(items.map(item => formatter.format(item.value).formattedSql)).toEqual([
+            '"d"."id"',
+            '"d"."id"'
+        ]);
+    });
+
     test('Wildcard expansion from nested CTEs', () => {
         // Arrange - * wildcard in nested CTEs
         const sql = `WITH cte1 AS (SELECT * FROM users), cte2 AS (SELECT * FROM cte1) SELECT * FROM cte2`;


### PR DESCRIPTION
## Summary

- Closes #905.
- Expands CTE and derived-table wildcard SELECT outputs from SQL syntax without requiring a table resolver.
- Preserves SELECT output order and keeps duplicate wildcard-expanded output names as separate positions.

## Verification

- `corepack pnpm --filter rawsql-ts exec vitest run tests/transformers/SelectValueCollectorWildcard.test.ts tests/transformers/SchemaCollector.test.ts`
- `corepack pnpm --filter rawsql-ts test`
- `corepack pnpm --filter rawsql-ts build`
- `corepack pnpm --filter rawsql-ts lint`
- Pre-commit hook passed workspace `typecheck`, `test`, `build`, and `lint` during commit `b1093bec4`.

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

<!-- Write values on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. -->
<!-- Do not add list markers like "-" before these labels; `Tracking issue:` and `Scoped checks run:` must start at column 0. -->
Tracking issue: #905
Scoped checks run: `corepack pnpm --filter rawsql-ts test`; `corepack pnpm --filter rawsql-ts build`; `corepack pnpm --filter rawsql-ts lint`; pre-commit workspace typecheck/test/build/lint
Why full baseline is not required: Full pre-commit workspace checks passed; no baseline exception is requested.

## Self Review

<!-- Fill these fields after running the repo self-review workflow or available self-review skill. -->
Self-review workflow: developer-self-review skill; consistency review and human acceptance review over implementation, tests, changeset, and PR text.
Self-review result: No blockers remain. The change is scoped to SelectValueCollector wildcard expansion and covered by acceptance tests plus package/core verification.
Concept-review workflow: packages/core/AGENTS.md and packages/core/DESIGN.md package-boundary review.
Concept-review result: No package-boundary violations found. The change stays within DBMS-neutral parser/analyzer behavior and does not add lineage viewer, driver, DB, or rewrite semantics.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-migration rationale: No CLI-facing files or command behavior changed.
Upgrade note: No user action required.
Deprecation/removal plan or issue: None; no CLI option or command was removed.
Docs/help/examples updated: Not required for this internal analyzer bug fix.
Release/changeset wording: `.changeset/syntax-derived-wildcards.md`

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-proof rationale: No scaffold-related files or generated scaffold contract changed.
Non-edit assertion: This PR does not edit scaffold templates or generated scaffold output.
Fail-fast input-contract proof: Not applicable; no scaffold input contract changed.
Generated-output viability proof: Not applicable; no scaffold output changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Wildcard SELECT queries in CTEs and derived tables now expand from SQL syntax, preserving output order and duplicate column names.
  * No longer requires table resolver for syntax-derived CTEs and subqueries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->