### PR TITLE
feat(core): expose select output source metadata

### DIFF
--- a/.changeset/select-output-source-metadata.md
+++ b/.changeset/select-output-source-metadata.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": patch
+---
+
+Include source metadata on `SelectOutputCollector` entries when wildcard expansion can identify the selected source from SQL structure. Expanded outputs now report `sourceAlias`, `sourceName`, and `sourceColumnName`, while unavailable metadata is represented as `null`.

--- a/packages/core/src/transformers/SelectOutputCollector.ts
+++ b/packages/core/src/transformers/SelectOutputCollector.ts
@@ -13,6 +13,9 @@ export interface SelectOutputColumn {
     name: string;
     value: ValueComponent;
     outputIndex: number;
+    sourceAlias: string | null;
+    sourceName: string | null;
+    sourceColumnName: string | null;
 }
 
 type RawSelectOutputColumn = Omit<SelectOutputColumn, "outputIndex">;
@@ -77,7 +80,7 @@ export class SelectOutputCollector {
 
     private collectSelectItem(item: SelectItem, fromClause: FromClause | null): RawSelectOutputColumn[] {
         if (item.identifier) {
-            return [{ name: item.identifier.name, value: item.value }];
+            return [this.createExplicitOutput(item.identifier.name, item.value)];
         }
 
         if (!(item.value instanceof ColumnReference)) {
@@ -89,7 +92,7 @@ export class SelectOutputCollector {
             return this.expandWildcard(item.value, fromClause);
         }
 
-        return [{ name: columnName, value: item.value }];
+        return [this.createExplicitOutput(columnName, item.value)];
     }
 
     private expandWildcard(value: ColumnReference, fromClause: FromClause | null): RawSelectOutputColumn[] {
@@ -134,7 +137,10 @@ export class SelectOutputCollector {
         if (source.aliasExpression?.columns) {
             return source.aliasExpression.columns.map(column => ({
                 name: column.name,
-                value: new ColumnReference(sourceName ? [sourceName] : null, column.name)
+                value: new ColumnReference(sourceName ? [sourceName] : null, column.name),
+                sourceAlias: sourceName,
+                sourceName: null,
+                sourceColumnName: column.name
             }));
         }
 
@@ -142,7 +148,7 @@ export class SelectOutputCollector {
         if (cte) {
             const innerCommonTables = this.commonTables.filter(item => item.getSourceAliasName() !== cte.getSourceAliasName());
             const innerOutputs = this.collectCteQuery(cte.query, innerCommonTables);
-            return this.qualifyOutputs(innerOutputs, sourceName);
+            return this.qualifyOutputs(innerOutputs, sourceName, cte.getSourceAliasName());
         }
 
         if (source.datasource instanceof TableSource) {
@@ -151,7 +157,7 @@ export class SelectOutputCollector {
 
         if (source.datasource instanceof SubQuerySource) {
             const innerOutputs = this.collectNestedSelectQuery(source.datasource.query);
-            return this.qualifyOutputs(innerOutputs, sourceName);
+            return this.qualifyOutputs(innerOutputs, sourceName, null);
         }
 
         if (source.datasource instanceof ParenSource) {
@@ -179,19 +185,34 @@ export class SelectOutputCollector {
         const qualifier = sourceName ?? tableName;
         return this.tableColumnResolver(tableName).map(column => ({
             name: column,
-            value: new ColumnReference([qualifier], column)
+            value: new ColumnReference([qualifier], column),
+            sourceAlias: sourceName,
+            sourceName: tableName,
+            sourceColumnName: column
         }));
     }
 
     private collectNestedSelectQuery(query: SelectQuery): RawSelectOutputColumn[] {
         const collector = new SelectOutputCollector(this.tableColumnResolver, this.commonTables);
-        return collector.collect(query).map(({ name, value }) => ({ name, value }));
+        return collector.collect(query).map(({ name, value, sourceAlias, sourceName, sourceColumnName }) => ({
+            name,
+            value,
+            sourceAlias,
+            sourceName,
+            sourceColumnName
+        }));
     }
 
     private collectCteQuery(query: CTEQuery, commonTables: CommonTable[]): RawSelectOutputColumn[] {
         if (this.isSelectQuery(query)) {
             const collector = new SelectOutputCollector(this.tableColumnResolver, commonTables);
-            return collector.collect(query).map(({ name, value }) => ({ name, value }));
+            return collector.collect(query).map(({ name, value, sourceAlias, sourceName, sourceColumnName }) => ({
+                name,
+                value,
+                sourceAlias,
+                sourceName,
+                sourceColumnName
+            }));
         }
 
         return this.collectReturningOutputs(query);
@@ -214,7 +235,7 @@ export class SelectOutputCollector {
         for (const item of clause.items) {
             const name = item.identifier?.name ?? this.extractSelectItemName(item);
             if (name) {
-                outputs.push({ name, value: item.value });
+                outputs.push(this.createExplicitOutput(name, item.value));
             }
         }
         return outputs;
@@ -230,11 +251,24 @@ export class SelectOutputCollector {
         return null;
     }
 
-    private qualifyOutputs(outputs: RawSelectOutputColumn[], sourceName: string | null): RawSelectOutputColumn[] {
+    private qualifyOutputs(outputs: RawSelectOutputColumn[], sourceAlias: string | null, sourceName: string | null): RawSelectOutputColumn[] {
         return outputs.map(item => ({
             name: item.name,
-            value: new ColumnReference(sourceName ? [sourceName] : null, item.name)
+            value: new ColumnReference(sourceAlias ? [sourceAlias] : null, item.name),
+            sourceAlias,
+            sourceName,
+            sourceColumnName: item.name
         }));
+    }
+
+    private createExplicitOutput(name: string, value: ValueComponent): RawSelectOutputColumn {
+        return {
+            name,
+            value,
+            sourceAlias: null,
+            sourceName: null,
+            sourceColumnName: null
+        };
     }
 
     private isSelectQuery(query: CTEQuery): query is SelectQuery {

--- a/packages/core/tests/transformers/SelectOutputCollector.test.ts
+++ b/packages/core/tests/transformers/SelectOutputCollector.test.ts
@@ -78,12 +78,74 @@ describe('SelectOutputCollector', () => {
         expect(outputs.map(item => ({
             name: item.name,
             outputIndex: item.outputIndex,
+            sourceAlias: item.sourceAlias,
+            sourceName: item.sourceName,
+            sourceColumnName: item.sourceColumnName,
             sql: formatter.format(item.value).formattedSql
         }))).toEqual([
-            { name: 'customer_id', outputIndex: 0, sql: '"s"."customer_id"' },
-            { name: 'amount', outputIndex: 1, sql: '"s"."amount"' },
-            { name: 'doubled', outputIndex: 2, sql: '"s"."doubled"' },
-            { name: 'adjusted_amount', outputIndex: 3, sql: '"s"."amount" + 1' }
+            { name: 'customer_id', outputIndex: 0, sourceAlias: 's', sourceName: 'scored', sourceColumnName: 'customer_id', sql: '"s"."customer_id"' },
+            { name: 'amount', outputIndex: 1, sourceAlias: 's', sourceName: 'scored', sourceColumnName: 'amount', sql: '"s"."amount"' },
+            { name: 'doubled', outputIndex: 2, sourceAlias: 's', sourceName: 'scored', sourceColumnName: 'doubled', sql: '"s"."doubled"' },
+            { name: 'adjusted_amount', outputIndex: 3, sourceAlias: null, sourceName: null, sourceColumnName: null, sql: '"s"."amount" + 1' }
+        ]);
+    });
+
+    test('expands derived table wildcard outputs with source metadata', () => {
+        const sql = `
+            SELECT
+                d.*,
+                d.a + d.b AS total
+            FROM (
+                SELECT
+                    a,
+                    b
+                FROM t
+            ) AS d
+        `;
+        const query = SelectQueryParser.parse(sql);
+
+        const outputs = new SelectOutputCollector().collect(query);
+
+        expect(outputs.map(item => ({
+            name: item.name,
+            outputIndex: item.outputIndex,
+            sourceAlias: item.sourceAlias,
+            sourceName: item.sourceName,
+            sourceColumnName: item.sourceColumnName,
+            sql: formatter.format(item.value).formattedSql
+        }))).toEqual([
+            { name: 'a', outputIndex: 0, sourceAlias: 'd', sourceName: null, sourceColumnName: 'a', sql: '"d"."a"' },
+            { name: 'b', outputIndex: 1, sourceAlias: 'd', sourceName: null, sourceColumnName: 'b', sql: '"d"."b"' },
+            { name: 'total', outputIndex: 2, sourceAlias: null, sourceName: null, sourceColumnName: null, sql: '"d"."a" + "d"."b"' }
+        ]);
+    });
+
+    test('keeps duplicate wildcard output names with source metadata', () => {
+        const sql = `
+            SELECT
+                d.*
+            FROM (
+                SELECT
+                    c.id,
+                    o.id
+                FROM customers AS c
+                JOIN orders AS o ON o.customer_id = c.id
+            ) AS d
+        `;
+        const query = SelectQueryParser.parse(sql);
+
+        const outputs = new SelectOutputCollector().collect(query);
+
+        expect(outputs.map(item => ({
+            name: item.name,
+            outputIndex: item.outputIndex,
+            sourceAlias: item.sourceAlias,
+            sourceName: item.sourceName,
+            sourceColumnName: item.sourceColumnName,
+            sql: formatter.format(item.value).formattedSql
+        }))).toEqual([
+            { name: 'id', outputIndex: 0, sourceAlias: 'd', sourceName: null, sourceColumnName: 'id', sql: '"d"."id"' },
+            { name: 'id', outputIndex: 1, sourceAlias: 'd', sourceName: null, sourceColumnName: 'id', sql: '"d"."id"' }
         ]);
     });
 });


### PR DESCRIPTION
## Summary

- Closes #907.
- Stacked on #910 because this extends the `SelectOutputCollector` API introduced there.
- Adds source metadata for wildcard-expanded SELECT outputs: `sourceAlias`, `sourceName`, and `sourceColumnName`.
- Represents unavailable metadata explicitly as `null` for non-wildcard expressions and derived sources without a named backing source.

## Verification

- `corepack pnpm --filter rawsql-ts exec vitest run tests/transformers/SelectOutputCollector.test.ts`
- `corepack pnpm --filter rawsql-ts test`
- `corepack pnpm --filter rawsql-ts build`
- `corepack pnpm --filter rawsql-ts lint`
- Pre-commit hook passed workspace `typecheck`, `test`, `build`, and `lint` during commit `1b811f0f`.

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

<!-- Write values on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. -->
<!-- Do not add list markers like "-" before these labels; `Tracking issue:` and `Scoped checks run:` must start at column 0. -->
Tracking issue: #907
Scoped checks run: `corepack pnpm --filter rawsql-ts test`; `corepack pnpm --filter rawsql-ts build`; `corepack pnpm --filter rawsql-ts lint`; pre-commit workspace typecheck/test/build/lint
Why full baseline is not required: Full pre-commit workspace checks passed; no baseline exception is requested.

## Self Review

<!-- Fill these fields after running the repo self-review workflow or available self-review skill. -->
Self-review workflow: developer-self-review skill; consistency review and human acceptance review over implementation, tests, changeset, and PR text.
Self-review result: No blockers remain. Metadata is added only to the opt-in output analysis API, and unavailable metadata is represented as `null`.
Concept-review workflow: packages/core/AGENTS.md and packages/core/DESIGN.md package-boundary review.
Concept-review result: No package-boundary violations found. The change stays within syntax-derived query analysis and does not infer lineage origin, viewer graph IDs, driver behavior, or rewrite semantics.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-migration rationale: No CLI-facing files or command behavior changed.
Upgrade note: No user action required.
Deprecation/removal plan or issue: None; no CLI option or command was removed.
Docs/help/examples updated: Not required for this internal analyzer API extension.
Release/changeset wording: `.changeset/select-output-source-metadata.md`

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-proof rationale: No scaffold-related files or generated scaffold contract changed.
Non-edit assertion: This PR does not edit scaffold templates or generated scaffold output.
Fail-fast input-contract proof: Not applicable; no scaffold input contract changed.
Generated-output viability proof: Not applicable; no scaffold output changed.
