### PR TITLE
fix(release): retry release versioning

### DIFF
--- a/scripts/version-packages-and-lockfile.mjs
+++ b/scripts/version-packages-and-lockfile.mjs
@@ -1,12 +1,21 @@
 import { spawnSync } from "node:child_process";
 
 const pnpm = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+const releaseVersionAttempts = 3;
+const releaseVersionRetryDelayMs = 5000;
+const useShell = process.platform === "win32";
+
+function wait(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
 
 function run(command, args) {
   const result = spawnSync(command, args, {
     cwd: process.cwd(),
     stdio: "inherit",
-    shell: false,
+    shell: useShell,
   });
 
   if (result.error) {
@@ -18,6 +27,34 @@ function run(command, args) {
   }
 }
 
+async function runWithRetry(command, args, attempts) {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const result = spawnSync(command, args, {
+      cwd: process.cwd(),
+      stdio: "inherit",
+      shell: useShell,
+    });
+
+    if (result.error) {
+      throw result.error;
+    }
+
+    if (result.status === 0) {
+      return;
+    }
+
+    if (attempt === attempts) {
+      process.exit(result.status ?? 1);
+    }
+
+    console.warn(
+      `[release-version] ${command} ${args.join(" ")} failed with exit code ${result.status ?? 1}; retrying ` +
+        `(${attempt + 1}/${attempts}) in ${releaseVersionRetryDelayMs / 1000}s...`,
+    );
+    await wait(releaseVersionRetryDelayMs);
+  }
+}
+
 // Version packages first, then regenerate the lockfile so the release PR commit stays installable.
-run(pnpm, ["changeset", "version"]);
+await runWithRetry(pnpm, ["changeset", "version"], releaseVersionAttempts);
 run(pnpm, ["install", "--lockfile-only", "--ignore-scripts"]);

--- a/scripts/version-packages-and-lockfile.mjs
+++ b/scripts/version-packages-and-lockfile.mjs
@@ -27,6 +27,10 @@ function run(command, args) {
   }
 }
 
+function resetTrackedFiles() {
+  run("git", ["reset", "--hard", "HEAD"]);
+}
+
 async function runWithRetry(command, args, attempts) {
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     const result = spawnSync(command, args, {
@@ -44,13 +48,15 @@ async function runWithRetry(command, args, attempts) {
     }
 
     if (attempt === attempts) {
+      resetTrackedFiles();
       process.exit(result.status ?? 1);
     }
 
     console.warn(
       `[release-version] ${command} ${args.join(" ")} failed with exit code ${result.status ?? 1}; retrying ` +
-        `(${attempt + 1}/${attempts}) in ${releaseVersionRetryDelayMs / 1000}s...`,
+        `(${attempt + 1}/${attempts}) from a clean checkout in ${releaseVersionRetryDelayMs / 1000}s...`,
     );
+    resetTrackedFiles();
     await wait(releaseVersionRetryDelayMs);
   }
 }


### PR DESCRIPTION
## Summary

- Retry `pnpm changeset version` up to three times during Release PR creation so transient GitHub changelog API failures do not immediately fail the workflow.
- Use the Windows shell for local `pnpm.cmd` spawning so the release versioning script can be exercised locally on Windows as well as in Linux CI.
- No changeset: this only changes release automation behavior and does not change package code or published runtime behavior.

## Verification

- `node --check scripts/version-packages-and-lockfile.mjs`
- fake `pnpm.cmd` simulation: two `changeset version` failures, third attempt succeeds, then lockfile install command runs
- `corepack pnpm lint`
- pre-commit hook: `pnpm typecheck`, `pnpm test`, `pnpm build`, `pnpm lint`

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

<!-- Write values on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. -->
<!-- Do not add list markers like "-" before these labels; `Tracking issue:` and `Scoped checks run:` must start at column 0. -->
Tracking issue: 
Scoped checks run: node --check scripts/version-packages-and-lockfile.mjs; fake pnpm retry simulation; corepack pnpm lint; pre-commit typecheck/test/build/lint
Why full baseline is not required: Scoped release-automation script change; pre-commit ran the full local baseline checks for this repository.

## Self Review

<!-- Fill these fields after running the repo self-review workflow or available self-review skill. -->
Self-review workflow: developer-self-review skill; CI log cause, script diff, and verification evidence reviewed before PR creation.
Self-review result: No blockers found; retry is limited to the network-sensitive changeset version step and keeps the final failure exit code.
Concept-review workflow: No concept-impact review required; release workflow automation only.
Concept-review result: No concept or package-boundary impact found.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-migration rationale: No CLI/user-facing surface changed.
Upgrade note: Not applicable; release automation only.
Deprecation/removal plan or issue: Not applicable; no user-facing deprecation or removal.
Docs/help/examples updated: Not applicable; no docs/help/example behavior changed.
Release/changeset wording: No changeset needed because published package behavior is unchanged.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-proof rationale: No scaffold-related files or generated output changed.
Non-edit assertion: Not applicable; no scaffold output changed.
Fail-fast input-contract proof: Not applicable; no scaffold input contract changed.
Generated-output viability proof: Not applicable; no generated scaffold output changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of the package versioning and lockfile update process.
  * Added automatic retries when versioning steps fail temporarily, with clearer warning messages during retries.
  * Updated command execution to work more consistently across operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->