### PR TITLE
feat(core): expose select output indexes

### DIFF
--- a/.changeset/select-output-indexes.md
+++ b/.changeset/select-output-indexes.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": patch
+---
+
+Add `SelectOutputCollector` for SELECT output analysis that preserves duplicate output names and exposes a stable `outputIndex` for each returned output position after supported wildcard expansion.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -68,6 +68,7 @@ export * from './transformers/SimulatedSelectConverter';
 export * from './transformers/DDLToFixtureConverter';
 export * from './transformers/DDLGeneralizer';
 export * from './transformers/DDLDiffGenerator';
+export * from './transformers/SelectOutputCollector';
 export * from './transformers/SelectValueCollector';
 export * from './transformers/SelectableColumnCollector';
 export { DuplicateDetectionMode } from './transformers/SelectableColumnCollector';

--- a/packages/core/src/transformers/SelectOutputCollector.ts
+++ b/packages/core/src/transformers/SelectOutputCollector.ts
@@ -1,0 +1,243 @@
+import { CommonTable, CTEQuery, FromClause, JoinClause, ParenSource, ReturningClause, SelectItem, SourceExpression, SubQuerySource, TableSource } from "../models/Clause";
+import { InsertQuery } from "../models/InsertQuery";
+import { DeleteQuery } from "../models/DeleteQuery";
+import { MergeQuery } from "../models/MergeQuery";
+import { SelectQuery, SimpleSelectQuery } from "../models/SelectQuery";
+import { SqlComponent } from "../models/SqlComponent";
+import { UpdateQuery } from "../models/UpdateQuery";
+import { ColumnReference, ValueComponent } from "../models/ValueComponent";
+import { CTECollector } from "./CTECollector";
+import { TableColumnResolver } from "./TableColumnResolver";
+
+export interface SelectOutputColumn {
+    name: string;
+    value: ValueComponent;
+    outputIndex: number;
+}
+
+type RawSelectOutputColumn = Omit<SelectOutputColumn, "outputIndex">;
+
+/**
+ * Collects SELECT output columns without collapsing duplicate output names.
+ *
+ * This collector is intended for callers that need stable SELECT-list positions.
+ * It keeps output order and assigns outputIndex after supported wildcard expansion.
+ */
+export class SelectOutputCollector {
+    private commonTableCollector = new CTECollector();
+    private commonTables: CommonTable[];
+
+    constructor(
+        private tableColumnResolver: TableColumnResolver | null = null,
+        initialCommonTables: CommonTable[] | null = null
+    ) {
+        this.commonTables = initialCommonTables ?? [];
+    }
+
+    public collect(arg: SqlComponent): SelectOutputColumn[] {
+        const rawColumns = this.collectRaw(arg);
+        return rawColumns.map((item, outputIndex) => ({
+            ...item,
+            outputIndex
+        }));
+    }
+
+    private collectRaw(arg: SqlComponent): RawSelectOutputColumn[] {
+        if (arg instanceof SimpleSelectQuery) {
+            return this.collectSimpleSelectQuery(arg);
+        }
+
+        if (arg instanceof SourceExpression) {
+            return this.collectSourceExpression(arg.getAliasName(), arg);
+        }
+
+        if (arg instanceof FromClause) {
+            return this.collectFromClause(arg, true);
+        }
+
+        return [];
+    }
+
+    private collectSimpleSelectQuery(query: SimpleSelectQuery): RawSelectOutputColumn[] {
+        const previousCommonTables = this.commonTables;
+        if (this.commonTables.length === 0) {
+            this.commonTables = this.commonTableCollector.collect(query);
+        }
+
+        try {
+            const outputs: RawSelectOutputColumn[] = [];
+            for (const item of query.selectClause.items) {
+                outputs.push(...this.collectSelectItem(item, query.fromClause));
+            }
+            return outputs;
+        } finally {
+            this.commonTables = previousCommonTables;
+        }
+    }
+
+    private collectSelectItem(item: SelectItem, fromClause: FromClause | null): RawSelectOutputColumn[] {
+        if (item.identifier) {
+            return [{ name: item.identifier.name, value: item.value }];
+        }
+
+        if (!(item.value instanceof ColumnReference)) {
+            return [];
+        }
+
+        const columnName = item.value.column.name;
+        if (columnName === "*") {
+            return this.expandWildcard(item.value, fromClause);
+        }
+
+        return [{ name: columnName, value: item.value }];
+    }
+
+    private expandWildcard(value: ColumnReference, fromClause: FromClause | null): RawSelectOutputColumn[] {
+        if (!fromClause) {
+            return [];
+        }
+
+        if (value.namespaces === null) {
+            return this.collectFromClause(fromClause, true);
+        }
+
+        const sourceName = value.getNamespace();
+        if (fromClause.getSourceAliasName() === sourceName) {
+            return this.collectFromClause(fromClause, false);
+        }
+
+        const join = fromClause.joins?.find(item => this.getJoinSourceName(item) === sourceName);
+        return join ? this.collectJoinClause(join) : [];
+    }
+
+    private collectFromClause(clause: FromClause, joinCascade: boolean): RawSelectOutputColumn[] {
+        const outputs = this.collectSourceExpression(clause.getSourceAliasName(), clause.source);
+
+        if (clause.joins && joinCascade) {
+            for (const join of clause.joins) {
+                outputs.push(...this.collectJoinClause(join));
+            }
+        }
+
+        return outputs;
+    }
+
+    private collectJoinClause(clause: JoinClause): RawSelectOutputColumn[] {
+        return this.collectSourceExpression(this.getJoinSourceName(clause), clause.source);
+    }
+
+    private getJoinSourceName(clause: JoinClause): string | null {
+        return clause.source.getAliasName();
+    }
+
+    private collectSourceExpression(sourceName: string | null, source: SourceExpression): RawSelectOutputColumn[] {
+        if (source.aliasExpression?.columns) {
+            return source.aliasExpression.columns.map(column => ({
+                name: column.name,
+                value: new ColumnReference(sourceName ? [sourceName] : null, column.name)
+            }));
+        }
+
+        const cte = this.findCommonTable(source);
+        if (cte) {
+            const innerCommonTables = this.commonTables.filter(item => item.getSourceAliasName() !== cte.getSourceAliasName());
+            const innerOutputs = this.collectCteQuery(cte.query, innerCommonTables);
+            return this.qualifyOutputs(innerOutputs, sourceName);
+        }
+
+        if (source.datasource instanceof TableSource) {
+            return this.collectTableSource(sourceName, source.datasource);
+        }
+
+        if (source.datasource instanceof SubQuerySource) {
+            const innerOutputs = this.collectNestedSelectQuery(source.datasource.query);
+            return this.qualifyOutputs(innerOutputs, sourceName);
+        }
+
+        if (source.datasource instanceof ParenSource) {
+            return [];
+        }
+
+        return [];
+    }
+
+    private findCommonTable(source: SourceExpression): CommonTable | null {
+        if (!(source.datasource instanceof TableSource)) {
+            return null;
+        }
+
+        const tableName = source.datasource.getSourceName();
+        return this.commonTables.find(item => item.getSourceAliasName() === tableName) ?? null;
+    }
+
+    private collectTableSource(sourceName: string | null, source: TableSource): RawSelectOutputColumn[] {
+        if (!this.tableColumnResolver) {
+            return [];
+        }
+
+        const tableName = source.getSourceName();
+        const qualifier = sourceName ?? tableName;
+        return this.tableColumnResolver(tableName).map(column => ({
+            name: column,
+            value: new ColumnReference([qualifier], column)
+        }));
+    }
+
+    private collectNestedSelectQuery(query: SelectQuery): RawSelectOutputColumn[] {
+        const collector = new SelectOutputCollector(this.tableColumnResolver, this.commonTables);
+        return collector.collect(query).map(({ name, value }) => ({ name, value }));
+    }
+
+    private collectCteQuery(query: CTEQuery, commonTables: CommonTable[]): RawSelectOutputColumn[] {
+        if (this.isSelectQuery(query)) {
+            const collector = new SelectOutputCollector(this.tableColumnResolver, commonTables);
+            return collector.collect(query).map(({ name, value }) => ({ name, value }));
+        }
+
+        return this.collectReturningOutputs(query);
+    }
+
+    private collectReturningOutputs(query: CTEQuery): RawSelectOutputColumn[] {
+        if (!(query instanceof InsertQuery || query instanceof UpdateQuery || query instanceof DeleteQuery || query instanceof MergeQuery)) {
+            return [];
+        }
+
+        if (!query.returningClause) {
+            return [];
+        }
+
+        return this.extractReturningOutputs(query.returningClause);
+    }
+
+    private extractReturningOutputs(clause: ReturningClause): RawSelectOutputColumn[] {
+        const outputs: RawSelectOutputColumn[] = [];
+        for (const item of clause.items) {
+            const name = item.identifier?.name ?? this.extractSelectItemName(item);
+            if (name) {
+                outputs.push({ name, value: item.value });
+            }
+        }
+        return outputs;
+    }
+
+    private extractSelectItemName(item: SelectItem): string | null {
+        if (item.identifier) {
+            return item.identifier.name;
+        }
+        if (item.value instanceof ColumnReference) {
+            return item.value.column.name;
+        }
+        return null;
+    }
+
+    private qualifyOutputs(outputs: RawSelectOutputColumn[], sourceName: string | null): RawSelectOutputColumn[] {
+        return outputs.map(item => ({
+            name: item.name,
+            value: new ColumnReference(sourceName ? [sourceName] : null, item.name)
+        }));
+    }
+
+    private isSelectQuery(query: CTEQuery): query is SelectQuery {
+        return "__selectQueryType" in query && (query as SelectQuery).__selectQueryType === "SelectQuery";
+    }
+}

--- a/packages/core/tests/transformers/SelectOutputCollector.test.ts
+++ b/packages/core/tests/transformers/SelectOutputCollector.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'vitest';
+import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
+import { SqlFormatter } from '../../src/transformers/Formatter';
+import { SelectOutputCollector } from '../../src/transformers/SelectOutputCollector';
+import { TableColumnResolver } from '../../src/transformers/TableColumnResolver';
+
+const formatter = new SqlFormatter();
+
+describe('SelectOutputCollector', () => {
+    test('keeps duplicate output names with distinct output indexes', () => {
+        const sql = `
+            SELECT
+                c.id,
+                o.id
+            FROM customers AS c
+            JOIN orders AS o ON o.customer_id = c.id
+        `;
+        const query = SelectQueryParser.parse(sql);
+
+        const outputs = new SelectOutputCollector().collect(query);
+
+        expect(outputs.map(item => ({
+            name: item.name,
+            outputIndex: item.outputIndex,
+            sql: formatter.format(item.value).formattedSql
+        }))).toEqual([
+            { name: 'id', outputIndex: 0, sql: '"c"."id"' },
+            { name: 'id', outputIndex: 1, sql: '"o"."id"' }
+        ]);
+    });
+
+    test('preserves wildcard plus explicit output order with resolver expansion', () => {
+        const resolver: TableColumnResolver = tableName => {
+            if (tableName === 'scored') {
+                return ['customer_id', 'amount'];
+            }
+            return [];
+        };
+        const sql = `
+            SELECT
+                s.*,
+                s.amount * 2 AS score
+            FROM scored AS s
+        `;
+        const query = SelectQueryParser.parse(sql);
+
+        const outputs = new SelectOutputCollector(resolver).collect(query);
+
+        expect(outputs.map(item => ({
+            name: item.name,
+            outputIndex: item.outputIndex,
+            sql: formatter.format(item.value).formattedSql
+        }))).toEqual([
+            { name: 'customer_id', outputIndex: 0, sql: '"s"."customer_id"' },
+            { name: 'amount', outputIndex: 1, sql: '"s"."amount"' },
+            { name: 'score', outputIndex: 2, sql: '"s"."amount" * 2' }
+        ]);
+    });
+
+    test('expands CTE wildcard outputs from syntax with stable output indexes', () => {
+        const sql = `
+            WITH scored AS (
+                SELECT
+                    customer_id,
+                    amount,
+                    amount * 2 AS doubled
+                FROM orders
+            )
+            SELECT
+                s.*,
+                s.amount + 1 AS adjusted_amount
+            FROM scored AS s
+        `;
+        const query = SelectQueryParser.parse(sql);
+
+        const outputs = new SelectOutputCollector().collect(query);
+
+        expect(outputs.map(item => ({
+            name: item.name,
+            outputIndex: item.outputIndex,
+            sql: formatter.format(item.value).formattedSql
+        }))).toEqual([
+            { name: 'customer_id', outputIndex: 0, sql: '"s"."customer_id"' },
+            { name: 'amount', outputIndex: 1, sql: '"s"."amount"' },
+            { name: 'doubled', outputIndex: 2, sql: '"s"."doubled"' },
+            { name: 'adjusted_amount', outputIndex: 3, sql: '"s"."amount" + 1' }
+        ]);
+    });
+});


### PR DESCRIPTION
## Summary

- Closes #906.
- Adds `SelectOutputCollector` as an opt-in SELECT output analysis API.
- Preserves duplicate output names and exposes a stable `outputIndex` for each SELECT output position after supported wildcard expansion.

## Verification

- `corepack pnpm --filter rawsql-ts exec vitest run tests/transformers/SelectOutputCollector.test.ts`
- `corepack pnpm --filter rawsql-ts test`
- `corepack pnpm --filter rawsql-ts build`
- `corepack pnpm --filter rawsql-ts lint`
- Pre-commit hook passed workspace `typecheck`, `test`, `build`, and `lint` during commit `95f6b08c`.

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

<!-- Write values on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. -->
<!-- Do not add list markers like "-" before these labels; `Tracking issue:` and `Scoped checks run:` must start at column 0. -->
Tracking issue: #906
Scoped checks run: `corepack pnpm --filter rawsql-ts test`; `corepack pnpm --filter rawsql-ts build`; `corepack pnpm --filter rawsql-ts lint`; pre-commit workspace typecheck/test/build/lint
Why full baseline is not required: Full pre-commit workspace checks passed; no baseline exception is requested.

## Self Review

<!-- Fill these fields after running the repo self-review workflow or available self-review skill. -->
Self-review workflow: developer-self-review skill; consistency review and human acceptance review over implementation, tests, changeset, and PR text.
Self-review result: No blockers remain. The new API is opt-in, preserves existing dedupe collectors, and is covered by duplicate-name and wildcard-order tests.
Concept-review workflow: packages/core/AGENTS.md and packages/core/DESIGN.md package-boundary review.
Concept-review result: No package-boundary violations found. The change stays within DBMS-neutral query analysis and does not add viewer IDs, graph semantics, driver behavior, or rewrite semantics.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-migration rationale: No CLI-facing files or command behavior changed.
Upgrade note: No user action required.
Deprecation/removal plan or issue: None; no CLI option or command was removed.
Docs/help/examples updated: Not required for this internal analyzer API addition.
Release/changeset wording: `.changeset/select-output-indexes.md`

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-proof rationale: No scaffold-related files or generated scaffold contract changed.
Non-edit assertion: This PR does not edit scaffold templates or generated scaffold output.
Fail-fast input-contract proof: Not applicable; no scaffold input contract changed.
Generated-output viability proof: Not applicable; no scaffold output changed.
