### PR TITLE
fix(core): recursively place static predicates safely

### DIFF
--- a/.changeset/recursive-static-predicate-placement.md
+++ b/.changeset/recursive-static-predicate-placement.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": patch
+---
+
+Move safe static predicates recursively through direct upstream query outputs while preserving OUTER JOIN nullable-side boundaries.

--- a/packages/core/src/transformers/StaticPredicatePlacementOptimizer.ts
+++ b/packages/core/src/transformers/StaticPredicatePlacementOptimizer.ts
@@ -169,6 +169,12 @@ interface StaticPredicateCandidate {
 
 type SkipDraft = Omit<StaticPredicateSkipped, "predicateSql" | "scopeId">;
 
+interface ScopeWorkItem {
+    query: SimpleSelectQuery;
+    scopeId: string;
+    pendingTerms?: ValueComponent[];
+}
+
 const VOLATILE_OR_UNSUPPORTED_FUNCTION_REASON = "Predicate contains a function call; volatile and expression predicates are not moved in the safe-only implementation.";
 
 const normalizeIdentifier = (value: string): string => value.trim().toLowerCase();
@@ -297,85 +303,9 @@ export class StaticPredicatePlacementOptimizer {
         const query = parsed.query;
         const applied: StaticPredicateMove[] = [];
         const skipped: StaticPredicateSkipped[] = [];
-        const movedTerms: ValueComponent[] = [];
+        this.placePredicatesInScopes(query, options, applied, skipped);
 
-        for (const term of query.whereClause ? collectTopLevelAndTerms(query.whereClause.condition) : []) {
-            const candidate = this.analyzeCandidate(query, term, options);
-            if (!candidate) {
-                continue;
-            }
-
-            if ("code" in candidate) {
-                skipped.push(this.makeSkipped(term, candidate, options));
-                continue;
-            }
-
-            const target = this.resolveTarget(query, candidate);
-            if ("code" in target) {
-                skipped.push(this.makeSkipped(term, target, options));
-                continue;
-            }
-
-            let appliedReason = "";
-            if (target.kind === "join_on") {
-                this.appendJoinOnPredicate(target.join, candidate.expression, options);
-                appliedReason = target.reason;
-            } else if (target.kind === "simple") {
-                const targetColumns = this.resolveTargetColumns(query, target.query, candidate.references);
-                if ("code" in targetColumns) {
-                    skipped.push(this.makeSkipped(term, targetColumns, options));
-                    continue;
-                }
-
-                const placement = this.resolveTargetPlacement(target.query, targetColumns);
-                if ("code" in placement) {
-                    skipped.push(this.makeSkipped(term, placement, options));
-                    continue;
-                }
-
-                const movedPredicate = this.rebasePredicate(candidate.expression, targetColumns, options);
-                target.query.appendWhere(movedPredicate);
-                dedupeWhereTopLevelAndConditions(target.query, options);
-                appliedReason = placement.reason;
-            } else {
-                const placements: TargetPlacement[] = [];
-                let skip: SkipDraft | null = null;
-                for (const branch of target.branches) {
-                    const placement = this.resolveTargetPlacement(branch.query, branch.targetColumns);
-                    if ("code" in placement) {
-                        skip = placement;
-                        break;
-                    }
-                    placements.push(placement);
-                }
-                if (skip) {
-                    skipped.push(this.makeSkipped(term, skip, options));
-                    continue;
-                }
-
-                for (const branch of target.branches) {
-                    const movedPredicate = this.rebasePredicate(candidate.expression, branch.targetColumns, options);
-                    branch.query.appendWhere(movedPredicate);
-                    dedupeWhereTopLevelAndConditions(branch.query, options);
-                }
-                appliedReason = placements.some(item => /group by/i.test(item.reason))
-                    ? "Predicate is distributed to every UNION branch by output column position; grouped branches only receive GROUP BY-key predicates."
-                    : "Predicate is distributed to every UNION branch by output column position before unsafe query boundaries.";
-            }
-            movedTerms.push(term);
-
-            applied.push({
-                kind: "move_static_predicate",
-                predicateSql: candidate.predicateSql,
-                fromScopeId: "scope:root",
-                toScopeId: target.scopeId,
-                reason: appliedReason,
-                columnReferences: candidate.references.map(columnReferenceText)
-            });
-        }
-
-        rebuildWhereWithoutTerms(query, new Set(movedTerms));
-
+        // API output shape review: keep result.sql/result.query compatibility while expanding scope-aware placement.
         const sql = applied.length > 0 || hasSqlComponentFormatOverride(options)
             ? formatSqlComponent(query, options)
             : parsed.sql;
@@ -389,6 +319,137 @@ export class StaticPredicatePlacementOptimizer {
             dryRun: options.dryRun ?? true,
             formatterGeneratedSource: parsed.formatterGeneratedSource
         });
+    }
+
+    private placePredicatesInScopes(
+        contextRoot: SimpleSelectQuery,
+        options: StaticPredicatePlacementOptions,
+        applied: StaticPredicateMove[],
+        skipped: StaticPredicateSkipped[]
+    ): void {
+        const queue: ScopeWorkItem[] = [{ query: contextRoot, scopeId: "scope:root" }];
+        let processed = 0;
+
+        while (queue.length > 0) {
+            processed += 1;
+            if (processed > 1000) {
+                skipped.push({
+                    predicateSql: "",
+                    scopeId: "scope:root",
+                    code: "RECURSIVE_PLACEMENT_LIMIT",
+                    reason: "Static predicate recursive placement stopped after reaching the safety iteration limit."
+                });
+                return;
+            }
+
+            const work = queue.shift()!;
+            const movedTerms: ValueComponent[] = [];
+            const reportSkipped = work.pendingTerms === undefined;
+            const terms = work.pendingTerms ?? (
+                work.query.whereClause
+                    ? collectTopLevelAndTerms(work.query.whereClause.condition)
+                    : []
+            );
+
+            for (const term of terms) {
+                const candidate = this.analyzeCandidate(work.query, term, options);
+                if (!candidate) {
+                    continue;
+                }
+
+                if ("code" in candidate) {
+                    if (reportSkipped) {
+                        skipped.push(this.makeSkipped(term, work.scopeId, candidate, options));
+                    }
+                    continue;
+                }
+
+                const target = this.resolveTarget(contextRoot, work.query, candidate);
+                if ("code" in target) {
+                    if (reportSkipped) {
+                        skipped.push(this.makeSkipped(term, work.scopeId, target, options));
+                    }
+                    continue;
+                }
+
+                let appliedReason = "";
+                if (target.kind === "join_on") {
+                    this.appendJoinOnPredicate(target.join, candidate.expression, options);
+                    appliedReason = target.reason;
+                } else if (target.kind === "simple") {
+                    const targetColumns = this.resolveTargetColumns(contextRoot, target.query, candidate.references);
+                    if ("code" in targetColumns) {
+                        if (reportSkipped) {
+                            skipped.push(this.makeSkipped(term, work.scopeId, targetColumns, options));
+                        }
+                        continue;
+                    }
+
+                    const placement = this.resolveTargetPlacement(contextRoot, target.query, targetColumns);
+                    if ("code" in placement) {
+                        if (reportSkipped) {
+                            skipped.push(this.makeSkipped(term, work.scopeId, placement, options));
+                        }
+                        continue;
+                    }
+
+                    const movedPredicate = this.rebasePredicate(candidate.expression, targetColumns, options);
+                    target.query.appendWhere(movedPredicate);
+                    dedupeWhereTopLevelAndConditions(target.query, options);
+                    appliedReason = work.scopeId === "scope:root"
+                        ? placement.reason
+                        : `${placement.reason} Predicate was safely rebased from a previously moved predicate.`;
+                    const retainedTerms = target.query.whereClause
+                        ? collectTopLevelAndTerms(target.query.whereClause.condition)
+                        : [];
+                    if (retainedTerms.includes(movedPredicate)) {
+                        queue.push({
+                            query: target.query,
+                            scopeId: target.scopeId,
+                            pendingTerms: [movedPredicate]
+                        });
+                    }
+                } else {
+                    const placements: TargetPlacement[] = [];
+                    let skip: SkipDraft | null = null;
+                    for (const branch of target.branches) {
+                        const placement = this.resolveTargetPlacement(contextRoot, branch.query, branch.targetColumns);
+                        if ("code" in placement) {
+                            skip = placement;
+                            break;
+                        }
+                        placements.push(placement);
+                    }
+                    if (skip) {
+                        if (reportSkipped) {
+                            skipped.push(this.makeSkipped(term, work.scopeId, skip, options));
+                        }
+                        continue;
+                    }
+
+                    for (const branch of target.branches) {
+                        const movedPredicate = this.rebasePredicate(candidate.expression, branch.targetColumns, options);
+                        branch.query.appendWhere(movedPredicate);
+                        dedupeWhereTopLevelAndConditions(branch.query, options);
+                    }
+                    appliedReason = placements.some(item => /group by/i.test(item.reason))
+                        ? "Predicate is distributed to every UNION branch by output column position; grouped branches only receive GROUP BY-key predicates."
+                        : "Predicate is distributed to every UNION branch by output column position before unsafe query boundaries.";
+                }
+                movedTerms.push(term);
+
+                applied.push({
+                    kind: "move_static_predicate",
+                    predicateSql: candidate.predicateSql,
+                    fromScopeId: work.scopeId,
+                    toScopeId: target.scopeId,
+                    reason: appliedReason,
+                    columnReferences: candidate.references.map(columnReferenceText)
+                });
+            }
+
+            rebuildWhereWithoutTerms(work.query, new Set(movedTerms));
+        }
     }
 
     public optimize(
@@ -616,13 +677,17 @@ export class StaticPredicatePlacementOptimizer {
         return found;
     }
 
-    private resolveTarget(root: SimpleSelectQuery, candidate: StaticPredicateCandidate): UpstreamTarget | SkipDraft {
-        const boundary = this.findRootQueryBoundary(root);
+    private resolveTarget(
+        contextRoot: SimpleSelectQuery,
+        currentQuery: SimpleSelectQuery,
+        candidate: StaticPredicateCandidate
+    ): UpstreamTarget | SkipDraft {
+        const boundary = this.findRootQueryBoundary(currentQuery);
         if (boundary) {
             return boundary;
         }
 
-        if (!root.fromClause) {
+        if (!currentQuery.fromClause) {
             return {
                 code: "NO_FROM_CLAUSE",
                 reason: "Predicate has no FROM source that can receive it safely."
@@ -631,7 +696,7 @@ export class StaticPredicatePlacementOptimizer {
 
         const bindings: SourceBinding[] = [];
         for (const reference of candidate.references) {
-            const binding = this.resolveSourceBinding(root, root, reference);
+            const binding = this.resolveSourceBinding(contextRoot, currentQuery, reference);
             if ("code" in binding) {
                 return binding;
             }
@@ -654,15 +719,15 @@ export class StaticPredicatePlacementOptimizer {
                 reason: "Predicate crosses a LATERAL JOIN boundary; moving it may change semantics."
             };
         }
-        const nullableSide = this.findNullableSideBoundary(root.fromClause, binding);
+        const nullableSide = this.findNullableSideBoundary(currentQuery.fromClause, binding);
         if (nullableSide) {
             return nullableSide;
         }
 
-        const upstream = this.resolveUpstreamQuery(root, binding, candidate.references);
+        const upstream = this.resolveUpstreamQuery(contextRoot, binding, candidate.references);
         if ("code" in upstream) {
             if (upstream.code === "NO_SAFE_UPSTREAM_QUERY") {
-                const joinOnTarget = this.resolveBaseTableJoinOnTarget(root, binding);
+                const joinOnTarget = this.resolveBaseTableJoinOnTarget(contextRoot, currentQuery, binding);
                 if (!("code" in joinOnTarget)) {
                     return joinOnTarget;
                 }
@@ -691,6 +756,7 @@ export class StaticPredicatePlacementOptimizer {
     }
 
     private resolveTargetPlacement(
+        contextRoot: SimpleSelectQuery,
         query: SimpleSelectQuery,
         targetColumns: readonly TargetColumnResolution[]
     ): TargetPlacement | SkipDraft {
@@ -713,11 +779,11 @@ export class StaticPredicatePlacementOptimizer {
                 reason: "Predicate crosses LIMIT/OFFSET/FETCH boundary; moving it may change row selection semantics."
             };
         }
-        if (query.fromClause && this.hasOuterJoin(query.fromClause)) {
-            return {
-                code: "OUTER_JOIN_BOUNDARY",
-                reason: "Target query contains an OUTER JOIN boundary that is not moved across in the safe-only implementation."
-            };
+        if (query.fromClause) {
+            const nullableSide = this.findNullableSideBoundaryForTargetColumns(contextRoot, query, targetColumns);
+            if (nullableSide) {
+                return nullableSide;
+            }
         }
         if (query.groupByClause) {
             const allReferencesAreGroupKeys = targetColumns.every(item =>
@@ -747,6 +813,28 @@ export class StaticPredicatePlacementOptimizer {
         return {
             reason: "All outer references resolve to direct upstream outputs before unsafe query boundaries."
         };
+    }
+
+    private findNullableSideBoundaryForTargetColumns(
+        contextRoot: SimpleSelectQuery,
+        query: SimpleSelectQuery,
+        targetColumns: readonly TargetColumnResolution[]
+    ): SkipDraft | null {
+        if (!query.fromClause) {
+            return null;
+        }
+
+        for (const item of targetColumns) {
+            const binding = this.resolveSourceBinding(contextRoot, query, item.targetColumn);
+            if ("code" in binding) {
+                return binding;
+            }
+            const nullableSide = this.findNullableSideBoundary(query.fromClause, binding);
+            if (nullableSide) {
+                return nullableSide;
+            }
+        }
+        return null;
     }
 
     private resolveSourceBinding(
@@ -973,15 +1061,19 @@ export class StaticPredicatePlacementOptimizer {
         return resolved;
     }
 
-    private resolveBaseTableJoinOnTarget(root: SimpleSelectQuery, binding: SourceBinding): JoinOnTarget | SkipDraft {
-        if (!root.fromClause || !this.isBaseTableBinding(root, binding)) {
+    private resolveBaseTableJoinOnTarget(
+        contextRoot: SimpleSelectQuery,
+        currentQuery: SimpleSelectQuery,
+        binding: SourceBinding
+    ): JoinOnTarget | SkipDraft {
+        if (!currentQuery.fromClause || !this.isBaseTableBinding(contextRoot, binding)) {
             return {
                 code: "NO_SAFE_UPSTREAM_QUERY",
                 reason: "The referenced source is a base table, so there is no upstream query block to move into."
             };
         }
 
-        if (this.hasOuterJoin(root.fromClause)) {
+        if (this.hasOuterJoin(currentQuery.fromClause)) {
             return {
                 code: "OUTER_JOIN_BOUNDARY",
                 reason: "Predicate crosses an OUTER JOIN boundary; moving it into JOIN ON may change semantics."
@@ -989,7 +1081,7 @@ export class StaticPredicatePlacementOptimizer {
         }
 
         const join = binding.isPrimary
-            ? root.fromClause.joins?.[0] ?? null
+            ? currentQuery.fromClause.joins?.[0] ?? null
             : binding.join;
         if (join?.lateral) {
             return {
@@ -1093,7 +1185,7 @@ export class StaticPredicatePlacementOptimizer {
             return { query, targetColumns: [...targetColumns] };
         }
 
-        const placement = this.resolveTargetPlacement(upstream.query, upstreamColumns);
+        const placement = this.resolveTargetPlacement(contextRoot, upstream.query, upstreamColumns);
         if ("code" in placement) {
             return { query, targetColumns: [...targetColumns] };
         }
@@ -2022,12 +2114,13 @@ export class StaticPredicatePlacementOptimizer {
 
     private makeSkipped(
         expression: ValueComponent,
+        scopeId: string,
         draft: SkipDraft,
         options: SqlComponentFormatOptions
     ): StaticPredicateSkipped {
         return {
             predicateSql: formatSqlComponent(expression, options),
-            scopeId: "scope:root",
+            scopeId,
             ...draft
         };
     }

--- a/packages/core/tests/transformers/ConditionOptimization.test.ts
+++ b/packages/core/tests/transformers/ConditionOptimization.test.ts
@@ -1047,6 +1047,13 @@ describe('ConditionOptimization', () => {
                 kind: 'move_static_predicate',
                 toScopeId: 'cte:active_users',
                 columnReferences: ['status']
+            }),
+            expect.objectContaining({
+                phaseKind: 'static_predicate_placement',
+                kind: 'move_static_predicate',
+                fromScopeId: 'cte:active_users',
+                toScopeId: 'subquery:user_status',
+                columnReferences: ['user_status.status']
             })
         ]);
         expect(result.skipped).toEqual([]);
@@ -1056,8 +1063,8 @@ describe('ConditionOptimization', () => {
                 from (
                     select u.status
                     from users u
+                    where u.status = 'active'
                 ) user_status
-                where user_status.status = 'active'
             )
             select *
             from active_users
@@ -2331,7 +2338,7 @@ describe('ConditionOptimization', () => {
                     'on "o"."customer_id" = "c"."id" and "o"."status" = \'paid\'',
                     'from "customers" as "c" left join "orders" as "o" on "o"."customer_id" = "c"."id" where "o"."status" = \'paid\''
                 ],
-                expectedSkippedCodes: ['OUTER_JOIN_BOUNDARY']
+                expectedSkippedCodes: ['OUTER_JOIN_NULLABLE_SIDE']
             });
         });
 
@@ -2355,7 +2362,7 @@ describe('ConditionOptimization', () => {
                 forbiddenFragments: [
                     'on "o"."customer_id" = "c"."id" and "o"."id" is null'
                 ],
-                expectedSkippedCodes: ['OUTER_JOIN_BOUNDARY']
+                expectedSkippedCodes: ['OUTER_JOIN_NULLABLE_SIDE']
             });
         });
 

--- a/packages/core/tests/transformers/StaticPredicatePlacementOptimizer.test.ts
+++ b/packages/core/tests/transformers/StaticPredicatePlacementOptimizer.test.ts
@@ -57,6 +57,171 @@ describe('StaticPredicatePlacementOptimizer', () => {
         `));
     });
 
+    it('recursively moves static predicates through grouped CTE keys into direct preserved-side source columns', () => {
+        const sql = `
+            with
+              source_summary as (
+                select
+                  t1.group_id,
+                  t1.org_id,
+                  count(t1.group_id) as item_count
+                from source_table as t1
+                group by
+                  t1.group_id,
+                  t1.org_id
+              ),
+              target_summary as (
+                select
+                  t2.group_id,
+                  m.org_id,
+                  count(t2.group_id) as item_count
+                from target_table as t2
+                inner join master_table as m
+                  on t2.related_id = m.related_id
+                group by
+                  t2.group_id,
+                  m.org_id
+              ),
+              detail_data as (
+                select
+                  o.org_id,
+                  o.org_name,
+                  s.group_id,
+                  s.item_count as source_count,
+                  t.item_count as target_count
+                from organization as o
+                left join source_summary as s
+                  on o.org_id = s.org_id
+                left join target_summary as t
+                  on s.group_id = t.group_id
+                where
+                  o.enabled_flg = true
+              ),
+              report as (
+                select
+                  org_id,
+                  org_name,
+                  sum(source_count) as source_count,
+                  sum(target_count) as target_count
+                from detail_data
+                group by
+                  org_id,
+                  org_name
+              )
+            select
+              org_id,
+              org_name,
+              source_count,
+              target_count
+            from report
+            where org_id in (1)
+        `;
+
+        const result = optimizeStaticPredicatePlacement(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([
+            expect.objectContaining({
+                fromScopeId: 'scope:root',
+                toScopeId: 'cte:report',
+                predicateSql: '"org_id" in (1)'
+            }),
+            expect.objectContaining({
+                fromScopeId: 'cte:report',
+                toScopeId: 'cte:detail_data',
+                predicateSql: '"org_id" in (1)',
+                reason: expect.stringMatching(/direct output|rebased|recursive/i)
+            })
+        ]);
+        expect(result.skipped).toEqual([]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(`
+            with
+              source_summary as (
+                select
+                  t1.group_id,
+                  t1.org_id,
+                  count(t1.group_id) as item_count
+                from source_table as t1
+                group by
+                  t1.group_id,
+                  t1.org_id
+              ),
+              target_summary as (
+                select
+                  t2.group_id,
+                  m.org_id,
+                  count(t2.group_id) as item_count
+                from target_table as t2
+                inner join master_table as m
+                  on t2.related_id = m.related_id
+                group by
+                  t2.group_id,
+                  m.org_id
+              ),
+              detail_data as (
+                select
+                  o.org_id,
+                  o.org_name,
+                  s.group_id,
+                  s.item_count as source_count,
+                  t.item_count as target_count
+                from organization as o
+                left join source_summary as s
+                  on o.org_id = s.org_id
+                left join target_summary as t
+                  on s.group_id = t.group_id
+                where
+                  o.enabled_flg = true
+                  and o.org_id in (1)
+              ),
+              report as (
+                select
+                  org_id,
+                  org_name,
+                  sum(source_count) as source_count,
+                  sum(target_count) as target_count
+                from detail_data
+                group by
+                  org_id,
+                  org_name
+              )
+            select
+              org_id,
+              org_name,
+              source_count,
+              target_count
+            from report
+        `));
+    });
+
+    it('does not recursively push predicates into the nullable side of a LEFT JOIN', () => {
+        const sql = `
+            with
+              detail_data as (
+                select
+                  o.org_id,
+                  s.item_count as source_count
+                from organization as o
+                left join source_summary as s
+                  on o.org_id = s.org_id
+              )
+            select *
+            from detail_data
+            where source_count > 0
+        `;
+
+        const result = optimizeStaticPredicatePlacement(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.applied).toEqual([]);
+        expect(result.skipped).toEqual([
+            expect.objectContaining({
+                code: 'OUTER_JOIN_NULLABLE_SIDE'
+            })
+        ]);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(sql));
+    });
+
     it('moves simple boolean and NULL static predicates into the safe upstream CTE', () => {
         const sql = `
             with customer_scope as (
@@ -535,6 +700,13 @@ describe('StaticPredicatePlacementOptimizer', () => {
                 predicateSql: `"d"."status" = 'paid'`,
                 toScopeId: 'subquery:d',
                 reason: expect.stringMatching(/DISTINCT output column/i)
+            }),
+            expect.objectContaining({
+                kind: 'move_static_predicate',
+                fromScopeId: 'subquery:d',
+                predicateSql: `"o"."status" = 'paid'`,
+                toScopeId: 'subquery:o',
+                reason: expect.stringMatching(/rebased/i)
             })
         ]);
         expect(result.skipped).toEqual([]);
@@ -545,8 +717,8 @@ describe('StaticPredicatePlacementOptimizer', () => {
                 from (
                     select o.customer_id, o.status
                     from orders o
+                    where o.status = 'paid'
                 ) as o
-                where o.status = 'paid'
             ) as d
         `));
     });


### PR DESCRIPTION
## Summary

- Refactor `StaticPredicatePlacementOptimizer` to process moved static predicates recursively per scope.
- Allow preserved-side predicates to move through OUTER JOIN query blocks while keeping nullable-side predicates blocked.
- Add regression coverage for grouped CTE key recursion, nullable-side blocking, integrated condition optimization metadata, and recursive DISTINCT/wildcard movement.
- Add a patch changeset for the optimizer behavior improvement.

## Verification

- `corepack pnpm --filter rawsql-ts test`
- `corepack pnpm --filter rawsql-ts build`
- `corepack pnpm --filter rawsql-ts lint`
- Pre-commit hook: workspace `typecheck`, workspace `test`, workspace `build`, workspace `lint`

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

<!-- Write values on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. -->
<!-- Do not add list markers like "-" before these labels; `Tracking issue:` and `Scoped checks run:` must start at column 0. -->
Tracking issue: Not applicable; no baseline exception requested.
Scoped checks run: `corepack pnpm --filter rawsql-ts test`, `corepack pnpm --filter rawsql-ts build`, `corepack pnpm --filter rawsql-ts lint`, pre-commit workspace checks.
Why full baseline is not required: Not applicable; no baseline exception requested.

## Self Review

<!-- Fill these fields after running the repo self-review workflow or available self-review skill. -->
Self-review workflow: developer-self-review two-cycle review.
Self-review result: No blockers remain; change is scoped to recursive static predicate placement and tests.
Concept-review workflow: Package-boundary review against `packages/core/DESIGN.md` and transformer/API output shape review.
Concept-review result: No package-boundary or API output shape violations remain; `result.sql` and `result.query` compatibility is preserved.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-migration rationale: No CLI command, flag, help text, or user-facing CLI contract changes.
Upgrade note: Not applicable; no CLI surface migration.
Deprecation/removal plan or issue: Not applicable; no deprecation or removal.
Docs/help/examples updated: Not applicable; no docs/help/example surface changed.
Release/changeset wording: `.changeset/recursive-static-predicate-placement.md` describes the patch behavior change.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-proof rationale: No scaffold generator, template, or generated-output contract changed.
Non-edit assertion: Not applicable; no scaffold output is touched.
Fail-fast input-contract proof: Not applicable; no scaffold input contract is touched.
Generated-output viability proof: Not applicable; no scaffold generated output is touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Static predicates can now be moved recursively across multiple query scopes when it is safe to do so.
  * Predicate placement now better handles CTEs, DISTINCT outputs, and other upstream query boundaries.

* **Bug Fixes**
  * Prevents predicate movement into the nullable side of `LEFT JOIN`s.
  * Improves skip reporting so the affected scope is shown more accurately.
  * Updates expected predicate rewrites to reflect the correct final query placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->