### PR TITLE
feat(core): classify condition optimization skips

### DIFF
--- a/.changeset/condition-skip-disposition.md
+++ b/.changeset/condition-skip-disposition.md
@@ -1,0 +1,9 @@
+---
+"rawsql-ts": minor
+---
+
+Add `skipDisposition` metadata to condition optimization skipped items so callers can distinguish blocked, unchanged, and ignored skips without parsing reason strings.
+
+SSSQL optional branch refresh now avoids treating duplicate parameters across UNION branches as a global refresh failure, keeping duplicate local branches unchanged while allowing unrelated branches to be classified independently.
+
+API output shape review: kept `result.sql` and the existing `applied`/`skipped`/`warnings`/`errors` result shape for compatibility, and added structured skipped-item metadata for downstream processing.

--- a/packages/core/src/transformers/ConditionOptimization.ts
+++ b/packages/core/src/transformers/ConditionOptimization.ts
@@ -245,7 +245,7 @@ const buildSssqlSkipped = (
         reason: parameterProvided
             ? "The optional branch parameter is present, so the branch remains active."
             : "No optional branch parameter value was provided, so the branch remains unchanged.",
-        skipDisposition: "ignored"
+        skipDisposition: parameterProvided ? "unchanged" : "ignored"
     };
 };
 

--- a/packages/core/src/transformers/ConditionOptimization.ts
+++ b/packages/core/src/transformers/ConditionOptimization.ts
@@ -52,6 +52,11 @@ export interface ConditionOptimizationPhaseSummary {
     errorCount: number;
 }
 
+export type ConditionOptimizationSkipDisposition =
+    | "blocked"
+    | "unchanged"
+    | "ignored";
+
 export interface SssqlOptionalConditionApplied {
     phaseKind: "sssql_optional_condition";
     kind: "prune_optional_branch" | "refresh_optional_branch";
@@ -68,6 +73,7 @@ export interface SssqlOptionalConditionSkipped {
     parameterName: string;
     code: string;
     reason: string;
+    skipDisposition: ConditionOptimizationSkipDisposition;
 }
 
 export type ConditionOptimizationApplied =
@@ -77,8 +83,14 @@ export type ConditionOptimizationApplied =
 
 export type ConditionOptimizationSkipped =
     | SssqlOptionalConditionSkipped
-    | (ParameterConditionSkipped & { phaseKind: "parameter_condition_placement" })
-    | (StaticPredicateSkipped & { phaseKind: "static_predicate_placement" });
+    | (ParameterConditionSkipped & {
+        phaseKind: "parameter_condition_placement";
+        skipDisposition: ConditionOptimizationSkipDisposition;
+    })
+    | (StaticPredicateSkipped & {
+        phaseKind: "static_predicate_placement";
+        skipDisposition: ConditionOptimizationSkipDisposition;
+    });
 
 export type ConditionOptimizationWarning =
     | (ParameterConditionOptimizationWarning & { phaseKind: ConditionOptimizationPhaseKind })
@@ -232,7 +244,8 @@ const buildSssqlSkipped = (
             : "SSSQL_OPTIONAL_PARAMETER_NOT_PROVIDED",
         reason: parameterProvided
             ? "The optional branch parameter is present, so the branch remains active."
-            : "No optional branch parameter value was provided, so the branch remains unchanged."
+            : "No optional branch parameter value was provided, so the branch remains unchanged.",
+        skipDisposition: "ignored"
     };
 };
 
@@ -240,6 +253,7 @@ const buildSssqlRefreshSkipped = (
     branch: SupportedOptionalConditionBranch,
     code: string,
     reason: string,
+    skipDisposition: ConditionOptimizationSkipDisposition,
     options: SqlComponentFormatOptions
 ): SssqlOptionalConditionSkipped => {
     return {
@@ -248,7 +262,8 @@ const buildSssqlRefreshSkipped = (
         conditionSql: formatSqlComponent(branch.expression, options),
         parameterName: branch.parameterName,
         code,
-        reason
+        reason,
+        skipDisposition
     };
 };
 
@@ -289,33 +304,52 @@ const refreshRemainingSssqlBranches = (
 
     const beforeBranchSql = new WeakMap<ValueComponent, string>();
     const beforeBranchQuery = new WeakMap<ValueComponent, SimpleSelectQuery>();
+    const parameterCounts = new Map<string, number>();
     for (const branch of beforeBranches) {
         beforeBranchSql.set(branch.expression, formatSqlComponent(branch.expression, options));
         beforeBranchQuery.set(branch.expression, branch.query);
+        parameterCounts.set(branch.parameterName, (parameterCounts.get(branch.parameterName) ?? 0) + 1);
     }
 
-    try {
-        new SSSQLFilterBuilder().refresh(query, buildSssqlRefreshFilters(beforeBranches, parameters));
-    } catch (error) {
-        const detail = error instanceof Error ? error.message : String(error);
-        return {
-            query,
-            sql: fallbackSql,
-            applied,
-            skipped: beforeBranches.map(branch => buildSssqlRefreshSkipped(
+    const alreadyReportedExpressions = new WeakSet<ValueComponent>();
+    const refreshableBranches: SupportedOptionalConditionBranch[] = [];
+    for (const branch of beforeBranches) {
+        if ((parameterCounts.get(branch.parameterName) ?? 0) > 1) {
+            skipped.push(buildSssqlRefreshSkipped(
+                branch,
+                "SSSQL_OPTIONAL_REFRESH_DUPLICATE_PARAMETER_UNCHANGED",
+                "SSSQL optional branch refresh left this duplicate parameter branch unchanged so each query scope can keep its existing local predicate.",
+                "unchanged",
+                options
+            ));
+            alreadyReportedExpressions.add(branch.expression);
+            continue;
+        }
+        refreshableBranches.push(branch);
+    }
+
+    for (const branch of refreshableBranches) {
+        try {
+            new SSSQLFilterBuilder().refresh(query, buildSssqlRefreshFilters([branch], parameters));
+        } catch (error) {
+            const detail = error instanceof Error ? error.message : String(error);
+            skipped.push(buildSssqlRefreshSkipped(
                 branch,
                 "SSSQL_OPTIONAL_REFRESH_UNSUPPORTED",
                 `SSSQL optional branch refresh was skipped because safe refresh could not be proven: ${detail}`,
+                "blocked",
                 options
-            )),
-            warnings: [],
-            errors: [],
-            formatterGeneratedSource: false
-        };
+            ));
+            alreadyReportedExpressions.add(branch.expression);
+        }
     }
 
     const afterBranches = collectSupportedOptionalConditionBranches(query);
     for (const branch of afterBranches) {
+        if (alreadyReportedExpressions.has(branch.expression)) {
+            continue;
+        }
+
         const previousSql = beforeBranchSql.get(branch.expression);
         const previousQuery = beforeBranchQuery.get(branch.expression);
         if (!previousSql || !previousQuery) {
@@ -323,6 +357,7 @@ const refreshRemainingSssqlBranches = (
                 branch,
                 "SSSQL_OPTIONAL_REFRESH_UNSUPPORTED",
                 "SSSQL optional branch refresh left an untracked branch unchanged.",
+                "blocked",
                 options
             ));
             continue;
@@ -334,10 +369,16 @@ const refreshRemainingSssqlBranches = (
             continue;
         }
 
+        const parameterProvided = hasOwnParameter(parameters, branch.parameterName);
         skipped.push(buildSssqlRefreshSkipped(
             branch,
-            "SSSQL_OPTIONAL_REFRESH_NOOP",
-            "SSSQL optional branch refresh found no safe placement change to apply.",
+            parameterProvided
+                ? "SSSQL_OPTIONAL_REFRESH_NOOP"
+                : "SSSQL_OPTIONAL_PARAMETER_NOT_PROVIDED",
+            parameterProvided
+                ? "SSSQL optional branch refresh found no safe placement change to apply."
+                : "No optional branch parameter value was provided, so the branch was not a refresh target.",
+            parameterProvided ? "unchanged" : "ignored",
             options
         ));
     }
@@ -486,6 +527,7 @@ const mapParameterSkipped = (
     skipped: readonly ParameterConditionSkipped[]
 ): ConditionOptimizationSkipped[] => skipped.map(item => ({
     phaseKind: "parameter_condition_placement",
+    skipDisposition: "blocked",
     ...item
 }));
 
@@ -514,6 +556,7 @@ const mapStaticSkipped = (
     skipped: readonly StaticPredicateSkipped[]
 ): ConditionOptimizationSkipped[] => skipped.map(item => ({
     phaseKind: "static_predicate_placement",
+    skipDisposition: "blocked",
     ...item
 }));
 

--- a/packages/core/tests/transformers/ConditionOptimization.test.ts
+++ b/packages/core/tests/transformers/ConditionOptimization.test.ts
@@ -425,7 +425,8 @@ describe('ConditionOptimization', () => {
         expect(result.skipped).toEqual(expect.arrayContaining([
             expect.objectContaining({
                 phaseKind: 'static_predicate_placement',
-                code: 'OUTER_JOIN_NULLABLE_SIDE'
+                code: 'OUTER_JOIN_NULLABLE_SIDE',
+                skipDisposition: 'blocked'
             })
         ]));
         expect(normalizeSql(result.sql)).toBe(normalizeSql(`
@@ -443,6 +444,151 @@ describe('ConditionOptimization', () => {
             left join payment_scope ps on ps.customer_id = cs.id
             where ps.is_successful = true
         `));
+    });
+
+    it('classifies SSSQL refresh no-op as unchanged', () => {
+        const sql = `
+            select *
+            from orders o
+            where (:customer_id is null or o.customer_id = :customer_id)
+        `;
+
+        const result = optimizeConditions(sql, {
+            optionalConditionParameters: { customer_id: 'C001' }
+        });
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([]);
+        expect(result.skipped).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                phaseKind: 'sssql_optional_condition',
+                code: 'SSSQL_OPTIONAL_REFRESH_NOOP',
+                parameterName: 'customer_id',
+                skipDisposition: 'unchanged'
+            })
+        ]));
+    });
+
+    it('classifies SSSQL optional branches without parameter input as ignored when unchanged', () => {
+        const sql = `
+            select *
+            from orders o
+            where (:customer_id is null or o.customer_id = :customer_id)
+        `;
+
+        const result = planConditionOptimization(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([]);
+        expect(result.skipped).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                phaseKind: 'sssql_optional_condition',
+                parameterName: 'customer_id',
+                skipDisposition: 'ignored'
+            })
+        ]));
+    });
+
+    it('keeps duplicate SSSQL parameter branches in UNION scopes unchanged without global refresh failure', () => {
+        const sql = `
+            select
+                o.customer_id,
+                o.order_date
+            from orders o
+            where (:customer_id is null or o.customer_id = :customer_id)
+
+            union all
+
+            select
+                r.customer_id,
+                r.refund_date as order_date
+            from refunds r
+            where (:customer_id is null or r.customer_id = :customer_id)
+        `;
+
+        const result = optimizeConditions(sql, {
+            optionalConditionParameters: { customer_id: 'C001' }
+        });
+
+        expect(result.ok).toBe(true);
+        expect(result.errors).toEqual([]);
+        expect(result.skipped.filter(item =>
+            item.phaseKind === 'sssql_optional_condition'
+            && item.parameterName === 'customer_id'
+        )).toHaveLength(2);
+        expect(result.skipped).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                phaseKind: 'sssql_optional_condition',
+                code: 'SSSQL_OPTIONAL_REFRESH_DUPLICATE_PARAMETER_UNCHANGED',
+                parameterName: 'customer_id',
+                skipDisposition: 'unchanged',
+                reason: expect.not.stringContaining('ambiguous')
+            })
+        ]));
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));
+    });
+
+    it('does not propagate duplicate UNION SSSQL parameter disposition to unrelated branches', () => {
+        const sql = `
+            with union_source as (
+                select
+                    o.customer_id,
+                    o.order_date
+                from orders o
+                where (:customer_id is null or o.customer_id = :customer_id)
+
+                union all
+
+                select
+                    r.customer_id,
+                    r.refund_date as order_date
+                from refunds r
+                where (:customer_id is null or r.customer_id = :customer_id)
+            ),
+            customer_scope as (
+                select c.id, c.name
+                from customers c
+            )
+            select *
+            from union_source u
+            join customer_scope c
+              on c.id = u.customer_id
+            where (:customer_name is null or c.name ilike '%' || :customer_name || '%')
+        `;
+
+        const result = optimizeConditions(sql, {
+            optionalConditionParameters: {
+                customer_id: 'C001',
+                customer_name: 'alice'
+            }
+        });
+
+        const customerIdSkips = result.skipped.filter(item =>
+            item.phaseKind === 'sssql_optional_condition'
+            && item.parameterName === 'customer_id'
+        );
+        const customerNameItems = [
+            ...result.applied.filter(item =>
+                item.phaseKind === 'sssql_optional_condition'
+                && item.parameterName === 'customer_name'
+            ),
+            ...result.skipped.filter(item =>
+                item.phaseKind === 'sssql_optional_condition'
+                && item.parameterName === 'customer_name'
+            )
+        ];
+
+        expect(result.ok).toBe(true);
+        expect(result.errors).toEqual([]);
+        expect(customerIdSkips).toHaveLength(2);
+        expect(customerIdSkips.every(item => item.skipDisposition === 'unchanged')).toBe(true);
+        expect(customerNameItems.length).toBeGreaterThan(0);
+        expect(customerNameItems).not.toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                parameterName: 'customer_name',
+                reason: expect.stringContaining('customer_id')
+            })
+        ]));
     });
 
     it('preserves existing SQL comments across the integrated optimization phases', () => {

--- a/packages/core/tests/transformers/ConditionOptimization.test.ts
+++ b/packages/core/tests/transformers/ConditionOptimization.test.ts
@@ -522,7 +522,7 @@ describe('ConditionOptimization', () => {
                 code: 'SSSQL_OPTIONAL_REFRESH_DUPLICATE_PARAMETER_UNCHANGED',
                 parameterName: 'customer_id',
                 skipDisposition: 'unchanged',
-                reason: expect.not.stringContaining('ambiguous')
+                reason: expect.stringContaining('duplicate parameter')
             })
         ]));
         expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));


### PR DESCRIPTION
## Summary

- Add `skipDisposition` to `ConditionOptimizationResult.skipped` items so downstream callers can distinguish `blocked`, `unchanged`, and `ignored` skips without parsing `code` or `reason` strings.
- Localize SSSQL refresh handling so duplicate optional parameters across UNION branches remain unchanged instead of failing refresh for unrelated branches.
- Add regression coverage for blocked static skips, SSSQL refresh no-op, ignored missing optional parameters, and UNION duplicate-parameter cases.

## Verification

- `corepack pnpm --filter rawsql-ts exec vitest run tests/transformers/ConditionOptimization.test.ts`
- `corepack pnpm --filter rawsql-ts test`
- `corepack pnpm --filter rawsql-ts build`
- `corepack pnpm --filter rawsql-ts lint`
- Pre-commit workspace gates:
  - `pnpm guard:api-output-shape-review`
  - `pnpm typecheck`
  - `pnpm test`
  - `pnpm build`
  - `pnpm lint`

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

<!-- Write values on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. -->
<!-- Do not add list markers like "-" before these labels; `Tracking issue:` and `Scoped checks run:` must start at column 0. -->
Tracking issue: Not requested; no baseline exception.
Scoped checks run: rawsql-ts focused test, rawsql-ts package test/build/lint, and pre-commit workspace typecheck/test/build/lint.
Why full baseline is not required: Full pre-commit workspace gates passed; no baseline exception is requested.

## Self Review

<!-- Fill these fields after running the repo self-review workflow or available self-review skill. -->
Self-review workflow: developer-self-review skill; consistency review plus human acceptance review.
Self-review result: No blockers remain.
Concept-review workflow: packages/core/AGENTS.md, packages/core/DESIGN.md, core-parser-analyzer-change, and api-output-shape-review.
Concept-review result: No package-boundary violation; this keeps core DBMS-neutral and preserves `result.sql` while adding structured skipped metadata.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-migration rationale: No CLI surface, command, help text, or CLI output contract changed.
Upgrade note: Not applicable; no CLI migration.
Deprecation/removal plan or issue: Not applicable; no CLI deprecation or removal.
Docs/help/examples updated: Not applicable; no CLI docs/help/examples changed.
Release/changeset wording: `.changeset/condition-skip-disposition.md` documents the rawsql-ts API metadata addition.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-proof rationale: No scaffold contract, scaffold generator, or generated scaffold output changed.
Non-edit assertion: Not applicable; no scaffold-owned files changed.
Fail-fast input-contract proof: Not applicable; no scaffold input contract changed.
Generated-output viability proof: Not applicable; no generated scaffold output changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured skip details so skipped optimization results can now be classified as blocked, unchanged, or ignored.

* **Bug Fixes**
  * Improved handling of optional branch refreshes so duplicate parameters in `UNION` paths no longer cause a global failure.
  * Preserved existing result output while adding clearer skip metadata for downstream consumers.

* **Tests**
  * Expanded coverage for skip classification and duplicate-branch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->