### PR TITLE
feat(core): add predicate probe target metadata

### DIFF
--- a/.changeset/predicate-probe-targets.md
+++ b/.changeset/predicate-probe-targets.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": minor
+---
+
+Add probe target metadata to predicate reachability analysis results for count and sample investigation workflows.

--- a/packages/core/src/transformers/PredicateReachabilityAnalyzer.ts
+++ b/packages/core/src/transformers/PredicateReachabilityAnalyzer.ts
@@ -50,6 +50,12 @@ export interface PredicateReachabilityError {
 
 export type PredicateReachabilityMode = "rewrite_safe" | "debug_only";
 export type PredicateReachabilityRelation = "origin" | "direct_output" | "join_equivalence";
+export type PredicateReachabilityProbeKind = "count" | "sample";
+
+export interface PredicateReachabilityScopeTarget {
+    kind: "scope" | "cte" | "table" | "subquery" | "source";
+    name: string;
+}
 
 export interface PredicateReachabilityTarget {
     scopeId: string;
@@ -67,12 +73,23 @@ export interface PredicateReachabilityBlocked {
     via?: readonly string[];
 }
 
+export interface PredicateReachabilityProbeTarget {
+    scopeId: string;
+    relation: PredicateReachabilityRelation;
+    mode: PredicateReachabilityMode;
+    predicateSql: string;
+    target: PredicateReachabilityScopeTarget;
+    probeKinds: readonly PredicateReachabilityProbeKind[];
+    caution?: string;
+}
+
 export interface PredicateReachabilityPredicate {
     predicateSql: string;
     originScopeId: string;
     columnReferences: readonly string[];
     reaches: readonly PredicateReachabilityTarget[];
     blocked: readonly PredicateReachabilityBlocked[];
+    probeTargets: readonly PredicateReachabilityProbeTarget[];
 }
 
 export interface PredicateReachabilitySafety {
@@ -243,9 +260,45 @@ export class PredicateReachabilityAnalyzer {
                 originScopeId: scopeId,
                 columnReferences: references.map(columnReferenceText),
                 reaches,
-                blocked
+                blocked,
+                probeTargets: this.buildProbeTargets(reaches)
             };
         });
+    }
+
+    private buildProbeTargets(
+        reaches: readonly PredicateReachabilityTarget[]
+    ): PredicateReachabilityProbeTarget[] {
+        return reaches.map(reach => ({
+            scopeId: reach.scopeId,
+            relation: reach.relation,
+            mode: reach.mode,
+            predicateSql: reach.predicateSql,
+            target: this.describeScopeTarget(reach.scopeId),
+            probeKinds: ["count", "sample"],
+            ...(reach.mode === "debug_only"
+                ? {
+                    caution: "This target is inferred through a debug-only relationship and is not a safe SQL rewrite target."
+                }
+                : {})
+        }));
+    }
+
+    private describeScopeTarget(scopeId: string): PredicateReachabilityScopeTarget {
+        const [kind, ...rest] = scopeId.split(":");
+        const name = rest.join(":") || scopeId;
+        switch (kind) {
+            case "cte":
+                return { kind: "cte", name };
+            case "table":
+                return { kind: "table", name };
+            case "subquery":
+                return { kind: "subquery", name };
+            case "source":
+                return { kind: "source", name };
+            default:
+                return { kind: "scope", name };
+        }
     }
 
     private resolveDirectOutputReach(

--- a/packages/core/tests/transformers/PredicateReachabilityAnalyzer.test.ts
+++ b/packages/core/tests/transformers/PredicateReachabilityAnalyzer.test.ts
@@ -53,6 +53,31 @@ describe('PredicateReachabilityAnalyzer', () => {
             })
         ]);
         expect(result.predicates[0]!.blocked).toEqual([]);
+        expect(result.predicates[0]!.probeTargets).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                scopeId: 'cte:order_scope',
+                relation: 'direct_output',
+                mode: 'rewrite_safe',
+                predicateSql: '"o"."customer_id" = :customer_id',
+                target: {
+                    kind: 'cte',
+                    name: 'order_scope'
+                },
+                probeKinds: ['count', 'sample']
+            }),
+            expect.objectContaining({
+                scopeId: 'table:customers',
+                relation: 'join_equivalence',
+                mode: 'debug_only',
+                predicateSql: '"c"."id" = :customer_id',
+                target: {
+                    kind: 'table',
+                    name: 'customers'
+                },
+                probeKinds: ['count', 'sample'],
+                caution: expect.stringContaining('debug-only')
+            })
+        ]));
         expect(result.query).not.toBeNull();
         expect(normalizeSql(new SqlFormatter().format(result.query!).formattedSql)).toBe(normalizeSql(sql));
     });
@@ -90,5 +115,11 @@ describe('PredicateReachabilityAnalyzer', () => {
                 ]
             })
         ]);
+        expect(result.predicates[0]!.probeTargets).not.toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                scopeId: 'table:customers',
+                relation: 'join_equivalence'
+            })
+        ]));
     });
 });


### PR DESCRIPTION
## Summary

- Add `probeTargets` to predicate reachability analysis results.
- Include count/sample probe kinds, target scope metadata, and debug-only cautions for JOIN-equivalence-derived targets.
- Keep blocked OUTER JOIN equivalence out of probe targets.
- Add a minor changeset for the new metadata shape.

## Verification

- `corepack pnpm --filter rawsql-ts test`
- `corepack pnpm --filter rawsql-ts build`
- `corepack pnpm --filter rawsql-ts lint`
- pre-commit workspace checks: API output shape guard, workspace typecheck, workspace tests, workspace build, workspace lint

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

<!-- Write values on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. -->
<!-- Do not add list markers like "-" before these labels; `Tracking issue:` and `Scoped checks run:` must start at column 0. -->
Tracking issue: No separate tracking issue; requested from the Codex task thread as follow-up to predicate reachability analysis.
Scoped checks run: rawsql-ts package test/build/lint plus pre-commit workspace typecheck/test/build/lint.
Why full baseline is not required: Full baseline exception is not requested because the workspace pre-commit baseline passed.

## Self Review

<!-- Fill these fields after running the repo self-review workflow or available self-review skill. -->
Self-review workflow: developer-self-review two-cycle pass covering consistency review and human acceptance review.
Self-review result: No blockers remain; this PR intentionally stops at metadata and does not generate or execute probe SQL.
Concept-review workflow: No Concept Spec impact; checked package boundary for core debug metadata that remains DBMS-neutral.
Concept-review result: No concept or package-boundary violation found.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-migration rationale: This adds core metadata only and does not change CLI flags, commands, help, or examples.
Upgrade note: Consumers of predicate reachability analysis can read `probeTargets`; existing callable behavior is unchanged.
Deprecation/removal plan or issue: No deprecation or removal is included.
Docs/help/examples updated: No CLI docs or help text changed.
Release/changeset wording: Minor changeset added for predicate reachability probe target metadata.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

<!-- Fill the fields below on the same line as each label, or generate this section via `pnpm pr:readiness:prepare ...`. Do not add list markers like "-" before labels. -->
No-proof rationale: This PR does not touch scaffold templates, generated output, or scaffold input contracts.
Non-edit assertion: Scaffold files are unchanged.
Fail-fast input-contract proof: Not applicable because scaffold inputs are unchanged.
Generated-output viability proof: Not applicable because generated scaffold output is unchanged.
