### PR TITLE
docs: add workflow guidance skills

### DIFF
--- a/.agents/skills/changeset-classification/SKILL.md
+++ b/.agents/skills/changeset-classification/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: changeset-classification
+description: Classify and review rawsql-ts Changeset entries for patch, minor, major, no-release, stale entries, public API additions, bug fixes, docs/demo updates, and reviewer comments that challenge release-note wording or bump level.
+---
+
+# Changeset Classification
+
+Use this skill when adding, editing, removing, or reviewing `.changeset/*.md` files, or when a reviewer questions whether a rawsql-ts change is patch, minor, major, or no-release.
+
+## Workflow
+
+1. Identify changed packages and whether the change affects published behavior, public API, CLI surface, scaffold output, docs/demo only, or internal tests.
+2. Classify the bump:
+   - `patch`: backward-compatible bug fix or documentation for an already released surface.
+   - `minor`: backward-compatible public API, option, output field, syntax support, CLI capability, or scaffold capability addition.
+   - `major`: breaking API, CLI, scaffold, runtime, or documented behavior change.
+   - `no-release`: repository-only workflow, CI, tests, or unpublished/internal-only maintenance.
+3. Check whether the changeset wording describes user-visible behavior rather than implementation mechanics.
+4. Check for stale entries that mention removed packages, superseded behavior, or a task no longer in the diff.
+5. If an automated reviewer suggests a different bump, verify the underlying semver reason before accepting or rejecting it.
+
+## Output Shape
+
+- Changed package
+- Release surface
+- Recommended bump
+- User-visible wording
+- Stale or conflicting changesets
+- Reviewer comments accepted or rejected
+- Rationale
+
+## Constraints
+
+- Do not add a changeset just to satisfy habit when no published package changes.
+- Do not downgrade an additive public API to patch solely because it is backward compatible.
+- Do not let release wording claim guarantees that tests or docs do not support.
+- Do not keep stale changesets for packages or behavior outside the final diff.

--- a/.agents/skills/core-parser-analyzer-change/SKILL.md
+++ b/.agents/skills/core-parser-analyzer-change/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: core-parser-analyzer-change
+description: Implement or review rawsql-ts packages/core parser, analyzer, formatter, SQL syntax, AST, SelectValueCollector, SelectOutputCollector, or SelectBodyExtractor changes with DBMS-neutral boundary checks, regression tests, benchmark/demo gates, and release-note classification.
+---
+
+# Core Parser Analyzer Change
+
+Use this skill for changes under `packages/core` that affect SQL parsing, AST shape, analyzer output, formatter behavior, syntax-derived metadata, wildcard expansion, select output collection, or wrapper SELECT extraction.
+
+## Required Reads
+
+1. Read `packages/core/AGENTS.md`.
+2. Read `packages/core/DESIGN.md` when the change touches parser/analyzer boundaries, dialect syntax, formatter output, or public API shape.
+3. Read the issue or PR comment that defines the requested SQL shape before editing.
+
+## Workflow
+
+1. Classify the change as parser, analyzer, formatter, public API, test-only, or documentation-only.
+2. State the DBMS-neutral boundary: what syntax is represented, and what driver, database, rewrite, testkit, lineage, or viewer semantics remain out of scope.
+3. Add or update regression tests that execute the changed parser/analyzer/formatter behavior.
+4. For syntax-derived collectors, cover ordering, duplicates, unsupported forms, and alias/source metadata explicitly when they are relevant.
+5. Prefer AST APIs and existing visitors. Use regex only when `packages/core/AGENTS.md` permits it, with an inline AST-limitation comment and tracking issue.
+6. Add or update a changeset when package behavior or public API changes.
+7. Run the package verification commands required by `packages/core/AGENTS.md`.
+
+## Verification
+
+Run these for behavior changes:
+
+```bash
+pnpm --filter rawsql-ts test
+pnpm --filter rawsql-ts build
+pnpm --filter rawsql-ts lint
+```
+
+Also run these when parser or formatter behavior changes:
+
+```bash
+pnpm --filter rawsql-ts benchmark
+pnpm demo:complex-sql
+```
+
+Focused tests may be run first, but they do not replace the package gates unless the final report explicitly narrows the claim.
+
+## PR Notes
+
+- Name the SQL forms covered by tests.
+- State whether duplicate output names, output order, aliases, source metadata, or unsupported cases were checked.
+- State the concept/package-boundary result without importing upper-layer semantics into `packages/core`.
+- If a verification command is skipped, keep the affected claim partial and explain the blocker.
+
+## Constraints
+
+- Do not add dialect flags or branch parser/analyzer behavior by runtime database.
+- Do not implement driver, DB, testkit, rewrite, lineage viewer, or graph semantics in `packages/core`.
+- Do not treat CodeRabbit comments as accepted requirements until they are checked against package policy and the source issue.

--- a/.agents/skills/pr-readiness/SKILL.md
+++ b/.agents/skills/pr-readiness/SKILL.md
@@ -11,6 +11,7 @@ Use this skill before creating or editing a rawsql-ts pull request.
 - Creating a PR body.
 - Editing an existing PR body after CI or reviewer feedback.
 - Any PR that changes CLI-facing files, scaffold behavior, release readiness, or documentation used by those gates.
+- Deciding whether a PR is ready to request external AI review after the body is validated.
 
 ## Workflow
 1. Read `.github/pull_request_template.md`.
@@ -24,7 +25,8 @@ Use this skill before creating or editing a rawsql-ts pull request.
 6. Fill required same-line fields exactly as labels appear in the template, including `Self-review workflow:`, `Self-review result:`, `Concept-review workflow:`, and `Concept-review result:`.
 7. After implementation verification, run the repo self-review workflow as the finishing review pass before PR authoring.
 8. Before `gh pr create` / `gh pr edit`, validate the prepared PR body by running the readiness script locally.
-9. Do not present the PR as ready while self-review has unresolved blockers or the readiness script fails.
+9. If requesting CodeRabbit or similar external AI review, use `review-tool-volume-management` after the body passes readiness validation.
+10. Do not present the PR as ready while self-review has unresolved blockers or the readiness script fails.
 
 ## Local Validation
 When validating a PR body locally, create a temporary event payload containing the PR body, then run:
@@ -52,6 +54,7 @@ Use the actual base and head SHAs from the PR or from `git merge-base` / `git re
 - Local readiness command
 - Readiness result
 - Remaining blockers
+- External review request timing, when relevant
 
 ## Constraints
 - Do not replace the repository template with a free-form PR body.

--- a/.agents/skills/review-tool-volume-management/SKILL.md
+++ b/.agents/skills/review-tool-volume-management/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: review-tool-volume-management
+description: Manage rawsql-ts external review-tool usage for CodeRabbit or similar AI review bots when PRs are stacked, small, generated, broad, rate-limited, or likely to consume review quota before the branch is ready.
+---
+
+# Review Tool Volume Management
+
+Use this skill before requesting external AI review, when CodeRabbit reports rate limits, or when a branch is being updated repeatedly before it is ready for human review.
+
+## Workflow
+
+1. Decide whether the PR is ready for external review:
+   - implementation complete,
+   - focused verification run,
+   - PR readiness body validated,
+   - self-review blockers resolved or surfaced.
+2. If the PR is still changing quickly, avoid manual review triggers until the next ready checkpoint.
+3. For stacked or closely related small PRs, request review on the PR where the source decision is clearest, then use the review result to update the rest.
+4. For generated or broad diffs, use `broad-generated-diff-review-packet` before requesting bot review.
+5. When a rate-limit comment appears, record it as review coverage unavailable, not as a code finding.
+6. If review is still needed after the refill window, trigger one review after the branch and PR body are stable.
+7. Do not treat `COMMENTED` bot review states as approval.
+
+## PR Notes
+
+Mention review-tool limits only when they affect review confidence. Keep the note short:
+
+- `External AI review was rate-limited; repository checks and self-review are the current evidence.`
+- `External AI review requested after readiness validation.`
+
+## Constraints
+
+- Do not spend review quota on WIP pushes when local checks or PR readiness are still failing.
+- Do not hide skipped or rate-limited review coverage if the final claim depends on it.
+- Do not copy bot marketing, tips, or generated poems into repository evidence.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,9 @@ Deeper `AGENTS.md` files take precedence when they add stricter or narrower rule
 - For package-level Scope, Test Policy, Authority Model, Technology Policy, review-plan, or generated review view changes, use `.agents/skills/package-spec-review/SKILL.md`.
 - For structured metadata migrations or rule registry changes, use `.agents/skills/structured-metadata-migration-review/SKILL.md` to check schema versioning, canonical enum parity, real fixture parsing, and evidence/display-label integrity.
 - For broad generated or derived diffs that may exceed review-tool limits, use `.agents/skills/broad-generated-diff-review-packet/SKILL.md` to prepare scoped review packets before PR handoff.
+- For `packages/core` parser, analyzer, formatter, AST, wildcard/select-output, or syntax-derived metadata changes, use `.agents/skills/core-parser-analyzer-change/SKILL.md` instead of re-deriving package-boundary and verification rules from memory.
+- For changeset additions, removals, stale-entry cleanup, or reviewer questions about patch/minor/major classification, use `.agents/skills/changeset-classification/SKILL.md`.
+- For CodeRabbit or similar external AI review requests, rate-limit comments, stacked PRs, generated diffs, or review-tool quota concerns, use `.agents/skills/review-tool-volume-management/SKILL.md`.
 - Do not turn `AGENTS.md` into the storage location for starter walkthroughs, AI onboarding prompts, dogfooding playbooks, or investigation scripts; keep those in dedicated docs or skills.
 
 ## Documentation Guardrails
@@ -133,6 +136,7 @@ Deeper `AGENTS.md` files take precedence when they add stricter or narrower rule
 - The finishing review pass must include a concept boundary review when the change touches package behavior, generated scaffold output, generated runtime code, docs, or PR wording. Read the owning package concept, package scope, technology policy, or Concept Spec when one exists.
 - Final PR text and final implementation reports must pass self-review before human review.
 - Before creating or editing a PR, read `.github/pull_request_template.md` and use `.agents/skills/pr-readiness/SKILL.md` when present.
+- Before manually requesting external AI review on a PR, use `.agents/skills/review-tool-volume-management/SKILL.md` when rate limits, stacked PRs, generated diffs, or repeated WIP pushes could affect review coverage.
 - Before claiming a PR is ready, run the repository PR readiness script locally when `scripts/check-pr-readiness.js` exists, or explicitly state why it could not be run.
 - Blockers must be resolved or explicitly called out before human review.
 - Before creating or presenting a PR, review `tmp/RETRO.md` and either resolve every PR-blocking retro item or explicitly surface the remaining item and why it is safe to defer.


### PR DESCRIPTION
## Summary

- Adds repo-local skills for recurring Codex workflow misses: core parser/analyzer changes, changeset classification, and external AI review-tool volume management.
- Routes those repeated procedures from `AGENTS.md` to focused skills instead of expanding root guidance with long operational detail.
- Updates PR readiness guidance to defer CodeRabbit or similar review requests until the PR body passes readiness validation.

## Verification

- `python C:/Users/mssgm/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/core-parser-analyzer-change`
- `python C:/Users/mssgm/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/changeset-classification`
- `python C:/Users/mssgm/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/review-tool-volume-management`
- `git diff --check`
- `git diff --cached --check`
- `node scripts/check-pr-readiness.js --base-sha 5f8b1a3f215645dafd6f4da81c376bf3669315a3 --head-sha 9a0d0a97288272e2c94dfdfaf39a8925a8a9ede1 --event-path tmp/pr-event.json`

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

<!-- Write values on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. -->
<!-- Do not add list markers like "-" before these labels; `Tracking issue:` and `Scoped checks run:` must start at column 0. -->
Tracking issue: Not requested; automation follow-up from recent Codex workflow review.
Scoped checks run: Skill quick validation for all new skills; diff whitespace checks; PR readiness validation.
Why full baseline is not required: Documentation and local skill routing only; no package code, generated artifacts, CLI, scaffold, or runtime behavior changed.

## Self Review

<!-- Fill these fields after running the repo self-review workflow or available self-review skill. -->
Self-review workflow: developer-self-review skill; consistency review and human acceptance review over AGENTS routing, new skill boundaries, and PR text.
Self-review result: No blockers remain. Root guidance only routes to skills, and detailed operational procedures live in focused repo-local skills.
Concept-review workflow: Explicit no package/product concept impact review; changed files are repository workflow guidance and local Codex skills only.
Concept-review result: No concept or package-boundary violations found. The change does not alter package behavior, generated scaffold output, generated runtime code, or user-facing APIs.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-migration rationale: No CLI-facing files, command behavior, help text, or user migration surface changed.
Upgrade note: No user action required.
Deprecation/removal plan or issue: None; no CLI option or command was removed.
Docs/help/examples updated: Not applicable; this is repository workflow guidance only.
Release/changeset wording: No changeset needed because no published package behavior changed.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-proof rationale: No scaffold templates, scaffold generated output, or scaffold input contracts changed.
Non-edit assertion: This PR does not edit scaffold-owned files.
Fail-fast input-contract proof: Not applicable; no scaffold input contract changed.
Generated-output viability proof: Not applicable; no generated scaffold output changed.
