### PR TITLE
fix(core): infer wildcard condition columns safely

### DIFF
--- a/.changeset/wildcard-condition-columns.md
+++ b/.changeset/wildcard-condition-columns.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": patch
+---
+
+Improve safe condition placement through wildcard CTE and derived-table outputs when the referenced column maps to a single upstream source column, while keeping schema-unknown wildcard UNION ordinals on the safe skip path.

--- a/packages/core/src/transformers/ParameterConditionPlacementOptimizer.ts
+++ b/packages/core/src/transformers/ParameterConditionPlacementOptimizer.ts
@@ -172,6 +172,14 @@ const SUPPORTED_OPERATORS = new Set(["=", "<>", "!=", "<", "<=", ">", ">=", "lik
 const VOLATILE_OR_UNSUPPORTED_FUNCTION_REASON = "Condition contains a function call; volatile and expression predicates are not moved in the safe-only implementation.";
 
 const normalizeIdentifier = (value: string): string => value.trim().toLowerCase();
+const isCaseSensitiveIdentifier = (value: string): boolean => /[A-Z]/.test(value.trim());
+const identifiersEqual = (left: string, right: string): boolean => {
+    const trimmedLeft = left.trim();
+    const trimmedRight = right.trim();
+    return isCaseSensitiveIdentifier(trimmedLeft) || isCaseSensitiveIdentifier(trimmedRight)
+        ? trimmedLeft === trimmedRight
+        : trimmedLeft.toLowerCase() === trimmedRight.toLowerCase();
+};
 
 const unwrapParens = (expression: ValueComponent): ValueComponent => {
     let candidate = expression;
@@ -237,8 +245,8 @@ const columnReferenceText = (reference: ColumnReference): string => {
 };
 
 const sameColumnReference = (left: ColumnReference, right: ColumnReference): boolean => {
-    return normalizeIdentifier(left.column.name) === normalizeIdentifier(right.column.name)
-        && normalizeIdentifier(left.getNamespace()) === normalizeIdentifier(right.getNamespace());
+    return identifiersEqual(left.column.name, right.column.name)
+        && identifiersEqual(left.getNamespace(), right.getNamespace());
 };
 
 const appendUnique = <T>(items: T[], value: T): void => {
@@ -753,11 +761,11 @@ export class ParameterConditionPlacementOptimizer {
         }
 
         const bindings = this.getSourceBindings(fromClause);
-        const namespace = normalizeIdentifier(column.getNamespace());
+        const namespace = column.getNamespace();
         const columnName = column.column.name;
 
         if (namespace) {
-            const matches = bindings.filter(binding => normalizeIdentifier(binding.alias) === namespace);
+            const matches = bindings.filter(binding => identifiersEqual(binding.alias, namespace));
             if (matches.length !== 1) {
                 return {
                     code: "AMBIGUOUS_COLUMN_SOURCE",
@@ -930,9 +938,7 @@ export class ParameterConditionPlacementOptimizer {
     ): TargetColumnResolution[] | SkipDraft {
         const resolved: TargetColumnResolution[] = [];
         for (const reference of references) {
-            const matches = this.collectSelectOutputs(root, query).filter(item =>
-                normalizeIdentifier(item.name) === normalizeIdentifier(reference.column.name)
-            );
+            const matches = this.collectDirectOutputMatches(root, query, reference.column.name);
 
             if (matches.length !== 1) {
                 return {
@@ -1039,6 +1045,14 @@ export class ParameterConditionPlacementOptimizer {
                 code: "UNION_COLUMN_MISMATCH",
                 reason: `UNION branch does not expose column '${sourceColumn.column.name}' at output position ${outputIndex + 1}.`
             };
+        } else if (identifiersEqual(output.name, sourceColumn.column.name)) {
+            const matches = this.collectDirectOutputMatches(root, query, sourceColumn.column.name);
+            if (matches.length > 1) {
+                return {
+                    code: "AMBIGUOUS_TARGET_COLUMN",
+                    reason: `UNION branch exposes multiple '${sourceColumn.column.name}' columns.`
+                };
+            }
         }
 
         if (!(output.value instanceof ColumnReference)) {
@@ -1138,9 +1152,9 @@ export class ParameterConditionPlacementOptimizer {
         }
 
         const bindings = this.getSourceBindings(query.fromClause);
-        const namespace = normalizeIdentifier(column.getNamespace());
+        const namespace = column.getNamespace();
         if (namespace) {
-            const matches = bindings.filter(binding => normalizeIdentifier(binding.alias) === namespace);
+            const matches = bindings.filter(binding => identifiersEqual(binding.alias, namespace));
             return matches.length === 1
                 ? null
                 : {
@@ -1180,7 +1194,7 @@ export class ParameterConditionPlacementOptimizer {
         if (sameColumnReference(left, right)) {
             return true;
         }
-        if (normalizeIdentifier(left.column.name) !== normalizeIdentifier(right.column.name)) {
+        if (!identifiersEqual(left.column.name, right.column.name)) {
             return false;
         }
         const leftSource = this.resolveColumnSourceAlias(query, left);
@@ -1193,12 +1207,12 @@ export class ParameterConditionPlacementOptimizer {
             return null;
         }
         const bindings = this.getSourceBindings(query.fromClause);
-        const namespace = normalizeIdentifier(column.getNamespace());
+        const namespace = column.getNamespace();
         if (namespace) {
-            const matches = bindings.filter(binding => normalizeIdentifier(binding.alias) === namespace);
-            return matches.length === 1 ? normalizeIdentifier(matches[0]!.alias) : null;
+            const matches = bindings.filter(binding => identifiersEqual(binding.alias, namespace));
+            return matches.length === 1 ? matches[0]!.alias : null;
         }
-        return bindings.length === 1 ? normalizeIdentifier(bindings[0]!.alias) : null;
+        return bindings.length === 1 ? bindings[0]!.alias : null;
     }
 
     private rebaseCondition(
@@ -1322,16 +1336,12 @@ export class ParameterConditionPlacementOptimizer {
             if ("code" in branches) {
                 return 0;
             }
-            return this.collectSelectOutputs(root, branches[0]!).filter(item =>
-                normalizeIdentifier(item.name) === normalizeIdentifier(columnName)
-            ).length;
+            return this.collectDirectOutputMatches(root, branches[0]!, columnName).length;
         }
         if (!(target instanceof SimpleSelectQuery)) {
             return 0;
         }
-        return this.collectSelectOutputs(root, target).filter(item =>
-            normalizeIdentifier(item.name) === normalizeIdentifier(columnName)
-        ).length;
+        return this.collectDirectOutputMatches(root, target, columnName, true).length;
     }
 
     private collectUnionBranches(query: BinarySelectQuery): SimpleSelectQuery[] | SkipDraft {
@@ -1370,7 +1380,7 @@ export class ParameterConditionPlacementOptimizer {
     ): { index: number } | SkipDraft {
         const matches: number[] = [];
         this.collectSelectOutputs(root, firstBranch).forEach((item, index) => {
-            if (normalizeIdentifier(item.name) === normalizeIdentifier(outputColumnName)) {
+            if (identifiersEqual(item.name, outputColumnName)) {
                 matches.push(index);
             }
         });
@@ -1394,6 +1404,144 @@ export class ParameterConditionPlacementOptimizer {
         ];
         const collector = new SelectOutputCollector(null, commonTables.length > 0 ? commonTables : null);
         return collector.collect(query);
+    }
+
+    private collectDirectOutputMatches(
+        root: SimpleSelectQuery,
+        query: SimpleSelectQuery,
+        columnName: string,
+        includeUnprovenPotential: boolean = false
+    ): SelectOutputColumn[] {
+        const collectedMatches = this.collectSelectOutputs(root, query).filter(item =>
+            identifiersEqual(item.name, columnName)
+        );
+        if (collectedMatches.length > 0) {
+            return this.hasExplicitOutputMatch(query, columnName)
+                ? [...collectedMatches, ...this.inferWildcardOutputMatches(root, query, columnName, true)]
+                : collectedMatches;
+        }
+
+        return this.inferWildcardOutputMatches(root, query, columnName, includeUnprovenPotential);
+    }
+
+    private hasExplicitOutputMatch(query: SimpleSelectQuery, columnName: string): boolean {
+        return query.selectClause.items.some(item => {
+            if (item.identifier) {
+                return identifiersEqual(item.identifier.name, columnName);
+            }
+
+            return item.value instanceof ColumnReference
+                && item.value.column.name !== "*"
+                && identifiersEqual(item.value.column.name, columnName);
+        });
+    }
+
+    private inferWildcardOutputMatches(
+        root: SimpleSelectQuery,
+        query: SimpleSelectQuery,
+        columnName: string,
+        includeUnprovenPotential: boolean
+    ): SelectOutputColumn[] {
+        const matches: SelectOutputColumn[] = [];
+        query.selectClause.items.forEach((item, outputIndex) => {
+            if (item.identifier || !(item.value instanceof ColumnReference) || item.value.column.name !== "*") {
+                return;
+            }
+
+            const targetColumn = this.inferWildcardTargetColumn(root, query, item.value, columnName, includeUnprovenPotential);
+            if (!targetColumn) {
+                return;
+            }
+
+            if (targetColumn === "ambiguous") {
+                matches.push(
+                    this.createInferredOutputColumn(columnName, new ColumnReference(null, columnName), outputIndex),
+                    this.createInferredOutputColumn(columnName, new ColumnReference(null, columnName), outputIndex)
+                );
+                return;
+            }
+
+            matches.push(this.createInferredOutputColumn(columnName, targetColumn, outputIndex));
+        });
+        return matches;
+    }
+
+    private inferWildcardTargetColumn(
+        root: SimpleSelectQuery,
+        query: SimpleSelectQuery,
+        wildcard: ColumnReference,
+        columnName: string,
+        includeUnprovenPotential: boolean
+    ): ColumnReference | "ambiguous" | null {
+        if (!query.fromClause) {
+            return null;
+        }
+
+        const bindings = this.getSourceBindings(query.fromClause);
+        if (wildcard.namespaces === null) {
+            if (bindings.length !== 1) {
+                return "ambiguous";
+            }
+            return this.resolveWildcardColumnFromBinding(root, query, bindings[0]!, columnName, includeUnprovenPotential);
+        }
+
+        const namespace = wildcard.getNamespace();
+        const matches = bindings.filter(binding => identifiersEqual(binding.alias, namespace));
+        if (matches.length === 0) {
+            return null;
+        }
+        return matches.length === 1
+            ? this.resolveWildcardColumnFromBinding(root, query, matches[0]!, columnName, includeUnprovenPotential)
+            : "ambiguous";
+    }
+
+    private resolveWildcardColumnFromBinding(
+        root: SimpleSelectQuery,
+        query: SimpleSelectQuery,
+        binding: SourceBinding,
+        columnName: string,
+        includeUnprovenPotential: boolean
+    ): ColumnReference | "ambiguous" | null {
+        const matches = this.collectSourceOutputMatches(root, query, binding.source, columnName);
+        if (matches.length > 1) {
+            return "ambiguous";
+        }
+        if (matches.length === 1) {
+            const value = matches[0]!.value;
+            return value instanceof ColumnReference ? value : null;
+        }
+        return includeUnprovenPotential && binding.source.datasource instanceof TableSource
+            ? this.createColumnForBinding(binding, columnName)
+            : null;
+    }
+
+    private collectSourceOutputMatches(
+        root: SimpleSelectQuery,
+        query: SimpleSelectQuery,
+        source: SourceExpression,
+        columnName: string
+    ): SelectOutputColumn[] {
+        const commonTables = [
+            ...(query.withClause?.tables ?? []),
+            ...(root.withClause?.tables ?? [])
+        ];
+        const collector = new SelectOutputCollector(null, commonTables.length > 0 ? commonTables : null);
+        return collector.collect(source).filter(item => identifiersEqual(item.name, columnName));
+    }
+
+    private createColumnForBinding(binding: SourceBinding, columnName: string): ColumnReference {
+        return new ColumnReference(binding.alias ? [binding.alias] : null, columnName);
+    }
+
+    private createInferredOutputColumn(name: string, value: ColumnReference, outputIndex: number): SelectOutputColumn {
+        return {
+            name,
+            value,
+            outputIndex,
+            sourceAlias: value.getNamespace() || null,
+            sourceName: null,
+            sourceColumnName: name
+        };
     }
 
     private resolveSourceQueryForColumns(root: SimpleSelectQuery, source: SourceExpression): SelectQuery | null {

--- a/packages/core/src/transformers/StaticPredicatePlacementOptimizer.ts
+++ b/packages/core/src/transformers/StaticPredicatePlacementOptimizer.ts
@@ -168,6 +168,14 @@ type SkipDraft = Omit<StaticPredicateSkipped, "predicateSql" | "scopeId">;
 const VOLATILE_OR_UNSUPPORTED_FUNCTION_REASON = "Predicate contains a function call; volatile and expression predicates are not moved in the safe-only implementation.";
 
 const normalizeIdentifier = (value: string): string => value.trim().toLowerCase();
+const isCaseSensitiveIdentifier = (value: string): boolean => /[A-Z]/.test(value.trim());
+const identifiersEqual = (left: string, right: string): boolean => {
+    const trimmedLeft = left.trim();
+    const trimmedRight = right.trim();
+    return isCaseSensitiveIdentifier(trimmedLeft) || isCaseSensitiveIdentifier(trimmedRight)
+        ? trimmedLeft === trimmedRight
+        : trimmedLeft.toLowerCase() === trimmedRight.toLowerCase();
+};
 
 const unwrapParens = (expression: ValueComponent): ValueComponent => {
     let candidate = expression;
@@ -233,8 +241,8 @@ const columnReferenceText = (reference: ColumnReference): string => {
 };
 
 const sameColumnReference = (left: ColumnReference, right: ColumnReference): boolean => {
-    return normalizeIdentifier(left.column.name) === normalizeIdentifier(right.column.name)
-        && normalizeIdentifier(left.getNamespace()) === normalizeIdentifier(right.getNamespace());
+    return identifiersEqual(left.column.name, right.column.name)
+        && identifiersEqual(left.getNamespace(), right.getNamespace());
 };
 
 const appendUnique = <T>(items: T[], value: T): void => {
@@ -749,11 +757,11 @@ export class StaticPredicatePlacementOptimizer {
         }
 
         const bindings = this.getSourceBindings(fromClause);
-        const namespace = normalizeIdentifier(column.getNamespace());
+        const namespace = column.getNamespace();
         const columnName = column.column.name;
 
         if (namespace) {
-            const matches = bindings.filter(binding => normalizeIdentifier(binding.alias) === namespace);
+            const matches = bindings.filter(binding => identifiersEqual(binding.alias, namespace));
             if (matches.length !== 1) {
                 return {
                     code: "AMBIGUOUS_COLUMN_SOURCE",
@@ -926,9 +934,7 @@ export class StaticPredicatePlacementOptimizer {
     ): TargetColumnResolution[] | SkipDraft {
         const resolved: TargetColumnResolution[] = [];
         for (const reference of references) {
-            const matches = this.collectSelectOutputs(root, query).filter(item =>
-                normalizeIdentifier(item.name) === normalizeIdentifier(reference.column.name)
-            );
+            const matches = this.collectDirectOutputMatches(root, query, reference.column.name);
 
             if (matches.length !== 1) {
                 return {
@@ -1102,9 +1108,9 @@ export class StaticPredicatePlacementOptimizer {
         }
 
         const bindings = this.getSourceBindings(query.fromClause);
-        const namespace = normalizeIdentifier(column.getNamespace());
+        const namespace = column.getNamespace();
         if (namespace) {
-            const matches = bindings.filter(binding => normalizeIdentifier(binding.alias) === namespace);
+            const matches = bindings.filter(binding => identifiersEqual(binding.alias, namespace));
             return matches.length === 1
                 ? null
                 : {
@@ -1144,7 +1150,7 @@ export class StaticPredicatePlacementOptimizer {
         if (sameColumnReference(left, right)) {
             return true;
         }
-        if (normalizeIdentifier(left.column.name) !== normalizeIdentifier(right.column.name)) {
+        if (!identifiersEqual(left.column.name, right.column.name)) {
             return false;
         }
         const leftSource = this.resolveColumnSourceAlias(query, left);
@@ -1157,12 +1163,12 @@ export class StaticPredicatePlacementOptimizer {
             return null;
         }
         const bindings = this.getSourceBindings(query.fromClause);
-        const namespace = normalizeIdentifier(column.getNamespace());
+        const namespace = column.getNamespace();
         if (namespace) {
-            const matches = bindings.filter(binding => normalizeIdentifier(binding.alias) === namespace);
-            return matches.length === 1 ? normalizeIdentifier(matches[0]!.alias) : null;
+            const matches = bindings.filter(binding => identifiersEqual(binding.alias, namespace));
+            return matches.length === 1 ? matches[0]!.alias : null;
         }
-        return bindings.length === 1 ? normalizeIdentifier(bindings[0]!.alias) : null;
+        return bindings.length === 1 ? bindings[0]!.alias : null;
     }
 
     private rebasePredicate(
@@ -1393,16 +1399,12 @@ export class StaticPredicatePlacementOptimizer {
             if ("code" in branches) {
                 return 0;
             }
-            return this.collectSelectOutputs(root, branches[0]!).filter(item =>
-                normalizeIdentifier(item.name) === normalizeIdentifier(columnName)
-            ).length;
+            return this.collectDirectOutputMatches(root, branches[0]!, columnName).length;
         }
         if (!(target instanceof SimpleSelectQuery)) {
             return 0;
         }
-        return this.collectSelectOutputs(root, target).filter(item =>
-            normalizeIdentifier(item.name) === normalizeIdentifier(columnName)
-        ).length;
+        return this.collectDirectOutputMatches(root, target, columnName).length;
     }
 
     private collectUnionBranches(query: BinarySelectQuery): SimpleSelectQuery[] | SkipDraft {
@@ -1441,7 +1443,7 @@ export class StaticPredicatePlacementOptimizer {
     ): { index: number } | SkipDraft {
         const matches: number[] = [];
         this.collectSelectOutputs(root, firstBranch).forEach((item, index) => {
-            if (normalizeIdentifier(item.name) === normalizeIdentifier(outputColumnName)) {
+            if (identifiersEqual(item.name, outputColumnName)) {
                 matches.push(index);
             }
         });
@@ -1470,6 +1472,14 @@ export class StaticPredicatePlacementOptimizer {
                 code: "UNION_COLUMN_MISMATCH",
                 reason: `UNION branch does not expose column '${sourceColumn.column.name}' at output position ${outputIndex + 1}.`
             };
+        } else if (identifiersEqual(output.name, sourceColumn.column.name)) {
+            const matches = this.collectDirectOutputMatches(root, query, sourceColumn.column.name);
+            if (matches.length > 1) {
+                return {
+                    code: "AMBIGUOUS_TARGET_COLUMN",
+                    reason: `UNION branch exposes multiple '${sourceColumn.column.name}' columns.`
+                };
+            }
         }
 
         if (!(output.value instanceof ColumnReference)) {
@@ -1497,6 +1507,137 @@ export class StaticPredicatePlacementOptimizer {
         ];
         const collector = new SelectOutputCollector(null, commonTables.length > 0 ? commonTables : null);
         return collector.collect(query);
+    }
+
+    private collectDirectOutputMatches(root: SimpleSelectQuery, query: SimpleSelectQuery, columnName: string): SelectOutputColumn[] {
+        const collectedMatches = this.collectSelectOutputs(root, query).filter(item =>
+            identifiersEqual(item.name, columnName)
+        );
+        if (collectedMatches.length > 0) {
+            return this.hasExplicitOutputMatch(query, columnName)
+                ? [...collectedMatches, ...this.inferWildcardOutputMatches(root, query, columnName, true)]
+                : collectedMatches;
+        }
+
+        return this.inferWildcardOutputMatches(root, query, columnName, false);
+    }
+
+    private hasExplicitOutputMatch(query: SimpleSelectQuery, columnName: string): boolean {
+        return query.selectClause.items.some(item => {
+            if (item.identifier) {
+                return identifiersEqual(item.identifier.name, columnName);
+            }
+
+            return item.value instanceof ColumnReference
+                && item.value.column.name !== "*"
+                && identifiersEqual(item.value.column.name, columnName);
+        });
+    }
+
+    private inferWildcardOutputMatches(
+        root: SimpleSelectQuery,
+        query: SimpleSelectQuery,
+        columnName: string,
+        includeUnprovenPotential: boolean
+    ): SelectOutputColumn[] {
+        const matches: SelectOutputColumn[] = [];
+        query.selectClause.items.forEach((item, outputIndex) => {
+            if (item.identifier || !(item.value instanceof ColumnReference) || item.value.column.name !== "*") {
+                return;
+            }
+
+            const targetColumn = this.inferWildcardTargetColumn(root, query, item.value, columnName, includeUnprovenPotential);
+            if (!targetColumn) {
+                return;
+            }
+
+            if (targetColumn === "ambiguous") {
+                matches.push(
+                    this.createInferredOutputColumn(columnName, new ColumnReference(null, columnName), outputIndex),
+                    this.createInferredOutputColumn(columnName, new ColumnReference(null, columnName), outputIndex)
+                );
+                return;
+            }
+
+            matches.push(this.createInferredOutputColumn(columnName, targetColumn, outputIndex));
+        });
+        return matches;
+    }
+
+    private inferWildcardTargetColumn(
+        root: SimpleSelectQuery,
+        query: SimpleSelectQuery,
+        wildcard: ColumnReference,
+        columnName: string,
+        includeUnprovenPotential: boolean
+    ): ColumnReference | "ambiguous" | null {
+        if (!query.fromClause) {
+            return null;
+        }
+
+        const bindings = this.getSourceBindings(query.fromClause);
+        if (wildcard.namespaces === null) {
+            if (bindings.length !== 1) {
+                return "ambiguous";
+            }
+            return this.resolveWildcardColumnFromBinding(root, query, bindings[0]!, columnName, includeUnprovenPotential);
+        }
+
+        const namespace = wildcard.getNamespace();
+        const matches = bindings.filter(binding => identifiersEqual(binding.alias, namespace));
+        if (matches.length === 0) {
+            return null;
+        }
+        return matches.length === 1
+            ? this.resolveWildcardColumnFromBinding(root, query, matches[0]!, columnName, includeUnprovenPotential)
+            : "ambiguous";
+    }
+
+    private resolveWildcardColumnFromBinding(
+        root: SimpleSelectQuery,
+        query: SimpleSelectQuery,
+        binding: SourceBinding,
+        columnName: string,
+        includeUnprovenPotential: boolean
+    ): ColumnReference | "ambiguous" | null {
+        const matches = this.collectSourceOutputMatches(root, query, binding.source, columnName);
+        if (matches.length > 1) {
+            return "ambiguous";
+        }
+        if (matches.length === 1) {
+            const value = matches[0]!.value;
+            return value instanceof ColumnReference ? value : null;
+        }
+        return includeUnprovenPotential ? this.createColumnForBinding(binding, columnName) : null;
+    }
+
+    private collectSourceOutputMatches(
+        root: SimpleSelectQuery,
+        query: SimpleSelectQuery,
+        source: SourceExpression,
+        columnName: string
+    ): SelectOutputColumn[] {
+        const commonTables = [
+            ...(query.withClause?.tables ?? []),
+            ...(root.withClause?.tables ?? [])
+        ];
+        const collector = new SelectOutputCollector(null, commonTables.length > 0 ? commonTables : null);
+        return collector.collect(source).filter(item => identifiersEqual(item.name, columnName));
+    }
+
+    private createColumnForBinding(binding: SourceBinding, columnName: string): ColumnReference {
+        return new ColumnReference(binding.alias ? [binding.alias] : null, columnName);
+    }
+
+    private createInferredOutputColumn(name: string, value: ColumnReference, outputIndex: number): SelectOutputColumn {
+        return {
+            name,
+            value,
+            outputIndex,
+            sourceAlias: value.getNamespace() || null,
+            sourceName: null,
+            sourceColumnName: name
+        };
     }
 
     private resolveSourceQueryForColumns(root: SimpleSelectQuery, source: SourceExpression): SelectQuery | null {

--- a/packages/core/tests/transformers/ConditionOptimization.test.ts
+++ b/packages/core/tests/transformers/ConditionOptimization.test.ts
@@ -408,6 +408,441 @@ describe('ConditionOptimization', () => {
         ]);
     });
 
+    it('moves parameter conditions through a derived table wildcard output', () => {
+        const sql = `
+            select *
+            from (
+                select *
+                from (
+                    select u.status
+                    from users u
+                ) user_status
+            ) active_users
+            where active_users.status = :status
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([
+            expect.objectContaining({
+                phaseKind: 'parameter_condition_placement',
+                kind: 'move_condition',
+                toScopeId: 'subquery:active_users',
+                columnReferences: ['active_users.status']
+            })
+        ]);
+        expect(result.skipped).toEqual([]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(`
+            select *
+            from (
+                select *
+                from (
+                    select u.status
+                    from users u
+                ) user_status
+                where user_status.status = :status
+            ) active_users
+        `));
+    });
+
+    it('moves parameter conditions through a CTE wildcard output', () => {
+        const sql = `
+            with active_users as (
+                select *
+                from (
+                    select u.status
+                    from users u
+                ) user_status
+            )
+            select *
+            from active_users
+            where status = :status
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([
+            expect.objectContaining({
+                phaseKind: 'parameter_condition_placement',
+                kind: 'move_condition',
+                toScopeId: 'cte:active_users',
+                columnReferences: ['status']
+            })
+        ]);
+        expect(result.skipped).toEqual([]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(`
+            with active_users as (
+                select *
+                from (
+                    select u.status
+                    from users u
+                ) user_status
+                where user_status.status = :status
+            )
+            select *
+            from active_users
+        `));
+    });
+
+    it('keeps ambiguous wildcard outputs skipped instead of guessing a source column', () => {
+        const sql = `
+            select *
+            from (
+                select *
+                from users u
+                join user_profiles p on p.user_id = u.id
+            ) user_search
+            where status = :status
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([]);
+        expect(result.skipped).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                phaseKind: 'parameter_condition_placement'
+            })
+        ]));
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));
+    });
+
+    it('keeps duplicate explicit output plus wildcard from a single source skipped', () => {
+        const sql = `
+            select *
+            from (
+                select *, u.status as status
+                from users u
+            ) active_users
+            where status = :status
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([]);
+        expect(result.skipped).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                phaseKind: 'parameter_condition_placement'
+            })
+        ]));
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));
+    });
+
+    it('keeps explicit output plus multi-source wildcard ownership skipped', () => {
+        const sql = `
+            select *
+            from (
+                select *, p.status as status
+                from users u
+                join profiles p on p.user_id = u.id
+            ) user_search
+            where status = :status
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([]);
+        expect(result.skipped).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                phaseKind: 'parameter_condition_placement'
+            })
+        ]));
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));
+    });
+
+    it('keeps wildcard UNION CTE branches skipped when output ordinals are not proven', () => {
+        const sql = `
+            with all_users as (
+                select *
+                from users u
+                union all
+                select *
+                from archived_users au
+            )
+            select *
+            from all_users
+            where status = :status
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([]);
+        expect(result.skipped).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                phaseKind: 'parameter_condition_placement',
+                code: 'AMBIGUOUS_COLUMN_REFERENCE'
+            })
+        ]));
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));
+    });
+
+    it('keeps wildcard UNION derived-table branches skipped when output ordinals are not proven', () => {
+        const sql = `
+            select *
+            from (
+                select *
+                from users u
+                union all
+                select *
+                from archived_users au
+            ) all_users
+            where all_users.status = :status
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([]);
+        expect(result.skipped).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                phaseKind: 'parameter_condition_placement'
+            })
+        ]));
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));
+    });
+
+    it('does not mix wildcard UNION select-item indexes with explicit branch output ordinals', () => {
+        const sql = `
+            with u as (
+                select *
+                from active_users a
+                union all
+                select r.id, r.state, r.status
+                from archived_users r
+            )
+            select *
+            from u
+            where status = :status
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([]);
+        expect(result.skipped).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                phaseKind: 'parameter_condition_placement'
+            })
+        ]));
+        expect(normalizeForSearch(result.sql)).not.toContain(collapseFragment('where r.id = :status'));
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));
+    });
+
+    it('moves explicit UNION branches by first-branch output name and ordinal', () => {
+        const sql = `
+            with all_users as (
+                select a.status, a.id
+                from active_users a
+                union all
+                select r.state as archived_state, r.id
+                from archived_users r
+            )
+            select *
+            from all_users
+            where status = :status
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([
+            expect.objectContaining({
+                phaseKind: 'parameter_condition_placement',
+                kind: 'move_condition',
+                toScopeId: 'cte:all_users',
+                columnReferences: ['status']
+            })
+        ]);
+        expect(result.skipped).toEqual([]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(`
+            with all_users as (
+                select a.status, a.id
+                from active_users a
+                where a.status = :status
+                union all
+                select r.state as archived_state, r.id
+                from archived_users r
+                where r.state = :status
+            )
+            select *
+            from all_users
+        `));
+    });
+
+    it('keeps wildcard columns skipped when the source output does not prove the column exists', () => {
+        const sql = `
+            select d.customer_id
+            from (
+                select distinct *
+                from (
+                    select o.customer_id
+                    from orders o
+                ) as o
+            ) as d
+            where d.status = :status
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([]);
+        expect(result.skipped).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                phaseKind: 'parameter_condition_placement'
+            })
+        ]));
+        expect(normalizeForSearch(result.sql)).not.toContain(collapseFragment('where o.status = :status'));
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));
+    });
+
+    it('matches quoted source aliases case-sensitively during wildcard placement', () => {
+        const sql = `
+            select *
+            from (
+                select *
+                from (
+                    select "User".status
+                    from users "User"
+                ) "User"
+            ) "UserScope"
+            join (
+                select *
+                from (
+                    select "user".status
+                    from users "user"
+                ) "user"
+            ) "userScope" on true
+            where "UserScope".status = :status
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([
+            expect.objectContaining({
+                phaseKind: 'parameter_condition_placement',
+                kind: 'move_condition',
+                toScopeId: 'subquery:UserScope',
+                columnReferences: ['UserScope.status']
+            })
+        ]);
+        expect(result.skipped).toEqual([]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(`
+            select *
+            from (
+                select *
+                from (
+                    select "User".status
+                    from users "User"
+                ) "User"
+                where "User".status = :status
+            ) "UserScope"
+            join (
+                select *
+                from (
+                    select "user".status
+                    from users "user"
+                ) "user"
+            ) "userScope" on true
+        `));
+    });
+
+    it('keeps ambiguous wildcard UNION first-branch ownership skipped', () => {
+        const sql = `
+            with all_users as (
+                select *, u.status as status
+                from users u
+                union all
+                select *
+                from archived_users au
+            )
+            select *
+            from all_users
+            where status = :status
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([]);
+        expect(result.skipped).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                phaseKind: 'parameter_condition_placement',
+                code: 'AMBIGUOUS_COLUMN_REFERENCE'
+            })
+        ]));
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));
+    });
+
+    it('keeps static predicates on base-table wildcard outputs skipped when column existence is not proven', () => {
+        const sql = `
+            with active_users as (
+                select *
+                from users u
+            )
+            select *
+            from active_users
+            where status = 'active'
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([]);
+        expect(result.skipped).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                phaseKind: 'static_predicate_placement',
+                code: 'AMBIGUOUS_COLUMN_REFERENCE'
+            })
+        ]));
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));
+    });
+
+    it('moves static predicates through syntax-proven CTE wildcard outputs', () => {
+        const sql = `
+            with active_users as (
+                select *
+                from (
+                    select u.status
+                    from users u
+                ) user_status
+            )
+            select *
+            from active_users
+            where status = 'active'
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([
+            expect.objectContaining({
+                phaseKind: 'static_predicate_placement',
+                kind: 'move_static_predicate',
+                toScopeId: 'cte:active_users',
+                columnReferences: ['status']
+            })
+        ]);
+        expect(result.skipped).toEqual([]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(`
+            with active_users as (
+                select *
+                from (
+                    select u.status
+                    from users u
+                ) user_status
+                where user_status.status = 'active'
+            )
+            select *
+            from active_users
+        `));
+    });
+
     it('prunes same-block optional WHERE branches even when the query groups later', () => {
         const sql = `
             select customer_id, count(*) as order_count


### PR DESCRIPTION
## Summary

- Improve safe condition placement when a CTE or derived table exposes a column through a wildcard and that column maps to one proven upstream source column.
- Keep ambiguous wildcard ownership, duplicate explicit-plus-wildcard outputs, and schema-unknown wildcard UNION ordinals on the safe skip path.
- Add regression coverage for derived tables, CTEs, UNION branch ordinal handling, quoted alias matching, and static predicate placement.

## Verification

- `corepack pnpm --filter rawsql-ts test -- tests/transformers/ConditionOptimization.test.ts`
- `corepack pnpm --filter rawsql-ts test`
- `corepack pnpm --filter rawsql-ts build`
- `corepack pnpm --filter rawsql-ts lint`
- `git diff --check`
- pre-commit: workspace `typecheck`, `test`, `build`, and `lint`

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

<!-- Write values on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. -->
<!-- Do not add list markers like "-" before these labels; `Tracking issue:` and `Scoped checks run:` must start at column 0. -->
Tracking issue: Not required.
Scoped checks run: Package test/build/lint, git diff --check, and pre-commit workspace typecheck/test/build/lint.
Why full baseline is not required: No baseline exception requested; required checks were run.

## Self Review

<!-- Fill these fields after running the repo self-review workflow or available self-review skill. -->
Self-review workflow: Manual two-pass self-review using self-review skill, focused on safe-skip boundaries and regression evidence.
Self-review result: No blockers found; ambiguous or schema-unknown wildcard cases remain skipped and covered by tests.
Concept-review workflow: Checked packages/core/AGENTS.md, packages/core/DESIGN.md, core-parser-analyzer-change, and changeset-classification guidance.
Concept-review result: No package-boundary violation found; implementation remains DBMS-neutral and uses existing AST/select-output analysis without driver, DB, testkit, CLI, scaffold, or lineage-viewer semantics.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-migration rationale: This PR changes core optimizer behavior only; no CLI options, commands, output contracts, help, or examples are changed.
Upgrade note: No CLI upgrade note required.
Deprecation/removal plan or issue: No CLI deprecation or removal.
Docs/help/examples updated: Not required; no CLI docs/help/example surface changed.
Release/changeset wording: Patch changeset added for safer wildcard CTE and derived-table condition placement.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-proof rationale: This PR does not touch scaffold inputs, generated output, templates, or scaffold-facing contracts.
Non-edit assertion: No scaffold files are edited.
Fail-fast input-contract proof: Not applicable.
Generated-output viability proof: Not applicable.
