### PR TITLE
refactor(core): share predicate expression helpers

### DIFF
--- a/packages/core/src/transformers/ParameterConditionPlacementOptimizer.ts
+++ b/packages/core/src/transformers/ParameterConditionPlacementOptimizer.ts
@@ -6,8 +6,7 @@ import {
     JoinOnClause,
     SourceExpression,
     SubQuerySource,
-    TableSource,
-    WhereClause
+    TableSource
 } from "../models/Clause";
 import { BinarySelectQuery, SelectQuery, SimpleSelectQuery } from "../models/SelectQuery";
 import {
@@ -22,7 +21,6 @@ import {
     InlineQuery,
     JsonPredicateExpression,
     ParameterExpression,
-    ParenExpression,
     TupleExpression,
     TypeValue,
     UnaryExpression,
@@ -30,7 +28,6 @@ import {
     ValueList
 } from "../models/ValueComponent";
 import { SelectQueryParser } from "../parsers/SelectQueryParser";
-import { ValueParser } from "../parsers/ValueParser";
 import {
     formatSqlComponent,
     hasSqlComponentFormatOverride,
@@ -41,6 +38,19 @@ import {
     dedupeTopLevelAndConditions,
     dedupeWhereTopLevelAndConditions
 } from "./TopLevelAndConditionDeduper";
+import {
+    appendUnique,
+    cloneColumnReference,
+    cloneValueComponent,
+    collectTopLevelAndTerms,
+    columnReferenceText,
+    identifiersEqual,
+    isBinaryOperator,
+    normalizeIdentifier,
+    rebuildWhereWithoutTerms,
+    sameColumnReference,
+    unwrapParens
+} from "./PredicateExpressionUtils";
 
 export type ParameterConditionOptimizationInput = string | SelectQuery | SimpleSelectQuery;
 
@@ -174,90 +184,6 @@ type SkipDraft = Omit<ParameterConditionSkipped, "conditionSql" | "scopeId">;
 
 const SUPPORTED_OPERATORS = new Set(["=", "<>", "!=", "<", "<=", ">", ">=", "like", "ilike", "in"]);
 const VOLATILE_OR_UNSUPPORTED_FUNCTION_REASON = "Condition contains a function call; volatile and expression predicates are not moved in the safe-only implementation.";
-
-const normalizeIdentifier = (value: string): string => value.trim().toLowerCase();
-const isCaseSensitiveIdentifier = (value: string): boolean => /[A-Z]/.test(value.trim());
-const identifiersEqual = (left: string, right: string): boolean => {
-    const trimmedLeft = left.trim();
-    const trimmedRight = right.trim();
-    return isCaseSensitiveIdentifier(trimmedLeft) || isCaseSensitiveIdentifier(trimmedRight)
-        ? trimmedLeft === trimmedRight
-        : trimmedLeft.toLowerCase() === trimmedRight.toLowerCase();
-};
-
-const unwrapParens = (expression: ValueComponent): ValueComponent => {
-    let candidate = expression;
-    while (candidate instanceof ParenExpression) {
-        candidate = candidate.expression;
-    }
-    return candidate;
-};
-
-const isBinaryOperator = (expression: ValueComponent, operator: string): expression is BinaryExpression => {
-    const candidate = unwrapParens(expression);
-    return candidate instanceof BinaryExpression
-        && candidate.operator.value.trim().toLowerCase() === operator;
-};
-
-const collectTopLevelAndTerms = (expression: ValueComponent): ValueComponent[] => {
-    const candidate = unwrapParens(expression);
-    if (!isBinaryOperator(candidate, "and")) {
-        return [expression];
-    }
-
-    return [
-        ...collectTopLevelAndTerms(candidate.left),
-        ...collectTopLevelAndTerms(candidate.right)
-    ];
-};
-
-const rebuildWhereWithoutTerms = (query: SimpleSelectQuery, termsToRemove: ReadonlySet<ValueComponent>): void => {
-    if (!query.whereClause || termsToRemove.size === 0) {
-        return;
-    }
-
-    const remaining = collectTopLevelAndTerms(query.whereClause.condition)
-        .filter(term => !termsToRemove.has(term));
-
-    if (remaining.length === 0) {
-        query.whereClause = null;
-        return;
-    }
-
-    let rebuilt = remaining[0]!;
-    for (let index = 1; index < remaining.length; index += 1) {
-        rebuilt = new BinaryExpression(rebuilt, "and", remaining[index]!);
-    }
-    query.whereClause = new WhereClause(rebuilt);
-};
-
-const cloneValueComponent = (
-    expression: ValueComponent,
-    options: SqlComponentFormatOptions
-): ValueComponent => {
-    return ValueParser.parse(formatSqlComponent(expression, options));
-};
-
-const cloneColumnReference = (reference: ColumnReference): ColumnReference => {
-    const namespaces = reference.namespaces?.map(namespace => namespace.name) ?? null;
-    return new ColumnReference(namespaces, reference.column.name);
-};
-
-const columnReferenceText = (reference: ColumnReference): string => {
-    const namespace = reference.getNamespace();
-    return namespace ? `${namespace}.${reference.column.name}` : reference.column.name;
-};
-
-const sameColumnReference = (left: ColumnReference, right: ColumnReference): boolean => {
-    return identifiersEqual(left.column.name, right.column.name)
-        && identifiersEqual(left.getNamespace(), right.getNamespace());
-};
-
-const appendUnique = <T>(items: T[], value: T): void => {
-    if (!items.includes(value)) {
-        items.push(value);
-    }
-};
 
 export class ParameterConditionPlacementOptimizer {
     public plan(

--- a/packages/core/src/transformers/PredicateExpressionUtils.ts
+++ b/packages/core/src/transformers/PredicateExpressionUtils.ts
@@ -1,0 +1,99 @@
+import { WhereClause } from "../models/Clause";
+import {
+    BinaryExpression,
+    ColumnReference,
+    ParenExpression,
+    ValueComponent
+} from "../models/ValueComponent";
+import { ValueParser } from "../parsers/ValueParser";
+import { formatSqlComponent, SqlComponentFormatOptions } from "./SqlComponentFormatter";
+
+export const normalizeIdentifier = (value: string): string => value.trim().toLowerCase();
+
+const isCaseSensitiveIdentifier = (value: string): boolean => /[A-Z]/.test(value.trim());
+
+export const identifiersEqual = (left: string, right: string): boolean => {
+    const trimmedLeft = left.trim();
+    const trimmedRight = right.trim();
+    return isCaseSensitiveIdentifier(trimmedLeft) || isCaseSensitiveIdentifier(trimmedRight)
+        ? trimmedLeft === trimmedRight
+        : trimmedLeft.toLowerCase() === trimmedRight.toLowerCase();
+};
+
+export const unwrapParens = (expression: ValueComponent): ValueComponent => {
+    let candidate = expression;
+    while (candidate instanceof ParenExpression) {
+        candidate = candidate.expression;
+    }
+    return candidate;
+};
+
+export const isBinaryOperator = (expression: ValueComponent, operator: string): expression is BinaryExpression => {
+    const candidate = unwrapParens(expression);
+    return candidate instanceof BinaryExpression
+        && candidate.operator.value.trim().toLowerCase() === operator;
+};
+
+export const collectTopLevelAndTerms = (expression: ValueComponent): ValueComponent[] => {
+    const candidate = unwrapParens(expression);
+    if (!isBinaryOperator(candidate, "and")) {
+        return [expression];
+    }
+
+    return [
+        ...collectTopLevelAndTerms(candidate.left),
+        ...collectTopLevelAndTerms(candidate.right)
+    ];
+};
+
+export const rebuildWhereWithoutTerms = (
+    query: { whereClause: WhereClause | null },
+    termsToRemove: ReadonlySet<ValueComponent>
+): void => {
+    if (!query.whereClause || termsToRemove.size === 0) {
+        return;
+    }
+
+    const remaining = collectTopLevelAndTerms(query.whereClause.condition)
+        .filter(term => !termsToRemove.has(term));
+
+    if (remaining.length === 0) {
+        query.whereClause = null;
+        return;
+    }
+
+    let rebuilt = remaining[0]!;
+    for (let index = 1; index < remaining.length; index += 1) {
+        rebuilt = new BinaryExpression(rebuilt, "and", remaining[index]!);
+    }
+    query.whereClause = new WhereClause(rebuilt);
+};
+
+// API output shape review: this helper preserves the existing AST -> SQL -> AST clone path used by callers without changing public result.sql/result.query shapes.
+export const cloneValueComponent = (
+    expression: ValueComponent,
+    options: SqlComponentFormatOptions
+): ValueComponent => {
+    return ValueParser.parse(formatSqlComponent(expression, options));
+};
+
+export const cloneColumnReference = (reference: ColumnReference): ColumnReference => {
+    const namespaces = reference.namespaces?.map(namespace => namespace.name) ?? null;
+    return new ColumnReference(namespaces, reference.column.name);
+};
+
+export const columnReferenceText = (reference: ColumnReference): string => {
+    const namespace = reference.getNamespace();
+    return namespace ? `${namespace}.${reference.column.name}` : reference.column.name;
+};
+
+export const sameColumnReference = (left: ColumnReference, right: ColumnReference): boolean => {
+    return identifiersEqual(left.column.name, right.column.name)
+        && identifiersEqual(left.getNamespace(), right.getNamespace());
+};
+
+export const appendUnique = <T>(items: T[], value: T): void => {
+    if (!items.includes(value)) {
+        items.push(value);
+    }
+};

--- a/packages/core/src/transformers/PredicateReachabilityAnalyzer.ts
+++ b/packages/core/src/transformers/PredicateReachabilityAnalyzer.ts
@@ -18,7 +18,6 @@ import {
     FunctionCall,
     InlineQuery,
     JsonPredicateExpression,
-    ParenExpression,
     TupleExpression,
     TypeValue,
     UnaryExpression,
@@ -26,9 +25,19 @@ import {
     ValueList
 } from "../models/ValueComponent";
 import { SelectQueryParser } from "../parsers/SelectQueryParser";
-import { ValueParser } from "../parsers/ValueParser";
 import { formatSqlComponent, SqlComponentFormatOptions } from "./SqlComponentFormatter";
 import { SelectOutputCollector, SelectOutputColumn } from "./SelectOutputCollector";
+import {
+    cloneColumnReference,
+    cloneValueComponent,
+    collectTopLevelAndTerms,
+    columnReferenceText,
+    identifiersEqual,
+    isBinaryOperator,
+    normalizeIdentifier,
+    sameColumnReference,
+    unwrapParens
+} from "./PredicateExpressionUtils";
 
 export type PredicateReachabilityInput = string | SelectQuery | SimpleSelectQuery;
 
@@ -123,64 +132,6 @@ interface TargetColumnResolution {
     sourceColumn: ColumnReference;
     targetColumn: ColumnReference;
 }
-
-const normalizeIdentifier = (value: string): string => value.trim().toLowerCase();
-const isCaseSensitiveIdentifier = (value: string): boolean => /[A-Z]/.test(value.trim());
-const identifiersEqual = (left: string, right: string): boolean => {
-    const trimmedLeft = left.trim();
-    const trimmedRight = right.trim();
-    return isCaseSensitiveIdentifier(trimmedLeft) || isCaseSensitiveIdentifier(trimmedRight)
-        ? trimmedLeft === trimmedRight
-        : trimmedLeft.toLowerCase() === trimmedRight.toLowerCase();
-};
-
-const unwrapParens = (expression: ValueComponent): ValueComponent => {
-    let candidate = expression;
-    while (candidate instanceof ParenExpression) {
-        candidate = candidate.expression;
-    }
-    return candidate;
-};
-
-const isBinaryOperator = (expression: ValueComponent, operator: string): expression is BinaryExpression => {
-    const candidate = unwrapParens(expression);
-    return candidate instanceof BinaryExpression
-        && candidate.operator.value.trim().toLowerCase() === operator;
-};
-
-const collectTopLevelAndTerms = (expression: ValueComponent): ValueComponent[] => {
-    const candidate = unwrapParens(expression);
-    if (!isBinaryOperator(candidate, "and")) {
-        return [expression];
-    }
-
-    return [
-        ...collectTopLevelAndTerms(candidate.left),
-        ...collectTopLevelAndTerms(candidate.right)
-    ];
-};
-
-const columnReferenceText = (reference: ColumnReference): string => {
-    const namespace = reference.getNamespace();
-    return namespace ? `${namespace}.${reference.column.name}` : reference.column.name;
-};
-
-const sameColumnReference = (left: ColumnReference, right: ColumnReference): boolean => {
-    return identifiersEqual(left.column.name, right.column.name)
-        && identifiersEqual(left.getNamespace(), right.getNamespace());
-};
-
-const cloneValueComponent = (
-    expression: ValueComponent,
-    options: SqlComponentFormatOptions
-): ValueComponent => {
-    return ValueParser.parse(formatSqlComponent(expression, options));
-};
-
-const cloneColumnReference = (reference: ColumnReference): ColumnReference => {
-    const namespaces = reference.namespaces?.map(namespace => namespace.name) ?? null;
-    return new ColumnReference(namespaces, reference.column.name);
-};
 
 export class PredicateReachabilityAnalyzer {
     public analyze(

--- a/packages/core/src/transformers/StaticPredicatePlacementOptimizer.ts
+++ b/packages/core/src/transformers/StaticPredicatePlacementOptimizer.ts
@@ -6,8 +6,7 @@ import {
     JoinOnClause,
     SourceExpression,
     SubQuerySource,
-    TableSource,
-    WhereClause
+    TableSource
 } from "../models/Clause";
 import { BinarySelectQuery, SelectQuery, SimpleSelectQuery } from "../models/SelectQuery";
 import {
@@ -22,7 +21,6 @@ import {
     InlineQuery,
     JsonPredicateExpression,
     ParameterExpression,
-    ParenExpression,
     TupleExpression,
     TypeValue,
     UnaryExpression,
@@ -30,7 +28,6 @@ import {
     ValueList
 } from "../models/ValueComponent";
 import { SelectQueryParser } from "../parsers/SelectQueryParser";
-import { ValueParser } from "../parsers/ValueParser";
 import {
     formatSqlComponent,
     hasSqlComponentFormatOverride,
@@ -41,6 +38,19 @@ import {
     dedupeTopLevelAndConditions,
     dedupeWhereTopLevelAndConditions
 } from "./TopLevelAndConditionDeduper";
+import {
+    appendUnique,
+    cloneColumnReference,
+    cloneValueComponent,
+    collectTopLevelAndTerms,
+    columnReferenceText,
+    identifiersEqual,
+    isBinaryOperator,
+    normalizeIdentifier,
+    rebuildWhereWithoutTerms,
+    sameColumnReference,
+    unwrapParens
+} from "./PredicateExpressionUtils";
 
 export type StaticPredicatePlacementInput = string | SelectQuery | SimpleSelectQuery;
 
@@ -176,90 +186,6 @@ interface ScopeWorkItem {
 }
 
 const VOLATILE_OR_UNSUPPORTED_FUNCTION_REASON = "Predicate contains a function call; volatile and expression predicates are not moved in the safe-only implementation.";
-
-const normalizeIdentifier = (value: string): string => value.trim().toLowerCase();
-const isCaseSensitiveIdentifier = (value: string): boolean => /[A-Z]/.test(value.trim());
-const identifiersEqual = (left: string, right: string): boolean => {
-    const trimmedLeft = left.trim();
-    const trimmedRight = right.trim();
-    return isCaseSensitiveIdentifier(trimmedLeft) || isCaseSensitiveIdentifier(trimmedRight)
-        ? trimmedLeft === trimmedRight
-        : trimmedLeft.toLowerCase() === trimmedRight.toLowerCase();
-};
-
-const unwrapParens = (expression: ValueComponent): ValueComponent => {
-    let candidate = expression;
-    while (candidate instanceof ParenExpression) {
-        candidate = candidate.expression;
-    }
-    return candidate;
-};
-
-const isBinaryOperator = (expression: ValueComponent, operator: string): expression is BinaryExpression => {
-    const candidate = unwrapParens(expression);
-    return candidate instanceof BinaryExpression
-        && candidate.operator.value.trim().toLowerCase() === operator;
-};
-
-const collectTopLevelAndTerms = (expression: ValueComponent): ValueComponent[] => {
-    const candidate = unwrapParens(expression);
-    if (!isBinaryOperator(candidate, "and")) {
-        return [expression];
-    }
-
-    return [
-        ...collectTopLevelAndTerms(candidate.left),
-        ...collectTopLevelAndTerms(candidate.right)
-    ];
-};
-
-const rebuildWhereWithoutTerms = (query: SimpleSelectQuery, termsToRemove: ReadonlySet<ValueComponent>): void => {
-    if (!query.whereClause || termsToRemove.size === 0) {
-        return;
-    }
-
-    const remaining = collectTopLevelAndTerms(query.whereClause.condition)
-        .filter(term => !termsToRemove.has(term));
-
-    if (remaining.length === 0) {
-        query.whereClause = null;
-        return;
-    }
-
-    let rebuilt = remaining[0]!;
-    for (let index = 1; index < remaining.length; index += 1) {
-        rebuilt = new BinaryExpression(rebuilt, "and", remaining[index]!);
-    }
-    query.whereClause = new WhereClause(rebuilt);
-};
-
-const cloneValueComponent = (
-    expression: ValueComponent,
-    options: SqlComponentFormatOptions
-): ValueComponent => {
-    return ValueParser.parse(formatSqlComponent(expression, options));
-};
-
-const cloneColumnReference = (reference: ColumnReference): ColumnReference => {
-    const namespaces = reference.namespaces?.map(namespace => namespace.name) ?? null;
-    return new ColumnReference(namespaces, reference.column.name);
-};
-
-const columnReferenceText = (reference: ColumnReference): string => {
-    const namespace = reference.getNamespace();
-    return namespace ? `${namespace}.${reference.column.name}` : reference.column.name;
-};
-
-const sameColumnReference = (left: ColumnReference, right: ColumnReference): boolean => {
-    return identifiersEqual(left.column.name, right.column.name)
-        && identifiersEqual(left.getNamespace(), right.getNamespace());
-};
-
-const appendUnique = <T>(items: T[], value: T): void => {
-    if (!items.includes(value)) {
-        items.push(value);
-    }
-};
 
 export class StaticPredicatePlacementOptimizer {
     public plan(


### PR DESCRIPTION
## Summary

- Extract shared predicate expression helpers into an internal `PredicateExpressionUtils` module.
- Update static predicate placement, parameter condition placement, and predicate reachability analysis to use the shared helpers.
- Keep public API, optimizer behavior, SQL output, and tests unchanged.

## Verification

- `corepack pnpm --filter rawsql-ts test`
- `corepack pnpm --filter rawsql-ts build`
- `corepack pnpm --filter rawsql-ts lint`
- Pre-commit workspace checks passed: API output shape guard, typecheck, tests, build, and lint.

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: Not required; no baseline exception requested.
Scoped checks run: `corepack pnpm --filter rawsql-ts test`; `corepack pnpm --filter rawsql-ts build`; `corepack pnpm --filter rawsql-ts lint`; pre-commit workspace checks.
Why full baseline is not required: Not applicable; no baseline exception requested.

## Self Review

Self-review workflow: `developer-self-review` two-cycle review, plus focused diff inspection for public API/output shape drift.
Self-review result: No blockers found; the change is limited to internal helper extraction and duplicated local helper removal.
Concept-review workflow: `packages/core/AGENTS.md`, `.agents/skills/core-parser-analyzer-change/SKILL.md`, and API output shape review guidance checked.
Concept-review result: No concept or package-boundary violations found; no parser, formatter, CLI, or public API contract changes.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: This is an internal core refactor and does not change CLI flags, output, help text, or user-facing behavior.
Upgrade note: No upgrade note required.
Deprecation/removal plan or issue: No deprecation or removal.
Docs/help/examples updated: Not required; no docs, help, or example behavior changed.
Release/changeset wording: No changeset because this is an internal refactor only and public API/behavior are unchanged.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: This change does not touch scaffold generation, scaffold input contracts, or generated scaffold output.
Non-edit assertion: Not applicable.
Fail-fast input-contract proof: Not applicable.
Generated-output viability proof: Not applicable.
