### PR TITLE
feat(core): add static predicate placement

### DIFF
--- a/.changeset/static-predicate-placement.md
+++ b/.changeset/static-predicate-placement.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": patch
+---
+
+Add safe-only static predicate placement APIs and integrate static predicate movement as the third condition optimization phase after SSSQL optional branches and parameter condition placement.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -83,6 +83,7 @@ export * from './transformers/DynamicQueryBuilder';
 export * from './transformers/SSSQLFilterBuilder';
 export * from './transformers/ConditionOptimization';
 export * from './transformers/ParameterConditionPlacementOptimizer';
+export * from './transformers/StaticPredicatePlacementOptimizer';
 export * from './transformers/PruneOptionalConditionBranches';
 export {
     SchemaInfo,

--- a/packages/core/src/transformers/ConditionOptimization.ts
+++ b/packages/core/src/transformers/ConditionOptimization.ts
@@ -11,6 +11,14 @@ import {
     planParameterConditionOptimization
 } from "./ParameterConditionPlacementOptimizer";
 import {
+    optimizeStaticPredicatePlacement,
+    planStaticPredicatePlacement,
+    StaticPredicateMove,
+    StaticPredicatePlacementError,
+    StaticPredicatePlacementWarning,
+    StaticPredicateSkipped
+} from "./StaticPredicatePlacementOptimizer";
+import {
     collectSupportedOptionalConditionBranches,
     OptionalConditionPruningParameters,
     pruneOptionalConditionBranches,
@@ -20,7 +28,10 @@ import { SSSQLFilterBuilder } from "./SSSQLFilterBuilder";
 import { formatSqlComponent } from "./SqlComponentFormatter";
 
 export type ConditionOptimizationInput = string | SelectQuery | SimpleSelectQuery;
-export type ConditionOptimizationPhaseKind = "sssql_optional_condition" | "parameter_condition_placement";
+export type ConditionOptimizationPhaseKind =
+    | "sssql_optional_condition"
+    | "parameter_condition_placement"
+    | "static_predicate_placement";
 
 export interface ConditionOptimizationOptions extends ParameterConditionOptimizationOptions {
     /**
@@ -59,17 +70,21 @@ export interface SssqlOptionalConditionSkipped {
 
 export type ConditionOptimizationApplied =
     | SssqlOptionalConditionApplied
-    | (ParameterConditionMove & { phaseKind: "parameter_condition_placement" });
+    | (ParameterConditionMove & { phaseKind: "parameter_condition_placement" })
+    | (StaticPredicateMove & { phaseKind: "static_predicate_placement" });
 
 export type ConditionOptimizationSkipped =
     | SssqlOptionalConditionSkipped
-    | (ParameterConditionSkipped & { phaseKind: "parameter_condition_placement" });
+    | (ParameterConditionSkipped & { phaseKind: "parameter_condition_placement" })
+    | (StaticPredicateSkipped & { phaseKind: "static_predicate_placement" });
 
 export type ConditionOptimizationWarning =
-    | (ParameterConditionOptimizationWarning & { phaseKind: ConditionOptimizationPhaseKind });
+    | (ParameterConditionOptimizationWarning & { phaseKind: ConditionOptimizationPhaseKind })
+    | (StaticPredicatePlacementWarning & { phaseKind: ConditionOptimizationPhaseKind });
 
 export type ConditionOptimizationError =
-    | (ParameterConditionOptimizationError & { phaseKind: ConditionOptimizationPhaseKind });
+    | (ParameterConditionOptimizationError & { phaseKind: ConditionOptimizationPhaseKind })
+    | (StaticPredicatePlacementError & { phaseKind: ConditionOptimizationPhaseKind });
 
 export interface ConditionOptimizationSafety {
     mode: "safe_only";
@@ -421,6 +436,34 @@ const mapParameterSkipped = (
     ...item
 }));
 
+const mapStaticWarnings = (
+    warnings: readonly StaticPredicatePlacementWarning[]
+): ConditionOptimizationWarning[] => warnings.map(warning => ({
+    phaseKind: "static_predicate_placement",
+    ...warning
+}));
+
+const mapStaticErrors = (
+    errors: readonly StaticPredicatePlacementError[]
+): ConditionOptimizationError[] => errors.map(error => ({
+    phaseKind: "static_predicate_placement",
+    ...error
+}));
+
+const mapStaticApplied = (
+    applied: readonly StaticPredicateMove[]
+): ConditionOptimizationApplied[] => applied.map(item => ({
+    phaseKind: "static_predicate_placement",
+    ...item
+}));
+
+const mapStaticSkipped = (
+    skipped: readonly StaticPredicateSkipped[]
+): ConditionOptimizationSkipped[] => skipped.map(item => ({
+    phaseKind: "static_predicate_placement",
+    ...item
+}));
+
 const makePhaseSummary = (
     kind: ConditionOptimizationPhaseKind,
     counts: {
@@ -444,9 +487,8 @@ const runConditionOptimization = (
 ): ConditionOptimizationResult => {
     const dryRun = options.dryRun ?? defaultDryRun;
 
-    // Run the semantic SSSQL phase before the generic placement phase so
-    // optional branches remain owned by SSSQL even if parameter placement grows
-    // broader OR-predicate support later.
+    // Run semantic SSSQL handling before generic placement phases so optional
+    // branches remain owned by SSSQL even if later phases grow broader support.
     const sssqlPhase = runSssqlOptionalConditionPhase(input, { ...options, dryRun });
     const parameterPhase = dryRun
         ? planParameterConditionOptimization(sssqlPhase.sql, { dryRun })
@@ -455,12 +497,19 @@ const runConditionOptimization = (
     const parameterErrors = mapParameterErrors(parameterPhase.errors);
     const parameterApplied = mapParameterApplied(parameterPhase.applied);
     const parameterSkipped = mapParameterSkipped(parameterPhase.skipped);
-    const warnings = [...sssqlPhase.warnings, ...parameterWarnings];
-    const errors = [...sssqlPhase.errors, ...parameterErrors];
+    const staticPhase = dryRun
+        ? planStaticPredicatePlacement(parameterPhase.sql, { dryRun })
+        : optimizeStaticPredicatePlacement(parameterPhase.sql, { dryRun });
+    const staticWarnings = mapStaticWarnings(staticPhase.warnings);
+    const staticErrors = mapStaticErrors(staticPhase.errors);
+    const staticApplied = mapStaticApplied(staticPhase.applied);
+    const staticSkipped = mapStaticSkipped(staticPhase.skipped);
+    const warnings = [...sssqlPhase.warnings, ...parameterWarnings, ...staticWarnings];
+    const errors = [...sssqlPhase.errors, ...parameterErrors, ...staticErrors];
 
     return {
         ok: errors.length === 0,
-        sql: parameterPhase.sql,
+        sql: staticPhase.sql,
         phases: [
             makePhaseSummary("sssql_optional_condition", {
                 appliedCount: sssqlPhase.applied.length,
@@ -473,17 +522,25 @@ const runConditionOptimization = (
                 skippedCount: parameterSkipped.length,
                 warningCount: parameterWarnings.length,
                 errorCount: parameterErrors.length
+            }),
+            makePhaseSummary("static_predicate_placement", {
+                appliedCount: staticApplied.length,
+                skippedCount: staticSkipped.length,
+                warningCount: staticWarnings.length,
+                errorCount: staticErrors.length
             })
         ],
-        applied: [...sssqlPhase.applied, ...parameterApplied],
-        skipped: [...sssqlPhase.skipped, ...parameterSkipped],
+        applied: [...sssqlPhase.applied, ...parameterApplied, ...staticApplied],
+        skipped: [...sssqlPhase.skipped, ...parameterSkipped, ...staticSkipped],
         warnings,
         errors,
         safety: {
             mode: "safe_only",
             unsafeRewriteApplied: false,
             dryRun,
-            formatterGeneratedSource: sssqlPhase.formatterGeneratedSource || parameterPhase.safety.formatterGeneratedSource
+            formatterGeneratedSource: sssqlPhase.formatterGeneratedSource
+                || parameterPhase.safety.formatterGeneratedSource
+                || staticPhase.safety.formatterGeneratedSource
         }
     };
 };

--- a/packages/core/src/transformers/StaticPredicatePlacementOptimizer.ts
+++ b/packages/core/src/transformers/StaticPredicatePlacementOptimizer.ts
@@ -1,0 +1,1462 @@
+import {
+    CommonTable,
+    FromClause,
+    JoinClause,
+    SourceExpression,
+    SubQuerySource,
+    TableSource,
+    WhereClause
+} from "../models/Clause";
+import { BinarySelectQuery, SelectQuery, SimpleSelectQuery } from "../models/SelectQuery";
+import {
+    ArrayExpression,
+    ArrayQueryExpression,
+    BetweenExpression,
+    BinaryExpression,
+    CaseExpression,
+    CastExpression,
+    ColumnReference,
+    FunctionCall,
+    InlineQuery,
+    JsonPredicateExpression,
+    ParameterExpression,
+    ParenExpression,
+    TupleExpression,
+    TypeValue,
+    UnaryExpression,
+    ValueComponent,
+    ValueList
+} from "../models/ValueComponent";
+import { SelectQueryParser } from "../parsers/SelectQueryParser";
+import { ValueParser } from "../parsers/ValueParser";
+import { formatSqlComponent } from "./SqlComponentFormatter";
+
+export type StaticPredicatePlacementInput = string | SelectQuery | SimpleSelectQuery;
+
+/**
+ * Safe-only placement for parameter-free static predicates.
+ *
+ * The optimizer only moves top-level AND terms whose outer column references can
+ * be mechanically rebased to direct outputs of a single-use simple CTE or
+ * derived table. Unsupported or ambiguous predicates stay in place.
+ */
+export interface StaticPredicatePlacementOptions {
+    dryRun?: boolean;
+}
+
+export interface StaticPredicatePlacementWarning {
+    code: string;
+    message: string;
+    detail?: unknown;
+}
+
+export interface StaticPredicatePlacementError {
+    code: string;
+    message: string;
+    detail?: unknown;
+}
+
+export interface StaticPredicateMove {
+    kind: "move_static_predicate";
+    predicateSql: string;
+    fromScopeId: string;
+    toScopeId: string;
+    reason: string;
+    columnReferences: readonly string[];
+}
+
+export interface StaticPredicateSkipped {
+    predicateSql: string;
+    scopeId: string;
+    reason: string;
+    code: string;
+}
+
+export interface StaticPredicatePlacementSafety {
+    mode: "safe_only";
+    unsafeRewriteApplied: false;
+    dryRun: boolean;
+    formatterGeneratedSource: boolean;
+}
+
+export interface StaticPredicatePlacementResult {
+    ok: boolean;
+    sql: string;
+    applied: readonly StaticPredicateMove[];
+    skipped: readonly StaticPredicateSkipped[];
+    warnings: readonly StaticPredicatePlacementWarning[];
+    errors: readonly StaticPredicatePlacementError[];
+    safety: StaticPredicatePlacementSafety;
+    staticPredicateMoves: readonly StaticPredicateMove[];
+}
+
+interface ParsedStaticPredicateInput {
+    query: SelectQuery | null;
+    sql: string;
+    formatterGeneratedSource: boolean;
+    warnings: StaticPredicatePlacementWarning[];
+    errors: StaticPredicatePlacementError[];
+}
+
+interface SourceBinding {
+    source: SourceExpression;
+    alias: string;
+    join: JoinClause | null;
+    joinIndex: number;
+    isPrimary: boolean;
+}
+
+interface UpstreamTarget {
+    query: SimpleSelectQuery;
+    scopeId: string;
+    sourceBinding: SourceBinding;
+    cteName?: string;
+}
+
+interface TargetColumnResolution {
+    sourceColumn: ColumnReference;
+    targetColumn: ColumnReference;
+}
+
+interface StaticPredicateCandidate {
+    expression: ValueComponent;
+    predicateSql: string;
+    references: ColumnReference[];
+}
+
+type SkipDraft = Omit<StaticPredicateSkipped, "predicateSql" | "scopeId">;
+
+const VOLATILE_OR_UNSUPPORTED_FUNCTION_REASON = "Predicate contains a function call; volatile and expression predicates are not moved in the safe-only implementation.";
+
+const normalizeIdentifier = (value: string): string => value.trim().toLowerCase();
+
+const unwrapParens = (expression: ValueComponent): ValueComponent => {
+    let candidate = expression;
+    while (candidate instanceof ParenExpression) {
+        candidate = candidate.expression;
+    }
+    return candidate;
+};
+
+const isBinaryOperator = (expression: ValueComponent, operator: string): expression is BinaryExpression => {
+    const candidate = unwrapParens(expression);
+    return candidate instanceof BinaryExpression
+        && candidate.operator.value.trim().toLowerCase() === operator;
+};
+
+const collectTopLevelAndTerms = (expression: ValueComponent): ValueComponent[] => {
+    const candidate = unwrapParens(expression);
+    if (!isBinaryOperator(candidate, "and")) {
+        return [expression];
+    }
+
+    return [
+        ...collectTopLevelAndTerms(candidate.left),
+        ...collectTopLevelAndTerms(candidate.right)
+    ];
+};
+
+const rebuildWhereWithoutTerms = (query: SimpleSelectQuery, termsToRemove: ReadonlySet<ValueComponent>): void => {
+    if (!query.whereClause || termsToRemove.size === 0) {
+        return;
+    }
+
+    const remaining = collectTopLevelAndTerms(query.whereClause.condition)
+        .filter(term => !termsToRemove.has(term));
+
+    if (remaining.length === 0) {
+        query.whereClause = null;
+        return;
+    }
+
+    let rebuilt = remaining[0]!;
+    for (let index = 1; index < remaining.length; index += 1) {
+        rebuilt = new BinaryExpression(rebuilt, "and", remaining[index]!);
+    }
+    query.whereClause = new WhereClause(rebuilt);
+};
+
+const cloneValueComponent = (expression: ValueComponent): ValueComponent => {
+    return ValueParser.parse(formatSqlComponent(expression));
+};
+
+const cloneColumnReference = (reference: ColumnReference): ColumnReference => {
+    const namespaces = reference.namespaces?.map(namespace => namespace.name) ?? null;
+    return new ColumnReference(namespaces, reference.column.name);
+};
+
+const columnReferenceText = (reference: ColumnReference): string => {
+    const namespace = reference.getNamespace();
+    return namespace ? `${namespace}.${reference.column.name}` : reference.column.name;
+};
+
+const sameColumnReference = (left: ColumnReference, right: ColumnReference): boolean => {
+    return normalizeIdentifier(left.column.name) === normalizeIdentifier(right.column.name)
+        && normalizeIdentifier(left.getNamespace()) === normalizeIdentifier(right.getNamespace());
+};
+
+const appendUnique = <T>(items: T[], value: T): void => {
+    if (!items.includes(value)) {
+        items.push(value);
+    }
+};
+
+export class StaticPredicatePlacementOptimizer {
+    public plan(
+        input: StaticPredicatePlacementInput,
+        options: StaticPredicatePlacementOptions = {}
+    ): StaticPredicatePlacementResult {
+        const parsed = this.parseInput(input);
+        const warnings = [...parsed.warnings];
+        const errors = [...parsed.errors];
+
+        if (!parsed.query) {
+            return this.buildResult({
+                sql: parsed.sql,
+                applied: [],
+                skipped: [],
+                warnings,
+                errors,
+                dryRun: options.dryRun ?? true,
+                formatterGeneratedSource: parsed.formatterGeneratedSource
+            });
+        }
+
+        if (!(parsed.query instanceof SimpleSelectQuery)) {
+            warnings.push({
+                code: "UNSUPPORTED_ROOT_QUERY",
+                message: "Static predicate placement currently supports only SimpleSelectQuery roots."
+            });
+            return this.buildResult({
+                sql: parsed.sql,
+                applied: [],
+                skipped: [],
+                warnings,
+                errors,
+                dryRun: options.dryRun ?? true,
+                formatterGeneratedSource: parsed.formatterGeneratedSource
+            });
+        }
+
+        const query = parsed.query;
+        const applied: StaticPredicateMove[] = [];
+        const skipped: StaticPredicateSkipped[] = [];
+        const movedTerms: ValueComponent[] = [];
+
+        for (const term of query.whereClause ? collectTopLevelAndTerms(query.whereClause.condition) : []) {
+            const candidate = this.analyzeCandidate(query, term);
+            if (!candidate) {
+                continue;
+            }
+
+            if ("code" in candidate) {
+                skipped.push(this.makeSkipped(term, candidate));
+                continue;
+            }
+
+            const target = this.resolveTarget(query, candidate);
+            if ("code" in target) {
+                skipped.push(this.makeSkipped(term, target));
+                continue;
+            }
+
+            const targetColumns = this.resolveTargetColumns(target.query, candidate.references);
+            if ("code" in targetColumns) {
+                skipped.push(this.makeSkipped(term, targetColumns));
+                continue;
+            }
+
+            const movedPredicate = this.rebasePredicate(candidate.expression, targetColumns);
+            target.query.appendWhere(movedPredicate);
+            movedTerms.push(term);
+
+            applied.push({
+                kind: "move_static_predicate",
+                predicateSql: candidate.predicateSql,
+                fromScopeId: "scope:root",
+                toScopeId: target.scopeId,
+                reason: "All outer references resolve to direct upstream outputs before unsafe query boundaries.",
+                columnReferences: candidate.references.map(columnReferenceText)
+            });
+        }
+
+        rebuildWhereWithoutTerms(query, new Set(movedTerms));
+
+        const sql = applied.length > 0 ? formatSqlComponent(query) : parsed.sql;
+        return this.buildResult({
+            sql,
+            applied,
+            skipped,
+            warnings,
+            errors,
+            dryRun: options.dryRun ?? true,
+            formatterGeneratedSource: parsed.formatterGeneratedSource
+        });
+    }
+
+    public optimize(
+        input: StaticPredicatePlacementInput,
+        options: StaticPredicatePlacementOptions = {}
+    ): StaticPredicatePlacementResult {
+        return this.plan(input, { ...options, dryRun: options.dryRun ?? false });
+    }
+
+    private parseInput(input: StaticPredicatePlacementInput): ParsedStaticPredicateInput {
+        const warnings: StaticPredicatePlacementWarning[] = [];
+        const errors: StaticPredicatePlacementError[] = [];
+
+        try {
+            const sourceSql = typeof input === "string"
+                ? input
+                : formatSqlComponent(input);
+
+            if (typeof input !== "string") {
+                warnings.push({
+                    code: "AST_INPUT_FORMATTED",
+                    message: "AST input is cloned through formatter output so the caller-owned query is not mutated."
+                });
+            }
+
+            return {
+                query: SelectQueryParser.parse(sourceSql),
+                sql: sourceSql,
+                formatterGeneratedSource: typeof input !== "string",
+                warnings,
+                errors
+            };
+        } catch (error) {
+            const detail = error instanceof Error ? error.message : String(error);
+            errors.push({
+                code: "PARSE_FAILED",
+                message: "Static predicate placement could not parse the input SQL.",
+                detail
+            });
+            return {
+                query: null,
+                sql: typeof input === "string" ? input : "",
+                formatterGeneratedSource: typeof input !== "string",
+                warnings,
+                errors
+            };
+        }
+    }
+
+    private analyzeCandidate(root: SimpleSelectQuery, expression: ValueComponent): StaticPredicateCandidate | SkipDraft | null {
+        if (this.collectParameterNames(expression).length > 0) {
+            return null;
+        }
+
+        const unsupported = this.findUnsupportedExpression(expression, this.isExistsPredicate(expression));
+        if (unsupported) {
+            return unsupported;
+        }
+
+        const references = this.collectRootColumnReferences(root, expression);
+        if (references.length === 0) {
+            return {
+                code: "NO_COLUMN_REFERENCE",
+                reason: "Static predicate has no outer column reference to anchor the move."
+            };
+        }
+
+        return {
+            expression,
+            predicateSql: formatSqlComponent(expression),
+            references
+        };
+    }
+
+    private isExistsPredicate(expression: ValueComponent): boolean {
+        const candidate = unwrapParens(expression);
+        if (!(candidate instanceof UnaryExpression)) {
+            return false;
+        }
+
+        const operator = candidate.operator.value.trim().toLowerCase();
+        return operator === "exists" && unwrapParens(candidate.expression) instanceof InlineQuery;
+    }
+
+    private findUnsupportedExpression(expression: ValueComponent, allowExistsSubquery: boolean): SkipDraft | null {
+        let found: SkipDraft | null = null;
+
+        const visitSelect = (query: SelectQuery): void => {
+            if (found) {
+                return;
+            }
+            if (query instanceof BinarySelectQuery) {
+                found = {
+                    code: "UNION_BOUNDARY",
+                    reason: "Static predicate would need distribution into a UNION branch, which is unsupported."
+                };
+                return;
+            }
+            if (!(query instanceof SimpleSelectQuery)) {
+                found = {
+                    code: "UNSUPPORTED_SUBQUERY",
+                    reason: "Static predicate contains a non-simple subquery, which is unsupported."
+                };
+                return;
+            }
+
+            query.selectClause.items.forEach(item => visit(item.value));
+            for (const join of query.fromClause?.joins ?? []) {
+                if (join.condition) {
+                    visit(join.condition.condition);
+                }
+                const source = join.source.datasource;
+                if (source instanceof SubQuerySource) {
+                    visitSelect(source.query);
+                }
+            }
+            if (query.whereClause) {
+                visit(query.whereClause.condition);
+            }
+            if (query.havingClause) {
+                visit(query.havingClause.condition);
+            }
+            for (const cte of query.withClause?.tables ?? []) {
+                if (cte.query instanceof SimpleSelectQuery || cte.query instanceof BinarySelectQuery) {
+                    visitSelect(cte.query);
+                }
+            }
+        };
+
+        const visit = (value: ValueComponent): void => {
+            if (found) {
+                return;
+            }
+
+            const candidate = unwrapParens(value);
+            if (candidate instanceof BinaryExpression) {
+                if (candidate.operator.value.trim().toLowerCase() === "or") {
+                    found = {
+                        code: "OR_PREDICATE_UNSUPPORTED",
+                        reason: "Predicate contains OR predicates, which are not moved in the first safe-only implementation."
+                    };
+                    return;
+                }
+                visit(candidate.left);
+                visit(candidate.right);
+                return;
+            }
+
+            if (candidate instanceof FunctionCall) {
+                found = {
+                    code: "FUNCTION_PREDICATE_UNSUPPORTED",
+                    reason: VOLATILE_OR_UNSUPPORTED_FUNCTION_REASON
+                };
+                return;
+            }
+
+            if (candidate instanceof CaseExpression) {
+                found = {
+                    code: "CASE_PREDICATE_UNSUPPORTED",
+                    reason: "CASE predicates are not moved in the first safe-only implementation."
+                };
+                return;
+            }
+
+            if (candidate instanceof InlineQuery) {
+                if (!allowExistsSubquery) {
+                    found = {
+                        code: "SUBQUERY_PREDICATE_UNSUPPORTED",
+                        reason: "Subquery predicates are only moved when they are simple EXISTS predicates."
+                    };
+                    return;
+                }
+                visitSelect(candidate.selectQuery);
+                return;
+            }
+
+            if (candidate instanceof ArrayQueryExpression) {
+                found = {
+                    code: "SUBQUERY_PREDICATE_UNSUPPORTED",
+                    reason: "Array subquery predicates are not moved in the first safe-only implementation."
+                };
+                return;
+            }
+
+            if (candidate instanceof BetweenExpression) {
+                found = {
+                    code: "BETWEEN_PREDICATE_UNSUPPORTED",
+                    reason: "BETWEEN predicates are not moved in the first safe-only implementation."
+                };
+                return;
+            }
+
+            if (candidate instanceof UnaryExpression) {
+                visit(candidate.expression);
+                return;
+            }
+            if (candidate instanceof CastExpression) {
+                visit(candidate.input);
+                return;
+            }
+            if (candidate instanceof JsonPredicateExpression) {
+                visit(candidate.expression);
+                return;
+            }
+            if (candidate instanceof ArrayExpression) {
+                visit(candidate.expression);
+                return;
+            }
+            if (candidate instanceof ValueList) {
+                candidate.values.forEach(visit);
+                return;
+            }
+            if (candidate instanceof TupleExpression) {
+                candidate.values.forEach(visit);
+                return;
+            }
+            if (candidate instanceof TypeValue && candidate.argument) {
+                visit(candidate.argument);
+            }
+        };
+
+        visit(expression);
+        return found;
+    }
+
+    private resolveTarget(root: SimpleSelectQuery, candidate: StaticPredicateCandidate): UpstreamTarget | SkipDraft {
+        const boundary = this.findCurrentQueryBoundary(root);
+        if (boundary) {
+            return boundary;
+        }
+
+        if (!root.fromClause) {
+            return {
+                code: "NO_FROM_CLAUSE",
+                reason: "Predicate has no FROM source that can receive it safely."
+            };
+        }
+
+        const bindings: SourceBinding[] = [];
+        for (const reference of candidate.references) {
+            const binding = this.resolveSourceBinding(root, reference);
+            if ("code" in binding) {
+                return binding;
+            }
+            if (!bindings.some(item => item.source === binding.source)) {
+                bindings.push(binding);
+            }
+        }
+
+        if (bindings.length !== 1) {
+            return {
+                code: "MULTIPLE_SOURCE_REFERENCES",
+                reason: "Static predicate references multiple source query blocks; moving it may change semantics."
+            };
+        }
+
+        const binding = bindings[0]!;
+        const nullableSide = this.findNullableSideBoundary(root.fromClause, binding);
+        if (nullableSide) {
+            return nullableSide;
+        }
+
+        const upstream = this.resolveUpstreamQuery(root, binding);
+        if ("code" in upstream) {
+            return upstream;
+        }
+
+        const targetBoundary = this.findTargetQueryBoundary(upstream.query);
+        if (targetBoundary) {
+            return targetBoundary;
+        }
+
+        return upstream;
+    }
+
+    private findCurrentQueryBoundary(query: SimpleSelectQuery): SkipDraft | null {
+        if (query.selectClause.distinct) {
+            return {
+                code: "DISTINCT_BOUNDARY",
+                reason: "Predicate crosses DISTINCT boundary; moving it may change semantics."
+            };
+        }
+        if (query.groupByClause || query.havingClause) {
+            return {
+                code: "GROUP_BY_BOUNDARY",
+                reason: "Predicate crosses GROUP BY boundary; moving it may change semantics."
+            };
+        }
+        if (this.hasWindowUsage(query)) {
+            return {
+                code: "WINDOW_BOUNDARY",
+                reason: "Predicate crosses WINDOW boundary; moving it may change semantics."
+            };
+        }
+        return null;
+    }
+
+    private findTargetQueryBoundary(query: SimpleSelectQuery): SkipDraft | null {
+        const commonBoundary = this.findCurrentQueryBoundary(query);
+        if (commonBoundary) {
+            return commonBoundary;
+        }
+        if (query.limitClause || query.offsetClause || query.fetchClause) {
+            return {
+                code: "ROW_LIMIT_BOUNDARY",
+                reason: "Predicate crosses LIMIT/OFFSET/FETCH boundary; moving it may change row selection semantics."
+            };
+        }
+        if (query.fromClause && this.hasOuterJoin(query.fromClause)) {
+            return {
+                code: "OUTER_JOIN_BOUNDARY",
+                reason: "Target query contains an OUTER JOIN boundary that is not moved across in the safe-only implementation."
+            };
+        }
+        return null;
+    }
+
+    private resolveSourceBinding(root: SimpleSelectQuery, column: ColumnReference): SourceBinding | SkipDraft {
+        const fromClause = root.fromClause;
+        if (!fromClause) {
+            return {
+                code: "NO_FROM_CLAUSE",
+                reason: "Predicate has no FROM source that can receive it safely."
+            };
+        }
+
+        const bindings = this.getSourceBindings(fromClause);
+        const namespace = normalizeIdentifier(column.getNamespace());
+        const columnName = column.column.name;
+
+        if (namespace) {
+            const matches = bindings.filter(binding => normalizeIdentifier(binding.alias) === namespace);
+            if (matches.length !== 1) {
+                return {
+                    code: "AMBIGUOUS_COLUMN_SOURCE",
+                    reason: `Column source alias '${column.getNamespace()}' is not uniquely resolvable.`
+                };
+            }
+
+            if (this.resolveSourceQueryForColumns(root, matches[0]!.source) instanceof BinarySelectQuery) {
+                return matches[0]!;
+            }
+
+            const matchCount = this.getOutputColumnMatchCount(root, matches[0]!, columnName);
+            if (matchCount === 0) {
+                return {
+                    code: "COLUMN_NOT_AVAILABLE_UPSTREAM",
+                    reason: `Column '${columnReferenceText(column)}' is not a direct output of the referenced source.`
+                };
+            }
+            if (matchCount > 1) {
+                return {
+                    code: "AMBIGUOUS_COLUMN_REFERENCE",
+                    reason: `Column '${columnReferenceText(column)}' resolves to multiple outputs in the referenced source.`
+                };
+            }
+            return matches[0]!;
+        }
+
+        const matches: SourceBinding[] = [];
+        let unionSource: SourceBinding | null = null;
+        for (const binding of bindings) {
+            if (this.resolveSourceQueryForColumns(root, binding.source) instanceof BinarySelectQuery) {
+                unionSource ??= binding;
+                continue;
+            }
+
+            const matchCount = this.getOutputColumnMatchCount(root, binding, columnName);
+            if (matchCount > 1) {
+                return {
+                    code: "AMBIGUOUS_COLUMN_REFERENCE",
+                    reason: `Column '${columnName}' resolves to multiple outputs in source '${binding.alias}'.`
+                };
+            }
+            if (matchCount === 1) {
+                matches.push(binding);
+            }
+        }
+
+        if (matches.length === 0 && unionSource) {
+            return {
+                code: "UNION_BOUNDARY",
+                reason: "Predicate would need distribution into a UNION branch, which is unsupported."
+            };
+        }
+
+        if (matches.length !== 1) {
+            return {
+                code: "AMBIGUOUS_COLUMN_REFERENCE",
+                reason: matches.length === 0
+                    ? `Column '${columnName}' is not uniquely resolvable to a safe upstream source.`
+                    : `Column '${columnName}' is ambiguous across source query blocks.`
+            };
+        }
+
+        return matches[0]!;
+    }
+
+    private resolveUpstreamQuery(root: SimpleSelectQuery, binding: SourceBinding): UpstreamTarget | SkipDraft {
+        const source = binding.source.datasource;
+        if (source instanceof SubQuerySource) {
+            if (source.query instanceof SimpleSelectQuery) {
+                return {
+                    query: source.query,
+                    scopeId: `subquery:${binding.alias}`,
+                    sourceBinding: binding
+                };
+            }
+            return {
+                code: "UNION_BOUNDARY",
+                reason: "Predicate would need distribution into a UNION or non-simple subquery, which is unsupported."
+            };
+        }
+
+        if (!(source instanceof TableSource)) {
+            return {
+                code: "UNSUPPORTED_SOURCE",
+                reason: "Only CTE and simple derived-table sources can receive moved static predicates."
+            };
+        }
+
+        const cteName = source.table.name;
+        const commonTable = this.findCte(root, cteName);
+        if (!commonTable) {
+            return {
+                code: "NO_SAFE_UPSTREAM_QUERY",
+                reason: "The referenced source is a base table, so there is no upstream query block to move into."
+            };
+        }
+
+        const referenceCount = this.countTableSourceReferences(root, cteName);
+        if (referenceCount !== 1) {
+            return {
+                code: "CTE_REUSE_UNSUPPORTED",
+                reason: `CTE '${cteName}' is referenced ${referenceCount} times; moving a predicate into it may affect other consumers.`
+            };
+        }
+
+        if (commonTable.query instanceof BinarySelectQuery) {
+            return {
+                code: "UNION_BOUNDARY",
+                reason: "Predicate would need distribution into a UNION branch, which is unsupported."
+            };
+        }
+
+        if (!(commonTable.query instanceof SimpleSelectQuery)) {
+            return {
+                code: "UNSUPPORTED_CTE_QUERY",
+                reason: "Writable or non-select CTE bodies are not moved into by static predicate placement."
+            };
+        }
+
+        return {
+            query: commonTable.query,
+            scopeId: `cte:${commonTable.getSourceAliasName()}`,
+            sourceBinding: binding,
+            cteName: commonTable.getSourceAliasName()
+        };
+    }
+
+    private resolveTargetColumns(query: SimpleSelectQuery, references: readonly ColumnReference[]): TargetColumnResolution[] | SkipDraft {
+        const resolved: TargetColumnResolution[] = [];
+        for (const reference of references) {
+            const matches = query.selectClause.items.filter(item =>
+                normalizeIdentifier(this.getSelectItemOutputName(item) ?? "") === normalizeIdentifier(reference.column.name)
+            );
+
+            if (matches.length !== 1) {
+                return {
+                    code: "AMBIGUOUS_TARGET_COLUMN",
+                    reason: matches.length === 0
+                        ? `Target query does not expose '${reference.column.name}' as a direct output column.`
+                        : `Target query exposes multiple '${reference.column.name}' columns.`
+                };
+            }
+
+            const value = matches[0]!.value;
+            if (!(value instanceof ColumnReference)) {
+                return {
+                    code: "EXPRESSION_OUTPUT_UNSUPPORTED",
+                    reason: `Target output '${reference.column.name}' is an expression, not a direct column reference.`
+                };
+            }
+
+            const sourceResolution = this.verifyColumnResolvableInQuery(query, value);
+            if (sourceResolution) {
+                return sourceResolution;
+            }
+
+            resolved.push({
+                sourceColumn: reference,
+                targetColumn: value
+            });
+        }
+
+        return resolved;
+    }
+
+    private verifyColumnResolvableInQuery(query: SimpleSelectQuery, column: ColumnReference): SkipDraft | null {
+        if (!query.fromClause) {
+            return {
+                code: "NO_TARGET_FROM_CLAUSE",
+                reason: "Target query has no FROM clause where the moved column can be resolved."
+            };
+        }
+
+        const bindings = this.getSourceBindings(query.fromClause);
+        const namespace = normalizeIdentifier(column.getNamespace());
+        if (namespace) {
+            const matches = bindings.filter(binding => normalizeIdentifier(binding.alias) === namespace);
+            return matches.length === 1
+                ? null
+                : {
+                    code: "AMBIGUOUS_TARGET_COLUMN",
+                    reason: `Target column '${columnReferenceText(column)}' is not uniquely resolvable in the destination query.`
+                };
+        }
+
+        if (bindings.length === 1) {
+            return null;
+        }
+
+        return {
+            code: "AMBIGUOUS_TARGET_COLUMN",
+            reason: `Unqualified target column '${column.column.name}' is ambiguous in a multi-source destination query.`
+        };
+    }
+
+    private rebasePredicate(
+        expression: ValueComponent,
+        targetColumns: readonly TargetColumnResolution[]
+    ): ValueComponent {
+        const cloned = cloneValueComponent(expression);
+        const visitSelect = (query: SelectQuery, inheritedLocalAliases: ReadonlySet<string>): void => {
+            if (!(query instanceof SimpleSelectQuery)) {
+                return;
+            }
+
+            const localAliases = new Set(inheritedLocalAliases);
+            for (const alias of this.collectSourceAliases(query)) {
+                localAliases.add(alias);
+            }
+
+            query.selectClause.items.forEach(item => visit(item.value, localAliases));
+            for (const join of query.fromClause?.joins ?? []) {
+                if (join.condition) {
+                    visit(join.condition.condition, localAliases);
+                }
+                const source = join.source.datasource;
+                if (source instanceof SubQuerySource) {
+                    visitSelect(source.query, localAliases);
+                }
+            }
+            if (query.whereClause) {
+                visit(query.whereClause.condition, localAliases);
+            }
+            if (query.havingClause) {
+                visit(query.havingClause.condition, localAliases);
+            }
+            for (const cte of query.withClause?.tables ?? []) {
+                if (cte.query instanceof SimpleSelectQuery || cte.query instanceof BinarySelectQuery) {
+                    visitSelect(cte.query, localAliases);
+                }
+            }
+        };
+
+        const visit = (value: ValueComponent, localAliases: ReadonlySet<string>): void => {
+            const candidate = unwrapParens(value);
+            if (candidate instanceof ColumnReference) {
+                const namespace = normalizeIdentifier(candidate.getNamespace());
+                if (namespace && localAliases.has(namespace)) {
+                    return;
+                }
+                const target = targetColumns.find(item => sameColumnReference(candidate, item.sourceColumn));
+                if (target) {
+                    candidate.qualifiedName = cloneColumnReference(target.targetColumn).qualifiedName;
+                }
+                return;
+            }
+            if (candidate instanceof BinaryExpression) {
+                visit(candidate.left, localAliases);
+                visit(candidate.right, localAliases);
+                return;
+            }
+            if (candidate instanceof UnaryExpression) {
+                visit(candidate.expression, localAliases);
+                return;
+            }
+            if (candidate instanceof InlineQuery) {
+                visitSelect(candidate.selectQuery, localAliases);
+                return;
+            }
+            if (candidate instanceof FunctionCall) {
+                if (candidate.argument) {
+                    visit(candidate.argument, localAliases);
+                }
+                if (candidate.filterCondition) {
+                    visit(candidate.filterCondition, localAliases);
+                }
+                return;
+            }
+            if (candidate instanceof CastExpression) {
+                visit(candidate.input, localAliases);
+                return;
+            }
+            if (candidate instanceof CaseExpression) {
+                if (candidate.condition) {
+                    visit(candidate.condition, localAliases);
+                }
+                for (const pair of candidate.switchCase.cases) {
+                    visit(pair.key, localAliases);
+                    visit(pair.value, localAliases);
+                }
+                if (candidate.switchCase.elseValue) {
+                    visit(candidate.switchCase.elseValue, localAliases);
+                }
+                return;
+            }
+            if (candidate instanceof BetweenExpression) {
+                visit(candidate.expression, localAliases);
+                visit(candidate.lower, localAliases);
+                visit(candidate.upper, localAliases);
+                return;
+            }
+            if (candidate instanceof JsonPredicateExpression) {
+                visit(candidate.expression, localAliases);
+                return;
+            }
+            if (candidate instanceof ArrayExpression) {
+                visit(candidate.expression, localAliases);
+                return;
+            }
+            if (candidate instanceof ValueList) {
+                candidate.values.forEach(item => visit(item, localAliases));
+                return;
+            }
+            if (candidate instanceof TupleExpression) {
+                candidate.values.forEach(item => visit(item, localAliases));
+                return;
+            }
+            if (candidate instanceof TypeValue && candidate.argument) {
+                visit(candidate.argument, localAliases);
+            }
+        };
+
+        visit(cloned, new Set());
+        return cloned;
+    }
+
+    private getSourceBindings(fromClause: FromClause): SourceBinding[] {
+        const bindings: SourceBinding[] = [{
+            source: fromClause.source,
+            alias: fromClause.source.getAliasName() ?? "",
+            join: null,
+            joinIndex: -1,
+            isPrimary: true
+        }];
+
+        for (let index = 0; index < (fromClause.joins ?? []).length; index += 1) {
+            const join = fromClause.joins![index]!;
+            bindings.push({
+                source: join.source,
+                alias: join.source.getAliasName() ?? "",
+                join,
+                joinIndex: index,
+                isPrimary: false
+            });
+        }
+
+        return bindings;
+    }
+
+    private findNullableSideBoundary(fromClause: FromClause, binding: SourceBinding): SkipDraft | null {
+        const joins = fromClause.joins ?? [];
+        if (binding.isPrimary) {
+            return this.hasLaterJoinThatNullsPriorSources(joins, -1)
+                ? {
+                    code: "OUTER_JOIN_NULLABLE_SIDE",
+                    reason: "Predicate crosses OUTER JOIN nullable side; moving it may change semantics."
+                }
+                : null;
+        }
+
+        const join = binding.join;
+        if (!join) {
+            return null;
+        }
+
+        const joinType = join.joinType.value.toLowerCase();
+        if (joinType.includes("left")) {
+            return {
+                code: "OUTER_JOIN_NULLABLE_SIDE",
+                reason: "Predicate crosses LEFT JOIN nullable side; moving it may change semantics."
+            };
+        }
+        if (joinType.includes("full")) {
+            return {
+                code: "OUTER_JOIN_NULLABLE_SIDE",
+                reason: "Predicate crosses FULL JOIN nullable side; moving it may change semantics."
+            };
+        }
+        if (this.hasLaterJoinThatNullsPriorSources(joins, binding.joinIndex)) {
+            return {
+                code: "OUTER_JOIN_NULLABLE_SIDE",
+                reason: "Predicate crosses later RIGHT/FULL JOIN nullable side; moving it may change semantics."
+            };
+        }
+
+        return null;
+    }
+
+    private hasLaterJoinThatNullsPriorSources(joins: readonly JoinClause[], sourceJoinIndex: number): boolean {
+        return joins
+            .slice(sourceJoinIndex + 1)
+            .some(join => {
+                const joinType = join.joinType.value.toLowerCase();
+                return joinType.includes("right") || joinType.includes("full");
+            });
+    }
+
+    private hasOuterJoin(fromClause: FromClause): boolean {
+        return (fromClause.joins ?? []).some(join => {
+            const joinType = join.joinType.value.toLowerCase();
+            return joinType.includes("left") || joinType.includes("right") || joinType.includes("full") || joinType.includes("outer");
+        });
+    }
+
+    private getOutputColumnMatchCount(root: SimpleSelectQuery, binding: SourceBinding, columnName: string): number {
+        const target = this.resolveSourceQueryForColumns(root, binding.source);
+        if (!target || !(target instanceof SimpleSelectQuery)) {
+            return 0;
+        }
+        return target.selectClause.items.filter(item =>
+            normalizeIdentifier(this.getSelectItemOutputName(item) ?? "") === normalizeIdentifier(columnName)
+        ).length;
+    }
+
+    private resolveSourceQueryForColumns(root: SimpleSelectQuery, source: SourceExpression): SelectQuery | null {
+        if (source.datasource instanceof SubQuerySource) {
+            return source.datasource.query;
+        }
+        if (source.datasource instanceof TableSource) {
+            const cteQuery = this.findCte(root, source.datasource.table.name)?.query;
+            return cteQuery instanceof SimpleSelectQuery || cteQuery instanceof BinarySelectQuery
+                ? cteQuery
+                : null;
+        }
+        return null;
+    }
+
+    private getSelectItemOutputName(item: { value: ValueComponent; identifier: { name: string } | null }): string | null {
+        if (item.identifier) {
+            return item.identifier.name;
+        }
+        if (item.value instanceof ColumnReference) {
+            return item.value.column.name;
+        }
+        return null;
+    }
+
+    private findCte(root: SimpleSelectQuery, name: string): CommonTable | null {
+        const normalized = normalizeIdentifier(name);
+        const matches = (root.withClause?.tables ?? [])
+            .filter(table => normalizeIdentifier(table.getSourceAliasName()) === normalized);
+        return matches.length === 1 ? matches[0]! : null;
+    }
+
+    private countTableSourceReferences(query: SelectQuery, tableName: string): number {
+        const normalized = normalizeIdentifier(tableName);
+        let count = 0;
+        const visitSelect = (select: SelectQuery): void => {
+            if (select instanceof BinarySelectQuery) {
+                visitSelect(select.left);
+                visitSelect(select.right);
+                return;
+            }
+            if (!(select instanceof SimpleSelectQuery)) {
+                return;
+            }
+
+            if (select.fromClause) {
+                for (const binding of this.getSourceBindings(select.fromClause)) {
+                    const source = binding.source.datasource;
+                    if (source instanceof TableSource && normalizeIdentifier(source.table.name) === normalized) {
+                        count += 1;
+                    }
+                    if (source instanceof SubQuerySource) {
+                        visitSelect(source.query);
+                    }
+                }
+            }
+
+            for (const cte of select.withClause?.tables ?? []) {
+                if (cte.query instanceof SimpleSelectQuery || cte.query instanceof BinarySelectQuery) {
+                    visitSelect(cte.query);
+                }
+            }
+        };
+
+        visitSelect(query);
+        return count;
+    }
+
+    private collectSourceAliases(query: SimpleSelectQuery): Set<string> {
+        const aliases = new Set<string>();
+        for (const source of query.fromClause?.getSources() ?? []) {
+            const alias = source.getAliasName();
+            if (alias) {
+                aliases.add(normalizeIdentifier(alias));
+            }
+        }
+        return aliases;
+    }
+
+    private collectRootColumnReferences(root: SimpleSelectQuery, expression: ValueComponent): ColumnReference[] {
+        const references: ColumnReference[] = [];
+        const rootAliases = this.collectSourceAliases(root);
+
+        const visitSelect = (query: SelectQuery, inheritedLocalAliases: ReadonlySet<string>): void => {
+            if (!(query instanceof SimpleSelectQuery)) {
+                return;
+            }
+
+            const localAliases = new Set(inheritedLocalAliases);
+            for (const alias of this.collectSourceAliases(query)) {
+                localAliases.add(alias);
+            }
+
+            query.selectClause.items.forEach(item => visit(item.value, localAliases));
+            for (const join of query.fromClause?.joins ?? []) {
+                if (join.condition) {
+                    visit(join.condition.condition, localAliases);
+                }
+                const source = join.source.datasource;
+                if (source instanceof SubQuerySource) {
+                    visitSelect(source.query, localAliases);
+                }
+            }
+            if (query.whereClause) {
+                visit(query.whereClause.condition, localAliases);
+            }
+            if (query.havingClause) {
+                visit(query.havingClause.condition, localAliases);
+            }
+            for (const cte of query.withClause?.tables ?? []) {
+                if (cte.query instanceof SimpleSelectQuery || cte.query instanceof BinarySelectQuery) {
+                    visitSelect(cte.query, localAliases);
+                }
+            }
+        };
+
+        const collect = (reference: ColumnReference): void => {
+            if (!references.some(existing => sameColumnReference(existing, reference))) {
+                references.push(reference);
+            }
+        };
+
+        const visit = (value: ValueComponent, localAliases: ReadonlySet<string>): void => {
+            const candidate = unwrapParens(value);
+            if (candidate instanceof ColumnReference) {
+                const namespace = normalizeIdentifier(candidate.getNamespace());
+                if (namespace) {
+                    if (rootAliases.has(namespace) && !localAliases.has(namespace)) {
+                        collect(candidate);
+                    }
+                    return;
+                }
+                if (localAliases.size === 0) {
+                    collect(candidate);
+                }
+                return;
+            }
+            if (candidate instanceof BinaryExpression) {
+                visit(candidate.left, localAliases);
+                visit(candidate.right, localAliases);
+                return;
+            }
+            if (candidate instanceof UnaryExpression) {
+                visit(candidate.expression, localAliases);
+                return;
+            }
+            if (candidate instanceof InlineQuery) {
+                visitSelect(candidate.selectQuery, localAliases);
+                return;
+            }
+            if (candidate instanceof FunctionCall) {
+                if (candidate.argument) {
+                    visit(candidate.argument, localAliases);
+                }
+                if (candidate.filterCondition) {
+                    visit(candidate.filterCondition, localAliases);
+                }
+                return;
+            }
+            if (candidate instanceof CastExpression) {
+                visit(candidate.input, localAliases);
+                return;
+            }
+            if (candidate instanceof CaseExpression) {
+                if (candidate.condition) {
+                    visit(candidate.condition, localAliases);
+                }
+                for (const pair of candidate.switchCase.cases) {
+                    visit(pair.key, localAliases);
+                    visit(pair.value, localAliases);
+                }
+                if (candidate.switchCase.elseValue) {
+                    visit(candidate.switchCase.elseValue, localAliases);
+                }
+                return;
+            }
+            if (candidate instanceof BetweenExpression) {
+                visit(candidate.expression, localAliases);
+                visit(candidate.lower, localAliases);
+                visit(candidate.upper, localAliases);
+                return;
+            }
+            if (candidate instanceof JsonPredicateExpression) {
+                visit(candidate.expression, localAliases);
+                return;
+            }
+            if (candidate instanceof ArrayExpression) {
+                visit(candidate.expression, localAliases);
+                return;
+            }
+            if (candidate instanceof ArrayQueryExpression) {
+                visitSelect(candidate.query, localAliases);
+                return;
+            }
+            if (candidate instanceof ValueList) {
+                candidate.values.forEach(item => visit(item, localAliases));
+                return;
+            }
+            if (candidate instanceof TupleExpression) {
+                candidate.values.forEach(item => visit(item, localAliases));
+                return;
+            }
+            if (candidate instanceof TypeValue && candidate.argument) {
+                visit(candidate.argument, localAliases);
+            }
+        };
+
+        visit(expression, new Set());
+        return references;
+    }
+
+    private hasWindowUsage(query: SimpleSelectQuery): boolean {
+        if (query.windowClause) {
+            return true;
+        }
+
+        let found = false;
+        const visit = (value: ValueComponent): void => {
+            if (found) {
+                return;
+            }
+            const candidate = unwrapParens(value);
+            if (candidate instanceof FunctionCall) {
+                if (candidate.over) {
+                    found = true;
+                    return;
+                }
+                if (candidate.argument) {
+                    visit(candidate.argument);
+                }
+                if (candidate.filterCondition) {
+                    visit(candidate.filterCondition);
+                }
+                return;
+            }
+            if (candidate instanceof BinaryExpression) {
+                visit(candidate.left);
+                visit(candidate.right);
+                return;
+            }
+            if (candidate instanceof UnaryExpression) {
+                visit(candidate.expression);
+                return;
+            }
+            if (candidate instanceof CastExpression) {
+                visit(candidate.input);
+                return;
+            }
+            if (candidate instanceof CaseExpression) {
+                if (candidate.condition) {
+                    visit(candidate.condition);
+                }
+                for (const pair of candidate.switchCase.cases) {
+                    visit(pair.key);
+                    visit(pair.value);
+                }
+                if (candidate.switchCase.elseValue) {
+                    visit(candidate.switchCase.elseValue);
+                }
+                return;
+            }
+            if (candidate instanceof ValueList) {
+                candidate.values.forEach(visit);
+            }
+        };
+
+        query.selectClause.items.forEach(item => visit(item.value));
+        return found;
+    }
+
+    private collectParameterNames(expression: ValueComponent): string[] {
+        const names: string[] = [];
+        const visitSelect = (query: SelectQuery): void => {
+            if (query instanceof BinarySelectQuery) {
+                visitSelect(query.left);
+                visitSelect(query.right);
+                return;
+            }
+            if (!(query instanceof SimpleSelectQuery)) {
+                return;
+            }
+
+            query.selectClause.items.forEach(item => visit(item.value));
+            for (const join of query.fromClause?.joins ?? []) {
+                if (join.condition) {
+                    visit(join.condition.condition);
+                }
+                const source = join.source.datasource;
+                if (source instanceof SubQuerySource) {
+                    visitSelect(source.query);
+                }
+            }
+            if (query.whereClause) {
+                visit(query.whereClause.condition);
+            }
+            if (query.havingClause) {
+                visit(query.havingClause.condition);
+            }
+            for (const cte of query.withClause?.tables ?? []) {
+                if (cte.query instanceof SimpleSelectQuery || cte.query instanceof BinarySelectQuery) {
+                    visitSelect(cte.query);
+                }
+            }
+        };
+
+        const visit = (value: ValueComponent): void => {
+            const candidate = unwrapParens(value);
+            if (candidate instanceof ParameterExpression) {
+                appendUnique(names, candidate.name.value);
+                return;
+            }
+            if (candidate instanceof BinaryExpression) {
+                visit(candidate.left);
+                visit(candidate.right);
+                return;
+            }
+            if (candidate instanceof UnaryExpression) {
+                visit(candidate.expression);
+                return;
+            }
+            if (candidate instanceof InlineQuery) {
+                visitSelect(candidate.selectQuery);
+                return;
+            }
+            if (candidate instanceof ArrayQueryExpression) {
+                visitSelect(candidate.query);
+                return;
+            }
+            if (candidate instanceof FunctionCall) {
+                if (candidate.argument) {
+                    visit(candidate.argument);
+                }
+                if (candidate.filterCondition) {
+                    visit(candidate.filterCondition);
+                }
+                return;
+            }
+            if (candidate instanceof CastExpression) {
+                visit(candidate.input);
+                return;
+            }
+            if (candidate instanceof CaseExpression) {
+                if (candidate.condition) {
+                    visit(candidate.condition);
+                }
+                for (const pair of candidate.switchCase.cases) {
+                    visit(pair.key);
+                    visit(pair.value);
+                }
+                if (candidate.switchCase.elseValue) {
+                    visit(candidate.switchCase.elseValue);
+                }
+                return;
+            }
+            if (candidate instanceof BetweenExpression) {
+                visit(candidate.expression);
+                visit(candidate.lower);
+                visit(candidate.upper);
+                return;
+            }
+            if (candidate instanceof JsonPredicateExpression) {
+                visit(candidate.expression);
+                return;
+            }
+            if (candidate instanceof ArrayExpression) {
+                visit(candidate.expression);
+                return;
+            }
+            if (candidate instanceof ValueList) {
+                candidate.values.forEach(visit);
+                return;
+            }
+            if (candidate instanceof TupleExpression) {
+                candidate.values.forEach(visit);
+                return;
+            }
+            if (candidate instanceof TypeValue && candidate.argument) {
+                visit(candidate.argument);
+            }
+        };
+
+        visit(expression);
+        return names;
+    }
+
+    private makeSkipped(expression: ValueComponent, draft: SkipDraft): StaticPredicateSkipped {
+        return {
+            predicateSql: formatSqlComponent(expression),
+            scopeId: "scope:root",
+            ...draft
+        };
+    }
+
+    private buildResult(params: {
+        sql: string;
+        applied: StaticPredicateMove[];
+        skipped: StaticPredicateSkipped[];
+        warnings: StaticPredicatePlacementWarning[];
+        errors: StaticPredicatePlacementError[];
+        dryRun: boolean;
+        formatterGeneratedSource: boolean;
+    }): StaticPredicatePlacementResult {
+        return {
+            ok: params.errors.length === 0,
+            sql: params.sql,
+            applied: params.applied,
+            skipped: params.skipped,
+            warnings: params.warnings,
+            errors: params.errors,
+            safety: {
+                mode: "safe_only",
+                unsafeRewriteApplied: false,
+                dryRun: params.dryRun,
+                formatterGeneratedSource: params.formatterGeneratedSource
+            },
+            staticPredicateMoves: params.applied
+        };
+    }
+}
+
+export const planStaticPredicatePlacement = (
+    input: StaticPredicatePlacementInput,
+    options: StaticPredicatePlacementOptions = {}
+): StaticPredicatePlacementResult => {
+    return new StaticPredicatePlacementOptimizer().plan(input, options);
+};
+
+export const optimizeStaticPredicatePlacement = (
+    input: StaticPredicatePlacementInput,
+    options: StaticPredicatePlacementOptions = {}
+): StaticPredicatePlacementResult => {
+    return new StaticPredicatePlacementOptimizer().optimize(input, options);
+};

--- a/packages/core/tests/transformers/ConditionOptimization.test.ts
+++ b/packages/core/tests/transformers/ConditionOptimization.test.ts
@@ -33,6 +33,10 @@ describe('ConditionOptimization', () => {
             expect.objectContaining({
                 kind: 'parameter_condition_placement',
                 appliedCount: 0
+            }),
+            expect.objectContaining({
+                kind: 'static_predicate_placement',
+                appliedCount: 0
             })
         ]);
         expect(result.applied).toEqual([
@@ -71,6 +75,11 @@ describe('ConditionOptimization', () => {
             expect.objectContaining({
                 kind: 'parameter_condition_placement',
                 appliedCount: 1,
+                skippedCount: 0
+            }),
+            expect.objectContaining({
+                kind: 'static_predicate_placement',
+                appliedCount: 0,
                 skippedCount: 0
             })
         ]);
@@ -121,6 +130,10 @@ describe('ConditionOptimization', () => {
             'sssql_optional_condition',
             'parameter_condition_placement'
         ]);
+        expect(result.phases[2]).toEqual(expect.objectContaining({
+            kind: 'static_predicate_placement',
+            appliedCount: 0
+        }));
         expect(normalizeSql(result.sql)).toBe(normalizeSql(`
             with orders_base as (
                 select o.order_id, o.customer_id, o.status
@@ -155,6 +168,11 @@ describe('ConditionOptimization', () => {
         }));
         expect(result.phases[1]).toEqual(expect.objectContaining({
             kind: 'parameter_condition_placement',
+            appliedCount: 0,
+            skippedCount: 0
+        }));
+        expect(result.phases[2]).toEqual(expect.objectContaining({
+            kind: 'static_predicate_placement',
             appliedCount: 0,
             skippedCount: 0
         }));
@@ -222,6 +240,10 @@ describe('ConditionOptimization', () => {
                 conditionSql: expect.stringContaining(':customer_tier')
             })
         ]));
+        expect(result.phases[2]).toEqual(expect.objectContaining({
+            kind: 'static_predicate_placement',
+            appliedCount: 0
+        }));
         expect(normalizeSql(result.sql)).toBe(normalizeSql(`
             with customer_scope as (
                 select c.id, c.customer_tier, c.region
@@ -237,6 +259,132 @@ describe('ConditionOptimization', () => {
             select cs.id
             from customer_scope cs
             left join order_totals ot on ot.customer_id = cs.id
+        `));
+    });
+
+    it('runs SSSQL, parameter, and static predicate placement in order for mixed conditions', () => {
+        const sql = `
+            with customer_scope as (
+                select c.id, c.customer_tier, c.region
+                from customers c
+            )
+            select cs.id
+            from customer_scope cs
+            where (:customer_tier is null or cs.customer_tier = :customer_tier)
+              and cs.region = :region
+              and exists (
+                select 1
+                from customer_favorites cf
+                where cf.customer_id = cs.id
+                  and cf.is_active = true
+              )
+        `;
+
+        const result = optimizeConditions(sql, {
+            optionalConditionParameters: { customer_tier: 'gold' }
+        });
+
+        expect(result.ok).toBe(true);
+        expect(result.phases.map(phase => phase.kind)).toEqual([
+            'sssql_optional_condition',
+            'parameter_condition_placement',
+            'static_predicate_placement'
+        ]);
+        expect(result.phases).toEqual([
+            expect.objectContaining({ kind: 'sssql_optional_condition', appliedCount: 1 }),
+            expect.objectContaining({ kind: 'parameter_condition_placement', appliedCount: 1 }),
+            expect.objectContaining({ kind: 'static_predicate_placement', appliedCount: 1 })
+        ]);
+        expect(result.applied.map(item => item.phaseKind)).toEqual([
+            'sssql_optional_condition',
+            'parameter_condition_placement',
+            'static_predicate_placement'
+        ]);
+        expect(result.applied).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                phaseKind: 'static_predicate_placement',
+                kind: 'move_static_predicate',
+                predicateSql: expect.stringContaining('exists'),
+                columnReferences: ['cs.id']
+            })
+        ]));
+        expect(result.applied).not.toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                phaseKind: 'static_predicate_placement',
+                predicateSql: expect.stringContaining(':region')
+            }),
+            expect.objectContaining({
+                phaseKind: 'static_predicate_placement',
+                predicateSql: expect.stringContaining(':customer_tier')
+            })
+        ]));
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(`
+            with customer_scope as (
+                select c.id, c.customer_tier, c.region
+                from customers c
+                where (:customer_tier is null or c.customer_tier = :customer_tier)
+                  and c.region = :region
+                  and exists (
+                    select 1
+                    from customer_favorites cf
+                    where cf.customer_id = c.id
+                      and cf.is_active = true
+                  )
+            )
+            select cs.id
+            from customer_scope cs
+        `));
+    });
+
+    it('keeps unsafe static predicate skipped reasons in the unified result', () => {
+        const sql = `
+            with customer_scope as (
+                select c.id, c.region
+                from customers c
+            ),
+            payment_scope as (
+                select p.customer_id, p.is_successful
+                from payments p
+            )
+            select cs.id
+            from customer_scope cs
+            left join payment_scope ps on ps.customer_id = cs.id
+            where cs.region = :region
+              and ps.is_successful = true
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.phases[1]).toEqual(expect.objectContaining({
+            kind: 'parameter_condition_placement',
+            appliedCount: 1
+        }));
+        expect(result.phases[2]).toEqual(expect.objectContaining({
+            kind: 'static_predicate_placement',
+            appliedCount: 0,
+            skippedCount: 1
+        }));
+        expect(result.skipped).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                phaseKind: 'static_predicate_placement',
+                code: 'OUTER_JOIN_NULLABLE_SIDE'
+            })
+        ]));
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(`
+            with customer_scope as (
+                select c.id, c.region
+                from customers c
+                where c.region = :region
+            ),
+            payment_scope as (
+                select p.customer_id, p.is_successful
+                from payments p
+            )
+            select cs.id
+            from customer_scope cs
+            left join payment_scope ps on ps.customer_id = cs.id
+            where ps.is_successful = true
         `));
     });
 
@@ -309,6 +457,11 @@ describe('ConditionOptimization', () => {
             appliedCount: 0,
             skippedCount: 1
         }));
+        expect(result.phases[2]).toEqual(expect.objectContaining({
+            kind: 'static_predicate_placement',
+            appliedCount: 0,
+            skippedCount: 0
+        }));
         expect(result.skipped).toEqual([
             expect.objectContaining({
                 phaseKind: 'parameter_condition_placement',
@@ -341,6 +494,10 @@ describe('ConditionOptimization', () => {
             kind: 'parameter_condition_placement',
             appliedCount: 1
         }));
+        expect(result.phases[2]).toEqual(expect.objectContaining({
+            kind: 'static_predicate_placement',
+            appliedCount: 0
+        }));
         expect(normalizeSql(result.sql)).toContain('where "c"."tier" = :tier');
     });
 
@@ -367,6 +524,9 @@ describe('ConditionOptimization', () => {
         expect(warningResult.phases[0]).toEqual(expect.objectContaining({
             warningCount: 1,
             errorCount: 0
+        }));
+        expect(warningResult.phases[2]).toEqual(expect.objectContaining({
+            kind: 'static_predicate_placement'
         }));
 
         const errorResult = planConditionOptimization('select from');

--- a/packages/core/tests/transformers/StaticPredicatePlacementOptimizer.test.ts
+++ b/packages/core/tests/transformers/StaticPredicatePlacementOptimizer.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, it } from 'vitest';
+import { SelectQueryParser } from '../../src/parsers/SelectQueryParser';
+import { SqlFormatter } from '../../src/transformers/SqlFormatter';
+import {
+    optimizeStaticPredicatePlacement,
+    planStaticPredicatePlacement
+} from '../../src/transformers/StaticPredicatePlacementOptimizer';
+
+const normalizeSql = (sql: string): string => {
+    const query = SelectQueryParser.parse(sql);
+    return new SqlFormatter().format(query).formattedSql;
+};
+
+describe('StaticPredicatePlacementOptimizer', () => {
+    it('moves a correlated EXISTS static predicate into a safe upstream CTE and rebases the outer reference', () => {
+        const sql = `
+            with customer_scope as (
+                select c.id, c.name
+                from customers c
+            )
+            select cs.id
+            from customer_scope cs
+            where exists (
+                select 1
+                from customer_favorites cf
+                where cf.customer_id = cs.id
+                  and cf.is_active = true
+            )
+        `;
+
+        const result = optimizeStaticPredicatePlacement(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([
+            expect.objectContaining({
+                kind: 'move_static_predicate',
+                predicateSql: expect.stringContaining('exists'),
+                fromScopeId: 'scope:root',
+                toScopeId: 'cte:customer_scope',
+                columnReferences: ['cs.id']
+            })
+        ]);
+        expect(result.skipped).toEqual([]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(`
+            with customer_scope as (
+                select c.id, c.name
+                from customers c
+                where exists (
+                    select 1
+                    from customer_favorites cf
+                    where cf.customer_id = c.id
+                      and cf.is_active = true
+                )
+            )
+            select cs.id
+            from customer_scope cs
+        `));
+    });
+
+    it('moves simple boolean and NULL static predicates into the safe upstream CTE', () => {
+        const sql = `
+            with customer_scope as (
+                select c.id, c.is_active, c.deleted_at
+                from customers c
+            )
+            select cs.id
+            from customer_scope cs
+            where cs.is_active = true
+              and cs.deleted_at is null
+        `;
+
+        const result = optimizeStaticPredicatePlacement(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toHaveLength(2);
+        expect(result.applied.map(item => item.columnReferences)).toEqual([
+            ['cs.is_active'],
+            ['cs.deleted_at']
+        ]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(`
+            with customer_scope as (
+                select c.id, c.is_active, c.deleted_at
+                from customers c
+                where c.is_active = true
+                  and c.deleted_at is null
+            )
+            select cs.id
+            from customer_scope cs
+        `));
+    });
+
+    it('is a no-op when the static predicate is already in the upstream CTE', () => {
+        const sql = `
+            with customer_scope as (
+                select c.id, c.is_active
+                from customers c
+                where c.is_active = true
+            )
+            select cs.id
+            from customer_scope cs
+        `;
+
+        const result = optimizeStaticPredicatePlacement(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([]);
+        expect(result.skipped).toEqual([]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));
+    });
+
+    it('does not handle parameter predicates or SSSQL optional predicates', () => {
+        const sql = `
+            with customer_scope as (
+                select c.id, c.region, c.customer_tier
+                from customers c
+            )
+            select cs.id
+            from customer_scope cs
+            where cs.region = :region
+              and (:customer_tier is null or cs.customer_tier = :customer_tier)
+        `;
+
+        const result = optimizeStaticPredicatePlacement(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([]);
+        expect(result.skipped).toEqual([]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));
+    });
+
+    it('skips predicates that reference the nullable side of a LEFT JOIN', () => {
+        const sql = `
+            with customer_scope as (
+                select c.id
+                from customers c
+            ),
+            payment_scope as (
+                select p.customer_id, p.is_successful
+                from payments p
+            )
+            select cs.id
+            from customer_scope cs
+            left join payment_scope ps on ps.customer_id = cs.id
+            where ps.is_successful = true
+        `;
+
+        const result = optimizeStaticPredicatePlacement(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([]);
+        expect(result.skipped).toEqual([
+            expect.objectContaining({
+                code: 'OUTER_JOIN_NULLABLE_SIDE',
+                reason: expect.stringMatching(/left join nullable side/i)
+            })
+        ]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));
+    });
+
+    it('skips predicates when a later RIGHT or FULL JOIN can null the joined source', () => {
+        for (const joinType of ['RIGHT JOIN', 'FULL JOIN']) {
+            const sql = `
+                with customer_scope as (
+                    select c.id
+                    from customers c
+                ),
+                order_scope as (
+                    select o.customer_id, o.is_open
+                    from orders o
+                ),
+                region_scope as (
+                    select r.customer_id
+                    from regions r
+                )
+                select cs.id
+                from customer_scope cs
+                join order_scope os on os.customer_id = cs.id
+                ${joinType} region_scope rs on rs.customer_id = cs.id
+                where os.is_open = true
+            `;
+
+            const result = optimizeStaticPredicatePlacement(sql);
+
+            expect(result.applied).toEqual([]);
+            expect(result.skipped).toEqual([
+                expect.objectContaining({
+                    code: 'OUTER_JOIN_NULLABLE_SIDE',
+                    reason: expect.stringMatching(/right\/full join nullable side/i)
+                })
+            ]);
+            expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));
+        }
+    });
+
+    it('skips GROUP BY, DISTINCT, and UNION boundaries', () => {
+        const groupByResult = optimizeStaticPredicatePlacement(`
+            with order_totals as (
+                select o.customer_id, count(*) as order_count
+                from orders o
+                group by o.customer_id
+            )
+            select ot.customer_id
+            from order_totals ot
+            where ot.customer_id = 10
+        `);
+
+        const distinctResult = optimizeStaticPredicatePlacement(`
+            with distinct_customers as (
+                select distinct c.id
+                from customers c
+            )
+            select dc.id
+            from distinct_customers dc
+            where dc.id = 10
+        `);
+
+        const unionResult = optimizeStaticPredicatePlacement(`
+            with combined_customers as (
+                select c.id
+                from customers c
+                union all
+                select a.id
+                from archived_customers a
+            )
+            select cc.id
+            from combined_customers cc
+            where cc.id = 10
+        `);
+
+        expect(groupByResult.skipped).toEqual([
+            expect.objectContaining({ code: 'GROUP_BY_BOUNDARY' })
+        ]);
+        expect(distinctResult.skipped).toEqual([
+            expect.objectContaining({ code: 'DISTINCT_BOUNDARY' })
+        ]);
+        expect(unionResult.skipped).toEqual([
+            expect.objectContaining({ code: 'UNION_BOUNDARY' })
+        ]);
+    });
+
+    it('skips OR predicates that would require boolean distribution', () => {
+        const sql = `
+            with customer_scope as (
+                select c.id, c.is_active, c.deleted_at
+                from customers c
+            )
+            select cs.id
+            from customer_scope cs
+            where cs.is_active = true or cs.deleted_at is null
+        `;
+
+        const result = optimizeStaticPredicatePlacement(sql);
+
+        expect(result.applied).toEqual([]);
+        expect(result.skipped).toEqual([
+            expect.objectContaining({
+                code: 'OR_PREDICATE_UNSUPPORTED'
+            })
+        ]);
+    });
+
+    it('skips reused CTEs, expression outputs, and function predicates', () => {
+        const reusedCteResult = optimizeStaticPredicatePlacement(`
+            with customer_scope as (
+                select c.id, c.is_active
+                from customers c
+            )
+            select left_cs.id
+            from customer_scope left_cs
+            join customer_scope right_cs on right_cs.id = left_cs.id
+            where left_cs.is_active = true
+        `);
+
+        const expressionOutputResult = optimizeStaticPredicatePlacement(`
+            with customer_scope as (
+                select c.id, lower(c.status) as status
+                from customers c
+            )
+            select cs.id
+            from customer_scope cs
+            where cs.status = 'active'
+        `);
+
+        const functionPredicateResult = optimizeStaticPredicatePlacement(`
+            with customer_scope as (
+                select c.id, c.status
+                from customers c
+            )
+            select cs.id
+            from customer_scope cs
+            where lower(cs.status) = 'active'
+        `);
+
+        expect(reusedCteResult.skipped).toEqual([
+            expect.objectContaining({ code: 'CTE_REUSE_UNSUPPORTED' })
+        ]);
+        expect(expressionOutputResult.skipped).toEqual([
+            expect.objectContaining({ code: 'EXPRESSION_OUTPUT_UNSUPPORTED' })
+        ]);
+        expect(functionPredicateResult.skipped).toEqual([
+            expect.objectContaining({ code: 'FUNCTION_PREDICATE_UNSUPPORTED' })
+        ]);
+    });
+
+    it('returns a dry-run plan without mutating caller-owned AST input', () => {
+        const query = SelectQueryParser.parse(`
+            with customer_scope as (
+                select c.id, c.is_active
+                from customers c
+            )
+            select cs.id
+            from customer_scope cs
+            where cs.is_active = true
+        `);
+        const before = new SqlFormatter().format(query).formattedSql;
+
+        const result = planStaticPredicatePlacement(query);
+
+        expect(result.ok).toBe(true);
+        expect(result.safety).toEqual(expect.objectContaining({
+            mode: 'safe_only',
+            unsafeRewriteApplied: false,
+            dryRun: true,
+            formatterGeneratedSource: true
+        }));
+        expect(result.applied).toHaveLength(1);
+        expect(new SqlFormatter().format(query).formattedSql).toBe(before);
+        expect(normalizeSql(result.sql)).toContain('where "c"."is_active" = true');
+    });
+});


### PR DESCRIPTION
## Summary

- Add safe-only static predicate placement APIs for parameter-free top-level predicates.
- Integrate `static_predicate_placement` as the third condition optimization phase after SSSQL optional branches and parameter condition placement.
- Cover safe moves, unsupported/ambiguous skips, mixed-phase metadata, comment preservation, and AST dry-run safety with regression tests.

## Verification

- `corepack pnpm --filter rawsql-ts test`
- `corepack pnpm --filter rawsql-ts build`
- `corepack pnpm --filter rawsql-ts lint`
- `corepack pnpm --filter rawsql-ts benchmark`
- `corepack pnpm demo:complex-sql`
- `git diff --check`
- pre-commit hook: workspace `typecheck`, `test`, `build`, and `lint`

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

<!-- Write values on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. -->
<!-- Do not add list markers like "-" before these labels; `Tracking issue:` and `Scoped checks run:` must start at column 0. -->
Tracking issue: Direct task request; no separate issue.
Scoped checks run: `corepack pnpm --filter rawsql-ts test`; `corepack pnpm --filter rawsql-ts build`; `corepack pnpm --filter rawsql-ts lint`; `corepack pnpm --filter rawsql-ts benchmark`; `corepack pnpm demo:complex-sql`; `git diff --check`; pre-commit workspace `typecheck`, `test`, `build`, and `lint`.
Why full baseline is not required: No baseline exception requested; local package gates and pre-commit workspace gates passed.

## Self Review

<!-- Fill these fields after running the repo self-review workflow or available self-review skill. -->
Self-review workflow: Repo-local `developer-self-review`: consistency review, package-boundary/concept review, and human acceptance review after verification.
Self-review result: No blockers found; regression tests and metadata assertions cover safe moves, skipped unsafe cases, phase ordering, and no double-processing of parameter or SSSQL predicates.
Concept-review workflow: Checked `packages/core/AGENTS.md` and `packages/core/DESIGN.md` for DBMS-neutral pure core transformer boundaries.
Concept-review result: No package-boundary violations found; no Node.js `fs`/`path`, driver, DB execution, EXPLAIN, or dialect-branch dependency introduced.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-migration rationale: No CLI-facing files changed; this is a core TypeScript API and integrated optimizer behavior change.
Upgrade note: New `planStaticPredicatePlacement` and `optimizeStaticPredicatePlacement` APIs are additive.
Deprecation/removal plan or issue: No deprecation or removal.
Docs/help/examples updated: No CLI help or scaffold examples changed.
Release/changeset wording: `.changeset/static-predicate-placement.md` describes the safe-only static predicate placement APIs and integrated phase.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-proof rationale: No scaffold-related files changed.
Non-edit assertion: No generated scaffold output is edited by this change.
Fail-fast input-contract proof: Not applicable because no scaffold input contract changes.
Generated-output viability proof: Not applicable because no scaffold output changes.
