### PR TITLE
Push predicates through ordinary DISTINCT

### DIFF
--- a/.changeset/distinct-condition-placement.md
+++ b/.changeset/distinct-condition-placement.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": patch
+---
+
+Allow condition placement to move safe predicates through ordinary DISTINCT outputs while keeping DISTINCT ON blocked.

--- a/packages/core/src/transformers/ParameterConditionPlacementOptimizer.ts
+++ b/packages/core/src/transformers/ParameterConditionPlacementOptimizer.ts
@@ -1,5 +1,6 @@
 import {
     CommonTable,
+    DistinctOn,
     FromClause,
     JoinClause,
     SourceExpression,
@@ -43,8 +44,8 @@ export type ParameterConditionOptimizationInput = string | SelectQuery | SimpleS
  *
  * The optimizer intentionally handles only root top-level AND predicates and one
  * CTE/derived-table hop where the destination output is a direct column reference.
- * Unsupported boundaries such as OR, UNION, DISTINCT, GROUP BY, WINDOW, OUTER
- * JOIN, expression outputs, and function predicates are reported as skipped.
+ * Unsupported boundaries such as OR, DISTINCT ON, WINDOW, OUTER JOIN,
+ * expression outputs, and function predicates are reported as skipped.
  */
 export interface ParameterConditionOptimizationOptions extends SqlComponentFormatOptions {
     dryRun?: boolean;
@@ -619,10 +620,10 @@ export class ParameterConditionPlacementOptimizer {
     }
 
     private findRootQueryBoundary(query: SimpleSelectQuery): SkipDraft | null {
-        if (query.selectClause.distinct) {
+        if (this.hasDistinctOnBoundary(query)) {
             return {
                 code: "DISTINCT_BOUNDARY",
-                reason: "Condition crosses DISTINCT boundary; moving it may change semantics."
+                reason: "Condition crosses DISTINCT ON boundary; moving it may change semantics."
             };
         }
         if (this.hasWindowUsage(query)) {
@@ -635,10 +636,11 @@ export class ParameterConditionPlacementOptimizer {
     }
 
     private resolveTargetPlacement(query: SimpleSelectQuery, targetColumn: ColumnReference): TargetPlacement | SkipDraft {
-        if (query.selectClause.distinct) {
+        const hasOrdinaryDistinct = this.hasOrdinaryDistinct(query);
+        if (this.hasDistinctOnBoundary(query)) {
             return {
                 code: "DISTINCT_BOUNDARY",
-                reason: "Condition crosses DISTINCT boundary; moving it may change semantics."
+                reason: "Condition crosses DISTINCT ON boundary; moving it may change semantics."
             };
         }
         if (this.hasWindowUsage(query)) {
@@ -674,6 +676,11 @@ export class ParameterConditionPlacementOptimizer {
             return {
                 code: "GROUP_BY_BOUNDARY",
                 reason: "Condition crosses HAVING aggregation boundary; moving it may change semantics."
+            };
+        }
+        if (hasOrdinaryDistinct) {
+            return {
+                reason: "Condition references a direct ordinary DISTINCT output column; it is moved into the DISTINCT input WHERE."
             };
         }
         return {
@@ -1106,6 +1113,14 @@ export class ParameterConditionPlacementOptimizer {
             const joinType = join.joinType.value.toLowerCase();
             return joinType.includes("left") || joinType.includes("right") || joinType.includes("full") || joinType.includes("outer");
         });
+    }
+
+    private hasDistinctOnBoundary(query: SimpleSelectQuery): boolean {
+        return query.selectClause.distinct instanceof DistinctOn;
+    }
+
+    private hasOrdinaryDistinct(query: SimpleSelectQuery): boolean {
+        return query.selectClause.distinct !== null && !this.hasDistinctOnBoundary(query);
     }
 
     private getOutputColumnMatchCount(root: SimpleSelectQuery, binding: SourceBinding, columnName: string): number {

--- a/packages/core/src/transformers/StaticPredicatePlacementOptimizer.ts
+++ b/packages/core/src/transformers/StaticPredicatePlacementOptimizer.ts
@@ -1,5 +1,6 @@
 import {
     CommonTable,
+    DistinctOn,
     FromClause,
     JoinClause,
     SourceExpression,
@@ -651,10 +652,10 @@ export class StaticPredicatePlacementOptimizer {
     }
 
     private findRootQueryBoundary(query: SimpleSelectQuery): SkipDraft | null {
-        if (query.selectClause.distinct) {
+        if (this.hasDistinctOnBoundary(query)) {
             return {
                 code: "DISTINCT_BOUNDARY",
-                reason: "Predicate crosses DISTINCT boundary; moving it may change semantics."
+                reason: "Predicate crosses DISTINCT ON boundary; moving it may change semantics."
             };
         }
         if (this.hasWindowUsage(query)) {
@@ -670,10 +671,11 @@ export class StaticPredicatePlacementOptimizer {
         query: SimpleSelectQuery,
         targetColumns: readonly TargetColumnResolution[]
     ): TargetPlacement | SkipDraft {
-        if (query.selectClause.distinct) {
+        const hasOrdinaryDistinct = this.hasOrdinaryDistinct(query);
+        if (this.hasDistinctOnBoundary(query)) {
             return {
                 code: "DISTINCT_BOUNDARY",
-                reason: "Predicate crosses DISTINCT boundary; moving it may change semantics."
+                reason: "Predicate crosses DISTINCT ON boundary; moving it may change semantics."
             };
         }
         if (this.hasWindowUsage(query)) {
@@ -712,6 +714,11 @@ export class StaticPredicatePlacementOptimizer {
             return {
                 code: "GROUP_BY_BOUNDARY",
                 reason: "Predicate crosses HAVING aggregation boundary; moving it may change semantics."
+            };
+        }
+        if (hasOrdinaryDistinct) {
+            return {
+                reason: "Predicate references direct ordinary DISTINCT output columns; it is moved into the DISTINCT input WHERE."
             };
         }
         return {
@@ -1279,6 +1286,14 @@ export class StaticPredicatePlacementOptimizer {
             const joinType = join.joinType.value.toLowerCase();
             return joinType.includes("left") || joinType.includes("right") || joinType.includes("full") || joinType.includes("outer");
         });
+    }
+
+    private hasDistinctOnBoundary(query: SimpleSelectQuery): boolean {
+        return query.selectClause.distinct instanceof DistinctOn;
+    }
+
+    private hasOrdinaryDistinct(query: SimpleSelectQuery): boolean {
+        return query.selectClause.distinct !== null && !this.hasDistinctOnBoundary(query);
     }
 
     private getOutputColumnMatchCount(root: SimpleSelectQuery, binding: SourceBinding, columnName: string): number {

--- a/packages/core/tests/transformers/ParameterConditionPlacementOptimizer.test.ts
+++ b/packages/core/tests/transformers/ParameterConditionPlacementOptimizer.test.ts
@@ -520,15 +520,49 @@ describe('ParameterConditionPlacementOptimizer', () => {
         expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));
     });
 
-    it('skips predicates that would cross DISTINCT boundaries', () => {
+    it('moves parameter predicates through ordinary DISTINCT direct output columns', () => {
         const sql = `
-            with distinct_customers as (
-                select distinct o.customer_id
+            with distinct_orders as (
+                select distinct o.customer_id, o.status
                 from orders o
             )
-            select dc.customer_id
-            from distinct_customers dc
-            where dc.customer_id = :customer_id
+            select d.customer_id
+            from distinct_orders d
+            where d.status = :status
+        `;
+
+        const result = optimizeParameterConditionPlacement(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([
+            expect.objectContaining({
+                kind: 'move_condition',
+                conditionSql: '"d"."status" = :status',
+                toScopeId: 'cte:distinct_orders',
+                reason: expect.stringMatching(/DISTINCT output column/i)
+            })
+        ]);
+        expect(result.skipped).toEqual([]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(`
+            with distinct_orders as (
+                select distinct o.customer_id, o.status
+                from orders o
+                where o.status = :status
+            )
+            select d.customer_id
+            from distinct_orders d
+        `));
+    });
+
+    it('keeps DISTINCT ON parameter predicates blocked', () => {
+        const sql = `
+            with latest_orders as (
+                select distinct on (o.customer_id) o.customer_id, o.status
+                from orders o
+            )
+            select lo.customer_id
+            from latest_orders lo
+            where lo.status = :status
         `;
 
         const result = optimizeParameterConditionPlacement(sql);
@@ -537,10 +571,72 @@ describe('ParameterConditionPlacementOptimizer', () => {
         expect(result.applied).toEqual([]);
         expect(result.skipped).toEqual([
             expect.objectContaining({
-                reason: expect.stringMatching(/distinct/i)
+                code: 'DISTINCT_BOUNDARY',
+                reason: expect.stringMatching(/DISTINCT ON/i)
             })
         ]);
         expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));
+    });
+
+    it('keeps DISTINCT expression aliases blocked for parameter predicates', () => {
+        const sql = `
+            with monthly_orders as (
+                select distinct date_trunc('month', o.created_at) as order_month
+                from orders o
+            )
+            select mo.order_month
+            from monthly_orders mo
+            where mo.order_month = :order_month
+        `;
+
+        const result = optimizeParameterConditionPlacement(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([]);
+        expect(result.skipped).toEqual([
+            expect.objectContaining({
+                code: 'EXPRESSION_OUTPUT_UNSUPPORTED'
+            })
+        ]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));
+    });
+
+    it('moves parameter predicates through single-source DISTINCT wildcard outputs', () => {
+        const sql = `
+            select d.customer_id
+            from (
+                select distinct *
+                from (
+                    select o.customer_id, o.status
+                    from orders o
+                ) as o
+            ) as d
+            where d.status = :status
+        `;
+
+        const result = optimizeParameterConditionPlacement(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([
+            expect.objectContaining({
+                kind: 'move_condition',
+                conditionSql: '"d"."status" = :status',
+                toScopeId: 'subquery:d',
+                reason: expect.stringMatching(/DISTINCT output column/i)
+            })
+        ]);
+        expect(result.skipped).toEqual([]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(`
+            select d.customer_id
+            from (
+                select distinct *
+                from (
+                    select o.customer_id, o.status
+                    from orders o
+                ) as o
+                where o.status = :status
+            ) as d
+        `));
     });
 
     it('distributes predicates into UNION branches', () => {

--- a/packages/core/tests/transformers/StaticPredicatePlacementOptimizer.test.ts
+++ b/packages/core/tests/transformers/StaticPredicatePlacementOptimizer.test.ts
@@ -340,17 +340,118 @@ describe('StaticPredicatePlacementOptimizer', () => {
         `));
     });
 
-    it('skips DISTINCT boundaries and unsafe UNION branches', () => {
-
-        const distinctResult = optimizeStaticPredicatePlacement(`
-            with distinct_customers as (
-                select distinct c.id
-                from customers c
+    it('moves static predicates through ordinary DISTINCT direct output columns', () => {
+        const result = optimizeStaticPredicatePlacement(`
+            with distinct_orders as (
+                select distinct o.customer_id, o.status
+                from orders o
             )
-            select dc.id
-            from distinct_customers dc
-            where dc.id = 10
+            select d.customer_id
+            from distinct_orders d
+            where d.status = 'paid'
         `);
+
+        expect(result.applied).toEqual([
+            expect.objectContaining({
+                kind: 'move_static_predicate',
+                predicateSql: `"d"."status" = 'paid'`,
+                toScopeId: 'cte:distinct_orders',
+                reason: expect.stringMatching(/DISTINCT output column/i)
+            })
+        ]);
+        expect(result.skipped).toEqual([]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(`
+            with distinct_orders as (
+                select distinct o.customer_id, o.status
+                from orders o
+                where o.status = 'paid'
+            )
+            select d.customer_id
+            from distinct_orders d
+        `));
+    });
+
+    it('keeps DISTINCT ON static predicates blocked', () => {
+        const sql = `
+            with latest_orders as (
+                select distinct on (o.customer_id) o.customer_id, o.status
+                from orders o
+            )
+            select lo.customer_id
+            from latest_orders lo
+            where lo.status = 'paid'
+        `;
+
+        const result = optimizeStaticPredicatePlacement(sql);
+
+        expect(result.applied).toEqual([]);
+        expect(result.skipped).toEqual([
+            expect.objectContaining({
+                code: 'DISTINCT_BOUNDARY',
+                reason: expect.stringMatching(/DISTINCT ON/i)
+            })
+        ]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));
+    });
+
+    it('keeps DISTINCT expression aliases blocked for static predicates', () => {
+        const sql = `
+            with monthly_orders as (
+                select distinct date_trunc('month', o.created_at) as order_month
+                from orders o
+            )
+            select mo.order_month
+            from monthly_orders mo
+            where mo.order_month = '2026-01-01'
+        `;
+
+        const result = optimizeStaticPredicatePlacement(sql);
+
+        expect(result.applied).toEqual([]);
+        expect(result.skipped).toEqual([
+            expect.objectContaining({
+                code: 'EXPRESSION_OUTPUT_UNSUPPORTED'
+            })
+        ]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));
+    });
+
+    it('moves static predicates through single-source DISTINCT wildcard outputs', () => {
+        const result = optimizeStaticPredicatePlacement(`
+            select d.customer_id
+            from (
+                select distinct *
+                from (
+                    select o.customer_id, o.status
+                    from orders o
+                ) as o
+            ) as d
+            where d.status = 'paid'
+        `);
+
+        expect(result.applied).toEqual([
+            expect.objectContaining({
+                kind: 'move_static_predicate',
+                predicateSql: `"d"."status" = 'paid'`,
+                toScopeId: 'subquery:d',
+                reason: expect.stringMatching(/DISTINCT output column/i)
+            })
+        ]);
+        expect(result.skipped).toEqual([]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(`
+            select d.customer_id
+            from (
+                select distinct *
+                from (
+                    select o.customer_id, o.status
+                    from orders o
+                ) as o
+                where o.status = 'paid'
+            ) as d
+        `));
+    });
+
+    it('skips unsafe UNION branches', () => {
 
         const unionResult = optimizeStaticPredicatePlacement(`
             with combined_customers as (
@@ -365,9 +466,6 @@ describe('StaticPredicatePlacementOptimizer', () => {
             where cc.id = 10
         `);
 
-        expect(distinctResult.skipped).toEqual([
-            expect.objectContaining({ code: 'DISTINCT_BOUNDARY' })
-        ]);
         expect(unionResult.skipped).toEqual([
             expect.objectContaining({ code: 'EXPRESSION_OUTPUT_UNSUPPORTED' })
         ]);


### PR DESCRIPTION
## Summary

- Allow parameter condition placement to move direct-column predicates into ordinary DISTINCT query blocks.
- Allow static predicate placement to do the same while keeping DISTINCT ON as a blocked boundary.
- Add regression coverage for direct DISTINCT columns, DISTINCT ON, expression aliases, and single-source DISTINCT wildcard output inference.

## Verification

- `corepack pnpm exec vitest run packages/core/tests/transformers/ParameterConditionPlacementOptimizer.test.ts packages/core/tests/transformers/StaticPredicatePlacementOptimizer.test.ts`
- `corepack pnpm --filter rawsql-ts test`
- `corepack pnpm --filter rawsql-ts build`
- `corepack pnpm --filter rawsql-ts lint`
- Pre-commit hook also passed workspace typecheck, workspace test, workspace build, and workspace lint.

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: Not required; no baseline exception requested.
Scoped checks run: Focused optimizer tests, rawsql-ts test/build/lint, and pre-commit workspace typecheck/test/build/lint.
Why full baseline is not required: Full baseline exception is not requested.

## Self Review

Self-review workflow: Codex self-review skill, two cycles.
Self-review result: No blockers remain; repository evidence covers the requested optimizer behavior.
Concept-review workflow: packages/core/AGENTS.md and packages/core/DESIGN.md package-boundary review.
Concept-review result: No package-boundary violations found; implementation stays DBMS-neutral and AST-based.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: This changes core optimizer behavior only; no CLI surface changed.
Upgrade note: Not applicable.
Deprecation/removal plan or issue: Not applicable.
Docs/help/examples updated: Not applicable.
Release/changeset wording: `.changeset/distinct-condition-placement.md` describes the user-visible optimizer fix.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: No scaffold files or generated scaffold contracts changed.
Non-edit assertion: This PR only changes core optimizer code, optimizer tests, and a changeset.
Fail-fast input-contract proof: Not applicable.
Generated-output viability proof: Not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved predicate placement across `DISTINCT` queries so safe conditions can now move through ordinary `DISTINCT` outputs.
  * Kept `DISTINCT ON` as a protected boundary, preventing unsafe condition movement.
  * Added clearer handling for expression-based `DISTINCT` outputs and wildcard projections, with safer fallback behavior.
  * Expanded coverage to verify rewritten queries and skipped cases behave as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->