### PR TITLE
fix(release): remove stale transfer changeset ignore

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,6 +6,5 @@
   "linked": [],
   "access": "public",
   "baseBranch": "main",
-  "updateInternalDependencies": "patch",
-  "ignore": ["@rawsql-ts/transfer"]
+  "updateInternalDependencies": "patch"
 }


### PR DESCRIPTION
## Summary

- Removed the stale `@rawsql-ts/transfer` entry from `.changeset/config.json` so `changeset version` no longer fails release PR creation after the transfer package was removed.
- No changeset: this only fixes release workflow configuration and does not change package code or published behavior.

## Verification

- `node -e "JSON.parse(require('node:fs').readFileSync('.changeset/config.json', 'utf8')); console.log('ok')"`
- `corepack pnpm changeset status`

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

<!-- Write values on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. -->
<!-- Do not add list markers like "-" before these labels; `Tracking issue:` and `Scoped checks run:` must start at column 0. -->
Tracking issue: 
Scoped checks run: changeset config JSON parse; corepack pnpm changeset status
Why full baseline is not required: Scoped release-configuration fix; no package source, tests, CLI behavior, or scaffold output changed.

## Self Review

<!-- Fill these fields after running the repo self-review workflow or available self-review skill. -->
Self-review workflow: developer-self-review skill; diff and verification evidence reviewed before PR creation.
Self-review result: No blockers found; change is limited to removing an invalid Changesets ignore entry.
Concept-review workflow: No concept-impact review required; release workflow configuration only.
Concept-review result: No concept or package-boundary impact found.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-migration rationale: No CLI/user-facing surface changed.
Upgrade note: Not applicable; release workflow configuration only.
Deprecation/removal plan or issue: Not applicable; no user-facing deprecation or removal.
Docs/help/examples updated: Not applicable; no docs/help/example behavior changed.
Release/changeset wording: No changeset needed because published package behavior is unchanged.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-proof rationale: No scaffold-related files or generated output changed.
Non-edit assertion: Not applicable; no scaffold output changed.
Fail-fast input-contract proof: Not applicable; no scaffold input contract changed.
Generated-output viability proof: Not applicable; no generated scaffold output changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release/versioning settings to better handle internal dependency updates.
  * Removed an outdated package exception from the release configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->