### PR TITLE
feat(core): add standalone condition deduplication

### DIFF
--- a/.changeset/standalone-condition-deduplication.md
+++ b/.changeset/standalone-condition-deduplication.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": patch
+---
+
+Run condition deduplication as a standalone condition optimization phase so identical top-level AND predicates can be removed even when no condition placement move occurs.

--- a/packages/core/src/transformers/ConditionDeduplicationOptimizer.ts
+++ b/packages/core/src/transformers/ConditionDeduplicationOptimizer.ts
@@ -1,0 +1,286 @@
+import {
+    FunctionSource,
+    HavingClause,
+    JoinOnClause,
+    OrderByItem,
+    ParenSource,
+    SourceExpression,
+    SubQuerySource,
+    WhereClause
+} from "../models/Clause";
+import { BinarySelectQuery, SelectQuery, SimpleSelectQuery } from "../models/SelectQuery";
+import {
+    ArrayExpression,
+    ArrayIndexExpression,
+    ArrayQueryExpression,
+    ArraySliceExpression,
+    BetweenExpression,
+    BinaryExpression,
+    CaseExpression,
+    CastExpression,
+    FunctionCall,
+    InlineQuery,
+    JsonPredicateExpression,
+    ParenExpression,
+    TupleExpression,
+    TypeValue,
+    UnaryExpression,
+    ValueComponent,
+    ValueList
+} from "../models/ValueComponent";
+import { SqlComponentFormatOptions } from "./SqlComponentFormatter";
+import { dedupeTopLevelAndConditionsWithMetadata } from "./TopLevelAndConditionDeduper";
+
+export interface ConditionDeduplicationApplied {
+    kind: "dedupe_condition";
+    conditionSql: string;
+    scopeId: string;
+    reason: string;
+}
+
+export interface ConditionDeduplicationResult {
+    /** API output shape review: this phase mutates and returns the model only; ConditionOptimization remains responsible for compatibility sql output. */
+    query: SelectQuery | null;
+    applied: readonly ConditionDeduplicationApplied[];
+}
+
+export class ConditionDeduplicationOptimizer {
+    private visited = new WeakSet<object>();
+    private applied: ConditionDeduplicationApplied[] = [];
+
+    public optimize(
+        query: SelectQuery | null,
+        options: SqlComponentFormatOptions
+    ): ConditionDeduplicationResult {
+        this.visited = new WeakSet<object>();
+        this.applied = [];
+
+        if (!query) {
+            return { query: null, applied: [] };
+        }
+
+        this.visitSelectQuery(query, "root", options);
+        return {
+            query,
+            applied: [...this.applied]
+        };
+    }
+
+    private visitSelectQuery(
+        query: SelectQuery,
+        scopeId: string,
+        options: SqlComponentFormatOptions
+    ): void {
+        if (this.visited.has(query)) {
+            return;
+        }
+        this.visited.add(query);
+
+        if (query instanceof BinarySelectQuery) {
+            this.visitSelectQuery(query.left, `${scopeId}.left`, options);
+            this.visitSelectQuery(query.right, `${scopeId}.right`, options);
+            return;
+        }
+
+        if (!(query instanceof SimpleSelectQuery)) {
+            return;
+        }
+
+        for (const cte of query.withClause?.tables ?? []) {
+            const cteQuery = cte.query;
+            if (cteQuery instanceof SimpleSelectQuery || cteQuery instanceof BinarySelectQuery) {
+                this.visitSelectQuery(cteQuery, `${scopeId}.cte:${cte.getSourceAliasName()}`, options);
+            }
+        }
+
+        for (const item of query.selectClause.items) {
+            this.visitValueComponent(item.value, `${scopeId}.select`, options);
+        }
+
+        if (query.fromClause) {
+            this.visitSourceExpression(query.fromClause.source, `${scopeId}.from`, options);
+            for (const join of query.fromClause.joins ?? []) {
+                const joinScope = `${scopeId}.join:${join.source.getAliasName() ?? "unknown"}`;
+                this.visitSourceExpression(join.source, joinScope, options);
+                if (join.condition instanceof JoinOnClause) {
+                    join.condition.condition = this.dedupeCondition(
+                        join.condition.condition,
+                        `${joinScope}.on`,
+                        "Removed a duplicate top-level AND condition from a JOIN ON clause.",
+                        options
+                    );
+                    this.visitValueComponent(join.condition.condition, `${joinScope}.on`, options);
+                }
+            }
+        }
+
+        if (query.whereClause) {
+            query.whereClause = new WhereClause(this.dedupeCondition(
+                query.whereClause.condition,
+                `${scopeId}.where`,
+                "Removed a duplicate top-level AND condition from a WHERE clause.",
+                options
+            ));
+            this.visitValueComponent(query.whereClause.condition, `${scopeId}.where`, options);
+        }
+
+        if (query.havingClause) {
+            query.havingClause = new HavingClause(this.dedupeCondition(
+                query.havingClause.condition,
+                `${scopeId}.having`,
+                "Removed a duplicate top-level AND condition from a HAVING clause.",
+                options
+            ));
+            this.visitValueComponent(query.havingClause.condition, `${scopeId}.having`, options);
+        }
+
+        for (const item of query.groupByClause?.grouping ?? []) {
+            this.visitValueComponent(item, `${scopeId}.group_by`, options);
+        }
+        for (const item of query.orderByClause?.order ?? []) {
+            if (item instanceof OrderByItem) {
+                this.visitValueComponent(item.value, `${scopeId}.order_by`, options);
+            } else {
+                this.visitValueComponent(item, `${scopeId}.order_by`, options);
+            }
+        }
+    }
+
+    private visitSourceExpression(
+        source: SourceExpression,
+        scopeId: string,
+        options: SqlComponentFormatOptions
+    ): void {
+        const datasource = source.datasource;
+        if (datasource instanceof SubQuerySource) {
+            this.visitSelectQuery(datasource.query, `${scopeId}.subquery`, options);
+            return;
+        }
+        if (datasource instanceof ParenSource) {
+            const nested = datasource.source;
+            if (nested instanceof SubQuerySource) {
+                this.visitSelectQuery(nested.query, `${scopeId}.subquery`, options);
+            }
+            return;
+        }
+        if (datasource instanceof FunctionSource && datasource.argument) {
+            this.visitValueComponent(datasource.argument, `${scopeId}.function`, options);
+        }
+    }
+
+    private visitValueComponent(
+        value: ValueComponent,
+        scopeId: string,
+        options: SqlComponentFormatOptions
+    ): void {
+        if (this.visited.has(value)) {
+            return;
+        }
+        this.visited.add(value);
+
+        if (value instanceof InlineQuery) {
+            this.visitSelectQuery(value.selectQuery, `${scopeId}.inline_query`, options);
+            return;
+        }
+        if (value instanceof ArrayQueryExpression) {
+            this.visitSelectQuery(value.query, `${scopeId}.array_query`, options);
+            return;
+        }
+        if (value instanceof ParenExpression) {
+            this.visitValueComponent(value.expression, scopeId, options);
+            return;
+        }
+        if (value instanceof BinaryExpression) {
+            this.visitValueComponent(value.left, scopeId, options);
+            this.visitValueComponent(value.right, scopeId, options);
+            return;
+        }
+        if (value instanceof UnaryExpression) {
+            this.visitValueComponent(value.expression, scopeId, options);
+            return;
+        }
+        if (value instanceof FunctionCall) {
+            if (value.argument) {
+                this.visitValueComponent(value.argument, scopeId, options);
+            }
+            if (value.filterCondition) {
+                this.visitValueComponent(value.filterCondition, `${scopeId}.filter`, options);
+            }
+            return;
+        }
+        if (value instanceof CastExpression) {
+            this.visitValueComponent(value.input, scopeId, options);
+            if (value.castType.argument) {
+                this.visitValueComponent(value.castType.argument, scopeId, options);
+            }
+            return;
+        }
+        if (value instanceof CaseExpression) {
+            if (value.condition) {
+                this.visitValueComponent(value.condition, scopeId, options);
+            }
+            for (const item of value.switchCase.cases) {
+                this.visitValueComponent(item.key, scopeId, options);
+                this.visitValueComponent(item.value, scopeId, options);
+            }
+            if (value.switchCase.elseValue) {
+                this.visitValueComponent(value.switchCase.elseValue, scopeId, options);
+            }
+            return;
+        }
+        if (value instanceof BetweenExpression) {
+            this.visitValueComponent(value.expression, scopeId, options);
+            this.visitValueComponent(value.lower, scopeId, options);
+            this.visitValueComponent(value.upper, scopeId, options);
+            return;
+        }
+        if (value instanceof JsonPredicateExpression) {
+            this.visitValueComponent(value.expression, scopeId, options);
+            return;
+        }
+        if (value instanceof ArrayExpression) {
+            this.visitValueComponent(value.expression, scopeId, options);
+            return;
+        }
+        if (value instanceof ArrayIndexExpression) {
+            this.visitValueComponent(value.array, scopeId, options);
+            this.visitValueComponent(value.index, scopeId, options);
+            return;
+        }
+        if (value instanceof ArraySliceExpression) {
+            this.visitValueComponent(value.array, scopeId, options);
+            if (value.startIndex) {
+                this.visitValueComponent(value.startIndex, scopeId, options);
+            }
+            if (value.endIndex) {
+                this.visitValueComponent(value.endIndex, scopeId, options);
+            }
+            return;
+        }
+        if (value instanceof ValueList || value instanceof TupleExpression) {
+            value.values.forEach(item => this.visitValueComponent(item, scopeId, options));
+            return;
+        }
+        if (value instanceof TypeValue && value.argument) {
+            this.visitValueComponent(value.argument, scopeId, options);
+        }
+    }
+
+    private dedupeCondition(
+        condition: ValueComponent,
+        scopeId: string,
+        reason: string,
+        options: SqlComponentFormatOptions
+    ): ValueComponent {
+        const result = dedupeTopLevelAndConditionsWithMetadata(condition, options);
+        for (const conditionSql of result.removedConditionSql) {
+            this.applied.push({
+                kind: "dedupe_condition",
+                conditionSql,
+                scopeId,
+                reason
+            });
+        }
+        return result.expression;
+    }
+}

--- a/packages/core/src/transformers/ConditionOptimization.ts
+++ b/packages/core/src/transformers/ConditionOptimization.ts
@@ -43,6 +43,10 @@ import {
     StaticPredicateSkipped
 } from "./StaticPredicatePlacementOptimizer";
 import {
+    ConditionDeduplicationApplied,
+    ConditionDeduplicationOptimizer
+} from "./ConditionDeduplicationOptimizer";
+import {
     collectSupportedOptionalConditionBranches,
     OptionalConditionPruningParameters,
     pruneOptionalConditionBranches,
@@ -60,7 +64,8 @@ export type ConditionOptimizationInput = string | SelectQuery | SimpleSelectQuer
 export type ConditionOptimizationPhaseKind =
     | "sssql_optional_condition"
     | "parameter_condition_placement"
-    | "static_predicate_placement";
+    | "static_predicate_placement"
+    | "condition_deduplication";
 
 export interface ConditionOptimizationOptions extends ParameterConditionOptimizationOptions {
     /**
@@ -106,7 +111,8 @@ export interface SssqlOptionalConditionSkipped {
 export type ConditionOptimizationApplied =
     | SssqlOptionalConditionApplied
     | (ParameterConditionMove & { phaseKind: "parameter_condition_placement" })
-    | (StaticPredicateMove & { phaseKind: "static_predicate_placement" });
+    | (StaticPredicateMove & { phaseKind: "static_predicate_placement" })
+    | (ConditionDeduplicationApplied & { phaseKind: "condition_deduplication" });
 
 export type ConditionOptimizationSkipped =
     | SssqlOptionalConditionSkipped
@@ -1021,6 +1027,13 @@ const mapStaticSkipped = (
     ...item
 }));
 
+const mapConditionDeduplicationApplied = (
+    applied: readonly ConditionDeduplicationApplied[]
+): ConditionOptimizationApplied[] => applied.map(item => ({
+    phaseKind: "condition_deduplication",
+    ...item
+}));
+
 const makePhaseSummary = (
     kind: ConditionOptimizationPhaseKind,
     counts: {
@@ -1083,11 +1096,18 @@ const runConditionOptimization = (
     const staticSkipped = mapStaticSkipped(staticPhase.skipped);
     const warnings = [...sssqlPhase.warnings, ...parameterWarnings, ...staticWarnings];
     const errors = [...sssqlPhase.errors, ...parameterErrors, ...staticErrors];
+    const dedupePhase = errors.length === 0
+        ? new ConditionDeduplicationOptimizer().optimize(staticPhase.query, options)
+        : { query: staticPhase.query, applied: [] };
+    const dedupeApplied = mapConditionDeduplicationApplied(dedupePhase.applied);
+    const finalSql = dedupePhase.applied.length > 0 && dedupePhase.query
+        ? formatSqlComponent(dedupePhase.query, options)
+        : staticPhase.sql;
 
     return {
         ok: errors.length === 0,
-        sql: staticPhase.sql,
-        query: staticPhase.query,
+        sql: finalSql,
+        query: dedupePhase.query,
         phases: [
             makePhaseSummary("sssql_optional_condition", {
                 appliedCount: sssqlPhase.applied.length,
@@ -1106,9 +1126,15 @@ const runConditionOptimization = (
                 skippedCount: staticSkipped.length,
                 warningCount: staticWarnings.length,
                 errorCount: staticErrors.length
+            }),
+            makePhaseSummary("condition_deduplication", {
+                appliedCount: dedupeApplied.length,
+                skippedCount: 0,
+                warningCount: 0,
+                errorCount: 0
             })
         ],
-        applied: [...sssqlPhase.applied, ...parameterApplied, ...staticApplied],
+        applied: [...sssqlPhase.applied, ...parameterApplied, ...staticApplied, ...dedupeApplied],
         skipped: [...sssqlPhase.skipped, ...parameterSkipped, ...staticSkipped],
         warnings,
         errors,

--- a/packages/core/src/transformers/TopLevelAndConditionDeduper.ts
+++ b/packages/core/src/transformers/TopLevelAndConditionDeduper.ts
@@ -7,6 +7,11 @@ import {
 } from "../models/ValueComponent";
 import { formatSqlComponent, SqlComponentFormatOptions } from "./SqlComponentFormatter";
 
+export interface TopLevelAndConditionDeduplicationResult {
+    expression: ValueComponent;
+    removedConditionSql: readonly string[];
+}
+
 // API output shape review: this internal helper keeps optimizer result sql/query shape unchanged;
 // formatSqlComponent is used only as a caller-configurable canonical key for exact duplicate detection.
 const unwrapParens = (expression: ValueComponent): ValueComponent => {
@@ -35,20 +40,22 @@ const collectTopLevelAndTerms = (expression: ValueComponent): ValueComponent[] =
     ];
 };
 
-export const dedupeTopLevelAndConditions = (
+export const dedupeTopLevelAndConditionsWithMetadata = (
     expression: ValueComponent,
     options: SqlComponentFormatOptions
-): ValueComponent => {
+): TopLevelAndConditionDeduplicationResult => {
     const terms = collectTopLevelAndTerms(expression);
     if (terms.length < 2) {
-        return expression;
+        return { expression, removedConditionSql: [] };
     }
 
     const seen = new Set<string>();
     const uniqueTerms: ValueComponent[] = [];
+    const removedConditionSql: string[] = [];
     for (const term of terms) {
         const key = formatSqlComponent(unwrapParens(term), options);
         if (seen.has(key)) {
+            removedConditionSql.push(key);
             continue;
         }
         seen.add(key);
@@ -56,14 +63,24 @@ export const dedupeTopLevelAndConditions = (
     }
 
     if (uniqueTerms.length === terms.length) {
-        return expression;
+        return { expression, removedConditionSql: [] };
     }
 
     let rebuilt = uniqueTerms[0]!;
     for (let index = 1; index < uniqueTerms.length; index += 1) {
         rebuilt = new BinaryExpression(rebuilt, "and", uniqueTerms[index]!);
     }
-    return rebuilt;
+    return {
+        expression: rebuilt,
+        removedConditionSql
+    };
+};
+
+export const dedupeTopLevelAndConditions = (
+    expression: ValueComponent,
+    options: SqlComponentFormatOptions
+): ValueComponent => {
+    return dedupeTopLevelAndConditionsWithMetadata(expression, options).expression;
 };
 
 export const dedupeWhereTopLevelAndConditions = (

--- a/packages/core/tests/transformers/ConditionOptimization.test.ts
+++ b/packages/core/tests/transformers/ConditionOptimization.test.ts
@@ -65,6 +65,10 @@ describe('ConditionOptimization', () => {
             expect.objectContaining({
                 kind: 'static_predicate_placement',
                 appliedCount: 0
+            }),
+            expect.objectContaining({
+                kind: 'condition_deduplication',
+                appliedCount: 0
             })
         ]);
         expect(result.applied).toEqual([
@@ -109,6 +113,11 @@ describe('ConditionOptimization', () => {
                 kind: 'static_predicate_placement',
                 appliedCount: 0,
                 skippedCount: 0
+            }),
+            expect.objectContaining({
+                kind: 'condition_deduplication',
+                appliedCount: 0,
+                skippedCount: 0
             })
         ]);
         expect(result.applied).toEqual([
@@ -126,6 +135,152 @@ describe('ConditionOptimization', () => {
             )
             select ob.order_id
             from orders_base ob
+        `));
+    });
+
+    it('deduplicates identical top-level WHERE conditions without condition placement', () => {
+        const sql = `
+            select u.id, u.status
+            from users u
+            where u.status = 'active'
+              and u.status = 'active'
+              and u.deleted_at is null
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.phases).toContainEqual(expect.objectContaining({
+            kind: 'condition_deduplication',
+            appliedCount: 1
+        }));
+        expect(result.applied).toContainEqual(expect.objectContaining({
+            phaseKind: 'condition_deduplication',
+            kind: 'dedupe_condition',
+            scopeId: 'root.where',
+            conditionSql: `"u"."status" = 'active'`
+        }));
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(`
+            select u.id, u.status
+            from users u
+            where u.status = 'active'
+              and u.deleted_at is null
+        `));
+    });
+
+    it('deduplicates identical top-level JOIN ON conditions without condition placement', () => {
+        const sql = `
+            select u.id, o.id as order_id
+            from users u
+            join orders o
+              on o.user_id = u.id
+             and o.user_id = u.id
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.phases).toContainEqual(expect.objectContaining({
+            kind: 'condition_deduplication',
+            appliedCount: 1
+        }));
+        expect(result.applied).toContainEqual(expect.objectContaining({
+            phaseKind: 'condition_deduplication',
+            kind: 'dedupe_condition',
+            scopeId: 'root.join:o.on',
+            conditionSql: '"o"."user_id" = "u"."id"'
+        }));
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(`
+            select u.id, o.id as order_id
+            from users u
+            join orders o
+              on o.user_id = u.id
+        `));
+    });
+
+    it('deduplicates identical top-level conditions inside CTE bodies', () => {
+        const sql = `
+            with active_orders as (
+                select o.id, o.customer_id
+                from orders o
+                where o.status = 'open'
+                  and o.status = 'open'
+            )
+            select ao.id
+            from active_orders ao
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toContainEqual(expect.objectContaining({
+            phaseKind: 'condition_deduplication',
+            kind: 'dedupe_condition',
+            scopeId: 'root.cte:active_orders.where',
+            conditionSql: `"o"."status" = 'open'`
+        }));
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(`
+            with active_orders as (
+                select o.id, o.customer_id
+                from orders o
+                where o.status = 'open'
+            )
+            select ao.id
+            from active_orders ao
+        `));
+    });
+
+    it('deduplicates identical top-level HAVING conditions', () => {
+        const sql = `
+            select o.customer_id, count(*) as order_count
+            from orders o
+            group by o.customer_id
+            having count(*) > 1
+               and count(*) > 1
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toContainEqual(expect.objectContaining({
+            phaseKind: 'condition_deduplication',
+            kind: 'dedupe_condition',
+            scopeId: 'root.having',
+            conditionSql: 'count(*) > 1'
+        }));
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(`
+            select o.customer_id, count(*) as order_count
+            from orders o
+            group by o.customer_id
+            having count(*) > 1
+        `));
+    });
+
+    it('reports standalone deduplication in dry-run plans', () => {
+        const sql = `
+            select u.id
+            from users u
+            where u.status = :status
+              and u.status = :status
+        `;
+
+        const result = planConditionOptimization(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.safety.dryRun).toBe(true);
+        expect(result.phases).toContainEqual(expect.objectContaining({
+            kind: 'condition_deduplication',
+            appliedCount: 1
+        }));
+        expect(result.applied).toContainEqual(expect.objectContaining({
+            phaseKind: 'condition_deduplication',
+            kind: 'dedupe_condition',
+            conditionSql: '"u"."status" = :status'
+        }));
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(`
+            select u.id
+            from users u
+            where u.status = :status
         `));
     });
 
@@ -1160,12 +1315,14 @@ describe('ConditionOptimization', () => {
         expect(result.phases.map(phase => phase.kind)).toEqual([
             'sssql_optional_condition',
             'parameter_condition_placement',
-            'static_predicate_placement'
+            'static_predicate_placement',
+            'condition_deduplication'
         ]);
         expect(result.phases).toEqual([
             expect.objectContaining({ kind: 'sssql_optional_condition', appliedCount: 1 }),
             expect.objectContaining({ kind: 'parameter_condition_placement', appliedCount: 1 }),
-            expect.objectContaining({ kind: 'static_predicate_placement', appliedCount: 1 })
+            expect.objectContaining({ kind: 'static_predicate_placement', appliedCount: 1 }),
+            expect.objectContaining({ kind: 'condition_deduplication', appliedCount: 0 })
         ]);
         expect(result.applied.map(item => item.phaseKind)).toEqual([
             'sssql_optional_condition',


### PR DESCRIPTION
## Summary

- Add a standalone `condition_deduplication` phase to `optimizeConditions` / `planConditionOptimization`.
- Remove exact duplicate top-level `AND` predicates from `WHERE`, `JOIN ON`, and `HAVING` even when no upstream condition placement occurs.
- Reuse the existing exact-match dedupe helper and keep the behavior conservative: no OR simplification, no commutative matching, and no broader boolean normalization.

## Verification

- `corepack pnpm --filter rawsql-ts test -- tests/transformers/ConditionOptimization.test.ts`
- `corepack pnpm --filter rawsql-ts test`
- `corepack pnpm --filter rawsql-ts build`
- `corepack pnpm --filter rawsql-ts lint`
- `git diff --check`
- pre-commit: workspace `typecheck`, `test`, `build`, and `lint`

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: Not required.
Scoped checks run: Package test/build/lint, git diff --check, and pre-commit workspace typecheck/test/build/lint.
Why full baseline is not required: No baseline exception requested; required checks were run.

## Self Review

Self-review workflow: Manual two-pass self-review using the self-review skill, focused on exact-match-only behavior, API output shape, model traversal boundaries, and regression coverage.
Self-review result: No blockers remain. The implementation only removes canonical-identical top-level AND predicates and does not attempt semantic equivalence rewriting.
Concept-review workflow: Checked packages/core/AGENTS.md, packages/core/DESIGN.md, core-parser-analyzer-change, api-output-shape-review, and developer-pr-readiness guidance.
Concept-review result: No package-boundary violation found; implementation stays DBMS-neutral and does not add driver, DB, testkit, CLI, scaffold, or lineage-viewer semantics.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: This PR changes core condition optimization behavior only; it does not change CLI commands, flags, output contracts, help, or examples.
Upgrade note: No CLI upgrade note required.
Deprecation/removal plan or issue: No CLI deprecation or removal.
Docs/help/examples updated: Not required; no CLI docs/help/example surface changed.
Release/changeset wording: Patch changeset added for standalone condition deduplication.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: This PR does not touch scaffold inputs, generated output, templates, or scaffold-facing contracts.
Non-edit assertion: No scaffold files are edited.
Fail-fast input-contract proof: Not applicable.
Generated-output viability proof: Not applicable.
