### PR TITLE
Add named query definition extraction API for CTEs

### DIFF
--- a/.changeset/named-query-definitions.md
+++ b/.changeset/named-query-definitions.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": minor
+---
+
+Add `NamedQueryDefinitionExtractor` for stable DTO-style extraction of CTE definitions from `WITH` clauses.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,6 +46,7 @@ export * from './transformers/CTEDependencyAnalyzer';
 export * from './transformers/CTETableReferenceCollector';
 export * from './transformers/CTEQueryDecomposer';
 export type { CTERestorationResult } from './transformers/CTEQueryDecomposer';
+export * from './transformers/NamedQueryDefinitionExtractor';
 export * from './transformers/CTEComposer';
 export * from './transformers/CTERenamer';
 export * from './transformers/AliasRenamer';

--- a/packages/core/src/transformers/NamedQueryDefinitionExtractor.ts
+++ b/packages/core/src/transformers/NamedQueryDefinitionExtractor.ts
@@ -1,0 +1,519 @@
+import {
+    CommonTable,
+    CTEQuery,
+    DeleteClause,
+    FromClause,
+    FunctionSource,
+    GroupByClause,
+    HavingClause,
+    InsertClause,
+    JoinClause,
+    JoinOnClause,
+    JoinUsingClause,
+    LimitClause,
+    OnConflictClause,
+    OrderByClause,
+    OrderByItem,
+    ParenSource,
+    ReturningClause,
+    SelectClause,
+    SelectItem,
+    SetClause,
+    SourceExpression,
+    SubQuerySource,
+    UpdateClause,
+    UsingClause,
+    WhereClause,
+    WindowFrameClause,
+    WindowsClause,
+    WithClause
+} from "../models/Clause";
+import { DeleteQuery } from "../models/DeleteQuery";
+import { InsertQuery } from "../models/InsertQuery";
+import { MergeDeleteAction, MergeInsertAction, MergeQuery, MergeUpdateAction, MergeWhenClause } from "../models/MergeQuery";
+import { BinarySelectQuery, SelectQuery, SimpleSelectQuery, ValuesQuery } from "../models/SelectQuery";
+import { SqlComponent } from "../models/SqlComponent";
+import { UpdateQuery } from "../models/UpdateQuery";
+import {
+    ArrayExpression,
+    ArrayIndexExpression,
+    ArrayQueryExpression,
+    ArraySliceExpression,
+    BetweenExpression,
+    BinaryExpression,
+    CaseExpression,
+    CaseKeyValuePair,
+    CastExpression,
+    FunctionCall,
+    InlineQuery,
+    JsonPredicateExpression,
+    ParenExpression,
+    SwitchCaseArgument,
+    TupleExpression,
+    TypeValue,
+    UnaryExpression,
+    ValueList,
+    WindowFrameBoundaryValue,
+    WindowFrameExpression,
+    WindowFrameSpec
+} from "../models/ValueComponent";
+import { SelectQueryWithClauseHelper } from "../utils/SelectQueryWithClauseHelper";
+
+/**
+ * Source span for a named query definition when parser position metadata is available.
+ *
+ * @remarks The current extractor does not synthesize ranges. `range` and `nameRange`
+ * are returned as `null` until AST nodes expose reliable definition spans.
+ */
+export interface NamedQueryDefinitionSourceRange {
+    start: number;
+    end: number;
+}
+
+/**
+ * DTO-style representation of a named query definition from a SQL AST.
+ */
+export interface NamedQueryDefinition {
+    /** The stable definition name, such as a CTE alias. */
+    name: string;
+    /** The AST query node that defines the named query. */
+    query: CTEQuery;
+    /** Whether the definition belongs to a `WITH RECURSIVE` clause, when that context is available. */
+    recursive?: boolean;
+    /** Full definition source range when available. Currently `null`. */
+    range: NamedQueryDefinitionSourceRange | null;
+    /** Definition-name source range when available. Currently `null`. */
+    nameRange: NamedQueryDefinitionSourceRange | null;
+}
+
+/**
+ * Extracts named query definitions, starting with CTE definitions from `WITH` clauses.
+ *
+ * @remarks Definitions are emitted in SQL source order. For nested CTEs, the outer
+ * CTE definition is emitted when its name is encountered, then definitions inside
+ * that CTE body are emitted before later sibling CTE definitions.
+ */
+export class NamedQueryDefinitionExtractor {
+    private readonly definitions: NamedQueryDefinition[] = [];
+    private readonly visited = new Set<object>();
+
+    /**
+     * Extract named query definitions from an AST component.
+     */
+    public static extract(input: SqlComponent | null | undefined): NamedQueryDefinition[] {
+        if (!input) {
+            return [];
+        }
+
+        const extractor = new NamedQueryDefinitionExtractor();
+        extractor.visit(input);
+        return extractor.definitions;
+    }
+
+    private visit(value: unknown): void {
+        if (!value || typeof value !== "object") {
+            return;
+        }
+
+        if (this.visited.has(value)) {
+            return;
+        }
+        this.visited.add(value);
+
+        if (value instanceof WithClause) {
+            this.visitWithClause(value);
+            return;
+        }
+
+        if (value instanceof CommonTable) {
+            this.visitCommonTable(value);
+            return;
+        }
+
+        if (value instanceof SimpleSelectQuery || value instanceof BinarySelectQuery || value instanceof ValuesQuery) {
+            this.visitSelectQuery(value);
+            return;
+        }
+
+        if (value instanceof InsertQuery) {
+            this.visitInsertQuery(value);
+            return;
+        }
+
+        if (value instanceof UpdateQuery) {
+            this.visitUpdateQuery(value);
+            return;
+        }
+
+        if (value instanceof DeleteQuery) {
+            this.visitDeleteQuery(value);
+            return;
+        }
+
+        if (value instanceof MergeQuery) {
+            this.visitMergeQuery(value);
+            return;
+        }
+
+        if (this.visitKnownValueComponent(value)) {
+            return;
+        }
+
+        if (this.visitKnownSqlComponent(value)) {
+            return;
+        }
+
+        if (Array.isArray(value)) {
+            for (const item of value) {
+                this.visit(item);
+            }
+            return;
+        }
+
+        for (const key of Object.keys(value)) {
+            this.visit((value as Record<string, unknown>)[key]);
+        }
+    }
+
+    private visitSelectQuery(query: SelectQuery, includeWith: boolean = true): void {
+        if (query instanceof SimpleSelectQuery) {
+            this.visitSimpleSelectQuery(query, includeWith);
+            return;
+        }
+
+        if (query instanceof BinarySelectQuery) {
+            this.visitSelectQuery(query.left, includeWith);
+            this.visitSelectQuery(query.right);
+            return;
+        }
+
+        if (query instanceof ValuesQuery) {
+            if (includeWith) {
+                this.visit(query.withClause);
+            }
+            this.visit(query.tuples);
+        }
+    }
+
+    private visitSimpleSelectQuery(query: SimpleSelectQuery, includeWith: boolean): void {
+        if (includeWith) {
+            this.visit(query.withClause);
+        }
+        this.visit(query.selectClause);
+        this.visit(query.fromClause);
+        this.visit(query.whereClause);
+        this.visit(query.groupByClause);
+        this.visit(query.havingClause);
+        this.visit(query.windowClause);
+        this.visit(query.orderByClause);
+        this.visit(query.limitClause);
+        this.visit(query.offsetClause);
+        this.visit(query.fetchClause);
+        this.visit(query.forClause);
+    }
+
+    private visitInsertQuery(query: InsertQuery): void {
+        const withClause = SelectQueryWithClauseHelper.getWithClause(query.selectQuery);
+        this.visit(withClause);
+        this.visit(query.insertClause);
+        if (query.selectQuery) {
+            this.visitSelectQuery(query.selectQuery, false);
+        }
+        this.visit(query.onConflictClause);
+        this.visit(query.returningClause);
+    }
+
+    private visitUpdateQuery(query: UpdateQuery): void {
+        this.visit(query.withClause);
+        this.visit(query.updateClause);
+        this.visit(query.setClause);
+        this.visit(query.fromClause);
+        this.visit(query.whereClause);
+        this.visit(query.returningClause);
+    }
+
+    private visitDeleteQuery(query: DeleteQuery): void {
+        this.visit(query.withClause);
+        this.visit(query.deleteClause);
+        this.visit(query.usingClause);
+        this.visit(query.whereClause);
+        this.visit(query.returningClause);
+    }
+
+    private visitMergeQuery(query: MergeQuery): void {
+        this.visit(query.withClause);
+        this.visit(query.target);
+        this.visit(query.source);
+        this.visit(query.onCondition);
+        this.visit(query.whenClauses);
+        this.visit(query.returningClause);
+    }
+
+    private visitWithClause(withClause: WithClause): void {
+        for (const commonTable of withClause.tables) {
+            this.visitCommonTable(commonTable, withClause.recursive);
+        }
+    }
+
+    private visitCommonTable(commonTable: CommonTable, recursive?: boolean): void {
+        const definition: NamedQueryDefinition = {
+            name: commonTable.getSourceAliasName(),
+            query: commonTable.query,
+            range: null,
+            nameRange: null
+        };
+
+        if (recursive !== undefined) {
+            definition.recursive = recursive;
+        }
+
+        this.definitions.push(definition);
+
+        this.visit(commonTable.query);
+    }
+
+    private visitKnownSqlComponent(value: object): boolean {
+        if (value instanceof SelectClause) {
+            this.visit(value.distinct);
+            this.visit(value.hints);
+            this.visit(value.items);
+            return true;
+        }
+
+        if (value instanceof SelectItem) {
+            this.visit(value.value);
+            return true;
+        }
+
+        if (value instanceof FromClause) {
+            this.visit(value.source);
+            this.visit(value.joins);
+            return true;
+        }
+
+        if (value instanceof JoinClause) {
+            this.visit(value.source);
+            this.visit(value.condition);
+            return true;
+        }
+
+        if (value instanceof JoinOnClause || value instanceof JoinUsingClause) {
+            this.visit(value.condition);
+            return true;
+        }
+
+        if (value instanceof SourceExpression) {
+            this.visit(value.datasource);
+            return true;
+        }
+
+        if (value instanceof SubQuerySource) {
+            this.visitSelectQuery(value.query);
+            return true;
+        }
+
+        if (value instanceof FunctionSource) {
+            this.visit(value.argument);
+            return true;
+        }
+
+        if (value instanceof ParenSource) {
+            this.visit(value.source);
+            return true;
+        }
+
+        if (value instanceof WhereClause || value instanceof HavingClause) {
+            this.visit(value.condition);
+            return true;
+        }
+
+        if (value instanceof LimitClause) {
+            this.visit(value.value);
+            return true;
+        }
+
+        if (value instanceof GroupByClause) {
+            this.visit(value.grouping);
+            return true;
+        }
+
+        if (value instanceof WindowsClause) {
+            this.visit(value.windows);
+            return true;
+        }
+
+        if (value instanceof WindowFrameClause) {
+            this.visit(value.expression);
+            return true;
+        }
+
+        if (value instanceof OrderByClause) {
+            this.visit(value.order);
+            return true;
+        }
+
+        if (value instanceof OrderByItem) {
+            this.visit(value.value);
+            return true;
+        }
+
+        if (value instanceof ReturningClause) {
+            this.visit(value.items);
+            return true;
+        }
+
+        if (value instanceof OnConflictClause) {
+            this.visit(value.setClause);
+            this.visit(value.whereClause);
+            this.visit(value.forClause);
+            return true;
+        }
+
+        if (value instanceof SetClause) {
+            for (const item of value.items) {
+                this.visit(item.value);
+            }
+            return true;
+        }
+
+        if (value instanceof UpdateClause || value instanceof DeleteClause || value instanceof InsertClause) {
+            this.visit(value.source);
+            return true;
+        }
+
+        if (value instanceof UsingClause) {
+            this.visit(value.sources);
+            return true;
+        }
+
+        if (value instanceof MergeWhenClause) {
+            this.visit(value.condition);
+            this.visit(value.action);
+            return true;
+        }
+
+        if (value instanceof MergeUpdateAction) {
+            this.visit(value.setClause);
+            this.visit(value.whereClause);
+            return true;
+        }
+
+        if (value instanceof MergeDeleteAction) {
+            this.visit(value.whereClause);
+            return true;
+        }
+
+        if (value instanceof MergeInsertAction) {
+            this.visit(value.values);
+            return true;
+        }
+
+        return false;
+    }
+
+    private visitKnownValueComponent(value: object): boolean {
+        if (value instanceof ValueList || value instanceof TupleExpression) {
+            this.visit(value.values);
+            return true;
+        }
+
+        if (value instanceof FunctionCall) {
+            this.visit(value.argument);
+            this.visit(value.internalOrderBy);
+            this.visit(value.withinGroup);
+            this.visit(value.filterCondition);
+            this.visit(value.over);
+            return true;
+        }
+
+        if (value instanceof WindowFrameExpression) {
+            this.visit(value.partition);
+            this.visit(value.order);
+            this.visit(value.frameSpec);
+            return true;
+        }
+
+        if (value instanceof WindowFrameSpec) {
+            this.visit(value.startBound);
+            this.visit(value.endBound);
+            return true;
+        }
+
+        if (value instanceof WindowFrameBoundaryValue) {
+            this.visit(value.value);
+            return true;
+        }
+
+        if (value instanceof UnaryExpression || value instanceof ParenExpression || value instanceof ArrayExpression || value instanceof JsonPredicateExpression) {
+            this.visit(value.expression);
+            return true;
+        }
+
+        if (value instanceof BinaryExpression) {
+            this.visit(value.left);
+            this.visit(value.right);
+            return true;
+        }
+
+        if (value instanceof SwitchCaseArgument) {
+            this.visit(value.cases);
+            this.visit(value.elseValue);
+            return true;
+        }
+
+        if (value instanceof CaseKeyValuePair) {
+            this.visit(value.key);
+            this.visit(value.value);
+            return true;
+        }
+
+        if (value instanceof CastExpression) {
+            this.visit(value.input);
+            this.visit(value.castType);
+            return true;
+        }
+
+        if (value instanceof CaseExpression) {
+            this.visit(value.condition);
+            this.visit(value.switchCase);
+            return true;
+        }
+
+        if (value instanceof ArrayQueryExpression) {
+            this.visitSelectQuery(value.query);
+            return true;
+        }
+
+        if (value instanceof InlineQuery) {
+            this.visitSelectQuery(value.selectQuery);
+            return true;
+        }
+
+        if (value instanceof BetweenExpression) {
+            this.visit(value.expression);
+            this.visit(value.lower);
+            this.visit(value.upper);
+            return true;
+        }
+
+        if (value instanceof TypeValue) {
+            this.visit(value.argument);
+            return true;
+        }
+
+        if (value instanceof ArraySliceExpression) {
+            this.visit(value.array);
+            this.visit(value.startIndex);
+            this.visit(value.endIndex);
+            return true;
+        }
+
+        if (value instanceof ArrayIndexExpression) {
+            this.visit(value.array);
+            this.visit(value.index);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/packages/core/tests/transformers/NamedQueryDefinitionExtractor.test.ts
+++ b/packages/core/tests/transformers/NamedQueryDefinitionExtractor.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, test } from 'vitest';
+import { CommonTable, PartitionByClause } from '../../src/models/Clause';
+import { InsertQuery } from '../../src/models/InsertQuery';
+import { UpdateQuery } from '../../src/models/UpdateQuery';
+import { DeleteQuery } from '../../src/models/DeleteQuery';
+import { MergeQuery } from '../../src/models/MergeQuery';
+import { FunctionCall, InlineQuery, WindowFrameExpression } from '../../src/models/ValueComponent';
+import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
+import { UpdateQueryParser } from '../../src/parsers/UpdateQueryParser';
+import { NamedQueryDefinitionExtractor } from '../../src/transformers/NamedQueryDefinitionExtractor';
+
+describe('NamedQueryDefinitionExtractor', () => {
+    test('extracts a simple CTE as a named query definition', () => {
+        const query = SelectQueryParser.parse(`
+            WITH cte AS (
+                SELECT id FROM users
+            )
+            SELECT * FROM cte
+        `);
+
+        const definitions = NamedQueryDefinitionExtractor.extract(query);
+
+        expect(definitions).toHaveLength(1);
+        expect(definitions[0]).toMatchObject({
+            name: 'cte',
+            recursive: false,
+            range: null,
+            nameRange: null
+        });
+        expect(definitions[0].query).toBeInstanceOf(Object);
+    });
+
+    test('preserves deterministic SQL order for multiple CTEs in one WITH clause', () => {
+        const query = SelectQueryParser.parse(`
+            WITH first_cte AS (
+                SELECT 1 AS id
+            ),
+            second_cte AS (
+                SELECT id FROM first_cte
+            ),
+            third_cte AS (
+                SELECT id FROM second_cte
+            )
+            SELECT * FROM third_cte
+        `);
+
+        const names = NamedQueryDefinitionExtractor.extract(query).map(definition => definition.name);
+
+        expect(names).toEqual(['first_cte', 'second_cte', 'third_cte']);
+    });
+
+    test('documents nested CTE order as outer definition before definitions inside its body', () => {
+        const query = SelectQueryParser.parse(`
+            WITH outer_cte AS (
+                WITH inner_cte AS (
+                    SELECT 1 AS id
+                )
+                SELECT id FROM inner_cte
+            ),
+            sibling_cte AS (
+                SELECT id FROM outer_cte
+            )
+            SELECT * FROM sibling_cte
+        `);
+
+        const names = NamedQueryDefinitionExtractor.extract(query).map(definition => definition.name);
+
+        expect(names).toEqual(['outer_cte', 'inner_cte', 'sibling_cte']);
+    });
+
+    test('keeps top-level WITH definitions before later subquery WITH definitions', () => {
+        const query = SelectQueryParser.parse(`
+            WITH top_cte AS (
+                SELECT 1 AS id
+            )
+            SELECT *
+            FROM (
+                WITH nested_cte AS (
+                    SELECT 2 AS id
+                )
+                SELECT id FROM nested_cte
+            ) AS nested_source
+        `);
+
+        const names = NamedQueryDefinitionExtractor.extract(query).map(definition => definition.name);
+
+        expect(names).toEqual(['top_cte', 'nested_cte']);
+    });
+
+    test('uses SQL clause order for nested CTEs inside UPDATE statements', () => {
+        const query = UpdateQueryParser.parse(`
+            UPDATE accounts
+            SET owner_id = (
+                WITH set_cte AS (
+                    SELECT 1 AS id
+                )
+                SELECT id FROM set_cte
+            )
+            FROM (
+                WITH from_cte AS (
+                    SELECT 2 AS id
+                )
+                SELECT id FROM from_cte
+            ) AS source_accounts
+            WHERE EXISTS (
+                WITH where_cte AS (
+                    SELECT 3 AS id
+                )
+                SELECT id FROM where_cte
+            )
+        `);
+
+        const names = NamedQueryDefinitionExtractor.extract(query).map(definition => definition.name);
+
+        expect(names).toEqual(['set_cte', 'from_cte', 'where_cte']);
+    });
+
+    test('keeps FILTER definitions before OVER definitions in function calls', () => {
+        const filterQuery = SelectQueryParser.parse(`
+            WITH filter_cte AS (
+                SELECT 1 AS id
+            )
+            SELECT id FROM filter_cte
+        `);
+        const overQuery = SelectQueryParser.parse(`
+            WITH over_cte AS (
+                SELECT 2 AS id
+            )
+            SELECT id FROM over_cte
+        `);
+        const functionCall = new FunctionCall(
+            null,
+            'count',
+            null,
+            new WindowFrameExpression(new PartitionByClause(new InlineQuery(overQuery)), null),
+            null,
+            false,
+            null,
+            new InlineQuery(filterQuery)
+        );
+
+        const names = NamedQueryDefinitionExtractor.extract(functionCall).map(definition => definition.name);
+
+        expect(names).toEqual(['filter_cte', 'over_cte']);
+    });
+
+    test('marks definitions from WITH RECURSIVE clauses', () => {
+        const query = SelectQueryParser.parse(`
+            WITH RECURSIVE tree AS (
+                SELECT id, parent_id FROM categories WHERE parent_id IS NULL
+                UNION ALL
+                SELECT c.id, c.parent_id
+                FROM categories c
+                JOIN tree t ON c.parent_id = t.id
+            )
+            SELECT * FROM tree
+        `);
+
+        const definitions = NamedQueryDefinitionExtractor.extract(query);
+
+        expect(definitions).toHaveLength(1);
+        expect(definitions[0].name).toBe('tree');
+        expect(definitions[0].recursive).toBe(true);
+    });
+
+    test('does not crash on writable CTE bodies', () => {
+        const cases = [
+            {
+                sql: `
+                    WITH inserted_rows AS (
+                        INSERT INTO audit_log (id, message)
+                        VALUES (1, 'created')
+                        RETURNING id
+                    )
+                    SELECT id FROM inserted_rows
+                `,
+                name: 'inserted_rows',
+                queryType: InsertQuery
+            },
+            {
+                sql: `
+                    WITH updated_rows AS (
+                        UPDATE users
+                        SET active = true
+                        WHERE id = 1
+                        RETURNING id
+                    )
+                    SELECT id FROM updated_rows
+                `,
+                name: 'updated_rows',
+                queryType: UpdateQuery
+            },
+            {
+                sql: `
+                    WITH deleted_rows AS (
+                        DELETE FROM sessions
+                        WHERE expired = true
+                        RETURNING id
+                    )
+                    SELECT id FROM deleted_rows
+                `,
+                name: 'deleted_rows',
+                queryType: DeleteQuery
+            },
+            {
+                sql: `
+                    WITH merged_rows AS (
+                        MERGE INTO users AS target
+                        USING incoming_users AS source
+                        ON target.user_id = source.user_id
+                        WHEN MATCHED THEN UPDATE SET name = source.name
+                        WHEN NOT MATCHED THEN INSERT (user_id, name) VALUES (source.user_id, source.name)
+                        RETURNING target.user_id AS user_id
+                    )
+                    SELECT user_id FROM merged_rows
+                `,
+                name: 'merged_rows',
+                queryType: MergeQuery
+            }
+        ];
+
+        for (const item of cases) {
+            const query = SelectQueryParser.parse(item.sql);
+
+            expect(() => NamedQueryDefinitionExtractor.extract(query)).not.toThrow();
+            const [definition] = NamedQueryDefinitionExtractor.extract(query);
+            expect(definition.name).toBe(item.name);
+            expect(definition.query).toBeInstanceOf(item.queryType);
+        }
+    });
+
+    test('extracts a CommonTable input directly', () => {
+        const query = SelectQueryParser.parse(`
+            WITH direct_cte AS (
+                SELECT 1 AS id
+            )
+            SELECT * FROM direct_cte
+        `).toSimpleQuery();
+        const commonTable = query.withClause?.tables[0];
+
+        expect(commonTable).toBeInstanceOf(CommonTable);
+        const definitions = NamedQueryDefinitionExtractor.extract(commonTable!);
+
+        expect(definitions.map(definition => definition.name)).toEqual(['direct_cte']);
+        expect(definitions[0]).not.toHaveProperty('recursive');
+    });
+
+    test('does not infer recursive context from a direct CommonTable input', () => {
+        const query = SelectQueryParser.parse(`
+            WITH RECURSIVE direct_tree AS (
+                SELECT id, parent_id FROM categories WHERE parent_id IS NULL
+                UNION ALL
+                SELECT c.id, c.parent_id
+                FROM categories c
+                JOIN direct_tree t ON c.parent_id = t.id
+            )
+            SELECT * FROM direct_tree
+        `).toSimpleQuery();
+        const commonTable = query.withClause?.tables[0];
+
+        const definitions = NamedQueryDefinitionExtractor.extract(commonTable!);
+
+        expect(definitions).toHaveLength(1);
+        expect(definitions[0].name).toBe('direct_tree');
+        expect(definitions[0]).not.toHaveProperty('recursive');
+    });
+});


### PR DESCRIPTION
## Summary

- Closes #914.
- Adds `NamedQueryDefinitionExtractor` as a stable DTO-style API for extracting named query definitions from `WITH` CTEs.
- Acceptance:
  - done: simple CTE definitions expose `name`, `query`, `recursive`, `range`, and `nameRange`.
  - done: multiple CTEs are returned in deterministic SQL source order.
  - done: nested CTE order is documented in JSDoc and tested as outer definition, then definitions inside that body, then later siblings.
  - done: writable CTE bodies do not crash extraction, including INSERT, UPDATE, DELETE, and MERGE CTE bodies.
  - done: existing `CTECollector` behavior is unchanged.
  - done: source ranges remain `null` instead of broadening range support ahead of #915.
- Residual risk: source ranges are intentionally unavailable in this API until AST nodes expose reliable definition spans; direct `CommonTable` inputs omit `recursive` because parent `WITH RECURSIVE` context is not available.

## Verification

- `corepack pnpm --filter rawsql-ts test` - 234 files passed, 2270 tests passed, 1 skipped.
- `corepack pnpm --filter rawsql-ts build` - passed.
- `corepack pnpm --filter rawsql-ts lint` - passed.
- Pre-commit hook - passed workspace typecheck, workspace tests, workspace build, and workspace lint.

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

<!-- Write values on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. -->
<!-- Do not add list markers like "-" before these labels; `Tracking issue:` and `Scoped checks run:` must start at column 0. -->
Tracking issue: #914
Scoped checks run: corepack pnpm --filter rawsql-ts test; corepack pnpm --filter rawsql-ts build; corepack pnpm --filter rawsql-ts lint; pre-commit workspace checks
Why full baseline is not required: Full baseline exception is not requested.

## Self Review

<!-- Fill these fields after running the repo self-review workflow or available self-review skill. -->
Self-review workflow: developer-self-review, with independent read-only reviewer passes for API correctness and source-order traversal.
Self-review result: Blockers found during review were resolved; no remaining blocker is known after final verification.
Concept-review workflow: packages/core AGENTS.md and DESIGN.md package-boundary review.
Concept-review result: No DBMS-specific, lineage graph, UI, rewrite, or #915 source-range boundary violation remains.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-migration rationale: This is a core AST extraction API change, not a CLI surface change.
Upgrade note: Not applicable.
Deprecation/removal plan or issue: Not applicable.
Docs/help/examples updated: Not applicable.
Release/changeset wording: .changeset/named-query-definitions.md

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-proof rationale: This change does not edit scaffold generation or scaffold-owned output.
Non-edit assertion: No scaffold files are edited.
Fail-fast input-contract proof: Not applicable.
Generated-output viability proof: Not applicable.
