### PR TITLE
Add clause-scoped column reference extraction API

### DIFF
--- a/.changeset/clause-scoped-column-references.md
+++ b/.changeset/clause-scoped-column-references.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": minor
+---
+
+Add `ClauseScopedColumnReferenceCollector` for collecting column references grouped by root `SimpleSelectQuery` clause, including SELECT, WHERE, JOIN conditions, GROUP BY, HAVING, ORDER BY, and row-limiting clauses.

--- a/.changeset/clause-scoped-column-references.md
+++ b/.changeset/clause-scoped-column-references.md
@@ -2,4 +2,4 @@
 "rawsql-ts": minor
 ---
 
-Add `ClauseScopedColumnReferenceCollector` for collecting column references grouped by root `SimpleSelectQuery` clause, including SELECT, WHERE, JOIN conditions, GROUP BY, HAVING, ORDER BY, and row-limiting clauses.
+Add `ClauseScopedColumnReferenceCollector` for collecting column references grouped by root `SimpleSelectQuery` clause, including SELECT, WHERE, JOIN conditions, GROUP BY, HAVING, ORDER BY, WINDOW, and row-limiting clauses.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,6 +54,7 @@ export * from './formatters/OriginalFormatRestorer';
 export * from './transformers/SqlIdentifierRenamer';
 export type { ScopeRange } from './transformers/SqlIdentifierRenamer';
 export * from './transformers/ColumnReferenceCollector';
+export * from './transformers/ClauseScopedColumnReferenceCollector';
 export * from './transformers/Formatter';
 export * from './transformers/SqlFormatter';
 export * from './transformers/QueryBuilder'; // old name:QueryConverter

--- a/packages/core/src/transformers/ClauseScopedColumnReferenceCollector.ts
+++ b/packages/core/src/transformers/ClauseScopedColumnReferenceCollector.ts
@@ -244,7 +244,7 @@ export class ClauseScopedColumnReferenceCollector {
                 this.collectFromValueComponent(item, target, result, value);
             }
         } else if (value instanceof TypeValue && value.argument) {
-            this.collectFromValueComponent(value.argument, target, result, value.argument);
+            this.collectFromValueComponent(value.argument, target, result, value);
         } else if (value instanceof InlineQuery || value instanceof ArrayQueryExpression) {
             return;
         }

--- a/packages/core/src/transformers/ClauseScopedColumnReferenceCollector.ts
+++ b/packages/core/src/transformers/ClauseScopedColumnReferenceCollector.ts
@@ -1,0 +1,318 @@
+import {
+    DistinctOn,
+    FetchClause,
+    GroupByClause,
+    HavingClause,
+    JoinOnClause,
+    JoinUsingClause,
+    LimitClause,
+    OffsetClause,
+    OrderByClause,
+    OrderByItem,
+    SelectClause,
+    WhereClause,
+} from "../models/Clause";
+import { SimpleSelectQuery } from "../models/SimpleSelectQuery";
+import {
+    ArrayExpression,
+    ArrayIndexExpression,
+    ArrayQueryExpression,
+    ArraySliceExpression,
+    BetweenExpression,
+    BinaryExpression,
+    CaseExpression,
+    CastExpression,
+    ColumnReference,
+    FunctionCall,
+    IdentifierString,
+    InlineQuery,
+    JsonPredicateExpression,
+    ParenExpression,
+    RawString,
+    TupleExpression,
+    TypeValue,
+    UnaryExpression,
+    ValueComponent,
+    ValueList,
+    WindowFrameBoundaryValue,
+    WindowFrameExpression,
+} from "../models/ValueComponent";
+
+export type ClauseScopedColumnReferenceClause =
+    | "select"
+    | "where"
+    | "joinOn"
+    | "groupBy"
+    | "having"
+    | "orderBy"
+    | "limitOffset";
+
+export interface ClauseScopedColumnReferenceInfo {
+    clause: ClauseScopedColumnReferenceClause;
+    reference: ColumnReference;
+    qualifiedName: string;
+    namespaces: string[];
+    namespace: string | null;
+    column: string;
+    expression: ValueComponent;
+}
+
+export interface ClauseScopedColumnReferences {
+    select: ClauseScopedColumnReferenceInfo[];
+    where: ClauseScopedColumnReferenceInfo[];
+    joinOn: ClauseScopedColumnReferenceInfo[];
+    groupBy: ClauseScopedColumnReferenceInfo[];
+    having: ClauseScopedColumnReferenceInfo[];
+    orderBy: ClauseScopedColumnReferenceInfo[];
+    limitOffset: ClauseScopedColumnReferenceInfo[];
+}
+
+/**
+ * Collects ColumnReference nodes grouped by the root SimpleSelectQuery clause that owns them.
+ *
+ * Subquery and CTE bodies are intentionally not traversed because they have their own query-body
+ * ownership. Use ColumnReferenceCollector when comprehensive tree traversal is required.
+ */
+export class ClauseScopedColumnReferenceCollector {
+    public collect(query: SimpleSelectQuery): ClauseScopedColumnReferences {
+        if (!(query instanceof SimpleSelectQuery)) {
+            throw new Error("ClauseScopedColumnReferenceCollector requires a SimpleSelectQuery.");
+        }
+
+        const result = this.createEmptyResult();
+
+        this.collectFromSelectClause(query.selectClause, result);
+        this.collectFromJoinClauses(query, result);
+
+        if (query.whereClause) {
+            this.collectFromWhereClause(query.whereClause, result);
+        }
+        if (query.groupByClause) {
+            this.collectFromGroupByClause(query.groupByClause, result);
+        }
+        if (query.havingClause) {
+            this.collectFromHavingClause(query.havingClause, result);
+        }
+        if (query.orderByClause) {
+            this.collectFromOrderByClause(query.orderByClause, "orderBy", result);
+        }
+        if (query.limitClause) {
+            this.collectFromLimitClause(query.limitClause, result);
+        }
+        if (query.offsetClause) {
+            this.collectFromOffsetClause(query.offsetClause, result);
+        }
+        if (query.fetchClause) {
+            this.collectFromFetchClause(query.fetchClause, result);
+        }
+
+        return result;
+    }
+
+    private createEmptyResult(): ClauseScopedColumnReferences {
+        return {
+            select: [],
+            where: [],
+            joinOn: [],
+            groupBy: [],
+            having: [],
+            orderBy: [],
+            limitOffset: [],
+        };
+    }
+
+    private collectFromSelectClause(clause: SelectClause, result: ClauseScopedColumnReferences): void {
+        if (clause.distinct instanceof DistinctOn) {
+            this.collectFromValueComponent(clause.distinct.value, "select", result);
+        }
+
+        for (const item of clause.items) {
+            this.collectFromValueComponent(item.value, "select", result);
+        }
+    }
+
+    private collectFromJoinClauses(query: SimpleSelectQuery, result: ClauseScopedColumnReferences): void {
+        if (!query.fromClause?.joins) {
+            return;
+        }
+
+        for (const join of query.fromClause.joins) {
+            if (join.condition instanceof JoinOnClause || join.condition instanceof JoinUsingClause) {
+                this.collectFromValueComponent(join.condition.condition, "joinOn", result);
+            }
+        }
+    }
+
+    private collectFromWhereClause(clause: WhereClause, result: ClauseScopedColumnReferences): void {
+        this.collectFromValueComponent(clause.condition, "where", result);
+    }
+
+    private collectFromGroupByClause(clause: GroupByClause, result: ClauseScopedColumnReferences): void {
+        for (const item of clause.grouping) {
+            this.collectFromValueComponent(item, "groupBy", result);
+        }
+    }
+
+    private collectFromHavingClause(clause: HavingClause, result: ClauseScopedColumnReferences): void {
+        this.collectFromValueComponent(clause.condition, "having", result);
+    }
+
+    private collectFromOrderByClause(
+        clause: OrderByClause,
+        target: ClauseScopedColumnReferenceClause,
+        result: ClauseScopedColumnReferences
+    ): void {
+        for (const item of clause.order) {
+            if (item instanceof OrderByItem) {
+                this.collectFromValueComponent(item.value, target, result);
+            } else {
+                this.collectFromValueComponent(item, target, result);
+            }
+        }
+    }
+
+    private collectFromLimitClause(clause: LimitClause, result: ClauseScopedColumnReferences): void {
+        this.collectFromValueComponent(clause.value, "limitOffset", result);
+    }
+
+    private collectFromOffsetClause(clause: OffsetClause, result: ClauseScopedColumnReferences): void {
+        this.collectFromValueComponent(clause.value, "limitOffset", result);
+    }
+
+    private collectFromFetchClause(clause: FetchClause, result: ClauseScopedColumnReferences): void {
+        this.collectFromValueComponent(clause.expression.count, "limitOffset", result);
+    }
+
+    private collectFromValueComponent(
+        value: ValueComponent,
+        target: ClauseScopedColumnReferenceClause,
+        result: ClauseScopedColumnReferences,
+        expression: ValueComponent = value
+    ): void {
+        if (value instanceof ColumnReference) {
+            result[target].push(this.createInfo(value, target, expression));
+            return;
+        }
+
+        if (value instanceof BinaryExpression) {
+            this.collectFromValueComponent(value.left, target, result, value);
+            this.collectFromValueComponent(value.right, target, result, value);
+        } else if (value instanceof UnaryExpression) {
+            this.collectFromValueComponent(value.expression, target, result, value);
+        } else if (value instanceof FunctionCall) {
+            this.collectFromFunctionCall(value, target, result);
+        } else if (value instanceof CaseExpression) {
+            if (value.condition) {
+                this.collectFromValueComponent(value.condition, target, result, value);
+            }
+            for (const pair of value.switchCase.cases) {
+                this.collectFromValueComponent(pair.key, target, result, value);
+                this.collectFromValueComponent(pair.value, target, result, value);
+            }
+            if (value.switchCase.elseValue) {
+                this.collectFromValueComponent(value.switchCase.elseValue, target, result, value);
+            }
+        } else if (value instanceof ParenExpression) {
+            this.collectFromValueComponent(value.expression, target, result, value);
+        } else if (value instanceof CastExpression) {
+            this.collectFromValueComponent(value.input, target, result, value);
+        } else if (value instanceof BetweenExpression) {
+            this.collectFromValueComponent(value.expression, target, result, value);
+            this.collectFromValueComponent(value.lower, target, result, value);
+            this.collectFromValueComponent(value.upper, target, result, value);
+        } else if (value instanceof JsonPredicateExpression) {
+            this.collectFromValueComponent(value.expression, target, result, value);
+        } else if (value instanceof ArrayExpression) {
+            this.collectFromValueComponent(value.expression, target, result, value);
+        } else if (value instanceof ArraySliceExpression) {
+            this.collectFromValueComponent(value.array, target, result, value);
+            if (value.startIndex) {
+                this.collectFromValueComponent(value.startIndex, target, result, value);
+            }
+            if (value.endIndex) {
+                this.collectFromValueComponent(value.endIndex, target, result, value);
+            }
+        } else if (value instanceof ArrayIndexExpression) {
+            this.collectFromValueComponent(value.array, target, result, value);
+            this.collectFromValueComponent(value.index, target, result, value);
+        } else if (value instanceof ValueList) {
+            for (const item of value.values) {
+                this.collectFromValueComponent(item, target, result, value);
+            }
+        } else if (value instanceof TupleExpression) {
+            for (const item of value.values) {
+                this.collectFromValueComponent(item, target, result, value);
+            }
+        } else if (value instanceof TypeValue && value.argument) {
+            this.collectFromValueComponent(value.argument, target, result, value.argument);
+        } else if (value instanceof InlineQuery || value instanceof ArrayQueryExpression) {
+            return;
+        }
+    }
+
+    private collectFromFunctionCall(
+        value: FunctionCall,
+        target: ClauseScopedColumnReferenceClause,
+        result: ClauseScopedColumnReferences
+    ): void {
+        if (value.argument) {
+            this.collectFromValueComponent(value.argument, target, result, value);
+        }
+        if (value.filterCondition) {
+            this.collectFromValueComponent(value.filterCondition, target, result, value);
+        }
+        if (value.withinGroup) {
+            this.collectFromOrderByClause(value.withinGroup, target, result);
+        }
+        if (value.internalOrderBy) {
+            this.collectFromOrderByClause(value.internalOrderBy, target, result);
+        }
+        if (value.over instanceof WindowFrameExpression) {
+            this.collectFromWindowFrameExpression(value.over, target, result);
+        }
+    }
+
+    private collectFromWindowFrameExpression(
+        value: WindowFrameExpression,
+        target: ClauseScopedColumnReferenceClause,
+        result: ClauseScopedColumnReferences
+    ): void {
+        if (value.partition) {
+            this.collectFromValueComponent(value.partition.value, target, result);
+        }
+        if (value.order) {
+            this.collectFromOrderByClause(value.order, target, result);
+        }
+        if (value.frameSpec) {
+            if (value.frameSpec.startBound instanceof WindowFrameBoundaryValue) {
+                this.collectFromValueComponent(value.frameSpec.startBound.value, target, result);
+            }
+            if (value.frameSpec.endBound instanceof WindowFrameBoundaryValue) {
+                this.collectFromValueComponent(value.frameSpec.endBound.value, target, result);
+            }
+        }
+    }
+
+    private createInfo(
+        reference: ColumnReference,
+        clause: ClauseScopedColumnReferenceClause,
+        expression: ValueComponent
+    ): ClauseScopedColumnReferenceInfo {
+        const namespaces = reference.namespaces?.map(namespace => namespace.name) ?? [];
+        const columnName = this.getNameText(reference.qualifiedName.name);
+
+        return {
+            clause,
+            reference,
+            qualifiedName: reference.qualifiedName.toString(),
+            namespaces,
+            namespace: namespaces.length > 0 ? namespaces.join(".") : null,
+            column: columnName,
+            expression,
+        };
+    }
+
+    private getNameText(name: IdentifierString | RawString): string {
+        return name instanceof IdentifierString ? name.name : name.value;
+    }
+}

--- a/packages/core/src/transformers/ClauseScopedColumnReferenceCollector.ts
+++ b/packages/core/src/transformers/ClauseScopedColumnReferenceCollector.ts
@@ -11,6 +11,7 @@ import {
     OrderByItem,
     SelectClause,
     WhereClause,
+    WindowsClause,
 } from "../models/Clause";
 import { SimpleSelectQuery } from "../models/SimpleSelectQuery";
 import {
@@ -45,6 +46,7 @@ export type ClauseScopedColumnReferenceClause =
     | "groupBy"
     | "having"
     | "orderBy"
+    | "window"
     | "limitOffset";
 
 export interface ClauseScopedColumnReferenceInfo {
@@ -64,6 +66,7 @@ export interface ClauseScopedColumnReferences {
     groupBy: ClauseScopedColumnReferenceInfo[];
     having: ClauseScopedColumnReferenceInfo[];
     orderBy: ClauseScopedColumnReferenceInfo[];
+    window: ClauseScopedColumnReferenceInfo[];
     limitOffset: ClauseScopedColumnReferenceInfo[];
 }
 
@@ -96,6 +99,9 @@ export class ClauseScopedColumnReferenceCollector {
         if (query.orderByClause) {
             this.collectFromOrderByClause(query.orderByClause, "orderBy", result);
         }
+        if (query.windowClause) {
+            this.collectFromWindowsClause(query.windowClause, result);
+        }
         if (query.limitClause) {
             this.collectFromLimitClause(query.limitClause, result);
         }
@@ -117,6 +123,7 @@ export class ClauseScopedColumnReferenceCollector {
             groupBy: [],
             having: [],
             orderBy: [],
+            window: [],
             limitOffset: [],
         };
     }
@@ -181,6 +188,12 @@ export class ClauseScopedColumnReferenceCollector {
 
     private collectFromFetchClause(clause: FetchClause, result: ClauseScopedColumnReferences): void {
         this.collectFromValueComponent(clause.expression.count, "limitOffset", result);
+    }
+
+    private collectFromWindowsClause(clause: WindowsClause, result: ClauseScopedColumnReferences): void {
+        for (const window of clause.windows) {
+            this.collectFromWindowFrameExpression(window.expression, "window", result);
+        }
     }
 
     private collectFromValueComponent(

--- a/packages/core/tests/transformers/ClauseScopedColumnReferenceCollector.test.ts
+++ b/packages/core/tests/transformers/ClauseScopedColumnReferenceCollector.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'vitest';
+import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
+import { SimpleSelectQuery } from '../../src/models/SimpleSelectQuery';
+import { ClauseScopedColumnReferenceCollector } from '../../src/transformers/ClauseScopedColumnReferenceCollector';
+import { ColumnReferenceCollector } from '../../src/transformers/ColumnReferenceCollector';
+
+const collect = (sql: string) => {
+    const query = SelectQueryParser.parse(sql) as SimpleSelectQuery;
+    return new ClauseScopedColumnReferenceCollector().collect(query);
+};
+
+const names = (refs: { qualifiedName: string }[]): string[] => {
+    return refs.map(ref => ref.qualifiedName);
+};
+
+describe('ClauseScopedColumnReferenceCollector', () => {
+    test('groups SELECT and WHERE references without mixing predicate-only columns into SELECT', () => {
+        const refs = collect(`
+            SELECT u.id
+            FROM users u
+            WHERE u.active = true
+        `);
+
+        expect(names(refs.select)).toEqual(['u.id']);
+        expect(names(refs.where)).toEqual(['u.active']);
+    });
+
+    test('groups JOIN ON references separately from SELECT references', () => {
+        const refs = collect(`
+            SELECT u.id, o.total
+            FROM users u
+            JOIN orders o ON o.user_id = u.id AND o.deleted_at IS NULL
+        `);
+
+        expect(names(refs.select)).toEqual(['u.id', 'o.total']);
+        expect(names(refs.joinOn)).toEqual(['o.user_id', 'u.id', 'o.deleted_at']);
+        expect(refs.where).toEqual([]);
+    });
+
+    test('groups GROUP BY, HAVING, and ORDER BY references by clause', () => {
+        const refs = collect(`
+            SELECT u.region, COUNT(o.id) AS order_count
+            FROM users u
+            JOIN orders o ON o.user_id = u.id
+            GROUP BY u.region
+            HAVING COUNT(o.id) > 1
+            ORDER BY u.region, COUNT(o.id) DESC
+        `);
+
+        expect(names(refs.groupBy)).toEqual(['u.region']);
+        expect(names(refs.having)).toEqual(['o.id']);
+        expect(names(refs.orderBy)).toEqual(['u.region', 'o.id']);
+    });
+
+    test('groups row-limiting clause references under limitOffset', () => {
+        const refs = collect(`
+            SELECT p.id
+            FROM products p
+            LIMIT p.max_rows
+            OFFSET p.skip_rows
+        `);
+
+        expect(names(refs.limitOffset)).toEqual(['p.max_rows', 'p.skip_rows']);
+    });
+
+    test('does not traverse subquery bodies as root clause references', () => {
+        const refs = collect(`
+            SELECT u.id
+            FROM users u
+            WHERE EXISTS (
+                SELECT 1
+                FROM orders o
+                WHERE o.user_id = u.id
+            )
+        `);
+
+        expect(names(refs.select)).toEqual(['u.id']);
+        expect(names(refs.where)).toEqual([]);
+    });
+
+    test('keeps existing ColumnReferenceCollector behavior compatible', () => {
+        const query = SelectQueryParser.parse(`
+            SELECT u.id
+            FROM users u
+            WHERE u.active = true
+        `);
+
+        const columnNames = new ColumnReferenceCollector()
+            .collect(query)
+            .map(ref => ref.qualifiedName.toString());
+
+        expect(columnNames).toEqual(['u.id', 'u.active']);
+    });
+});

--- a/packages/core/tests/transformers/ClauseScopedColumnReferenceCollector.test.ts
+++ b/packages/core/tests/transformers/ClauseScopedColumnReferenceCollector.test.ts
@@ -3,6 +3,8 @@ import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
 import { SimpleSelectQuery } from '../../src/models/SimpleSelectQuery';
 import { ClauseScopedColumnReferenceCollector } from '../../src/transformers/ClauseScopedColumnReferenceCollector';
 import { ColumnReferenceCollector } from '../../src/transformers/ColumnReferenceCollector';
+import { SelectClause, SelectItem } from '../../src/models/Clause';
+import { ColumnReference, TypeValue } from '../../src/models/ValueComponent';
 
 const collect = (sql: string) => {
     const query = SelectQueryParser.parse(sql) as SimpleSelectQuery;
@@ -37,6 +39,18 @@ describe('ClauseScopedColumnReferenceCollector', () => {
         expect(refs.where).toEqual([]);
     });
 
+    test('groups JOIN USING references separately from SELECT and WHERE references', () => {
+        const refs = collect(`
+            SELECT u.name
+            FROM users u
+            JOIN orders o USING (user_id)
+        `);
+
+        expect(names(refs.select)).toEqual(['u.name']);
+        expect(names(refs.joinOn)).toEqual(['user_id']);
+        expect(refs.where).toEqual([]);
+    });
+
     test('groups GROUP BY, HAVING, and ORDER BY references by clause', () => {
         const refs = collect(`
             SELECT u.region, COUNT(o.id) AS order_count
@@ -61,6 +75,28 @@ describe('ClauseScopedColumnReferenceCollector', () => {
         `);
 
         expect(names(refs.limitOffset)).toEqual(['p.max_rows', 'p.skip_rows']);
+    });
+
+    test('groups FETCH clause references under limitOffset', () => {
+        const refs = collect(`
+            SELECT p.id
+            FROM products p
+            FETCH FIRST p.fetch_rows ROWS ONLY
+        `);
+
+        expect(names(refs.limitOffset)).toEqual(['p.fetch_rows']);
+    });
+
+    test('keeps TypeValue as expression metadata owner for nested references', () => {
+        const typeValue = new TypeValue(null, 'numeric', new ColumnReference(null, 'amount'));
+        const query = new SimpleSelectQuery({
+            selectClause: new SelectClause([new SelectItem(typeValue)]),
+        });
+
+        const refs = new ClauseScopedColumnReferenceCollector().collect(query);
+
+        expect(names(refs.select)).toEqual(['amount']);
+        expect(refs.select[0].expression).toBe(typeValue);
     });
 
     test('does not traverse subquery bodies as root clause references', () => {

--- a/packages/core/tests/transformers/ClauseScopedColumnReferenceCollector.test.ts
+++ b/packages/core/tests/transformers/ClauseScopedColumnReferenceCollector.test.ts
@@ -66,6 +66,17 @@ describe('ClauseScopedColumnReferenceCollector', () => {
         expect(names(refs.orderBy)).toEqual(['u.region', 'o.id']);
     });
 
+    test('groups top-level WINDOW clause references separately from SELECT references', () => {
+        const refs = collect(`
+            SELECT SUM(o.amount) OVER w
+            FROM orders o
+            WINDOW w AS (PARTITION BY o.customer_id ORDER BY o.created_at)
+        `);
+
+        expect(names(refs.select)).toEqual(['o.amount']);
+        expect(names(refs.window)).toEqual(['o.customer_id', 'o.created_at']);
+    });
+
     test('groups row-limiting clause references under limitOffset', () => {
         const refs = collect(`
             SELECT p.id


### PR DESCRIPTION
## Summary

- Adds `ClauseScopedColumnReferenceCollector` for root `SimpleSelectQuery` AST analysis.
- Returns column references grouped by `select`, `where`, `joinOn`, `groupBy`, `having`, `orderBy`, `window`, and `limitOffset`.
- Leaves CTE and subquery bodies out of root clause buckets so query-body ownership is not blurred.
- Exports the new API from `rawsql-ts` and adds a minor changeset.
- Addresses review feedback by preserving `TypeValue` expression ownership and adding `JOIN USING` plus `FETCH` regression coverage.
- Adds top-level `WINDOW` clause traversal so named window definitions keep their own clause bucket.

### Acceptance / Attainment

acceptance item: `SELECT` references appear under `select`.
status: done
evidence: `ClauseScopedColumnReferenceCollector.test.ts` asserts `u.id` is returned in `select`.
gap: none.

acceptance item: `WHERE`-only references appear under `where`, not SELECT output metadata.
status: done
evidence: `ClauseScopedColumnReferenceCollector.test.ts` asserts `u.active` is returned in `where` while `select` remains `u.id`.
gap: none.

acceptance item: `JOIN ON` references appear under `joinOn`.
status: done
evidence: `ClauseScopedColumnReferenceCollector.test.ts` asserts `o.user_id`, `u.id`, and `o.deleted_at` are returned in `joinOn`.
gap: none.

acceptance item: `GROUP BY`, `HAVING`, and `ORDER BY` references retain clause context.
status: done
evidence: `ClauseScopedColumnReferenceCollector.test.ts` asserts `u.region` in `groupBy`, `o.id` in `having`, and `u.region` plus `o.id` in `orderBy`.
gap: none.

acceptance item: Top-level `WINDOW` clause references appear under `window`.
status: done
evidence: `ClauseScopedColumnReferenceCollector.test.ts` asserts `o.customer_id` and `o.created_at` are returned in `window` while `SUM(o.amount) OVER w` contributes only `o.amount` to `select`.
gap: none.

acceptance item: Existing `ColumnReferenceCollector` behavior remains compatible.
status: done
evidence: Existing `ColumnReferenceCollector` tests pass, and the new test asserts the existing collector still returns the unscoped `u.id` and `u.active` references.
gap: none.

acceptance item: Tests cover a query where the same table contributes output and predicate-only references.
status: done
evidence: The SELECT/WHERE test uses `users u` for both `u.id` output and `u.active` predicate-only usage.
gap: none.

## Verification

- `pnpm --filter rawsql-ts test` passed: 234 test files, 2270 passed, 1 skipped.
- `pnpm --filter rawsql-ts build` passed.
- `pnpm --filter rawsql-ts lint` passed.
- Pre-commit hook passed workspace typecheck, workspace tests, workspace build, and workspace lint.
- `node scripts/check-pr-readiness.js --base-sha 25ef1ef9f55992357654ca4ac489198dcbd5e67f --head-sha f0cdac4102145829f7936ac148c82eabbdd6879a --event-path tmp/pr-event.json` passed locally.

### Residual Risk

- Subquery and CTE bodies are intentionally not included in root clause buckets. This keeps query-body ownership explicit, but consumers that need nested ownership will need a future nested result shape.
- The API is currently scoped to `SimpleSelectQuery`, matching the issue's first-target requirement.

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

<!-- Write values on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. -->
<!-- Do not add list markers like "-" before these labels; `Tracking issue:` and `Scoped checks run:` must start at column 0. -->
Tracking issue: #913
Scoped checks run: `pnpm --filter rawsql-ts test`; `pnpm --filter rawsql-ts build`; `pnpm --filter rawsql-ts lint`; pre-commit workspace checks; `node scripts/check-pr-readiness.js --base-sha 25ef1ef9f55992357654ca4ac489198dcbd5e67f --head-sha f0cdac4102145829f7936ac148c82eabbdd6879a --event-path tmp/pr-event.json`
Why full baseline is not required: No exception requested; core package checks and pre-commit workspace checks passed.

## Self Review

<!-- Fill these fields after running the repo self-review workflow or available self-review skill. -->
Self-review workflow: `.agents/skills/self-review` consistency review, concept boundary review, and human acceptance review.
Self-review result: No blockers remain.
Concept-review workflow: Checked `packages/core/AGENTS.md` and `packages/core/DESIGN.md`; no separate core Concept Spec was found.
Concept-review result: No package-boundary violation remains; the change stays in DBMS-neutral AST analysis and does not add lineage graph, UI, value-origin, or population diagnostics.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-migration rationale: No CLI-facing files or behavior changed; this is a core library AST API addition.
Upgrade note: New optional API only; no migration required.
Deprecation/removal plan or issue: None.
Docs/help/examples updated: Tests and changeset added; no CLI docs/help/examples are affected.
Release/changeset wording: `.changeset/clause-scoped-column-references.md`

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-proof rationale: No scaffold files, templates, generated scaffold output, or scaffold contracts changed.
Non-edit assertion: The PR changes only core source/tests, package export, and changeset.
Fail-fast input-contract proof: Not applicable; no scaffold input contract changed.
Generated-output viability proof: Not applicable; no scaffold generated output changed.
