### PR TITLE
Harden SELECT output metadata continuity

### DIFF
--- a/.changeset/select-output-source-metadata.md
+++ b/.changeset/select-output-source-metadata.md
@@ -2,4 +2,4 @@
 "rawsql-ts": patch
 ---
 
-Include source metadata on `SelectOutputCollector` entries when wildcard expansion can identify the selected source from SQL structure. Expanded outputs now report `sourceAlias`, `sourceName`, and `sourceColumnName`, while unavailable metadata is represented as `null`.
+Include source metadata on `SelectOutputCollector` entries when SQL structure can safely identify the selected source. Wildcard expansion and uniquely matched qualified column references now report `sourceAlias`, `sourceName`, and `sourceColumnName`, while unavailable or unsafe-to-infer metadata is represented as `null`.

--- a/packages/core/src/transformers/SelectOutputCollector.ts
+++ b/packages/core/src/transformers/SelectOutputCollector.ts
@@ -80,7 +80,7 @@ export class SelectOutputCollector {
 
     private collectSelectItem(item: SelectItem, fromClause: FromClause | null): RawSelectOutputColumn[] {
         if (item.identifier) {
-            return [this.createExplicitOutput(item.identifier.name, item.value)];
+            return [this.createExplicitOutput(item.identifier.name, item.value, fromClause)];
         }
 
         if (!(item.value instanceof ColumnReference)) {
@@ -92,7 +92,7 @@ export class SelectOutputCollector {
             return this.expandWildcard(item.value, fromClause);
         }
 
-        return [this.createExplicitOutput(columnName, item.value)];
+        return [this.createExplicitOutput(columnName, item.value, fromClause)];
     }
 
     private expandWildcard(value: ColumnReference, fromClause: FromClause | null): RawSelectOutputColumn[] {
@@ -261,7 +261,18 @@ export class SelectOutputCollector {
         }));
     }
 
-    private createExplicitOutput(name: string, value: ValueComponent): RawSelectOutputColumn {
+    private createExplicitOutput(name: string, value: ValueComponent, fromClause: FromClause | null = null): RawSelectOutputColumn {
+        if (value instanceof ColumnReference && value.column.name !== "*") {
+            const sourceMetadata = this.resolveColumnSourceMetadata(value, fromClause);
+            if (sourceMetadata) {
+                return {
+                    name,
+                    value,
+                    ...sourceMetadata
+                };
+            }
+        }
+
         return {
             name,
             value,
@@ -269,6 +280,71 @@ export class SelectOutputCollector {
             sourceName: null,
             sourceColumnName: null
         };
+    }
+
+    private resolveColumnSourceMetadata(value: ColumnReference, fromClause: FromClause | null): Pick<RawSelectOutputColumn, "sourceAlias" | "sourceName" | "sourceColumnName"> | null {
+        if (!fromClause || value.namespaces === null) {
+            return null;
+        }
+
+        const namespace = value.getNamespace();
+        const matches = fromClause.getSources().filter(source => this.getSourceMatchNames(source).includes(namespace));
+        if (matches.length !== 1) {
+            return null;
+        }
+
+        const source = matches[0];
+        const sourceAlias = this.getColumnReferenceSourceAlias(source, namespace);
+        return {
+            sourceAlias,
+            sourceName: this.getColumnReferenceSourceName(source),
+            sourceColumnName: value.column.name
+        };
+    }
+
+    private getSourceMatchNames(source: SourceExpression): string[] {
+        const names = new Set<string>();
+        if (source.aliasExpression) {
+            names.add(source.aliasExpression.table.name);
+            return [...names];
+        }
+
+        const aliasName = source.getAliasName();
+        if (aliasName) {
+            names.add(aliasName);
+        }
+
+        if (source.datasource instanceof TableSource) {
+            names.add(source.datasource.table.name);
+            names.add(source.datasource.getSourceName());
+        }
+
+        return [...names];
+    }
+
+    private getColumnReferenceSourceAlias(source: SourceExpression, namespace: string): string | null {
+        if (source.aliasExpression) {
+            return source.aliasExpression.table.name;
+        }
+
+        return namespace;
+    }
+
+    private getColumnReferenceSourceName(source: SourceExpression): string | null {
+        const cte = this.findCommonTable(source);
+        if (cte) {
+            return cte.getSourceAliasName();
+        }
+
+        if (source.aliasExpression?.columns) {
+            return null;
+        }
+
+        if (source.datasource instanceof TableSource) {
+            return source.datasource.getSourceName();
+        }
+
+        return null;
     }
 
     private isSelectQuery(query: CTEQuery): query is SelectQuery {

--- a/packages/core/tests/transformers/SelectOutputCollector.test.ts
+++ b/packages/core/tests/transformers/SelectOutputCollector.test.ts
@@ -22,10 +22,161 @@ describe('SelectOutputCollector', () => {
         expect(outputs.map(item => ({
             name: item.name,
             outputIndex: item.outputIndex,
+            sourceAlias: item.sourceAlias,
+            sourceName: item.sourceName,
+            sourceColumnName: item.sourceColumnName,
             sql: formatter.format(item.value).formattedSql
         }))).toEqual([
-            { name: 'id', outputIndex: 0, sql: '"c"."id"' },
-            { name: 'id', outputIndex: 1, sql: '"o"."id"' }
+            { name: 'id', outputIndex: 0, sourceAlias: 'c', sourceName: 'customers', sourceColumnName: 'id', sql: '"c"."id"' },
+            { name: 'id', outputIndex: 1, sourceAlias: 'o', sourceName: 'orders', sourceColumnName: 'id', sql: '"o"."id"' }
+        ]);
+    });
+
+    test('resolves qualified explicit source metadata from source aliases', () => {
+        const sql = `
+            SELECT
+                c.id AS customer_id,
+                o.id
+            FROM customers AS c
+            JOIN orders AS o ON o.customer_id = c.id
+        `;
+        const query = SelectQueryParser.parse(sql);
+
+        const outputs = new SelectOutputCollector().collect(query);
+
+        expect(outputs.map(item => ({
+            name: item.name,
+            outputIndex: item.outputIndex,
+            sourceAlias: item.sourceAlias,
+            sourceName: item.sourceName,
+            sourceColumnName: item.sourceColumnName,
+            sql: formatter.format(item.value).formattedSql
+        }))).toEqual([
+            { name: 'customer_id', outputIndex: 0, sourceAlias: 'c', sourceName: 'customers', sourceColumnName: 'id', sql: '"c"."id"' },
+            { name: 'id', outputIndex: 1, sourceAlias: 'o', sourceName: 'orders', sourceColumnName: 'id', sql: '"o"."id"' }
+        ]);
+    });
+
+    test('leaves unqualified explicit source metadata null', () => {
+        const sql = `
+            SELECT
+                id,
+                amount
+            FROM orders
+        `;
+        const query = SelectQueryParser.parse(sql);
+
+        const outputs = new SelectOutputCollector().collect(query);
+
+        expect(outputs.map(item => ({
+            name: item.name,
+            outputIndex: item.outputIndex,
+            sourceAlias: item.sourceAlias,
+            sourceName: item.sourceName,
+            sourceColumnName: item.sourceColumnName,
+            sql: formatter.format(item.value).formattedSql
+        }))).toEqual([
+            { name: 'id', outputIndex: 0, sourceAlias: null, sourceName: null, sourceColumnName: null, sql: '"id"' },
+            { name: 'amount', outputIndex: 1, sourceAlias: null, sourceName: null, sourceColumnName: null, sql: '"amount"' }
+        ]);
+    });
+
+    test('leaves non-alias qualified metadata null when source alias exists', () => {
+        const sql = `
+            SELECT
+                customers.id
+            FROM customers AS c
+        `;
+        const query = SelectQueryParser.parse(sql);
+
+        const outputs = new SelectOutputCollector().collect(query);
+
+        expect(outputs.map(item => ({
+            name: item.name,
+            outputIndex: item.outputIndex,
+            sourceAlias: item.sourceAlias,
+            sourceName: item.sourceName,
+            sourceColumnName: item.sourceColumnName,
+            sql: formatter.format(item.value).formattedSql
+        }))).toEqual([
+            { name: 'id', outputIndex: 0, sourceAlias: null, sourceName: null, sourceColumnName: null, sql: '"customers"."id"' }
+        ]);
+    });
+
+    test('resolves qualified explicit CTE source metadata', () => {
+        const sql = `
+            WITH scored AS (
+                SELECT
+                    customer_id,
+                    amount
+                FROM orders
+            )
+            SELECT
+                s.customer_id
+            FROM scored AS s
+        `;
+        const query = SelectQueryParser.parse(sql);
+
+        const outputs = new SelectOutputCollector().collect(query);
+
+        expect(outputs.map(item => ({
+            name: item.name,
+            outputIndex: item.outputIndex,
+            sourceAlias: item.sourceAlias,
+            sourceName: item.sourceName,
+            sourceColumnName: item.sourceColumnName,
+            sql: formatter.format(item.value).formattedSql
+        }))).toEqual([
+            { name: 'customer_id', outputIndex: 0, sourceAlias: 's', sourceName: 'scored', sourceColumnName: 'customer_id', sql: '"s"."customer_id"' }
+        ]);
+    });
+
+    test('resolves qualified explicit derived-table source metadata', () => {
+        const sql = `
+            SELECT
+                d.a
+            FROM (
+                SELECT
+                    a
+                FROM t
+            ) AS d
+        `;
+        const query = SelectQueryParser.parse(sql);
+
+        const outputs = new SelectOutputCollector().collect(query);
+
+        expect(outputs.map(item => ({
+            name: item.name,
+            outputIndex: item.outputIndex,
+            sourceAlias: item.sourceAlias,
+            sourceName: item.sourceName,
+            sourceColumnName: item.sourceColumnName,
+            sql: formatter.format(item.value).formattedSql
+        }))).toEqual([
+            { name: 'a', outputIndex: 0, sourceAlias: 'd', sourceName: null, sourceColumnName: 'a', sql: '"d"."a"' }
+        ]);
+    });
+
+    test('leaves ambiguous qualified source metadata null', () => {
+        const sql = `
+            SELECT
+                users.id
+            FROM public.users
+            JOIN archive.users ON archive.users.id = public.users.id
+        `;
+        const query = SelectQueryParser.parse(sql);
+
+        const outputs = new SelectOutputCollector().collect(query);
+
+        expect(outputs.map(item => ({
+            name: item.name,
+            outputIndex: item.outputIndex,
+            sourceAlias: item.sourceAlias,
+            sourceName: item.sourceName,
+            sourceColumnName: item.sourceColumnName,
+            sql: formatter.format(item.value).formattedSql
+        }))).toEqual([
+            { name: 'id', outputIndex: 0, sourceAlias: null, sourceName: null, sourceColumnName: null, sql: '"users"."id"' }
         ]);
     });
 
@@ -49,11 +200,14 @@ describe('SelectOutputCollector', () => {
         expect(outputs.map(item => ({
             name: item.name,
             outputIndex: item.outputIndex,
+            sourceAlias: item.sourceAlias,
+            sourceName: item.sourceName,
+            sourceColumnName: item.sourceColumnName,
             sql: formatter.format(item.value).formattedSql
         }))).toEqual([
-            { name: 'customer_id', outputIndex: 0, sql: '"s"."customer_id"' },
-            { name: 'amount', outputIndex: 1, sql: '"s"."amount"' },
-            { name: 'score', outputIndex: 2, sql: '"s"."amount" * 2' }
+            { name: 'customer_id', outputIndex: 0, sourceAlias: 's', sourceName: 'scored', sourceColumnName: 'customer_id', sql: '"s"."customer_id"' },
+            { name: 'amount', outputIndex: 1, sourceAlias: 's', sourceName: 'scored', sourceColumnName: 'amount', sql: '"s"."amount"' },
+            { name: 'score', outputIndex: 2, sourceAlias: null, sourceName: null, sourceColumnName: null, sql: '"s"."amount" * 2' }
         ]);
     });
 


### PR DESCRIPTION
## Summary

- Harden `SelectOutputCollector` output metadata continuity for downstream AST consumers.
- Add source metadata for qualified explicit column references when a FROM/JOIN source can be identified safely and uniquely from SQL structure.
- Preserve deterministic output order, duplicate output names, wildcard expansion metadata, and `null` metadata for unqualified or unsafe-to-infer cases.
- Update the existing changeset wording for the broadened source metadata behavior.

Acceptance:

| acceptance item | status | evidence | gap |
| --- | --- | --- | --- |
| `SELECT c.id, o.id` returns two distinct output entries with stable indexes. | done | `SelectOutputCollector.test.ts` asserts duplicate `id` outputs with `outputIndex` 0 and 1 plus source metadata. | None. |
| `SELECT s.*, s.amount * 2 AS score` preserves SQL output order. | done | `SelectOutputCollector.test.ts` asserts wildcard-expanded columns before `score`, with `score` metadata remaining `null`. | None. |
| CTE wildcard outputs remain deterministic. | done | `SelectOutputCollector.test.ts` asserts CTE wildcard order, indexes, and generic CTE source metadata. | None. |
| Derived-table wildcard outputs remain deterministic. | done | `SelectOutputCollector.test.ts` asserts derived-table wildcard order, indexes, and source metadata. | None. |
| Source metadata remains `null` when it cannot be inferred safely. | done | `SelectOutputCollector.test.ts` asserts unqualified explicit columns, non-alias qualified references, and ambiguous qualified references stay `null`. | None. |
| Existing `SelectOutputCollector` API remains backward compatible. | done | Public interface shape is unchanged; `pnpm --filter rawsql-ts build` passed. | None. |

Residual risk:

- Source metadata is still intentionally syntax-derived. It does not validate database semantics or infer unqualified columns without schema evidence.
- Expression-level value origin remains out of scope; computed expressions keep `sourceAlias`, `sourceName`, and `sourceColumnName` as `null`.

## Verification

- `pnpm --filter rawsql-ts test`
- `pnpm --filter rawsql-ts build`
- `pnpm --filter rawsql-ts lint`

Repository evidence:

- `packages/core/src/transformers/SelectOutputCollector.ts`
- `packages/core/tests/transformers/SelectOutputCollector.test.ts`
- `.changeset/select-output-source-metadata.md`

Supplementary evidence:

- Read-only exploration checked `SelectOutputCollector`, `SelectValueCollector`, and nearby tests before editing.
- Read-only review found an initial explicit-column metadata contract drift; the blocker was resolved by implementing safe qualified-column metadata instead of freezing those entries as `null`.

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

<!-- Write values on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. -->
<!-- Do not add list markers like "-" before these labels; `Tracking issue:` and `Scoped checks run:` must start at column 0. -->
Tracking issue: #917
Scoped checks run: pnpm --filter rawsql-ts test; pnpm --filter rawsql-ts build; pnpm --filter rawsql-ts lint
Why full baseline is not required: Full required core package checks were run; no baseline exception is requested.

## Self Review

<!-- Fill these fields after running the repo self-review workflow or available self-review skill. -->
Self-review workflow: Repo self-review workflow: consistency review, concept boundary review, human acceptance review, and pre-PR retro gate.
Self-review result: No blockers remain. The initial explicit-column null-metadata contract drift was resolved before PR creation.
Concept-review workflow: packages/core AGENTS.md and DESIGN.md package-boundary review.
Concept-review result: No package-boundary violations. The change remains DBMS-neutral core AST metadata and does not add lineage graph, UI, or value-origin diagnostics.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-migration rationale: No CLI-facing files or commands changed.
Upgrade note: No CLI upgrade note required.
Deprecation/removal plan or issue: No deprecation or removal.
Docs/help/examples updated: No CLI docs, help, or examples changed.
Release/changeset wording: Existing source metadata changeset wording updated.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-proof rationale: No scaffold-related files or generated scaffold contracts changed.
Non-edit assertion: No scaffold files are modified.
Fail-fast input-contract proof: Not applicable; no scaffold input contract changed.
Generated-output viability proof: Not applicable; no generated scaffold output changed.
