### PR TITLE
fix(core): deduplicate moved conditions

### DIFF
--- a/.changeset/dedupe-moved-conditions.md
+++ b/.changeset/dedupe-moved-conditions.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": patch
+---
+
+Deduplicate identical top-level AND conditions when condition optimization moves a predicate into a WHERE or JOIN ON clause that already contains the same predicate.

--- a/packages/core/src/transformers/ParameterConditionPlacementOptimizer.ts
+++ b/packages/core/src/transformers/ParameterConditionPlacementOptimizer.ts
@@ -37,6 +37,10 @@ import {
     SqlComponentFormatOptions
 } from "./SqlComponentFormatter";
 import { SelectOutputCollector, SelectOutputColumn } from "./SelectOutputCollector";
+import {
+    dedupeTopLevelAndConditions,
+    dedupeWhereTopLevelAndConditions
+} from "./TopLevelAndConditionDeduper";
 
 export type ParameterConditionOptimizationInput = string | SelectQuery | SimpleSelectQuery;
 
@@ -335,6 +339,7 @@ export class ParameterConditionPlacementOptimizer {
 
                 const movedCondition = this.rebaseCondition(candidate.expression, targetColumns, options);
                 target.query.appendWhere(movedCondition);
+                dedupeWhereTopLevelAndConditions(target.query, options);
                 appliedReason = placement.reason;
             } else {
                 const placements: TargetPlacement[] = [];
@@ -355,6 +360,7 @@ export class ParameterConditionPlacementOptimizer {
                 for (const branch of target.branches) {
                     const movedCondition = this.rebaseCondition(candidate.expression, branch.targetColumns, options);
                     branch.query.appendWhere(movedCondition);
+                    dedupeWhereTopLevelAndConditions(branch.query, options);
                 }
                 appliedReason = placements.some(item => /group by/i.test(item.reason))
                     ? "Condition is distributed to every UNION branch by output column position; grouped branches only receive GROUP BY-key predicates."
@@ -1031,6 +1037,7 @@ export class ParameterConditionPlacementOptimizer {
             "and",
             cloneValueComponent(expression, options)
         );
+        join.condition.condition = dedupeTopLevelAndConditions(join.condition.condition, options);
     }
 
     private resolveTargetColumnByOutputIndex(

--- a/packages/core/src/transformers/StaticPredicatePlacementOptimizer.ts
+++ b/packages/core/src/transformers/StaticPredicatePlacementOptimizer.ts
@@ -37,6 +37,10 @@ import {
     SqlComponentFormatOptions
 } from "./SqlComponentFormatter";
 import { SelectOutputCollector, SelectOutputColumn } from "./SelectOutputCollector";
+import {
+    dedupeTopLevelAndConditions,
+    dedupeWhereTopLevelAndConditions
+} from "./TopLevelAndConditionDeduper";
 
 export type StaticPredicatePlacementInput = string | SelectQuery | SimpleSelectQuery;
 
@@ -331,6 +335,7 @@ export class StaticPredicatePlacementOptimizer {
 
                 const movedPredicate = this.rebasePredicate(candidate.expression, targetColumns, options);
                 target.query.appendWhere(movedPredicate);
+                dedupeWhereTopLevelAndConditions(target.query, options);
                 appliedReason = placement.reason;
             } else {
                 const placements: TargetPlacement[] = [];
@@ -351,6 +356,7 @@ export class StaticPredicatePlacementOptimizer {
                 for (const branch of target.branches) {
                     const movedPredicate = this.rebasePredicate(candidate.expression, branch.targetColumns, options);
                     branch.query.appendWhere(movedPredicate);
+                    dedupeWhereTopLevelAndConditions(branch.query, options);
                 }
                 appliedReason = placements.some(item => /group by/i.test(item.reason))
                     ? "Predicate is distributed to every UNION branch by output column position; grouped branches only receive GROUP BY-key predicates."
@@ -1027,6 +1033,7 @@ export class StaticPredicatePlacementOptimizer {
             "and",
             cloneValueComponent(expression, options)
         );
+        join.condition.condition = dedupeTopLevelAndConditions(join.condition.condition, options);
     }
 
     private resolveDeepestBranchTarget(

--- a/packages/core/src/transformers/TopLevelAndConditionDeduper.ts
+++ b/packages/core/src/transformers/TopLevelAndConditionDeduper.ts
@@ -1,0 +1,78 @@
+import { WhereClause } from "../models/Clause";
+import { SimpleSelectQuery } from "../models/SelectQuery";
+import {
+    BinaryExpression,
+    ParenExpression,
+    ValueComponent
+} from "../models/ValueComponent";
+import { formatSqlComponent, SqlComponentFormatOptions } from "./SqlComponentFormatter";
+
+// API output shape review: this internal helper keeps optimizer result sql/query shape unchanged;
+// formatSqlComponent is used only as a caller-configurable canonical key for exact duplicate detection.
+const unwrapParens = (expression: ValueComponent): ValueComponent => {
+    let candidate = expression;
+    while (candidate instanceof ParenExpression) {
+        candidate = candidate.expression;
+    }
+    return candidate;
+};
+
+const isAndExpression = (expression: ValueComponent): expression is BinaryExpression => {
+    const candidate = unwrapParens(expression);
+    return candidate instanceof BinaryExpression
+        && candidate.operator.value.trim().toLowerCase() === "and";
+};
+
+const collectTopLevelAndTerms = (expression: ValueComponent): ValueComponent[] => {
+    const candidate = unwrapParens(expression);
+    if (!isAndExpression(candidate)) {
+        return [expression];
+    }
+
+    return [
+        ...collectTopLevelAndTerms(candidate.left),
+        ...collectTopLevelAndTerms(candidate.right)
+    ];
+};
+
+export const dedupeTopLevelAndConditions = (
+    expression: ValueComponent,
+    options: SqlComponentFormatOptions
+): ValueComponent => {
+    const terms = collectTopLevelAndTerms(expression);
+    if (terms.length < 2) {
+        return expression;
+    }
+
+    const seen = new Set<string>();
+    const uniqueTerms: ValueComponent[] = [];
+    for (const term of terms) {
+        const key = formatSqlComponent(unwrapParens(term), options);
+        if (seen.has(key)) {
+            continue;
+        }
+        seen.add(key);
+        uniqueTerms.push(term);
+    }
+
+    if (uniqueTerms.length === terms.length) {
+        return expression;
+    }
+
+    let rebuilt = uniqueTerms[0]!;
+    for (let index = 1; index < uniqueTerms.length; index += 1) {
+        rebuilt = new BinaryExpression(rebuilt, "and", uniqueTerms[index]!);
+    }
+    return rebuilt;
+};
+
+export const dedupeWhereTopLevelAndConditions = (
+    query: SimpleSelectQuery,
+    options: SqlComponentFormatOptions
+): void => {
+    if (!query.whereClause) {
+        return;
+    }
+
+    query.whereClause = new WhereClause(dedupeTopLevelAndConditions(query.whereClause.condition, options));
+};

--- a/packages/core/tests/transformers/ConditionOptimization.test.ts
+++ b/packages/core/tests/transformers/ConditionOptimization.test.ts
@@ -486,6 +486,72 @@ describe('ConditionOptimization', () => {
         `));
     });
 
+    it('deduplicates identical parameter conditions after moving into an existing upstream WHERE', () => {
+        const sql = `
+            with active_users as (
+                select u.id, u.status
+                from users u
+                where u.status = :status
+            )
+            select *
+            from active_users au
+            where au.status = :status
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([
+            expect.objectContaining({
+                phaseKind: 'parameter_condition_placement',
+                kind: 'move_condition',
+                toScopeId: 'cte:active_users',
+                columnReferences: ['au.status']
+            })
+        ]);
+        expect(result.skipped).toEqual([]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(`
+            with active_users as (
+                select u.id, u.status
+                from users u
+                where u.status = :status
+            )
+            select *
+            from active_users au
+        `));
+    });
+
+    it('deduplicates identical parameter conditions after moving into an existing JOIN ON condition', () => {
+        const sql = `
+            select *
+            from orders o
+            join users u
+              on u.id = o.user_id
+             and u.status = :status
+            where u.status = :status
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([
+            expect.objectContaining({
+                phaseKind: 'parameter_condition_placement',
+                kind: 'move_condition',
+                toScopeId: 'join_on:u',
+                columnReferences: ['u.status']
+            })
+        ]);
+        expect(result.skipped).toEqual([]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(`
+            select *
+            from orders o
+            join users u
+              on u.id = o.user_id
+             and u.status = :status
+        `));
+    });
+
     it('keeps ambiguous wildcard outputs skipped instead of guessing a source column', () => {
         const sql = `
             select *
@@ -840,6 +906,41 @@ describe('ConditionOptimization', () => {
             )
             select *
             from active_users
+        `));
+    });
+
+    it('deduplicates identical static predicates after moving into an existing upstream WHERE', () => {
+        const sql = `
+            with active_users as (
+                select u.id, u.status
+                from users u
+                where u.status = 'active'
+            )
+            select *
+            from active_users au
+            where au.status = 'active'
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([
+            expect.objectContaining({
+                phaseKind: 'static_predicate_placement',
+                kind: 'move_static_predicate',
+                toScopeId: 'cte:active_users',
+                columnReferences: ['au.status']
+            })
+        ]);
+        expect(result.skipped).toEqual([]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(`
+            with active_users as (
+                select u.id, u.status
+                from users u
+                where u.status = 'active'
+            )
+            select *
+            from active_users au
         `));
     });
 


### PR DESCRIPTION
## Summary

- Deduplicate exact top-level AND predicates after condition optimization moves a predicate into a destination WHERE or JOIN ON that already has the same condition.
- Keep the behavior conservative: no OR simplification, no commutative rewrite, and no broader boolean logic normalization.
- Cover parameter WHERE, parameter JOIN ON, and static predicate upstream WHERE cases.

## Verification

- `corepack pnpm --filter rawsql-ts test -- tests/transformers/ConditionOptimization.test.ts`
- `corepack pnpm --filter rawsql-ts test`
- `corepack pnpm --filter rawsql-ts build`
- `corepack pnpm --filter rawsql-ts lint`
- `git diff --check`
- pre-commit: workspace `typecheck`, `test`, `build`, and `lint`

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: Not required.
Scoped checks run: Package test/build/lint, git diff --check, and pre-commit workspace typecheck/test/build/lint.
Why full baseline is not required: No baseline exception requested; required checks were run.

## Self Review

Self-review workflow: Manual two-pass self-review using self-review skill, focused on exact-match-only behavior, destination-only dedupe, and regression evidence.
Self-review result: No blockers found; dedupe is limited to canonical-identical top-level AND terms and preserves broader boolean logic.
Concept-review workflow: Checked packages/core/AGENTS.md, packages/core/DESIGN.md, core-parser-analyzer-change, api-output-shape-review, and changeset-classification guidance.
Concept-review result: No package-boundary violation found; implementation remains DBMS-neutral and does not add driver, DB, testkit, CLI, scaffold, or lineage-viewer semantics.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: This PR changes core optimizer behavior only; no CLI options, commands, output contracts, help, or examples are changed.
Upgrade note: No CLI upgrade note required.
Deprecation/removal plan or issue: No CLI deprecation or removal.
Docs/help/examples updated: Not required; no CLI docs/help/example surface changed.
Release/changeset wording: Patch changeset added for deduplicating identical moved conditions.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: This PR does not touch scaffold inputs, generated output, templates, or scaffold-facing contracts.
Non-edit assertion: No scaffold files are edited.
Fail-fast input-contract proof: Not applicable.
Generated-output viability proof: Not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Query condition optimization now removes duplicate top-level `AND` predicates when conditions are moved into `WHERE` or `JOIN ... ON` clauses.

* **Bug Fixes**
  * Prevented redundant filters from appearing in generated SQL, including cases involving nested queries and `UNION` branches.

* **Tests**
  * Added coverage to verify optimized SQL no longer repeats identical conditions after predicate placement changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->