### PR TITLE
Add AST comment attachment extractor

### DIFF
--- a/.changeset/ast-comment-attachments.md
+++ b/.changeset/ast-comment-attachments.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": minor
+---
+
+Add a generic AST comment attachment extraction API for comment text, source order, conservative placement, and optional target nodes.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,6 +47,7 @@ export * from './transformers/CTETableReferenceCollector';
 export * from './transformers/CTEQueryDecomposer';
 export type { CTERestorationResult } from './transformers/CTEQueryDecomposer';
 export * from './transformers/NamedQueryDefinitionExtractor';
+export * from './transformers/AstCommentAttachmentExtractor';
 export * from './transformers/CTEComposer';
 export * from './transformers/CTERenamer';
 export * from './transformers/AliasRenamer';

--- a/packages/core/src/transformers/AstCommentAttachmentExtractor.ts
+++ b/packages/core/src/transformers/AstCommentAttachmentExtractor.ts
@@ -1,0 +1,308 @@
+import { BinarySelectQuery, SelectQuery, SimpleSelectQuery, ValuesQuery } from "../models/SelectQuery";
+import { CommonTable, SelectClause, SelectItem, SourceAliasExpression, WithClause } from "../models/Clause";
+import { SqlComponent, PositionedComment } from "../models/SqlComponent";
+
+/**
+ * Source span for a comment when parser metadata is available.
+ *
+ * @remarks The current parser stores comment text on AST nodes but does not
+ * retain reliable per-comment source spans, so extractors usually omit this.
+ */
+export interface AstCommentSourceRange {
+    start: number;
+    end: number;
+}
+
+/**
+ * Conservatively describes where an AST comment fact appears relative to syntax.
+ */
+export type AstCommentPlacement = "leading" | "trailing" | "inner" | "detached";
+
+/**
+ * Generic comment fact extracted from SQL AST comment metadata.
+ *
+ * @remarks `targetNode` is optional because SQL comments do not always have a
+ * strict syntactic owner. Ambiguous legacy buckets are emitted as detached.
+ */
+export interface AstCommentAttachment {
+    text: string;
+    sourceOrder: number;
+    placement: AstCommentPlacement;
+    targetNode?: SqlComponent;
+    range?: AstCommentSourceRange;
+}
+
+/**
+ * Extracts comment attachment facts already represented in the SQL AST.
+ *
+ * @remarks This API does not infer product-specific meanings or rewrite
+ * comments. It returns a deterministic flat list without mutating the input AST.
+ */
+export class AstCommentAttachmentExtractor {
+    private readonly attachments: AstCommentAttachment[] = [];
+    private readonly visited = new Set<object>();
+    private readonly suppressedDetachedCommentArrays = new WeakSet<string[]>();
+
+    /**
+     * Extract comment attachment facts from a SQL AST component.
+     */
+    public static extract(input: SqlComponent | null | undefined): AstCommentAttachment[] {
+        if (!input) {
+            return [];
+        }
+
+        const extractor = new AstCommentAttachmentExtractor();
+        extractor.visit(input);
+        return extractor.attachments;
+    }
+
+    private visit(value: unknown): void {
+        if (!value || typeof value !== "object") {
+            return;
+        }
+
+        if (this.visited.has(value)) {
+            return;
+        }
+        this.visited.add(value);
+
+        if (Array.isArray(value)) {
+            for (const item of value) {
+                this.visit(item);
+            }
+            return;
+        }
+
+        if (value instanceof SqlComponent) {
+            this.visitSqlComponent(value);
+            return;
+        }
+    }
+
+    private visitSqlComponent(component: SqlComponent): void {
+        this.emitHeaderComments(component);
+        this.emitPositionedComments(component, "before");
+        if (!(component instanceof SimpleSelectQuery)) {
+            this.emitLegacyComments(component);
+        }
+
+        if (component instanceof SelectItem) {
+            this.emitPositionedComments(component, "after");
+            this.emitSelectItemKeywordComments(component);
+            this.visit(component.value);
+            this.visit(component.identifier);
+            return;
+        }
+
+        if (component instanceof CommonTable) {
+            this.visit(component.aliasExpression);
+            this.visit(component.query);
+            this.emitPositionedComments(component, "after");
+            return;
+        }
+
+        if (component instanceof WithClause) {
+            this.visit(component.tables);
+            this.emitDetachedComments(component.trailingComments);
+            this.emitDetachedComments(component.globalComments);
+            this.emitPositionedComments(component, "after");
+            return;
+        }
+
+        if (component instanceof SimpleSelectQuery) {
+            this.suppressWithClauseTrailingCommentsAlreadyCopiedToQuery(component);
+            this.visit(component.withClause);
+            this.emitLegacyComments(component);
+            this.visit(component.selectClause);
+            this.visit(component.fromClause);
+            this.visit(component.whereClause);
+            this.visit(component.groupByClause);
+            this.visit(component.havingClause);
+            this.visit(component.windowClause);
+            this.visit(component.orderByClause);
+            this.visit(component.limitClause);
+            this.visit(component.offsetClause);
+            this.visit(component.fetchClause);
+            this.visit(component.forClause);
+            this.emitPositionedComments(component, "after");
+            return;
+        }
+
+        if (component instanceof BinarySelectQuery) {
+            this.visit(component.left);
+            this.visit(component.right);
+            this.emitPositionedComments(component, "after");
+            return;
+        }
+
+        if (component instanceof ValuesQuery) {
+            this.visit(component.withClause);
+            this.visit(component.tuples);
+            this.emitPositionedComments(component, "after");
+            return;
+        }
+
+        if (component instanceof SelectClause) {
+            this.visit(component.distinct);
+            this.visit(component.hints);
+            this.visit(component.items);
+            this.emitPositionedComments(component, "after");
+            return;
+        }
+
+        if (component instanceof SourceAliasExpression) {
+            this.visit(component.table);
+            this.visit(component.columns);
+            this.emitPositionedComments(component, "after");
+            return;
+        }
+
+        this.visitFallbackProperties(component);
+        this.emitPositionedComments(component, "after");
+    }
+
+    private visitFallbackProperties(component: SqlComponent): void {
+        for (const key of Object.keys(component)) {
+            if (this.shouldSkipProperty(key)) {
+                continue;
+            }
+            this.visit((component as unknown as Record<string, unknown>)[key]);
+        }
+    }
+
+    private shouldSkipProperty(key: string): boolean {
+        return key === "comments" ||
+            key === "positionedComments" ||
+            key === "headerComments" ||
+            key === "trailingComments" ||
+            key === "globalComments" ||
+            key === "asKeywordPositionedComments" ||
+            key === "asKeywordComments" ||
+            key === "aliasPositionedComments" ||
+            key === "aliasComments" ||
+            key === "cteNameCache";
+    }
+
+    private emitHeaderComments(component: SqlComponent): void {
+        if (!this.isSelectQuery(component)) {
+            return;
+        }
+
+        this.emitComments(component.headerComments, "leading", component);
+    }
+
+    private emitLegacyComments(component: SqlComponent): void {
+        this.emitComments(component.comments, "detached");
+    }
+
+    private emitPositionedComments(component: SqlComponent, position: PositionedComment["position"]): void {
+        if (!component.positionedComments) {
+            return;
+        }
+
+        for (const positionedComment of component.positionedComments) {
+            if (positionedComment.position !== position) {
+                continue;
+            }
+            this.emitComments(
+                positionedComment.comments,
+                position === "before" ? "leading" : "trailing",
+                component
+            );
+        }
+    }
+
+    private emitSelectItemKeywordComments(selectItem: SelectItem): void {
+        const itemWithCommentFields = selectItem as SelectItem & {
+            asKeywordPositionedComments?: PositionedComment[];
+            asKeywordComments?: string[] | null;
+            aliasPositionedComments?: PositionedComment[];
+            aliasComments?: string[] | null;
+        };
+
+        this.emitKeywordPositionedComments(itemWithCommentFields.asKeywordPositionedComments, selectItem, "inner");
+        this.emitComments(itemWithCommentFields.asKeywordComments, "inner", selectItem);
+        this.emitKeywordPositionedComments(itemWithCommentFields.aliasPositionedComments, selectItem);
+        this.emitComments(itemWithCommentFields.aliasComments, "trailing", selectItem);
+    }
+
+    private emitKeywordPositionedComments(
+        positionedComments: PositionedComment[] | undefined,
+        targetNode: SqlComponent,
+        placementOverride?: AstCommentPlacement
+    ): void {
+        if (!positionedComments) {
+            return;
+        }
+
+        for (const positionedComment of positionedComments) {
+            const placement = placementOverride ??
+                (positionedComment.position === "before" ? "leading" : "trailing");
+            this.emitComments(positionedComment.comments, placement, targetNode);
+        }
+    }
+
+    private emitDetachedComments(comments: string[] | null | undefined): void {
+        if (comments && this.suppressedDetachedCommentArrays.has(comments)) {
+            return;
+        }
+        this.emitComments(comments, "detached");
+    }
+
+    private emitComments(
+        comments: string[] | null | undefined,
+        placement: AstCommentPlacement,
+        targetNode?: SqlComponent
+    ): void {
+        if (!comments) {
+            return;
+        }
+
+        for (const text of comments) {
+            this.attachments.push({
+                text,
+                sourceOrder: this.attachments.length,
+                placement,
+                ...(targetNode ? { targetNode } : {})
+            });
+        }
+    }
+
+    private isSelectQuery(component: SqlComponent): component is SelectQuery {
+        return "__selectQueryType" in component &&
+            (component as SelectQuery).__selectQueryType === "SelectQuery";
+    }
+
+    private suppressWithClauseTrailingCommentsAlreadyCopiedToQuery(query: SimpleSelectQuery): void {
+        const trailingComments = query.withClause?.trailingComments;
+        if (!trailingComments || !query.comments) {
+            return;
+        }
+
+        if (this.containsCommentSequence(query.comments, trailingComments)) {
+            this.suppressedDetachedCommentArrays.add(trailingComments);
+        }
+    }
+
+    private containsCommentSequence(source: string[], candidate: string[]): boolean {
+        if (candidate.length === 0) {
+            return true;
+        }
+
+        for (let start = 0; start <= source.length - candidate.length; start++) {
+            const matches = candidate.every((comment, index) => source[start + index] === comment);
+            if (matches) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
+/**
+ * Extract comment attachment facts from a SQL AST component.
+ */
+export function extractAstCommentAttachments(input: SqlComponent | null | undefined): AstCommentAttachment[] {
+    return AstCommentAttachmentExtractor.extract(input);
+}

--- a/packages/core/tests/transformers/AstCommentAttachmentExtractor.test.ts
+++ b/packages/core/tests/transformers/AstCommentAttachmentExtractor.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "vitest";
+import {
+    AstCommentAttachment,
+    extractAstCommentAttachments,
+    SelectItem,
+    SelectQueryParser,
+    SqlFormatter
+} from "../../src";
+
+function texts(attachments: AstCommentAttachment[]): string[] {
+    return attachments.map((attachment) => attachment.text);
+}
+
+describe("AstCommentAttachmentExtractor", () => {
+    test("extracts query header comments in source order", () => {
+        const query = SelectQueryParser.parse(`
+            -- query header one
+            -- query header two
+            SELECT id FROM users
+        `);
+
+        const attachments = extractAstCommentAttachments(query);
+
+        expect(texts(attachments).slice(0, 2)).toEqual([
+            "query header one",
+            "query header two"
+        ]);
+        expect(attachments[0]).toMatchObject({
+            text: "query header one",
+            sourceOrder: 0,
+            placement: "leading",
+            targetNode: query
+        });
+        expect(attachments[1]).toMatchObject({
+            text: "query header two",
+            sourceOrder: 1,
+            placement: "leading",
+            targetNode: query
+        });
+    });
+
+    test("extracts CTE leading comments without assigning product meaning", () => {
+        const query = SelectQueryParser.parse(`
+            -- query header
+            WITH
+            -- first cte leading
+            raw_sales AS (
+                -- inner query header
+                SELECT id FROM sales
+            ),
+            -- second cte leading
+            summarized AS (
+                SELECT id FROM raw_sales
+            )
+            SELECT id FROM summarized
+        `).toSimpleQuery();
+
+        const attachments = extractAstCommentAttachments(query);
+
+        expect(texts(attachments).slice(0, 5)).toEqual([
+            "query header",
+            "first cte leading",
+            "inner query header",
+            "second cte leading"
+        ]);
+
+        const firstCteComment = attachments.find((attachment) => attachment.text === "first cte leading");
+        const secondCteComment = attachments.find((attachment) => attachment.text === "second cte leading");
+
+        expect(firstCteComment).toMatchObject({
+            placement: "leading",
+            targetNode: query.withClause!.tables[0].aliasExpression.table
+        });
+        expect(secondCteComment).toMatchObject({
+            placement: "leading",
+            targetNode: query.withClause!.tables[1].aliasExpression
+        });
+    });
+
+    test("extracts SELECT item comments already represented in the AST", () => {
+        const query = SelectQueryParser.parse(`
+            SELECT /* value leading */ id /* value trailing */ AS /* as keyword */ identifier /* alias trailing */
+            FROM users
+        `).toSimpleQuery();
+        const selectItem = query.selectClause.items[0];
+
+        const attachments = extractAstCommentAttachments(query);
+        const itemAttachments = attachments.filter((attachment) => attachment.targetNode === selectItem);
+
+        expect(selectItem).toBeInstanceOf(SelectItem);
+        expect(texts(itemAttachments)).toEqual([
+            "value leading",
+            "value trailing",
+            "as keyword",
+            "alias trailing"
+        ]);
+        expect(itemAttachments.map((attachment) => attachment.placement)).toEqual([
+            "leading",
+            "trailing",
+            "inner",
+            "trailing"
+        ]);
+    });
+
+    test("marks ambiguous comments as detached instead of over-associating them", () => {
+        const query = SelectQueryParser.parse(`
+            WITH raw_sales AS (
+                SELECT id FROM sales
+            )
+            -- ambiguous main select prefix
+            SELECT id FROM raw_sales
+        `);
+
+        const attachments = extractAstCommentAttachments(query);
+        const ambiguousAttachments = attachments.filter((attachment) => attachment.text === "ambiguous main select prefix");
+        const ambiguous = ambiguousAttachments[0];
+
+        expect(ambiguousAttachments).toHaveLength(1);
+        expect(ambiguous).toMatchObject({
+            placement: "detached"
+        });
+        expect(ambiguous?.targetNode).toBeUndefined();
+    });
+
+    test("does not mutate formatter comment preservation behavior", () => {
+        const sql = `
+            -- query header
+            WITH
+            -- cte leading
+            raw_sales AS (
+                SELECT /* selected id */ id FROM sales
+            )
+            SELECT id FROM raw_sales
+        `;
+        const query = SelectQueryParser.parse(sql);
+        const untouchedQuery = SelectQueryParser.parse(sql);
+        const formatter = new SqlFormatter({ exportComment: "full" });
+
+        extractAstCommentAttachments(query);
+
+        const after = formatter.format(query).formattedSql;
+        const before = formatter.format(untouchedQuery).formattedSql;
+        expect(after).toEqual(before);
+    });
+});


### PR DESCRIPTION
## Summary

- Fixes #916.
- Adds `AstCommentAttachmentExtractor.extract(...)` and `extractAstCommentAttachments(...)` as a generic AST comment fact API.
- Returns comment text, deterministic `sourceOrder`, conservative `placement`, optional `targetNode`, and optional future `range` without assigning product-specific comment meaning.
- Covers query header comments, CTE leading comments, SELECT item represented comments, detached ambiguous comments, and formatter non-mutation behavior.

## Verification

- `pnpm --filter rawsql-ts test`
- `pnpm --filter rawsql-ts build`
- `pnpm --filter rawsql-ts lint`
- Pre-commit hook: workspace `typecheck`, workspace `test`, workspace `build`, workspace `lint`

Acceptance:
- Query header comments can be extracted in source order: verified by `AstCommentAttachmentExtractor.test.ts`.
- Leading comments before CTE definitions can be extracted without losing text: verified by `AstCommentAttachmentExtractor.test.ts`.
- SELECT item comments already represented in AST can be extracted: verified by `AstCommentAttachmentExtractor.test.ts`.
- Ambiguous comments are detached/unowned and not duplicated: verified by `AstCommentAttachmentExtractor.test.ts`.
- Existing formatter/comment preservation behavior remains compatible: verified by the extractor non-mutation test and full core test suite.

Residual risk:
- `range` is intentionally optional and currently omitted because parser AST nodes do not retain reliable per-comment source spans.
- `targetNode` reflects where existing AST metadata stores the comment, not stronger SQL ownership semantics.

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

<!-- Write values on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. -->
<!-- Do not add list markers like "-" before these labels; `Tracking issue:` and `Scoped checks run:` must start at column 0. -->
Tracking issue: #916
Scoped checks run: `pnpm --filter rawsql-ts test`, `pnpm --filter rawsql-ts build`, `pnpm --filter rawsql-ts lint`, pre-commit workspace checks
Why full baseline is not required: Full baseline exception is not requested.

## Self Review

<!-- Fill these fields after running the repo self-review workflow or available self-review skill. -->
Self-review workflow: Repo self-review workflow plus independent reviewer pass.
Self-review result: Blocker for duplicate detached CTE boundary comments was fixed; no blockers remain.
Concept-review workflow: Core package scope and design boundary review from package guidance.
Concept-review result: No package-boundary violations; the change stays DBMS-neutral and does not add parser, formatter, UI, lineage, or rewrite semantics.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-migration rationale: This changes the core TypeScript API only, with no CLI command, flag, help, or migration behavior change.
Upgrade note: New optional API only.
Deprecation/removal plan or issue: None.
Docs/help/examples updated: Not required for CLI help or examples.
Release/changeset wording: `.changeset/ast-comment-attachments.md`

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-proof rationale: No scaffold templates, generated runtime output, or scaffold contract files changed.
Non-edit assertion: Not applicable.
Fail-fast input-contract proof: Not applicable.
Generated-output viability proof: Not applicable.
