### PR TITLE
feat(core): extract select bodies from wrappers

### DIFF
--- a/.changeset/select-body-extractor.md
+++ b/.changeset/select-body-extractor.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": patch
+---
+
+Add `SelectBodyExtractor` for wrapper statements that contain an embedded SELECT body. It supports CREATE TABLE AS SELECT, CREATE VIEW AS SELECT, CREATE MATERIALIZED VIEW AS SELECT, and INSERT SELECT, and returns explicit unsupported results when no SELECT body is available.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -68,6 +68,7 @@ export * from './transformers/SimulatedSelectConverter';
 export * from './transformers/DDLToFixtureConverter';
 export * from './transformers/DDLGeneralizer';
 export * from './transformers/DDLDiffGenerator';
+export * from './transformers/SelectBodyExtractor';
 export * from './transformers/SelectOutputCollector';
 export * from './transformers/SelectValueCollector';
 export * from './transformers/SelectableColumnCollector';

--- a/packages/core/src/transformers/SelectBodyExtractor.ts
+++ b/packages/core/src/transformers/SelectBodyExtractor.ts
@@ -1,0 +1,171 @@
+import { CreateTableQuery } from "../models/CreateTableQuery";
+import { InsertQuery } from "../models/InsertQuery";
+import { TokenType } from "../models/Lexeme";
+import { SelectQuery } from "../models/SelectQuery";
+import { SqlComponent } from "../models/SqlComponent";
+import { ValuesQuery } from "../models/ValuesQuery";
+import { TableSource } from "../models/Clause";
+import { FullNameParser } from "../parsers/FullNameParser";
+import { SelectQueryParser } from "../parsers/SelectQueryParser";
+import { SqlParser, ParsedStatement } from "../parsers/SqlParser";
+import { SqlTokenizer } from "../parsers/SqlTokenizer";
+
+export type SelectBodyWrapperKind =
+    | "create-table-as"
+    | "create-view"
+    | "create-materialized-view"
+    | "insert-select";
+
+export interface SelectBodyExtractionResult {
+    supported: boolean;
+    kind: SelectBodyWrapperKind | null;
+    targetName: string | null;
+    selectQuery: SelectQuery | null;
+    reason?: string;
+}
+
+export class SelectBodyExtractor {
+    public static extract(input: string | SqlComponent): SelectBodyExtractionResult {
+        if (typeof input === "string") {
+            return this.extractFromSql(input);
+        }
+
+        return this.extractFromStatement(input);
+    }
+
+    private static extractFromSql(sql: string): SelectBodyExtractionResult {
+        const lexemes = new SqlTokenizer(sql).readLexemes();
+        if (this.isCreateViewStatement(lexemes)) {
+            return this.extractCreateViewFromLexemes(lexemes);
+        }
+
+        return this.extractFromStatement(SqlParser.parse(sql));
+    }
+
+    private static extractFromStatement(statement: SqlComponent | ParsedStatement): SelectBodyExtractionResult {
+        if (statement instanceof CreateTableQuery) {
+            const targetName = this.createTableTargetName(statement);
+            if (!statement.asSelectQuery) {
+                return this.unsupported(targetName);
+            }
+
+            return {
+                supported: true,
+                kind: "create-table-as",
+                targetName,
+                selectQuery: statement.asSelectQuery
+            };
+        }
+
+        if (statement instanceof InsertQuery) {
+            const targetName = this.insertTargetName(statement);
+            if (!statement.selectQuery || statement.selectQuery instanceof ValuesQuery) {
+                return this.unsupported(targetName);
+            }
+
+            return {
+                supported: true,
+                kind: "insert-select",
+                targetName,
+                selectQuery: statement.selectQuery
+            };
+        }
+
+        return {
+            supported: false,
+            kind: null,
+            targetName: null,
+            selectQuery: null,
+            reason: "Statement type is not supported."
+        };
+    }
+
+    private static extractCreateViewFromLexemes(lexemes: ReturnType<SqlTokenizer["readLexemes"]>): SelectBodyExtractionResult {
+        let idx = 0;
+        idx++; // CREATE
+
+        const materialized = lexemes[idx]?.value.toLowerCase() === "materialized";
+        if (materialized) {
+            idx++;
+        }
+
+        if (lexemes[idx]?.value.toLowerCase() !== "view") {
+            return this.unsupported(null, "Statement type is not supported.");
+        }
+        idx++;
+
+        if (lexemes[idx]?.value.toLowerCase() === "if not exists") {
+            idx++;
+        }
+
+        const targetResult = FullNameParser.parseFromLexeme(lexemes, idx);
+        idx = targetResult.newIndex;
+        const targetName = [...(targetResult.namespaces ?? []), targetResult.name.name].join(".");
+
+        if (lexemes[idx]?.type === TokenType.OpenParen) {
+            idx = this.consumeBalancedParentheses(lexemes, idx);
+        }
+
+        if (lexemes[idx]?.value.toLowerCase() !== "as") {
+            return this.unsupported(targetName);
+        }
+        idx++;
+
+        const selectResult = SelectQueryParser.parseFromLexeme(lexemes, idx);
+        return {
+            supported: true,
+            kind: materialized ? "create-materialized-view" : "create-view",
+            targetName,
+            selectQuery: selectResult.value
+        };
+    }
+
+    private static isCreateViewStatement(lexemes: ReturnType<SqlTokenizer["readLexemes"]>): boolean {
+        if (lexemes[0]?.value.toLowerCase() !== "create") {
+            return false;
+        }
+
+        const second = lexemes[1]?.value.toLowerCase();
+        const third = lexemes[2]?.value.toLowerCase();
+        return second === "view" || (second === "materialized" && third === "view");
+    }
+
+    private static consumeBalancedParentheses(lexemes: ReturnType<SqlTokenizer["readLexemes"]>, index: number): number {
+        let idx = index;
+        let depth = 0;
+        while (idx < lexemes.length) {
+            if (lexemes[idx].type === TokenType.OpenParen) {
+                depth++;
+            } else if (lexemes[idx].type === TokenType.CloseParen) {
+                depth--;
+                if (depth === 0) {
+                    return idx + 1;
+                }
+            }
+            idx++;
+        }
+        return idx;
+    }
+
+    private static createTableTargetName(query: CreateTableQuery): string {
+        return [...(query.namespaces ?? []), query.tableName.name].join(".");
+    }
+
+    private static insertTargetName(query: InsertQuery): string | null {
+        const source = query.insertClause.source;
+        if (source.datasource instanceof TableSource) {
+            return source.datasource.getSourceName();
+        }
+        return source.getAliasName();
+    }
+
+    private static unsupported(targetName: string | null, reason: string = "No embedded SELECT body found."): SelectBodyExtractionResult {
+        return {
+            supported: false,
+            kind: null,
+            targetName,
+            selectQuery: null,
+            reason
+        };
+    }
+}

--- a/packages/core/tests/transformers/SelectBodyExtractor.test.ts
+++ b/packages/core/tests/transformers/SelectBodyExtractor.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'vitest';
+import { Formatter } from '../../src/transformers/Formatter';
+import { SelectBodyExtractor } from '../../src/transformers/SelectBodyExtractor';
+
+const formatter = new Formatter();
+
+describe('SelectBodyExtractor', () => {
+    test('extracts SELECT body from CREATE TABLE AS SELECT', () => {
+        const result = SelectBodyExtractor.extract(`
+            CREATE TABLE reporting.customer_totals AS
+            SELECT customer_id, SUM(amount) AS total
+            FROM orders
+            GROUP BY customer_id
+        `);
+
+        expect(result.supported).toBe(true);
+        expect(result.kind).toBe('create-table-as');
+        expect(result.targetName).toBe('reporting.customer_totals');
+        expect(formatter.format(result.selectQuery!)).toBe('select "customer_id", sum("amount") as "total" from "orders" group by "customer_id"');
+    });
+
+    test('extracts SELECT body from CREATE TEMPORARY TABLE AS SELECT', () => {
+        const result = SelectBodyExtractor.extract(`
+            CREATE TEMPORARY TABLE temp_report AS
+            SELECT id FROM orders
+        `);
+
+        expect(result.supported).toBe(true);
+        expect(result.kind).toBe('create-table-as');
+        expect(result.targetName).toBe('temp_report');
+        expect(formatter.format(result.selectQuery!)).toBe('select "id" from "orders"');
+    });
+
+    test('extracts SELECT body from CREATE VIEW AS SELECT', () => {
+        const result = SelectBodyExtractor.extract(`
+            CREATE VIEW reporting.customer_view AS
+            SELECT id, name FROM customers
+        `);
+
+        expect(result.supported).toBe(true);
+        expect(result.kind).toBe('create-view');
+        expect(result.targetName).toBe('reporting.customer_view');
+        expect(formatter.format(result.selectQuery!)).toBe('select "id", "name" from "customers"');
+    });
+
+    test('extracts SELECT body from CREATE MATERIALIZED VIEW AS SELECT', () => {
+        const result = SelectBodyExtractor.extract(`
+            CREATE MATERIALIZED VIEW reporting.customer_snapshot AS
+            SELECT id, name FROM customers
+        `);
+
+        expect(result.supported).toBe(true);
+        expect(result.kind).toBe('create-materialized-view');
+        expect(result.targetName).toBe('reporting.customer_snapshot');
+        expect(formatter.format(result.selectQuery!)).toBe('select "id", "name" from "customers"');
+    });
+
+    test('extracts SELECT body from INSERT SELECT', () => {
+        const result = SelectBodyExtractor.extract(`
+            INSERT INTO reporting.customer_totals (customer_id, total)
+            SELECT customer_id, SUM(amount) AS total
+            FROM orders
+            GROUP BY customer_id
+        `);
+
+        expect(result.supported).toBe(true);
+        expect(result.kind).toBe('insert-select');
+        expect(result.targetName).toBe('reporting.customer_totals');
+        expect(formatter.format(result.selectQuery!)).toBe('select "customer_id", sum("amount") as "total" from "orders" group by "customer_id"');
+    });
+
+    test('returns unsupported result for wrappers without SELECT bodies', () => {
+        const createResult = SelectBodyExtractor.extract(`CREATE TABLE users (id integer)`);
+        expect(createResult).toMatchObject({
+            supported: false,
+            kind: null,
+            targetName: 'users',
+            selectQuery: null,
+            reason: 'No embedded SELECT body found.'
+        });
+
+        const insertResult = SelectBodyExtractor.extract(`INSERT INTO users (id) VALUES (1)`);
+        expect(insertResult).toMatchObject({
+            supported: false,
+            kind: null,
+            targetName: 'users',
+            selectQuery: null,
+            reason: 'No embedded SELECT body found.'
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Closes #908.
- Adds `SelectBodyExtractor` for wrapper statements with embedded SELECT bodies.
- Supports CTAS, CREATE VIEW, CREATE MATERIALIZED VIEW, and INSERT SELECT, returning wrapper kind, target name, and the parsed SELECT AST.
- Returns an explicit unsupported result when no SELECT body is available.

## Verification

- `corepack pnpm --filter rawsql-ts exec vitest run tests/transformers/SelectBodyExtractor.test.ts`
- `corepack pnpm --filter rawsql-ts test`
- `corepack pnpm --filter rawsql-ts build`
- `corepack pnpm --filter rawsql-ts lint`
- Pre-commit hook passed workspace `typecheck`, `test`, `build`, and `lint` during commit `ed5c4cf3`.

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

<!-- Write values on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. -->
<!-- Do not add list markers like "-" before these labels; `Tracking issue:` and `Scoped checks run:` must start at column 0. -->
Tracking issue: #908
Scoped checks run: `corepack pnpm --filter rawsql-ts test`; `corepack pnpm --filter rawsql-ts build`; `corepack pnpm --filter rawsql-ts lint`; pre-commit workspace typecheck/test/build/lint
Why full baseline is not required: Full pre-commit workspace checks passed; no baseline exception is requested.

## Self Review

<!-- Fill these fields after running the repo self-review workflow or available self-review skill. -->
Self-review workflow: developer-self-review skill; consistency review and human acceptance review over implementation, tests, changeset, and PR text.
Self-review result: No blockers remain. The helper returns SELECT ASTs and wrapper metadata only, with explicit unsupported results for non-SELECT wrappers.
Concept-review workflow: packages/core/AGENTS.md and packages/core/DESIGN.md package-boundary review.
Concept-review result: No package-boundary violations found. The change stays within parser/analyzer helper behavior and does not add lineage interpretation, DB validation, execution semantics, or viewer behavior.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-migration rationale: No CLI-facing files or command behavior changed.
Upgrade note: No user action required.
Deprecation/removal plan or issue: None; no CLI option or command was removed.
Docs/help/examples updated: Not required for this internal analyzer helper addition.
Release/changeset wording: `.changeset/select-body-extractor.md`

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-proof rationale: No scaffold-related files or generated scaffold contract changed.
Non-edit assertion: This PR does not edit scaffold templates or generated scaffold output.
Fail-fast input-contract proof: Not applicable; no scaffold input contract changed.
Generated-output viability proof: Not applicable; no scaffold output changed.
