### PR TITLE
feat(core): infer wildcard column requirements

### DIFF
--- a/.changeset/wildcard-column-inference.md
+++ b/.changeset/wildcard-column-inference.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": minor
+---
+
+Add `WildcardColumnInferenceCollector` for metadata-only inference of required wildcard output columns from downstream CTE and derived-table references, including clause-scoped requirement details and conservative unresolved states for ambiguous ownership.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,6 +72,7 @@ export * from './transformers/DDLGeneralizer';
 export * from './transformers/DDLDiffGenerator';
 export * from './transformers/SelectBodyExtractor';
 export * from './transformers/SelectOutputCollector';
+export * from './transformers/WildcardColumnInferenceCollector';
 export * from './transformers/SelectValueCollector';
 export * from './transformers/SelectableColumnCollector';
 export { DuplicateDetectionMode } from './transformers/SelectableColumnCollector';

--- a/packages/core/src/transformers/WildcardColumnInferenceCollector.ts
+++ b/packages/core/src/transformers/WildcardColumnInferenceCollector.ts
@@ -1,0 +1,558 @@
+import { CommonTable, FromClause, SelectItem, SourceExpression, SubQuerySource, TableSource } from "../models/Clause";
+import { BinarySelectQuery, SelectQuery, SimpleSelectQuery } from "../models/SelectQuery";
+import { ColumnReference } from "../models/ValueComponent";
+import {
+    ClauseScopedColumnReferenceClause,
+    ClauseScopedColumnReferenceCollector,
+    ClauseScopedColumnReferenceInfo
+} from "./ClauseScopedColumnReferenceCollector";
+import { SelectOutputCollector } from "./SelectOutputCollector";
+
+/** Kind of named query boundary whose wildcard output is being inferred. */
+export type WildcardColumnInferenceTargetKind = "cte" | "derivedTable";
+
+/** Syntax form of the wildcard SELECT item that may supply required columns. */
+export type WildcardColumnInferenceWildcardKind = "qualified" | "unqualified";
+
+/** Conservative reason why a downstream requirement could not be assigned to one wildcard supplier. */
+export type WildcardColumnInferenceUnresolvedReason =
+    | "duplicateOutputOwnership"
+    | "multipleWildcardSuppliers"
+    | "unqualifiedWildcardMultipleSources"
+    | "noWildcardSupplier"
+    | "unsupportedQueryShape";
+
+/** Clause-scoped downstream reference that requires an output column from the target. */
+export interface WildcardColumnInferenceRequiredBy {
+    /** Clause that owns the downstream reference. */
+    clause: ClauseScopedColumnReferenceClause;
+    /** SQL text form of the downstream column reference. */
+    qualifiedName: string;
+    /** Namespace or alias used by the downstream reference, if present. */
+    namespace: string | null;
+    /** Output column name required by the downstream reference. */
+    column: string;
+}
+
+/** Metadata for a wildcard SELECT item inside the target query. */
+export interface WildcardColumnInferenceWildcard {
+    /** Whether the wildcard was written as `*` or as a qualified form such as `a.*`. */
+    kind: WildcardColumnInferenceWildcardKind;
+    /** SELECT-list position of the wildcard item. */
+    outputIndex: number;
+    /** Source alias that the wildcard can safely be associated with, when known. */
+    sourceAlias: string | null;
+    /** Physical source name for the wildcard source, when it is statically visible. */
+    sourceName: string | null;
+}
+
+/** Explicit non-wildcard output preserved alongside inferred wildcard requirements. */
+export interface WildcardColumnInferenceExplicitColumn {
+    /** Output name exposed by the explicit SELECT item. */
+    outputName: string;
+    /** Source alias for a simple qualified column expression, when uniquely known. */
+    sourceAlias: string | null;
+    /** Physical source name for a simple qualified column expression, when uniquely known. */
+    sourceName: string | null;
+    /** Source column name for a simple qualified column expression, when uniquely known. */
+    sourceColumnName: string | null;
+}
+
+/** Resolved required column supplied by a single unambiguous wildcard. */
+export interface WildcardColumnInferenceResolvedColumn {
+    /** Output column name required from the target. */
+    outputName: string;
+    /** Source alias selected as the wildcard supplier. */
+    sourceAlias: string | null;
+    /** Physical source name selected as the wildcard supplier, when known. */
+    sourceName: string | null;
+    /** Source column name inferred from the downstream output requirement. */
+    sourceColumnName: string;
+    /** Wildcard SELECT item that supplies this required column. */
+    wildcard: WildcardColumnInferenceWildcard;
+    /** Distinct downstream clauses that required this column. */
+    requiredByClause: ClauseScopedColumnReferenceClause[];
+    /** Clause-scoped downstream references that required this column. */
+    requiredBy: WildcardColumnInferenceRequiredBy[];
+}
+
+/** Required output column that could not be assigned to a single wildcard supplier. */
+export interface WildcardColumnInferenceUnresolvedColumn {
+    /** Output column name required from the target. */
+    outputName: string;
+    /** Conservative reason why inference did not choose a supplier. */
+    reason: WildcardColumnInferenceUnresolvedReason;
+    /** Candidate wildcard suppliers visible for this requirement. */
+    candidateWildcards: WildcardColumnInferenceWildcard[];
+    /** Distinct downstream clauses that required this column. */
+    requiredByClause: ClauseScopedColumnReferenceClause[];
+    /** Clause-scoped downstream references that required this column. */
+    requiredBy: WildcardColumnInferenceRequiredBy[];
+}
+
+/** Metadata-only wildcard inference result for one CTE or derived table target. */
+export interface WildcardColumnInferenceResult {
+    /** Kind of target whose wildcard output was inspected. */
+    targetKind: WildcardColumnInferenceTargetKind;
+    /** CTE name for CTE targets, otherwise null. */
+    targetName: string | null;
+    /** Alias used by the downstream consumer when available. */
+    targetAlias: string | null;
+    /** Wildcard SELECT items found inside the target query. */
+    wildcards: WildcardColumnInferenceWildcard[];
+    /** Explicit non-wildcard outputs found inside the target query. */
+    explicitColumns: WildcardColumnInferenceExplicitColumn[];
+    /** Downstream requirements assigned to exactly one wildcard supplier. */
+    requiredColumns: WildcardColumnInferenceResolvedColumn[];
+    /** Downstream requirements that were intentionally left unresolved. */
+    unresolvedColumns: WildcardColumnInferenceUnresolvedColumn[];
+}
+
+interface TargetDescriptor {
+    key: string;
+    targetKind: WildcardColumnInferenceTargetKind;
+    targetName: string | null;
+    targetAlias: string | null;
+    query: SelectQuery;
+}
+
+interface TargetRequirement {
+    descriptor: TargetDescriptor;
+    requiredByColumn: Map<string, WildcardColumnInferenceRequiredBy[]>;
+}
+
+interface TargetOutputMetadata {
+    wildcards: WildcardColumnInferenceWildcard[];
+    explicitColumns: WildcardColumnInferenceExplicitColumn[];
+    unqualifiedWildcardWithMultipleSources: boolean;
+}
+
+const clauseOrder: ClauseScopedColumnReferenceClause[] = [
+    "select",
+    "where",
+    "joinOn",
+    "groupBy",
+    "having",
+    "orderBy",
+    "window",
+    "limitOffset"
+];
+
+/**
+ * Infers the subset of wildcard columns required by downstream references.
+ *
+ * This collector only returns metadata. It does not rewrite SQL and does not attempt full
+ * table-column discovery. When ownership is ambiguous, the requirement is reported as unresolved.
+ */
+export class WildcardColumnInferenceCollector {
+    private readonly clauseCollector = new ClauseScopedColumnReferenceCollector();
+    private readonly requirements = new Map<string, TargetRequirement>();
+    private readonly visitedQueries = new Set<object>();
+    private nextObjectId = 0;
+    private objectIds = new WeakMap<object, number>();
+
+    /**
+     * Collect wildcard column inference metadata for CTEs and derived tables visible in a SELECT query.
+     */
+    public collect(query: SelectQuery): WildcardColumnInferenceResult[] {
+        this.requirements.clear();
+        this.visitedQueries.clear();
+        this.nextObjectId = 0;
+        this.objectIds = new WeakMap<object, number>();
+        this.collectFromSelectQuery(query, []);
+        return [...this.requirements.values()].map(item => this.inferTarget(item));
+    }
+
+    private collectFromSelectQuery(query: SelectQuery, commonTables: CommonTable[]): void {
+        if (this.visitedQueries.has(query)) {
+            return;
+        }
+        this.visitedQueries.add(query);
+
+        if (query instanceof BinarySelectQuery) {
+            const rightCommonTables = this.mergeCommonTables(commonTables, this.collectLeadingCommonTables(query.left));
+            this.collectFromSelectQuery(query.left, commonTables);
+            this.collectFromSelectQuery(query.right, rightCommonTables);
+            return;
+        }
+
+        if (!(query instanceof SimpleSelectQuery)) {
+            return;
+        }
+
+        const scopedCommonTables = this.mergeCommonTables(commonTables, query.withClause?.tables ?? []);
+        this.collectConsumerRequirements(query, scopedCommonTables);
+        this.collectNestedSources(query.fromClause, scopedCommonTables);
+
+        for (const commonTable of query.withClause?.tables ?? []) {
+            this.collectCteQuery(commonTable.query, scopedCommonTables);
+        }
+    }
+
+    private collectCteQuery(query: unknown, commonTables: CommonTable[]): void {
+        if (this.isSelectQuery(query)) {
+            this.collectFromSelectQuery(query, commonTables);
+        }
+    }
+
+    private collectConsumerRequirements(query: SimpleSelectQuery, commonTables: CommonTable[]): void {
+        if (!query.fromClause) {
+            return;
+        }
+
+        const targets = this.collectConsumerTargets(query.fromClause, commonTables);
+        if (targets.length === 0) {
+            return;
+        }
+
+        const targetByMatchName = new Map<string, TargetDescriptor[]>();
+        for (const target of targets) {
+            for (const name of this.getTargetMatchNames(target)) {
+                const existing = targetByMatchName.get(name) ?? [];
+                existing.push(target);
+                targetByMatchName.set(name, existing);
+            }
+        }
+
+        const singleUnqualifiedTarget = query.fromClause.getSources().length === 1 && targets.length === 1 ? targets[0] : null;
+        for (const reference of this.flattenReferences(this.clauseCollector.collect(query))) {
+            if (reference.column === "*") {
+                continue;
+            }
+
+            const matchedTarget = reference.namespace
+                ? this.getUniqueTarget(targetByMatchName.get(reference.namespace) ?? [])
+                : singleUnqualifiedTarget;
+
+            if (matchedTarget) {
+                this.addRequirement(matchedTarget, reference.column, this.createRequiredBy(reference));
+            }
+        }
+    }
+
+    private collectConsumerTargets(fromClause: FromClause, commonTables: CommonTable[]): TargetDescriptor[] {
+        const targets: TargetDescriptor[] = [];
+        for (const source of fromClause.getSources()) {
+            const cteTarget = this.createCteTarget(source, commonTables);
+            if (cteTarget) {
+                targets.push(cteTarget);
+                continue;
+            }
+
+            const derivedTarget = this.createDerivedTableTarget(source);
+            if (derivedTarget) {
+                targets.push(derivedTarget);
+            }
+        }
+        return targets;
+    }
+
+    private createCteTarget(source: SourceExpression, commonTables: CommonTable[]): TargetDescriptor | null {
+        if (!(source.datasource instanceof TableSource)) {
+            return null;
+        }
+
+        const tableName = source.datasource.getSourceName();
+        const commonTable = commonTables.find(item => item.getSourceAliasName() === tableName);
+        if (!commonTable || !this.isSelectQuery(commonTable.query)) {
+            return null;
+        }
+
+        return {
+            key: `cte:${this.getObjectId(commonTable)}`,
+            targetKind: "cte",
+            targetName: commonTable.getSourceAliasName(),
+            targetAlias: source.aliasExpression ? source.getAliasName() : commonTable.getSourceAliasName(),
+            query: commonTable.query
+        };
+    }
+
+    private createDerivedTableTarget(source: SourceExpression): TargetDescriptor | null {
+        if (!(source.datasource instanceof SubQuerySource)) {
+            return null;
+        }
+
+        return {
+            key: `derived:${this.getObjectId(source.datasource.query)}`,
+            targetKind: "derivedTable",
+            targetName: null,
+            targetAlias: source.getAliasName(),
+            query: source.datasource.query
+        };
+    }
+
+    private collectNestedSources(fromClause: FromClause | null, commonTables: CommonTable[]): void {
+        if (!fromClause) {
+            return;
+        }
+
+        for (const source of fromClause.getSources()) {
+            if (source.datasource instanceof SubQuerySource) {
+                this.collectFromSelectQuery(source.datasource.query, commonTables);
+            }
+        }
+    }
+
+    private addRequirement(target: TargetDescriptor, column: string, requiredBy: WildcardColumnInferenceRequiredBy): void {
+        let requirement = this.requirements.get(target.key);
+        if (!requirement) {
+            requirement = {
+                descriptor: target,
+                requiredByColumn: new Map()
+            };
+            this.requirements.set(target.key, requirement);
+        }
+
+        const existing = requirement.requiredByColumn.get(column) ?? [];
+        existing.push(requiredBy);
+        requirement.requiredByColumn.set(column, existing);
+    }
+
+    private inferTarget(requirement: TargetRequirement): WildcardColumnInferenceResult {
+        const descriptor = requirement.descriptor;
+        const baseResult: WildcardColumnInferenceResult = {
+            targetKind: descriptor.targetKind,
+            targetName: descriptor.targetName,
+            targetAlias: descriptor.targetAlias,
+            wildcards: [],
+            explicitColumns: [],
+            requiredColumns: [],
+            unresolvedColumns: []
+        };
+
+        if (!(descriptor.query instanceof SimpleSelectQuery)) {
+            for (const [outputName, requiredBy] of requirement.requiredByColumn) {
+                baseResult.unresolvedColumns.push(this.createUnresolved(outputName, "unsupportedQueryShape", [], requiredBy));
+            }
+            return baseResult;
+        }
+
+        const outputMetadata = this.collectTargetOutputMetadata(descriptor.query);
+        baseResult.wildcards = outputMetadata.wildcards;
+        baseResult.explicitColumns = outputMetadata.explicitColumns;
+
+        for (const [outputName, requiredBy] of requirement.requiredByColumn) {
+            const explicitMatches = outputMetadata.explicitColumns.filter(item => item.outputName === outputName);
+            const candidateWildcards = outputMetadata.wildcards;
+
+            if (explicitMatches.length > 0 && candidateWildcards.length > 0) {
+                baseResult.unresolvedColumns.push(this.createUnresolved(outputName, "duplicateOutputOwnership", candidateWildcards, requiredBy));
+                continue;
+            }
+
+            if (explicitMatches.length > 0) {
+                continue;
+            }
+
+            if (outputMetadata.unqualifiedWildcardWithMultipleSources) {
+                baseResult.unresolvedColumns.push(this.createUnresolved(outputName, "unqualifiedWildcardMultipleSources", candidateWildcards, requiredBy));
+                continue;
+            }
+
+            if (candidateWildcards.length === 0) {
+                baseResult.unresolvedColumns.push(this.createUnresolved(outputName, "noWildcardSupplier", [], requiredBy));
+                continue;
+            }
+
+            if (candidateWildcards.length > 1) {
+                baseResult.unresolvedColumns.push(this.createUnresolved(outputName, "multipleWildcardSuppliers", candidateWildcards, requiredBy));
+                continue;
+            }
+
+            const wildcard = candidateWildcards[0];
+            baseResult.requiredColumns.push({
+                outputName,
+                sourceAlias: wildcard.sourceAlias,
+                sourceName: wildcard.sourceName,
+                sourceColumnName: outputName,
+                wildcard,
+                requiredByClause: this.collectRequiredByClauses(requiredBy),
+                requiredBy
+            });
+        }
+
+        return baseResult;
+    }
+
+    private collectTargetOutputMetadata(query: SimpleSelectQuery): TargetOutputMetadata {
+        const wildcards: WildcardColumnInferenceWildcard[] = [];
+        let unqualifiedWildcardWithMultipleSources = false;
+
+        query.selectClause.items.forEach((item, outputIndex) => {
+            const wildcard = this.collectWildcardMetadata(item, outputIndex, query.fromClause);
+            if (wildcard === "unqualifiedWildcardMultipleSources") {
+                unqualifiedWildcardWithMultipleSources = true;
+                wildcards.push({
+                    kind: "unqualified",
+                    outputIndex,
+                    sourceAlias: null,
+                    sourceName: null
+                });
+                return;
+            }
+            if (wildcard) {
+                wildcards.push(wildcard);
+            }
+        });
+
+        const explicitColumns = new SelectOutputCollector()
+            .collect(query)
+            .filter(item => !(item.value instanceof ColumnReference && item.value.column.name === "*"))
+            .map(item => ({
+                outputName: item.name,
+                sourceAlias: item.sourceAlias,
+                sourceName: item.sourceName,
+                sourceColumnName: item.sourceColumnName
+            }));
+
+        return {
+            wildcards,
+            explicitColumns,
+            unqualifiedWildcardWithMultipleSources
+        };
+    }
+
+    private collectWildcardMetadata(
+        item: SelectItem,
+        outputIndex: number,
+        fromClause: FromClause | null
+    ): WildcardColumnInferenceWildcard | "unqualifiedWildcardMultipleSources" | null {
+        if (!(item.value instanceof ColumnReference) || item.value.column.name !== "*") {
+            return null;
+        }
+
+        if (!fromClause) {
+            return null;
+        }
+
+        if (item.value.namespaces === null) {
+            const sources = fromClause.getSources();
+            if (sources.length !== 1) {
+                return "unqualifiedWildcardMultipleSources";
+            }
+            return {
+                kind: "unqualified",
+                outputIndex,
+                sourceAlias: sources[0].getAliasName(),
+                sourceName: this.getSourceName(sources[0])
+            };
+        }
+
+        const namespace = item.value.getNamespace();
+        const source = this.getUniqueSource(fromClause.getSources().filter(candidate => this.getSourceMatchNames(candidate).includes(namespace)));
+        return {
+            kind: "qualified",
+            outputIndex,
+            sourceAlias: namespace,
+            sourceName: source ? this.getSourceName(source) : null
+        };
+    }
+
+    private createUnresolved(
+        outputName: string,
+        reason: WildcardColumnInferenceUnresolvedReason,
+        candidateWildcards: WildcardColumnInferenceWildcard[],
+        requiredBy: WildcardColumnInferenceRequiredBy[]
+    ): WildcardColumnInferenceUnresolvedColumn {
+        return {
+            outputName,
+            reason,
+            candidateWildcards,
+            requiredByClause: this.collectRequiredByClauses(requiredBy),
+            requiredBy
+        };
+    }
+
+    private flattenReferences(references: ReturnType<ClauseScopedColumnReferenceCollector["collect"]>): ClauseScopedColumnReferenceInfo[] {
+        return clauseOrder.flatMap(clause => references[clause]);
+    }
+
+    private createRequiredBy(reference: ClauseScopedColumnReferenceInfo): WildcardColumnInferenceRequiredBy {
+        return {
+            clause: reference.clause,
+            qualifiedName: reference.qualifiedName,
+            namespace: reference.namespace,
+            column: reference.column
+        };
+    }
+
+    private collectRequiredByClauses(requiredBy: WildcardColumnInferenceRequiredBy[]): ClauseScopedColumnReferenceClause[] {
+        const clauses = new Set(requiredBy.map(item => item.clause));
+        return clauseOrder.filter(clause => clauses.has(clause));
+    }
+
+    private getTargetMatchNames(target: TargetDescriptor): string[] {
+        if (target.targetAlias) {
+            return [target.targetAlias];
+        }
+        return target.targetName ? [target.targetName] : [];
+    }
+
+    private getUniqueTarget(targets: TargetDescriptor[]): TargetDescriptor | null {
+        return targets.length === 1 ? targets[0] : null;
+    }
+
+    private getUniqueSource(sources: SourceExpression[]): SourceExpression | null {
+        return sources.length === 1 ? sources[0] : null;
+    }
+
+    private getSourceMatchNames(source: SourceExpression): string[] {
+        const names = new Set<string>();
+        const aliasName = source.getAliasName();
+        if (aliasName) {
+            names.add(aliasName);
+        }
+        if (source.datasource instanceof TableSource) {
+            names.add(source.datasource.table.name);
+            names.add(source.datasource.getSourceName());
+        }
+        return [...names];
+    }
+
+    private getSourceName(source: SourceExpression): string | null {
+        if (source.datasource instanceof TableSource) {
+            return source.datasource.getSourceName();
+        }
+        return null;
+    }
+
+    private collectLeadingCommonTables(query: SelectQuery): CommonTable[] {
+        if (query instanceof SimpleSelectQuery) {
+            return query.withClause?.tables ?? [];
+        }
+
+        if (query instanceof BinarySelectQuery) {
+            return this.collectLeadingCommonTables(query.left);
+        }
+
+        return [];
+    }
+
+    private mergeCommonTables(left: CommonTable[], right: CommonTable[]): CommonTable[] {
+        const merged = [...left];
+        for (const table of right) {
+            const existingIndex = merged.findIndex(item => item.getSourceAliasName() === table.getSourceAliasName());
+            if (existingIndex === -1) {
+                merged.push(table);
+            } else {
+                merged[existingIndex] = table;
+            }
+        }
+        return merged;
+    }
+
+    private getObjectId(value: object): number {
+        const existing = this.objectIds.get(value);
+        if (existing !== undefined) {
+            return existing;
+        }
+
+        const id = this.nextObjectId++;
+        this.objectIds.set(value, id);
+        return id;
+    }
+
+    private isSelectQuery(query: unknown): query is SelectQuery {
+        return !!query && typeof query === "object" && "__selectQueryType" in query && (query as SelectQuery).__selectQueryType === "SelectQuery";
+    }
+}

--- a/packages/core/tests/transformers/WildcardColumnInferenceCollector.test.ts
+++ b/packages/core/tests/transformers/WildcardColumnInferenceCollector.test.ts
@@ -1,0 +1,433 @@
+import { describe, expect, test } from 'vitest';
+import { SubQuerySource } from '../../src/models/Clause';
+import { SimpleSelectQuery } from '../../src/models/SimpleSelectQuery';
+import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
+import { WildcardColumnInferenceCollector } from '../../src/transformers/WildcardColumnInferenceCollector';
+
+const collect = (sql: string) => new WildcardColumnInferenceCollector().collect(SelectQueryParser.parse(sql));
+
+describe('WildcardColumnInferenceCollector', () => {
+    test('infers qualified wildcard columns required by downstream CTE references', () => {
+        const result = collect(`
+            WITH cte AS (
+                SELECT a.*
+                FROM a
+            )
+            SELECT cte.id
+            FROM cte
+        `);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].targetKind).toBe('cte');
+        expect(result[0].targetName).toBe('cte');
+        expect(result[0].wildcards).toEqual([
+            { kind: 'qualified', outputIndex: 0, sourceAlias: 'a', sourceName: 'a' }
+        ]);
+        expect(result[0].requiredColumns).toEqual([
+            {
+                outputName: 'id',
+                sourceAlias: 'a',
+                sourceName: 'a',
+                sourceColumnName: 'id',
+                wildcard: { kind: 'qualified', outputIndex: 0, sourceAlias: 'a', sourceName: 'a' },
+                requiredByClause: ['select'],
+                requiredBy: [{ clause: 'select', qualifiedName: 'cte.id', namespace: 'cte', column: 'id' }]
+            }
+        ]);
+        expect(result[0].unresolvedColumns).toEqual([]);
+    });
+
+    test('uses the CTE consumer alias when one is present', () => {
+        const result = collect(`
+            WITH cte AS (
+                SELECT a.*
+                FROM a
+            )
+            SELECT x.id
+            FROM cte AS x
+        `);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].targetName).toBe('cte');
+        expect(result[0].targetAlias).toBe('x');
+        expect(result[0].requiredColumns.map(item => item.outputName)).toEqual(['id']);
+        expect(result[0].requiredColumns[0].requiredBy).toEqual([
+            { clause: 'select', qualifiedName: 'x.id', namespace: 'x', column: 'id' }
+        ]);
+    });
+
+    test('does not treat a CTE name as a downstream requirement after consumer aliasing', () => {
+        const result = collect(`
+            WITH cte AS (
+                SELECT a.*
+                FROM a
+            )
+            SELECT cte.id
+            FROM cte AS x
+        `);
+
+        expect(result).toEqual([]);
+    });
+
+    test('unions qualified wildcard requirements across UNION ALL branches and preserves explicit outputs', () => {
+        const result = collect(`
+            WITH cte AS (
+                SELECT
+                    a.*,
+                    b.value
+                FROM a
+                JOIN b ON b.a_id = a.id
+            )
+            SELECT cte.id
+            FROM cte
+            UNION ALL
+            SELECT cte.parent_id
+            FROM cte
+        `);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].explicitColumns).toEqual([
+            { outputName: 'value', sourceAlias: 'b', sourceName: 'b', sourceColumnName: 'value' }
+        ]);
+        expect(result[0].requiredColumns.map(item => ({
+            outputName: item.outputName,
+            sourceAlias: item.sourceAlias,
+            sourceName: item.sourceName,
+            sourceColumnName: item.sourceColumnName,
+            requiredByClause: item.requiredByClause,
+            requiredBy: item.requiredBy
+        }))).toEqual([
+            {
+                outputName: 'id',
+                sourceAlias: 'a',
+                sourceName: 'a',
+                sourceColumnName: 'id',
+                requiredByClause: ['select'],
+                requiredBy: [{ clause: 'select', qualifiedName: 'cte.id', namespace: 'cte', column: 'id' }]
+            },
+            {
+                outputName: 'parent_id',
+                sourceAlias: 'a',
+                sourceName: 'a',
+                sourceColumnName: 'parent_id',
+                requiredByClause: ['select'],
+                requiredBy: [{ clause: 'select', qualifiedName: 'cte.parent_id', namespace: 'cte', column: 'parent_id' }]
+            }
+        ]);
+        expect(result[0].unresolvedColumns).toEqual([]);
+    });
+
+    test('infers unqualified wildcard only when the target has a single source candidate', () => {
+        const result = collect(`
+            SELECT id
+            FROM (
+                SELECT *
+                FROM table_a
+            ) AS a
+        `);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].targetKind).toBe('derivedTable');
+        expect(result[0].targetAlias).toBe('a');
+        expect(result[0].wildcards).toEqual([
+            { kind: 'unqualified', outputIndex: 0, sourceAlias: 'table_a', sourceName: 'table_a' }
+        ]);
+        expect(result[0].requiredColumns.map(item => ({
+            outputName: item.outputName,
+            sourceAlias: item.sourceAlias,
+            sourceName: item.sourceName,
+            sourceColumnName: item.sourceColumnName,
+            requiredByClause: item.requiredByClause
+        }))).toEqual([
+            {
+                outputName: 'id',
+                sourceAlias: 'table_a',
+                sourceName: 'table_a',
+                sourceColumnName: 'id',
+                requiredByClause: ['select']
+            }
+        ]);
+        expect(result[0].unresolvedColumns).toEqual([]);
+    });
+
+    test('reports unresolved when unqualified wildcard ownership is ambiguous', () => {
+        const result = collect(`
+            SELECT d.id
+            FROM (
+                SELECT *
+                FROM table_a AS a
+                JOIN table_b AS b ON b.a_id = a.id
+            ) AS d
+        `);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].requiredColumns).toEqual([]);
+        expect(result[0].unresolvedColumns).toEqual([
+            {
+                outputName: 'id',
+                reason: 'unqualifiedWildcardMultipleSources',
+                candidateWildcards: [
+                    { kind: 'unqualified', outputIndex: 0, sourceAlias: null, sourceName: null }
+                ],
+                requiredByClause: ['select'],
+                requiredBy: [{ clause: 'select', qualifiedName: 'd.id', namespace: 'd', column: 'id' }]
+            }
+        ]);
+    });
+
+    test('reports unresolved when multiple qualified wildcards could supply the same output', () => {
+        const result = collect(`
+            WITH cte AS (
+                SELECT
+                    a.*,
+                    b.*
+                FROM table_a AS a
+                JOIN table_b AS b ON b.a_id = a.id
+            )
+            SELECT cte.id
+            FROM cte
+        `);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].requiredColumns).toEqual([]);
+        expect(result[0].unresolvedColumns.map(item => ({
+            outputName: item.outputName,
+            reason: item.reason,
+            candidateWildcards: item.candidateWildcards,
+            requiredByClause: item.requiredByClause
+        }))).toEqual([
+            {
+                outputName: 'id',
+                reason: 'multipleWildcardSuppliers',
+                candidateWildcards: [
+                    { kind: 'qualified', outputIndex: 0, sourceAlias: 'a', sourceName: 'table_a' },
+                    { kind: 'qualified', outputIndex: 1, sourceAlias: 'b', sourceName: 'table_b' }
+                ],
+                requiredByClause: ['select']
+            }
+        ]);
+    });
+
+    test('reports unresolved when explicit output and wildcard both expose a required name', () => {
+        const result = collect(`
+            WITH cte AS (
+                SELECT
+                    a.*,
+                    b.id
+                FROM table_a AS a
+                JOIN table_b AS b ON b.a_id = a.id
+            )
+            SELECT cte.id
+            FROM cte
+        `);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].requiredColumns).toEqual([]);
+        expect(result[0].unresolvedColumns).toEqual([
+            {
+                outputName: 'id',
+                reason: 'duplicateOutputOwnership',
+                candidateWildcards: [
+                    { kind: 'qualified', outputIndex: 0, sourceAlias: 'a', sourceName: 'table_a' }
+                ],
+                requiredByClause: ['select'],
+                requiredBy: [{ clause: 'select', qualifiedName: 'cte.id', namespace: 'cte', column: 'id' }]
+            }
+        ]);
+    });
+
+    test('reports unresolved when no wildcard can supply a missing required output', () => {
+        const result = collect(`
+            WITH cte AS (
+                SELECT b.value
+                FROM table_b AS b
+            )
+            SELECT cte.id
+            FROM cte
+        `);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].requiredColumns).toEqual([]);
+        expect(result[0].unresolvedColumns).toEqual([
+            {
+                outputName: 'id',
+                reason: 'noWildcardSupplier',
+                candidateWildcards: [],
+                requiredByClause: ['select'],
+                requiredBy: [{ clause: 'select', qualifiedName: 'cte.id', namespace: 'cte', column: 'id' }]
+            }
+        ]);
+    });
+
+    test('reports unresolved for unsupported target query shapes', () => {
+        const result = collect(`
+            WITH cte AS (
+                SELECT a.*
+                FROM table_a AS a
+                UNION ALL
+                SELECT b.*
+                FROM table_b AS b
+            )
+            SELECT cte.id
+            FROM cte
+        `);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].targetKind).toBe('cte');
+        expect(result[0].targetName).toBe('cte');
+        expect(result[0].requiredColumns).toEqual([]);
+        expect(result[0].unresolvedColumns).toEqual([
+            {
+                outputName: 'id',
+                reason: 'unsupportedQueryShape',
+                candidateWildcards: [],
+                requiredByClause: ['select'],
+                requiredBy: [{ clause: 'select', qualifiedName: 'cte.id', namespace: 'cte', column: 'id' }]
+            }
+        ]);
+    });
+
+    test('uses the innermost CTE when nested WITH clauses shadow outer names', () => {
+        const result = collect(`
+            WITH cte AS (
+                SELECT outer_source.*
+                FROM outer_source
+            )
+            SELECT wrapper.id
+            FROM (
+                WITH cte AS (
+                    SELECT inner_source.*
+                    FROM inner_source
+                )
+                SELECT cte.id
+                FROM cte
+            ) AS wrapper
+        `);
+
+        expect(result).toHaveLength(2);
+        expect(result.map(item => ({
+            targetKind: item.targetKind,
+            targetName: item.targetName,
+            targetAlias: item.targetAlias,
+            requiredColumns: item.requiredColumns.map(column => ({
+                outputName: column.outputName,
+                sourceAlias: column.sourceAlias,
+                sourceName: column.sourceName
+            }))
+        }))).toEqual([
+            {
+                targetKind: 'derivedTable',
+                targetName: null,
+                targetAlias: 'wrapper',
+                requiredColumns: []
+            },
+            {
+                targetKind: 'cte',
+                targetName: 'cte',
+                targetAlias: 'cte',
+                requiredColumns: [
+                    { outputName: 'id', sourceAlias: 'inner_source', sourceName: 'inner_source' }
+                ]
+            }
+        ]);
+    });
+
+    test('tracks requiredByClause across downstream consumer clauses', () => {
+        const result = collect(`
+            WITH cte AS (
+                SELECT a.*
+                FROM accounts AS a
+            )
+            SELECT cte.id, SUM(cte.score) AS total_score
+            FROM cte
+            JOIN audit_log AS l ON l.account_id = cte.join_id
+            WHERE cte.active = true
+            GROUP BY cte.id, cte.region
+            HAVING SUM(cte.score) > 0
+            ORDER BY cte.created_at
+        `);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].requiredColumns.map(item => ({
+            outputName: item.outputName,
+            requiredByClause: item.requiredByClause,
+            requiredBy: item.requiredBy
+        }))).toEqual([
+            {
+                outputName: 'id',
+                requiredByClause: ['select', 'groupBy'],
+                requiredBy: [
+                    { clause: 'select', qualifiedName: 'cte.id', namespace: 'cte', column: 'id' },
+                    { clause: 'groupBy', qualifiedName: 'cte.id', namespace: 'cte', column: 'id' }
+                ]
+            },
+            {
+                outputName: 'score',
+                requiredByClause: ['select', 'having'],
+                requiredBy: [
+                    { clause: 'select', qualifiedName: 'cte.score', namespace: 'cte', column: 'score' },
+                    { clause: 'having', qualifiedName: 'cte.score', namespace: 'cte', column: 'score' }
+                ]
+            },
+            {
+                outputName: 'active',
+                requiredByClause: ['where'],
+                requiredBy: [{ clause: 'where', qualifiedName: 'cte.active', namespace: 'cte', column: 'active' }]
+            },
+            {
+                outputName: 'join_id',
+                requiredByClause: ['joinOn'],
+                requiredBy: [{ clause: 'joinOn', qualifiedName: 'cte.join_id', namespace: 'cte', column: 'join_id' }]
+            },
+            {
+                outputName: 'region',
+                requiredByClause: ['groupBy'],
+                requiredBy: [{ clause: 'groupBy', qualifiedName: 'cte.region', namespace: 'cte', column: 'region' }]
+            },
+            {
+                outputName: 'created_at',
+                requiredByClause: ['orderBy'],
+                requiredBy: [{ clause: 'orderBy', qualifiedName: 'cte.created_at', namespace: 'cte', column: 'created_at' }]
+            }
+        ]);
+        expect(result[0].unresolvedColumns).toEqual([]);
+    });
+
+    test('resets object id tracking for each collect call on reused collector instances', () => {
+        const collector = new WildcardColumnInferenceCollector();
+        const warmup = SelectQueryParser.parse(`
+            SELECT x.id
+            FROM (
+                SELECT *
+                FROM x_source
+            ) AS x
+        `) as SimpleSelectQuery;
+
+        collector.collect(warmup);
+
+        const previousDerivedQuery = (warmup.fromClause!.source.datasource as SubQuerySource).query;
+        const mixed = SelectQueryParser.parse(`
+            SELECT x.id, y.code
+            FROM (
+                SELECT *
+                FROM placeholder
+            ) AS x
+            JOIN (
+                SELECT *
+                FROM y_source
+            ) AS y ON 1 = 1
+        `) as SimpleSelectQuery;
+
+        (mixed.fromClause!.source.datasource as SubQuerySource).query = previousDerivedQuery;
+
+        const result = collector.collect(mixed);
+
+        expect(result.map(item => ({
+            targetAlias: item.targetAlias,
+            requiredColumns: item.requiredColumns.map(column => column.outputName)
+        }))).toEqual([
+            { targetAlias: 'x', requiredColumns: ['id'] },
+            { targetAlias: 'y', requiredColumns: ['code'] }
+        ]);
+    });
+});


### PR DESCRIPTION
## Summary

- Fixes #918.
- Adds `WildcardColumnInferenceCollector`, a metadata-only core API that infers the subset of wildcard output columns required by downstream CTE and derived-table references.
- Reports `requiredByClause`/`requiredBy` clause metadata and conservative unresolved states for ambiguous wildcard ownership, without SQL rewrite or full table-column discovery.
- Exports the new collector and adds a changeset for the public core API.

## Acceptance / Residual Risk

- Qualified wildcard inference: covered by `WITH cte AS (SELECT a.* FROM a) SELECT cte.id FROM cte`, resolving `a.id`.
- Qualified wildcard plus explicit output and `UNION ALL` branch union: covered by CTE tests resolving `a.id` and `a.parent_id` while preserving explicit `b.value`.
- Unqualified wildcard inference: covered for a single-source derived table and unresolved for a multi-source join.
- Ambiguous ownership: covered for multiple qualified wildcard suppliers and multi-source unqualified wildcard ownership.
- Clause-scoped downstream references: covered for SELECT, WHERE, JOIN ON, GROUP BY, HAVING, and ORDER BY.
- Residual risk: this is intentionally a conservative metadata API. It does not infer complete table schemas, resolve ambiguous duplicate output ownership, or rewrite SQL.

## Verification

- `pnpm --filter rawsql-ts test`
- `pnpm --filter rawsql-ts build`
- `pnpm --filter rawsql-ts lint`
- Pre-commit hook also passed workspace `typecheck`, workspace `test`, workspace `build`, and workspace `lint`.

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

<!-- Write values on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. -->
<!-- Do not add list markers like "-" before these labels; `Tracking issue:` and `Scoped checks run:` must start at column 0. -->
Tracking issue: #918
Scoped checks run: pnpm --filter rawsql-ts test; pnpm --filter rawsql-ts build; pnpm --filter rawsql-ts lint; pre-commit workspace typecheck/test/build/lint
Why full baseline is not required: No baseline exception requested; the pre-commit hook ran the workspace checks.

## Self Review

<!-- Fill these fields after running the repo self-review workflow or available self-review skill. -->
Self-review workflow: developer-self-review and self-review two-cycle review
Self-review result: No blockers remain; unqualified ambiguous wildcard metadata was tightened before PR.
Concept-review workflow: packages/core AGENTS.md and DESIGN.md package-boundary review
Concept-review result: No package-boundary or concept violation found; change stays DBMS-neutral, metadata-only, and avoids rewrite/runtime semantics.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-migration rationale: Core analyzer API addition only; no CLI behavior or command surface changed.
Upgrade note: New optional core metadata API is available as `WildcardColumnInferenceCollector`.
Deprecation/removal plan or issue: No deprecation or removal.
Docs/help/examples updated: Not required for CLI help; behavior is covered by core tests and changeset.
Release/changeset wording: `.changeset/wildcard-column-inference.md`

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-proof rationale: No scaffold files, generated scaffold output, or scaffold contracts changed.
Non-edit assertion: Not applicable.
Fail-fast input-contract proof: Not applicable.
Generated-output viability proof: Not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for inferring which wildcard columns are needed from downstream query usage.
  * Expanded the public API with new wildcard inference results and collector utilities.
  * Added coverage for common SQL patterns, including CTEs, derived tables, joins, unions, and clause-specific references.

* **Bug Fixes**
  * Improved handling of ambiguous wildcard ownership by marking unclear columns as unresolved instead of guessing.
  * Better tracks column requirements across multiple query clauses such as `WHERE`, `GROUP BY`, `HAVING`, and `ORDER BY`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->