### PR TITLE
fix(core): guard condition placement across join boundaries

### DIFF
--- a/.changeset/condition-join-on-safety.md
+++ b/.changeset/condition-join-on-safety.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": patch
+---
+
+Improve safe condition placement for base-table INNER JOIN predicates and keep joined-source predicates behind later RIGHT/FULL JOIN nullable boundaries.

--- a/packages/core/src/transformers/ParameterConditionPlacementOptimizer.ts
+++ b/packages/core/src/transformers/ParameterConditionPlacementOptimizer.ts
@@ -3,6 +3,7 @@ import {
     DistinctOn,
     FromClause,
     JoinClause,
+    JoinOnClause,
     SourceExpression,
     SubQuerySource,
     TableSource,
@@ -124,6 +125,7 @@ interface SourceBinding {
     source: SourceExpression;
     alias: string;
     join: JoinClause | null;
+    joinIndex: number;
     isPrimary: boolean;
 }
 
@@ -146,7 +148,14 @@ interface UnionUpstreamTarget {
     branches: UnionBranchTarget[];
 }
 
-type UpstreamTarget = SimpleUpstreamTarget | UnionUpstreamTarget;
+interface JoinOnTarget {
+    kind: "join_on";
+    join: JoinClause;
+    scopeId: string;
+    reason: string;
+}
+
+type UpstreamTarget = SimpleUpstreamTarget | UnionUpstreamTarget | JoinOnTarget;
 
 interface TargetColumnResolution {
     sourceColumn: ColumnReference;
@@ -300,7 +309,10 @@ export class ParameterConditionPlacementOptimizer {
             }
 
             let appliedReason = "";
-            if (target.kind === "simple") {
+            if (target.kind === "join_on") {
+                this.appendJoinOnCondition(target.join, candidate.expression, options);
+                appliedReason = target.reason;
+            } else if (target.kind === "simple") {
                 const targetColumns = this.resolveTargetColumns(query, target.query, candidate.references);
                 if ("code" in targetColumns) {
                     skipped.push(this.makeSkipped(term, targetColumns, options));
@@ -562,10 +574,16 @@ export class ParameterConditionPlacementOptimizer {
                 }
                 return null;
             }
+            if (candidate instanceof UnaryExpression) {
+                const operator = candidate.operator.value.trim().toLowerCase();
+                if (operator === "not") {
+                    return visit(candidate.expression);
+                }
+            }
 
             return {
                 code: "UNSUPPORTED_PARAMETER_CONDITION",
-                reason: "Only simple binary, BETWEEN, and whole OR/AND parameter predicates are moved in the safe-only implementation."
+                reason: "Only simple binary, BETWEEN, and whole OR/AND/NOT parameter predicates are moved in the safe-only implementation."
             };
         };
 
@@ -620,6 +638,12 @@ export class ParameterConditionPlacementOptimizer {
         }
 
         const binding = bindings[0]!;
+        if (binding.join?.lateral) {
+            return {
+                code: "LATERAL_JOIN_BOUNDARY",
+                reason: "Condition crosses a LATERAL JOIN boundary; moving it may change semantics."
+            };
+        }
         const nullableSide = this.findNullableSideBoundary(root.fromClause, binding);
         if (nullableSide) {
             return nullableSide;
@@ -627,6 +651,13 @@ export class ParameterConditionPlacementOptimizer {
 
         const upstream = this.resolveUpstreamQuery(root, binding, candidate.references);
         if ("code" in upstream) {
+            if (upstream.code === "NO_SAFE_UPSTREAM_QUERY") {
+                const joinOnTarget = this.resolveBaseTableJoinOnTarget(root, binding);
+                if (!("code" in joinOnTarget)) {
+                    return joinOnTarget;
+                }
+                return joinOnTarget;
+            }
             return upstream;
         }
 
@@ -735,6 +766,9 @@ export class ParameterConditionPlacementOptimizer {
             }
 
             const matchCount = this.getOutputColumnMatchCount(contextRoot, matches[0]!, columnName);
+            if (matchCount === 0 && this.isBaseTableBinding(contextRoot, matches[0]!)) {
+                return matches[0]!;
+            }
             if (matchCount === 0) {
                 return {
                     code: "COLUMN_NOT_AVAILABLE_UPSTREAM",
@@ -931,6 +965,68 @@ export class ParameterConditionPlacementOptimizer {
         return resolved;
     }
 
+    private resolveBaseTableJoinOnTarget(root: SimpleSelectQuery, binding: SourceBinding): JoinOnTarget | SkipDraft {
+        if (!root.fromClause || !this.isBaseTableBinding(root, binding)) {
+            return {
+                code: "NO_SAFE_UPSTREAM_QUERY",
+                reason: "The referenced source is a base table, so there is no upstream query block to move into."
+            };
+        }
+
+        if (this.hasOuterJoin(root.fromClause)) {
+            return {
+                code: "OUTER_JOIN_BOUNDARY",
+                reason: "Condition crosses an OUTER JOIN boundary; moving it into JOIN ON may change semantics."
+            };
+        }
+
+        const join = binding.isPrimary
+            ? root.fromClause.joins?.[0] ?? null
+            : binding.join;
+        if (join?.lateral) {
+            return {
+                code: "LATERAL_JOIN_BOUNDARY",
+                reason: "Condition crosses a LATERAL JOIN boundary; moving it into JOIN ON may change semantics."
+            };
+        }
+        if (!join || !this.isInnerJoin(join)) {
+            return {
+                code: "NO_SAFE_JOIN_ON_TARGET",
+                reason: "Base-table conditions are moved only into INNER JOIN ON clauses in the safe-only implementation."
+            };
+        }
+        if (!(join.condition instanceof JoinOnClause)) {
+            return {
+                code: "NO_SAFE_JOIN_ON_TARGET",
+                reason: "Base-table conditions are moved only into existing JOIN ON clauses, not USING or conditionless joins."
+            };
+        }
+
+        return {
+            kind: "join_on",
+            join,
+            scopeId: `join_on:${join.source.getAliasName() ?? "unknown"}`,
+            reason: binding.isPrimary
+                ? "Condition references the primary source of an INNER JOIN; it is moved into the first JOIN ON clause."
+                : "Condition references the joined source of an INNER JOIN; it is moved into that JOIN ON clause."
+        };
+    }
+
+    private appendJoinOnCondition(
+        join: JoinClause,
+        expression: ValueComponent,
+        options: SqlComponentFormatOptions
+    ): void {
+        if (!(join.condition instanceof JoinOnClause)) {
+            return;
+        }
+        join.condition.condition = new BinaryExpression(
+            join.condition.condition,
+            "and",
+            cloneValueComponent(expression, options)
+        );
+    }
+
     private resolveTargetColumnByOutputIndex(
         root: SimpleSelectQuery,
         query: SimpleSelectQuery,
@@ -1004,7 +1100,10 @@ export class ParameterConditionPlacementOptimizer {
             binding,
             targetColumns.map(item => item.targetColumn)
         );
-        if ("code" in upstream || upstream.kind === "union") {
+        if ("code" in upstream) {
+            return { query, targetColumns: [...targetColumns] };
+        }
+        if (upstream.kind !== "simple") {
             return { query, targetColumns: [...targetColumns] };
         }
 
@@ -1122,14 +1221,17 @@ export class ParameterConditionPlacementOptimizer {
             source: fromClause.source,
             alias: fromClause.source.getAliasName() ?? "",
             join: null,
+            joinIndex: -1,
             isPrimary: true
         }];
 
-        for (const join of fromClause.joins ?? []) {
+        for (let index = 0; index < (fromClause.joins ?? []).length; index += 1) {
+            const join = fromClause.joins![index]!;
             bindings.push({
                 source: join.source,
                 alias: join.source.getAliasName() ?? "",
                 join,
+                joinIndex: index,
                 isPrimary: false
             });
         }
@@ -1137,13 +1239,20 @@ export class ParameterConditionPlacementOptimizer {
         return bindings;
     }
 
+    private isBaseTableBinding(root: SimpleSelectQuery, binding: SourceBinding): boolean {
+        const source = binding.source.datasource;
+        return source instanceof TableSource && !this.findCte(root, source.table.name);
+    }
+
+    private isInnerJoin(join: JoinClause): boolean {
+        const joinType = join.joinType.value.trim().toLowerCase();
+        return joinType === "join" || joinType === "inner join";
+    }
+
     private findNullableSideBoundary(fromClause: FromClause, binding: SourceBinding): SkipDraft | null {
-        if (!binding.join) {
-            const rightOrFull = (fromClause.joins ?? []).some(join => {
-                const joinType = join.joinType.value.toLowerCase();
-                return joinType.includes("right") || joinType.includes("full");
-            });
-            return rightOrFull
+        const joins = fromClause.joins ?? [];
+        if (binding.isPrimary) {
+            return this.hasLaterJoinThatNullsPriorSources(joins, -1)
                 ? {
                     code: "OUTER_JOIN_NULLABLE_SIDE",
                     reason: "Condition crosses OUTER JOIN nullable side; moving it may change semantics."
@@ -1151,7 +1260,12 @@ export class ParameterConditionPlacementOptimizer {
                 : null;
         }
 
-        const joinType = binding.join.joinType.value.toLowerCase();
+        const join = binding.join;
+        if (!join) {
+            return null;
+        }
+
+        const joinType = join.joinType.value.toLowerCase();
         if (joinType.includes("left")) {
             return {
                 code: "OUTER_JOIN_NULLABLE_SIDE",
@@ -1164,8 +1278,23 @@ export class ParameterConditionPlacementOptimizer {
                 reason: "Condition crosses FULL JOIN nullable side; moving it may change semantics."
             };
         }
+        if (this.hasLaterJoinThatNullsPriorSources(joins, binding.joinIndex)) {
+            return {
+                code: "OUTER_JOIN_NULLABLE_SIDE",
+                reason: "Condition crosses later RIGHT/FULL JOIN nullable side; moving it may change semantics."
+            };
+        }
 
         return null;
+    }
+
+    private hasLaterJoinThatNullsPriorSources(joins: readonly JoinClause[], sourceJoinIndex: number): boolean {
+        return joins
+            .slice(sourceJoinIndex + 1)
+            .some(join => {
+                const joinType = join.joinType.value.toLowerCase();
+                return joinType.includes("right") || joinType.includes("full");
+            });
     }
 
     private hasOuterJoin(fromClause: FromClause): boolean {

--- a/packages/core/src/transformers/StaticPredicatePlacementOptimizer.ts
+++ b/packages/core/src/transformers/StaticPredicatePlacementOptimizer.ts
@@ -3,6 +3,7 @@ import {
     DistinctOn,
     FromClause,
     JoinClause,
+    JoinOnClause,
     SourceExpression,
     SubQuerySource,
     TableSource,
@@ -138,7 +139,14 @@ interface UnionUpstreamTarget {
     branches: UnionBranchTarget[];
 }
 
-type UpstreamTarget = SimpleUpstreamTarget | UnionUpstreamTarget;
+interface JoinOnTarget {
+    kind: "join_on";
+    join: JoinClause;
+    scopeId: string;
+    reason: string;
+}
+
+type UpstreamTarget = SimpleUpstreamTarget | UnionUpstreamTarget | JoinOnTarget;
 
 interface TargetColumnResolution {
     sourceColumn: ColumnReference;
@@ -297,7 +305,10 @@ export class StaticPredicatePlacementOptimizer {
             }
 
             let appliedReason = "";
-            if (target.kind === "simple") {
+            if (target.kind === "join_on") {
+                this.appendJoinOnPredicate(target.join, candidate.expression, options);
+                appliedReason = target.reason;
+            } else if (target.kind === "simple") {
                 const targetColumns = this.resolveTargetColumns(query, target.query, candidate.references);
                 if ("code" in targetColumns) {
                     skipped.push(this.makeSkipped(term, targetColumns, options));
@@ -623,6 +634,12 @@ export class StaticPredicatePlacementOptimizer {
         }
 
         const binding = bindings[0]!;
+        if (binding.join?.lateral) {
+            return {
+                code: "LATERAL_JOIN_BOUNDARY",
+                reason: "Predicate crosses a LATERAL JOIN boundary; moving it may change semantics."
+            };
+        }
         const nullableSide = this.findNullableSideBoundary(root.fromClause, binding);
         if (nullableSide) {
             return nullableSide;
@@ -630,6 +647,13 @@ export class StaticPredicatePlacementOptimizer {
 
         const upstream = this.resolveUpstreamQuery(root, binding, candidate.references);
         if ("code" in upstream) {
+            if (upstream.code === "NO_SAFE_UPSTREAM_QUERY") {
+                const joinOnTarget = this.resolveBaseTableJoinOnTarget(root, binding);
+                if (!("code" in joinOnTarget)) {
+                    return joinOnTarget;
+                }
+                return joinOnTarget;
+            }
             return upstream;
         }
 
@@ -738,6 +762,9 @@ export class StaticPredicatePlacementOptimizer {
             }
 
             const matchCount = this.getOutputColumnMatchCount(contextRoot, matches[0]!, columnName);
+            if (matchCount === 0 && this.isBaseTableBinding(contextRoot, matches[0]!)) {
+                return matches[0]!;
+            }
             if (matchCount === 0) {
                 return {
                     code: "COLUMN_NOT_AVAILABLE_UPSTREAM",
@@ -934,6 +961,68 @@ export class StaticPredicatePlacementOptimizer {
         return resolved;
     }
 
+    private resolveBaseTableJoinOnTarget(root: SimpleSelectQuery, binding: SourceBinding): JoinOnTarget | SkipDraft {
+        if (!root.fromClause || !this.isBaseTableBinding(root, binding)) {
+            return {
+                code: "NO_SAFE_UPSTREAM_QUERY",
+                reason: "The referenced source is a base table, so there is no upstream query block to move into."
+            };
+        }
+
+        if (this.hasOuterJoin(root.fromClause)) {
+            return {
+                code: "OUTER_JOIN_BOUNDARY",
+                reason: "Predicate crosses an OUTER JOIN boundary; moving it into JOIN ON may change semantics."
+            };
+        }
+
+        const join = binding.isPrimary
+            ? root.fromClause.joins?.[0] ?? null
+            : binding.join;
+        if (join?.lateral) {
+            return {
+                code: "LATERAL_JOIN_BOUNDARY",
+                reason: "Predicate crosses a LATERAL JOIN boundary; moving it into JOIN ON may change semantics."
+            };
+        }
+        if (!join || !this.isInnerJoin(join)) {
+            return {
+                code: "NO_SAFE_JOIN_ON_TARGET",
+                reason: "Base-table predicates are moved only into INNER JOIN ON clauses in the safe-only implementation."
+            };
+        }
+        if (!(join.condition instanceof JoinOnClause)) {
+            return {
+                code: "NO_SAFE_JOIN_ON_TARGET",
+                reason: "Base-table predicates are moved only into existing JOIN ON clauses, not USING or conditionless joins."
+            };
+        }
+
+        return {
+            kind: "join_on",
+            join,
+            scopeId: `join_on:${join.source.getAliasName() ?? "unknown"}`,
+            reason: binding.isPrimary
+                ? "Predicate references the primary source of an INNER JOIN; it is moved into the first JOIN ON clause."
+                : "Predicate references the joined source of an INNER JOIN; it is moved into that JOIN ON clause."
+        };
+    }
+
+    private appendJoinOnPredicate(
+        join: JoinClause,
+        expression: ValueComponent,
+        options: SqlComponentFormatOptions
+    ): void {
+        if (!(join.condition instanceof JoinOnClause)) {
+            return;
+        }
+        join.condition.condition = new BinaryExpression(
+            join.condition.condition,
+            "and",
+            cloneValueComponent(expression, options)
+        );
+    }
+
     private resolveDeepestBranchTarget(
         contextRoot: SimpleSelectQuery,
         query: SimpleSelectQuery,
@@ -975,7 +1064,10 @@ export class StaticPredicatePlacementOptimizer {
             binding,
             targetColumns.map(item => item.targetColumn)
         );
-        if ("code" in upstream || upstream.kind === "union") {
+        if ("code" in upstream) {
+            return { query, targetColumns: [...targetColumns] };
+        }
+        if (upstream.kind !== "simple") {
             return { query, targetColumns: [...targetColumns] };
         }
 
@@ -1216,6 +1308,16 @@ export class StaticPredicatePlacementOptimizer {
         }
 
         return bindings;
+    }
+
+    private isBaseTableBinding(root: SimpleSelectQuery, binding: SourceBinding): boolean {
+        const source = binding.source.datasource;
+        return source instanceof TableSource && !this.findCte(root, source.table.name);
+    }
+
+    private isInnerJoin(join: JoinClause): boolean {
+        const joinType = join.joinType.value.trim().toLowerCase();
+        return joinType === "join" || joinType === "inner join";
     }
 
     private findNullableSideBoundary(fromClause: FromClause, binding: SourceBinding): SkipDraft | null {

--- a/packages/core/tests/transformers/ConditionOptimization.test.ts
+++ b/packages/core/tests/transformers/ConditionOptimization.test.ts
@@ -759,6 +759,330 @@ describe('ConditionOptimization', () => {
         `));
     });
 
+    it('moves safe base-table AND conjuncts into INNER JOIN ON while keeping OR predicates whole', () => {
+        const sql = `
+            select *
+            from a
+            join b on b.a_id = a.id
+            where a.type = :type
+              and (b.flag = true or b.flag is null)
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.phases[1]).toEqual(expect.objectContaining({
+            kind: 'parameter_condition_placement',
+            appliedCount: 1,
+            skippedCount: 0
+        }));
+        expect(result.phases[2]).toEqual(expect.objectContaining({
+            kind: 'static_predicate_placement',
+            appliedCount: 1,
+            skippedCount: 0
+        }));
+        expect(result.applied).toEqual([
+            expect.objectContaining({
+                phaseKind: 'parameter_condition_placement',
+                kind: 'move_condition',
+                conditionSql: '"a"."type" = :type',
+                toScopeId: 'join_on:b'
+            }),
+            expect.objectContaining({
+                phaseKind: 'static_predicate_placement',
+                kind: 'move_static_predicate',
+                predicateSql: '("b"."flag" = true or "b"."flag" is null)',
+                toScopeId: 'join_on:b'
+            })
+        ]);
+        expect(result.skipped).toEqual([]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(`
+            select *
+            from a
+            join b on b.a_id = a.id
+                and a.type = :type
+                and (b.flag = true or b.flag is null)
+        `));
+    });
+
+    it('moves a safe base-table conjunct even when another conjunct is unsafe to move', () => {
+        const sql = `
+            select *
+            from a
+            join b on b.a_id = a.id
+            where a.type = :type
+              and (a.status = :status or b.flag = true)
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([
+            expect.objectContaining({
+                phaseKind: 'parameter_condition_placement',
+                conditionSql: '"a"."type" = :type',
+                toScopeId: 'join_on:b'
+            })
+        ]);
+        expect(result.skipped).toEqual([
+            expect.objectContaining({
+                phaseKind: 'parameter_condition_placement',
+                code: 'MULTIPLE_SOURCE_REFERENCES',
+                conditionSql: '("a"."status" = :status or "b"."flag" = true)'
+            })
+        ]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(`
+            select *
+            from a
+            join b on b.a_id = a.id
+                and a.type = :type
+            where (a.status = :status or b.flag = true)
+        `));
+    });
+
+    it('reports NO_SAFE_JOIN_ON_TARGET for USING joins instead of the generic upstream skip', () => {
+        const sql = `
+            select *
+            from a
+            join b using (id)
+            where b.flag = :flag
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([]);
+        expect(result.skipped).toEqual([
+            expect.objectContaining({
+                phaseKind: 'parameter_condition_placement',
+                code: 'NO_SAFE_JOIN_ON_TARGET',
+                conditionSql: '"b"."flag" = :flag'
+            })
+        ]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));
+    });
+
+    it('reports NO_SAFE_JOIN_ON_TARGET for conditionless CROSS JOIN predicates', () => {
+        const sql = `
+            select *
+            from a
+            cross join b
+            where b.flag = true
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([]);
+        expect(result.skipped).toEqual([
+            expect.objectContaining({
+                phaseKind: 'static_predicate_placement',
+                code: 'NO_SAFE_JOIN_ON_TARGET',
+                predicateSql: '"b"."flag" = true'
+            })
+        ]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));
+    });
+
+    it('reports OUTER_JOIN_BOUNDARY when a later outer join makes JOIN ON relocation unsafe', () => {
+        const sql = `
+            select *
+            from a
+            join b on b.a_id = a.id
+            left join c on c.b_id = b.id
+            where a.type = :type
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([]);
+        expect(result.skipped).toEqual([
+            expect.objectContaining({
+                phaseKind: 'parameter_condition_placement',
+                code: 'OUTER_JOIN_BOUNDARY',
+                conditionSql: '"a"."type" = :type'
+            })
+        ]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));
+    });
+
+    it('does not move joined CTE parameter predicates when a later RIGHT JOIN can null the source', () => {
+        const sql = `
+            with b_scope as (
+                select b.a_id, b.status
+                from b
+            )
+            select a.id
+            from a
+            join b_scope b on b.a_id = a.id
+            right join c on c.a_id = a.id
+            where b.status = :status
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([]);
+        expect(result.skipped).toEqual([
+            expect.objectContaining({
+                phaseKind: 'parameter_condition_placement',
+                code: 'OUTER_JOIN_NULLABLE_SIDE',
+                conditionSql: '"b"."status" = :status'
+            })
+        ]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));
+    });
+
+    it('keeps parameter and static joined-source predicates aligned behind later FULL JOIN nullable boundaries', () => {
+        const sql = `
+            with b_scope as (
+                select b.a_id, b.status, b.is_active
+                from b
+            )
+            select a.id
+            from a
+            join b_scope b on b.a_id = a.id
+            full join c on c.a_id = a.id
+            where b.status = :status
+              and b.is_active = true
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([]);
+        expect(result.skipped).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                phaseKind: 'parameter_condition_placement',
+                code: 'OUTER_JOIN_NULLABLE_SIDE',
+                conditionSql: '"b"."status" = :status'
+            }),
+            expect.objectContaining({
+                phaseKind: 'static_predicate_placement',
+                code: 'OUTER_JOIN_NULLABLE_SIDE',
+                predicateSql: '"b"."is_active" = true'
+            })
+        ]));
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));
+    });
+
+    it('keeps lateral join source predicates behind the lateral safety boundary', () => {
+        const sql = `
+            select *
+            from a
+            join lateral (
+                select b.a_id, b.flag
+                from b
+                where b.a_id = a.id
+            ) lb on true
+            where lb.flag = :flag
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([]);
+        expect(result.skipped).toEqual([
+            expect.objectContaining({
+                phaseKind: 'parameter_condition_placement',
+                code: 'LATERAL_JOIN_BOUNDARY',
+                conditionSql: '"lb"."flag" = :flag'
+            })
+        ]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));
+    });
+
+    it('keeps derived expression-output predicates out of JOIN ON relocation', () => {
+        const sql = `
+            select *
+            from a
+            join (
+                select b.a_id, b.flag = true as flag_match
+                from b
+            ) bx on bx.a_id = a.id
+            where bx.flag_match = true
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([]);
+        expect(result.skipped).toEqual([
+            expect.objectContaining({
+                phaseKind: 'static_predicate_placement',
+                code: 'EXPRESSION_OUTPUT_UNSUPPORTED',
+                predicateSql: '"bx"."flag_match" = true'
+            })
+        ]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));
+    });
+
+    it('moves primary-source predicates to the first INNER JOIN and joined-source predicates to their own INNER JOIN', () => {
+        const sql = `
+            select *
+            from a
+            join b on b.a_id = a.id
+            join c on c.b_id = b.id
+            where a.type = :type
+              and c.kind = :kind
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([
+            expect.objectContaining({
+                phaseKind: 'parameter_condition_placement',
+                conditionSql: '"a"."type" = :type',
+                toScopeId: 'join_on:b'
+            }),
+            expect.objectContaining({
+                phaseKind: 'parameter_condition_placement',
+                conditionSql: '"c"."kind" = :kind',
+                toScopeId: 'join_on:c'
+            })
+        ]);
+        expect(result.skipped).toEqual([]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(`
+            select *
+            from a
+            join b on b.a_id = a.id
+                and a.type = :type
+            join c on c.b_id = b.id
+                and c.kind = :kind
+        `));
+    });
+
+    it('moves whole NOT predicates consistently for parameter and static JOIN ON relocation', () => {
+        const sql = `
+            select *
+            from a
+            join b on b.a_id = a.id
+            where (not (a.type = :type))
+              and (not (b.flag = true))
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([
+            expect.objectContaining({
+                phaseKind: 'parameter_condition_placement',
+                conditionSql: '(not ("a"."type" = :type))',
+                toScopeId: 'join_on:b'
+            }),
+            expect.objectContaining({
+                phaseKind: 'static_predicate_placement',
+                predicateSql: '(not ("b"."flag" = true))',
+                toScopeId: 'join_on:b'
+            })
+        ]);
+        expect(result.skipped).toEqual([]);
+        expect(result.sql).toContain('and (not ("a"."type" = :type))');
+        expect(result.sql).toContain('and (not ("b"."flag" = true))');
+    });
+
     it('runs the later phase even when the SSSQL phase is a no-op', () => {
         const sql = `
             with customers_base as (


### PR DESCRIPTION
## Summary

- Move safe base-table parameter/static predicates into INNER JOIN ON clauses when no upstream query block exists.
- Keep unsafe JOIN boundaries conservative, including USING/conditionless joins, lateral sources, outer join chains, and later RIGHT/FULL nullable-side boundaries.
- Add focused regression coverage for AND conjunct splitting, whole OR/NOT predicate handling, and joined CTE nullable-side safety.

## Verification

- `corepack pnpm --filter rawsql-ts test -- tests/transformers/ConditionOptimization.test.ts` - passed
- `corepack pnpm --filter rawsql-ts build` - passed
- `corepack pnpm --filter rawsql-ts lint` - passed
- `git diff --check` - passed
- Pre-commit hook - passed: workspace typecheck, workspace tests, workspace build, workspace lint

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: Not required; no baseline exception requested.
Scoped checks run: ConditionOptimization focused test, rawsql-ts build, rawsql-ts lint, git diff --check, and pre-commit workspace typecheck/test/build/lint.
Why full baseline is not required: The PR is limited to core condition optimizer behavior and has focused regression tests plus pre-commit workspace checks.

## Self Review

Self-review workflow: self-review skill, two-cycle review after focused verification and before PR authoring.
Self-review result: No merge blockers found; remaining note is conservative outer-join behavior by design for safe-only placement.
Concept-review workflow: No Concept Spec impact; this changes core optimizer mechanics and tests only.
Concept-review result: No concept or package-boundary violation found; no CLI, scaffold, DB, or filesystem dependency added.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: No CLI command, option, help text, or user-facing CLI contract changed.
Upgrade note: Not applicable; no CLI surface migration.
Deprecation/removal plan or issue: Not applicable; no deprecation or removal.
Docs/help/examples updated: Not applicable; no CLI docs or examples changed.
Release/changeset wording: Patch changeset added for rawsql-ts condition placement behavior.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: No scaffold-related files or generated scaffold contracts changed.
Non-edit assertion: This PR edits core transformer implementation, focused tests, and a changeset only.
Fail-fast input-contract proof: Not applicable; no scaffold input contract changed.
Generated-output viability proof: Not applicable; no generated scaffold output changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved condition placement so safe filters can move into `JOIN ... ON` when appropriate, including support for `NOT(...)` conditions.
  * Expanded handling of inner joins, multiple joins, and base-table conditions for more precise SQL generation.

* **Bug Fixes**
  * Prevented unsafe movement across outer-join and lateral-join boundaries.
  * Fixed cases where valid base-table conditions were previously skipped.
  * Kept unsupported or unsafe predicates in place while still moving safe parts where possible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->