### PR TITLE
fix(core): add debug probe SQL for join equivalence

### DIFF
--- a/.changeset/left-join-debug-probes.md
+++ b/.changeset/left-join-debug-probes.md
@@ -1,0 +1,5 @@
+---
+"rawsql-ts": patch
+---
+
+Add debug-probe SQL output for JOIN-equivalence predicate investigation and allow LEFT JOIN preserved-side predicates to probe nullable-side inputs.

--- a/packages/core/src/transformers/ConditionOptimization.ts
+++ b/packages/core/src/transformers/ConditionOptimization.ts
@@ -26,6 +26,7 @@ import {
     TableSource
 } from "../models/Clause";
 import { SelectQueryParser } from "../parsers/SelectQueryParser";
+import { ValueParser } from "../parsers/ValueParser";
 import { rewriteValueComponentWithColumnResolver } from "../utils/ValueComponentRewriter";
 import {
     ParameterConditionPlacementOptimizer,
@@ -46,6 +47,10 @@ import {
     ConditionDeduplicationApplied,
     ConditionDeduplicationOptimizer
 } from "./ConditionDeduplicationOptimizer";
+import {
+    analyzePredicateReachability,
+    PredicateReachabilityResult
+} from "./PredicateReachabilityAnalyzer";
 import {
     collectSupportedOptionalConditionBranches,
     OptionalConditionPruningParameters,
@@ -147,6 +152,12 @@ export interface ConditionOptimizationSourceFilterProbe {
     predicate: string;
     suggestedSql: string;
     reason: string;
+    relation?: "source_filter" | "join_equivalence";
+    targetPredicate?: string;
+    targetScope?: {
+        kind: "scope" | "cte" | "table" | "subquery" | "source";
+        name: string;
+    };
 }
 
 export interface ConditionOptimizationSkippedProbe {
@@ -166,6 +177,16 @@ export interface ConditionOptimizationDiagnostics {
      */
     probes: readonly ConditionOptimizationSourceFilterProbe[];
     skippedProbes: readonly ConditionOptimizationSkippedProbe[];
+    /**
+     * API output shape review: keep result.sql/result.query as the production-safe
+     * rewrite output and expose debugSql/debugQuery only for diagnostic pipelines.
+     *
+     * Debug-only probe SQL is additive: result.sql/result.query remain the safe-only
+     * production rewrite output, while debugSql/debugQuery include investigation
+     * probes that callers can feed into lineage/debug surfaces.
+     */
+    debugSql?: string;
+    debugQuery?: SelectQuery | null;
 }
 
 export interface ConditionOptimizationResult {
@@ -609,6 +630,121 @@ const collectConditionOptimizationDiagnostics = (
     return { probes, skippedProbes };
 };
 
+const makeReachabilityProbeSuggestedSql = (
+    sourceName: string,
+    predicate: string | undefined,
+    options: SqlComponentFormatOptions
+): string => {
+    if (!predicate) {
+        return `select * from ${sourceName}`;
+    }
+
+    const sourceLocalPredicate = rewriteValueComponentWithColumnResolver(
+        ValueParser.parse(predicate),
+        reference => new ColumnReference(null, reference.column.name)
+    );
+    return sourceLocalPredicate
+        ? `select * from ${sourceName} where ${formatSqlComponent(sourceLocalPredicate, options)}`
+        : `select * from ${sourceName}`;
+};
+
+const collectJoinEquivalenceProbeDiagnostics = (
+    reachability: PredicateReachabilityResult,
+    options: SqlComponentFormatOptions
+): Pick<ConditionOptimizationDiagnostics, "probes" | "skippedProbes"> => {
+    const probes: ConditionOptimizationSourceFilterProbe[] = [];
+    const skippedProbes: ConditionOptimizationSkippedProbe[] = [];
+
+    for (const predicate of reachability.predicates) {
+        for (const target of predicate.probeTargets) {
+            if (target.relation !== "join_equivalence") {
+                continue;
+            }
+            probes.push({
+                kind: "source_filter_probe",
+                source: target.target.name,
+                sourceAlias: target.target.name,
+                predicate: target.predicateSql,
+                suggestedSql: makeReachabilityProbeSuggestedSql(target.target.name, target.targetPredicateSql, options),
+                reason: "predicate inferred through JOIN equivalence for debug probing",
+                relation: "join_equivalence",
+                ...(target.targetPredicateSql ? { targetPredicate: target.targetPredicateSql } : {}),
+                targetScope: target.target
+            });
+        }
+
+        for (const blocked of predicate.blocked) {
+            if (blocked.relation !== "join_equivalence") {
+                continue;
+            }
+            const [, ...nameParts] = blocked.scopeId.split(":");
+            const source = nameParts.join(":") || undefined;
+            skippedProbes.push({
+                kind: "source_filter_probe_skipped",
+                source,
+                sourceAlias: source,
+                predicate: predicate.predicateSql,
+                code: blocked.code,
+                reason: blocked.reason
+            });
+        }
+    }
+
+    return { probes, skippedProbes };
+};
+
+const findDebugCte = (
+    query: SimpleSelectQuery,
+    name: string
+) => {
+    const normalized = normalizeIdentifier(name);
+    const matches = (query.withClause?.tables ?? [])
+        .filter(table => normalizeIdentifier(table.getSourceAliasName()) === normalized);
+    return matches.length === 1 ? matches[0]! : null;
+};
+
+const buildDebugProbeQuery = (
+    baseQuery: SelectQuery | null,
+    reachability: PredicateReachabilityResult,
+    options: SqlComponentFormatOptions
+): SelectQuery | null => {
+    if (!(baseQuery instanceof SimpleSelectQuery)) {
+        return null;
+    }
+
+    const applicableTargets = reachability.predicates.flatMap(predicate => predicate.probeTargets)
+        .filter(target =>
+            target.relation === "join_equivalence"
+            && Boolean(target.targetPredicateSql)
+            && target.target.kind === "cte"
+        );
+    if (applicableTargets.length === 0) {
+        return null;
+    }
+
+    const debugQuery = SelectQueryParser.parse(formatSqlComponent(baseQuery, options));
+    if (!(debugQuery instanceof SimpleSelectQuery)) {
+        return null;
+    }
+
+    let applied = false;
+    for (const target of applicableTargets) {
+        const cte = findDebugCte(debugQuery, target.target.name);
+        if (!cte || !(cte.query instanceof SimpleSelectQuery) || !target.targetPredicateSql) {
+            continue;
+        }
+        cte.query.appendWhereRaw(target.targetPredicateSql);
+        applied = true;
+    }
+
+    if (!applied) {
+        return null;
+    }
+
+    const dedupePhase = new ConditionDeduplicationOptimizer().optimize(debugQuery, options);
+    return dedupePhase.query ?? debugQuery;
+};
+
 const isAbsentOptionalValue = (
     parameters: OptionalConditionPruningParameters,
     parameterName: string
@@ -1050,6 +1186,54 @@ const makePhaseSummary = (
     errorCount: counts.errorCount
 });
 
+const getAppliedConditionSql = (applied: ConditionOptimizationApplied): string | undefined => {
+    if ("predicateSql" in applied) {
+        return applied.predicateSql;
+    }
+    if ("conditionSql" in applied) {
+        return applied.conditionSql;
+    }
+    return undefined;
+};
+
+const normalizeDiagnosticPredicate = (
+    predicate: string,
+    options: SqlComponentFormatOptions
+): string => {
+    try {
+        return formatSqlComponent(ValueParser.parse(predicate), options)
+            .replace(/\s+/g, " ")
+            .trim()
+            .toLowerCase();
+    } catch {
+        return predicate
+            .replace(/\s+/g, " ")
+            .trim()
+            .toLowerCase();
+    }
+};
+
+const filterSkippedProbesAlreadyApplied = (
+    skippedProbes: readonly ConditionOptimizationSkippedProbe[],
+    applied: readonly ConditionOptimizationApplied[],
+    options: SqlComponentFormatOptions
+): ConditionOptimizationSkippedProbe[] => {
+    const appliedPredicates = new Set(
+        applied
+            .map(item => getAppliedConditionSql(item))
+            .filter((predicate): predicate is string => Boolean(predicate))
+            .map(predicate => normalizeDiagnosticPredicate(predicate, options))
+    );
+
+    if (appliedPredicates.size === 0) {
+        return [...skippedProbes];
+    }
+
+    return skippedProbes.filter(probe => probe.code !== "NESTED_QUERY_UNSUPPORTED" || !appliedPredicates.has(
+        normalizeDiagnosticPredicate(probe.predicate, options)
+    ));
+};
+
 const runConditionOptimization = (
     input: ConditionOptimizationInput,
     options: ConditionOptimizationOptions,
@@ -1061,7 +1245,13 @@ const runConditionOptimization = (
     // Run semantic SSSQL handling before generic placement phases so optional
     // branches remain owned by SSSQL even if later phases grow broader support.
     const sssqlPhase = runSssqlOptionalConditionPhase(input, { ...options, dryRun });
-    const diagnostics = collectConditionOptimizationDiagnostics(sssqlPhase.query, options);
+    const sourceDiagnostics = collectConditionOptimizationDiagnostics(sssqlPhase.query, options);
+    const reachability = sssqlPhase.query
+        ? analyzePredicateReachability(sssqlPhase.query, { ...options, cloneInput: false })
+        : null;
+    const reachabilityDiagnostics = reachability
+        ? collectJoinEquivalenceProbeDiagnostics(reachability, options)
+        : { probes: [], skippedProbes: [] };
     const parameterOptimizer = new ParameterConditionPlacementOptimizer();
     const parameterInput = reuseOwnedModel
         ? sssqlPhase.query ?? sssqlPhase.sql
@@ -1103,6 +1293,20 @@ const runConditionOptimization = (
     const finalSql = dedupePhase.applied.length > 0 && dedupePhase.query
         ? formatSqlComponent(dedupePhase.query, options)
         : staticPhase.sql;
+    const applied = [...sssqlPhase.applied, ...parameterApplied, ...staticApplied, ...dedupeApplied];
+    const debugQuery = reachability
+        ? buildDebugProbeQuery(dedupePhase.query, reachability, options)
+        : null;
+    const debugSql = debugQuery ? formatSqlComponent(debugQuery, options) : undefined;
+    const diagnostics: ConditionOptimizationDiagnostics = {
+        probes: [...sourceDiagnostics.probes, ...reachabilityDiagnostics.probes],
+        skippedProbes: filterSkippedProbesAlreadyApplied(
+            [...sourceDiagnostics.skippedProbes, ...reachabilityDiagnostics.skippedProbes],
+            applied,
+            options
+        ),
+        ...(debugSql ? { debugSql, debugQuery } : {})
+    };
 
     return {
         ok: errors.length === 0,
@@ -1134,7 +1338,7 @@ const runConditionOptimization = (
                 errorCount: 0
             })
         ],
-        applied: [...sssqlPhase.applied, ...parameterApplied, ...staticApplied, ...dedupeApplied],
+        applied,
         skipped: [...sssqlPhase.skipped, ...parameterSkipped, ...staticSkipped],
         warnings,
         errors,

--- a/packages/core/src/transformers/PredicateReachabilityAnalyzer.ts
+++ b/packages/core/src/transformers/PredicateReachabilityAnalyzer.ts
@@ -71,6 +71,7 @@ export interface PredicateReachabilityTarget {
     relation: PredicateReachabilityRelation;
     mode: PredicateReachabilityMode;
     predicateSql: string;
+    targetPredicateSql?: string;
     via?: readonly string[];
 }
 
@@ -87,6 +88,7 @@ export interface PredicateReachabilityProbeTarget {
     relation: PredicateReachabilityRelation;
     mode: PredicateReachabilityMode;
     predicateSql: string;
+    targetPredicateSql?: string;
     target: PredicateReachabilityScopeTarget;
     probeKinds: readonly PredicateReachabilityProbeKind[];
     caution?: string;
@@ -202,7 +204,7 @@ export class PredicateReachabilityAnalyzer {
                 });
             }
 
-            const joinReachability = this.resolveJoinEquivalenceReach(query, references, term, options);
+            const joinReachability = this.resolveJoinEquivalenceReach(contextRoot, query, references, term, options);
             reaches.push(...joinReachability.reaches);
             blocked.push(...joinReachability.blocked);
 
@@ -225,6 +227,7 @@ export class PredicateReachabilityAnalyzer {
             relation: reach.relation,
             mode: reach.mode,
             predicateSql: reach.predicateSql,
+            ...(reach.targetPredicateSql ? { targetPredicateSql: reach.targetPredicateSql } : {}),
             target: this.describeScopeTarget(reach.scopeId),
             probeKinds: ["count", "sample"],
             ...(reach.mode === "debug_only"
@@ -301,6 +304,7 @@ export class PredicateReachabilityAnalyzer {
     }
 
     private resolveJoinEquivalenceReach(
+        contextRoot: SimpleSelectQuery,
         query: SimpleSelectQuery,
         references: readonly ColumnReference[],
         predicate: ValueComponent,
@@ -331,6 +335,10 @@ export class PredicateReachabilityAnalyzer {
                     if (!equivalent) {
                         continue;
                     }
+                    const referenceBinding = this.resolveSourceBindingFromList(bindings, reference);
+                    if (!referenceBinding) {
+                        continue;
+                    }
                     const targetBinding = this.resolveSourceBindingFromList(bindings, equivalent);
                     if (!targetBinding) {
                         continue;
@@ -340,22 +348,32 @@ export class PredicateReachabilityAnalyzer {
                         sourceColumn: reference,
                         targetColumn: equivalent
                     }], options);
-                    const scopeId = this.scopeIdForBinding(null, targetBinding);
-                    if (!this.isInnerJoin(join)) {
+                    const scopeId = this.scopeIdForBinding(contextRoot, targetBinding);
+                    const joinEquivalenceAllowed = this.isInnerJoin(join)
+                        || this.isLeftJoinPreservedToNullableReach(join, referenceBinding, targetBinding);
+                    if (!joinEquivalenceAllowed) {
                         blocked.push({
                             scopeId,
                             relation: "join_equivalence",
                             code: "OUTER_JOIN_EQUIVALENCE_UNSUPPORTED",
-                            reason: "JOIN equivalence debug reachability is reported only for INNER JOIN predicates in this safe diagnostic API.",
+                            reason: "JOIN equivalence debug reachability is reported for INNER JOIN predicates and LEFT JOIN preserved-side predicates only.",
                             via
                         });
                         continue;
                     }
+                    const targetPredicate = this.rebasePredicateToSourceQuery(
+                        contextRoot,
+                        targetBinding,
+                        equivalent,
+                        rebased,
+                        options
+                    );
                     reaches.push({
                         scopeId,
                         relation: "join_equivalence",
                         mode: "debug_only",
                         predicateSql: formatSqlComponent(rebased, options),
+                        ...(targetPredicate ? { targetPredicateSql: formatSqlComponent(targetPredicate, options) } : {}),
                         via
                     });
                 }
@@ -499,6 +517,40 @@ export class PredicateReachabilityAnalyzer {
     private isInnerJoin(join: JoinClause): boolean {
         const joinType = join.joinType.value.trim().toLowerCase();
         return joinType === "join" || joinType === "inner join";
+    }
+
+    private isLeftJoinPreservedToNullableReach(
+        join: JoinClause,
+        referenceBinding: SourceBinding,
+        targetBinding: SourceBinding
+    ): boolean {
+        const joinType = join.joinType.value.trim().toLowerCase();
+        return (joinType === "left join" || joinType === "left outer join")
+            && targetBinding.source === join.source
+            && referenceBinding.source !== join.source;
+    }
+
+    private rebasePredicateToSourceQuery(
+        contextRoot: SimpleSelectQuery,
+        targetBinding: SourceBinding,
+        equivalentColumn: ColumnReference,
+        predicate: ValueComponent,
+        options: SqlComponentFormatOptions
+    ): ValueComponent | null {
+        const target = this.resolveSourceQuery(contextRoot, targetBinding);
+        if (!target) {
+            return null;
+        }
+
+        const output = this.resolveDirectOutputColumn(contextRoot, target.query, equivalentColumn.column.name);
+        if (!output || !(output.value instanceof ColumnReference)) {
+            return null;
+        }
+
+        return this.rebasePredicate(predicate, [{
+            sourceColumn: equivalentColumn,
+            targetColumn: output.value
+        }], options);
     }
 
     private rebasePredicate(

--- a/packages/core/tests/transformers/ConditionOptimization.test.ts
+++ b/packages/core/tests/transformers/ConditionOptimization.test.ts
@@ -563,6 +563,99 @@ describe('ConditionOptimization', () => {
         ]);
     });
 
+    it('adds JOIN-equivalence debug probes to diagnostics and debug SQL without changing safe SQL', () => {
+        const sql = `
+            with order_totals as (
+                select customer_id, count(*) as order_count
+                from orders
+                group by customer_id
+            )
+            select c.id, ot.order_count
+            from customers c
+            join order_totals ot on ot.customer_id = c.id
+            where c.id = 1000
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(normalizeSql(result.sql)).toBe(normalizeSql(`
+            with order_totals as (
+                select customer_id, count(*) as order_count
+                from orders
+                group by customer_id
+            )
+            select c.id, ot.order_count
+            from customers c
+            join order_totals ot on ot.customer_id = c.id and c.id = 1000
+        `));
+        expect(result.diagnostics?.probes).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                source: 'order_totals',
+                sourceAlias: 'order_totals',
+                predicate: '"ot"."customer_id" = 1000',
+                reason: 'predicate inferred through JOIN equivalence for debug probing'
+            })
+        ]));
+        expect(result.diagnostics?.debugQuery).not.toBeNull();
+        expect(normalizeSql(result.diagnostics!.debugSql!)).toBe(normalizeSql(`
+            with order_totals as (
+                select customer_id, count(*) as order_count
+                from orders
+                where customer_id = 1000
+                group by customer_id
+            )
+            select c.id, ot.order_count
+            from customers c
+            join order_totals ot on ot.customer_id = c.id and c.id = 1000
+        `));
+    });
+
+    it('allows LEFT JOIN preserved-side JOIN-equivalence debug probes into nullable CTE input', () => {
+        const sql = `
+            with customer_scope as (
+                select c.id, c.name
+                from customers c
+            ),
+            payment_summary as (
+                select p.customer_id, sum(p.amount) as paid_amount
+                from payments p
+                group by p.customer_id
+            )
+            select cs.id, ps.paid_amount
+            from customer_scope cs
+            left join payment_summary ps on ps.customer_id = cs.id
+            where cs.id = 1000
+        `;
+
+        const result = optimizeConditions(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.diagnostics?.skippedProbes).toEqual([]);
+        expect(result.diagnostics?.probes).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                source: 'payment_summary',
+                predicate: '"ps"."customer_id" = 1000'
+            })
+        ]));
+        expect(normalizeSql(result.diagnostics!.debugSql!)).toBe(normalizeSql(`
+            with customer_scope as (
+                select c.id, c.name
+                from customers c
+                where c.id = 1000
+            ),
+            payment_summary as (
+                select p.customer_id, sum(p.amount) as paid_amount
+                from payments p
+                where p.customer_id = 1000
+                group by p.customer_id
+            )
+            select cs.id, ps.paid_amount
+            from customer_scope cs
+            left join payment_summary ps on ps.customer_id = cs.id
+        `));
+    });
+
     it('moves parameter conditions through a derived table wildcard output', () => {
         const sql = `
             select *
@@ -1352,6 +1445,12 @@ describe('ConditionOptimization', () => {
             expect.objectContaining({
                 phaseKind: 'static_predicate_placement',
                 predicateSql: expect.stringContaining(':customer_tier')
+            })
+        ]));
+        expect(result.diagnostics?.skippedProbes).not.toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                code: 'NESTED_QUERY_UNSUPPORTED',
+                predicate: expect.stringContaining('exists')
             })
         ]));
         expect(normalizeSql(result.sql)).toBe(normalizeSql(`

--- a/packages/core/tests/transformers/PredicateReachabilityAnalyzer.test.ts
+++ b/packages/core/tests/transformers/PredicateReachabilityAnalyzer.test.ts
@@ -82,7 +82,7 @@ describe('PredicateReachabilityAnalyzer', () => {
         expect(normalizeSql(new SqlFormatter().format(result.query!).formattedSql)).toBe(normalizeSql(sql));
     });
 
-    it('keeps OUTER JOIN equivalence as blocked debug reachability instead of treating it as a rewrite target', () => {
+    it('reports LEFT JOIN preserved-side predicates as debug-only nullable-side probes', () => {
         const sql = `
             with order_scope as (
                 select o.id, o.customer_id
@@ -104,13 +104,123 @@ describe('PredicateReachabilityAnalyzer', () => {
                         scopeId: 'cte:order_scope',
                         relation: 'direct_output',
                         mode: 'rewrite_safe'
+                    }),
+                    expect.objectContaining({
+                        scopeId: 'table:customers',
+                        relation: 'join_equivalence',
+                        mode: 'debug_only',
+                        predicateSql: '"c"."id" = :customer_id'
+                    })
+                ]),
+                blocked: []
+            })
+        ]);
+        expect(result.predicates[0]!.probeTargets).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                scopeId: 'table:customers',
+                relation: 'join_equivalence',
+                mode: 'debug_only'
+            })
+        ]));
+    });
+
+    it('keeps LEFT JOIN nullable-side predicates blocked from preserved-side debug reachability', () => {
+        const sql = `
+            with order_scope as (
+                select o.id, o.customer_id
+                from orders o
+            )
+            select os.id
+            from order_scope os
+            left join customers c on c.id = os.customer_id
+            where c.id = :customer_id
+        `;
+
+        const result = analyzePredicateReachability(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.predicates).toEqual([
+            expect.objectContaining({
+                reaches: expect.arrayContaining([
+                    expect.objectContaining({
+                        scopeId: 'scope:root',
+                        relation: 'origin',
+                        mode: 'rewrite_safe'
                     })
                 ]),
                 blocked: [
                     expect.objectContaining({
                         code: 'OUTER_JOIN_EQUIVALENCE_UNSUPPORTED',
                         relation: 'join_equivalence',
-                        scopeId: 'table:customers'
+                        scopeId: 'cte:order_scope'
+                    })
+                ]
+            })
+        ]);
+        expect(result.predicates[0]!.probeTargets).not.toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                scopeId: 'cte:order_scope',
+                relation: 'join_equivalence'
+            })
+        ]));
+    });
+
+    it('rebases JOIN-equivalence probes to CTE-local predicates when possible', () => {
+        const sql = `
+            with order_totals as (
+                select customer_id, count(*) as order_count
+                from orders
+                group by customer_id
+            )
+            select c.id, ot.order_count
+            from customers c
+            join order_totals ot on ot.customer_id = c.id
+            where c.id = 1000
+        `;
+
+        const result = analyzePredicateReachability(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.predicates[0]!.probeTargets).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                scopeId: 'cte:order_totals',
+                relation: 'join_equivalence',
+                mode: 'debug_only',
+                predicateSql: '"ot"."customer_id" = 1000',
+                targetPredicateSql: '"customer_id" = 1000'
+            })
+        ]));
+    });
+
+    it('keeps unsupported outer join directions as blocked debug reachability', () => {
+        const sql = `
+            with order_scope as (
+                select o.id, o.customer_id
+                from orders o
+            )
+            select os.id
+            from customers c
+            right join order_scope os on c.id = os.customer_id
+            where c.id = :customer_id
+        `;
+
+        const result = analyzePredicateReachability(sql);
+
+        expect(result.ok).toBe(true);
+        expect(result.predicates).toEqual([
+            expect.objectContaining({
+                reaches: expect.arrayContaining([
+                    expect.objectContaining({
+                        scopeId: 'scope:root',
+                        relation: 'origin',
+                        mode: 'rewrite_safe'
+                    })
+                ]),
+                blocked: [
+                    expect.objectContaining({
+                        code: 'OUTER_JOIN_EQUIVALENCE_UNSUPPORTED',
+                        relation: 'join_equivalence',
+                        scopeId: 'cte:order_scope'
                     })
                 ]
             })


### PR DESCRIPTION
## Summary

- Add diagnostic-only debug SQL output for JOIN-equivalence predicate probes while keeping the safe optimized SQL output unchanged.
- Allow LEFT JOIN preserved-side predicates to produce nullable-side debug probes.
- Filter skipped nested-query probe metadata when the predicate was already applied by safe optimization.

## Verification

- `corepack pnpm --filter rawsql-ts test -- ConditionOptimization PredicateReachabilityAnalyzer`
- `corepack pnpm --filter rawsql-ts build`
- `corepack pnpm --filter rawsql-ts lint`
- Pre-commit: workspace `typecheck`, `test`, `build`, and `lint`

## Merge Readiness

- [x] No baseline exception requested.
- [ ] Baseline exception requested and linked below.

Tracking issue: Not required; no baseline exception requested.
Scoped checks run: `corepack pnpm --filter rawsql-ts test -- ConditionOptimization PredicateReachabilityAnalyzer`; `corepack pnpm --filter rawsql-ts build`; `corepack pnpm --filter rawsql-ts lint`; pre-commit workspace typecheck/test/build/lint.
Why full baseline is not required: Targeted core transformer change with package verification and pre-commit workspace gates.

## Self Review

Self-review workflow: developer-self-review two-cycle review: consistency review and human acceptance review.
Self-review result: No blockers found; tests cover debug SQL output, LEFT JOIN preserved-side probes, unsupported outer join directions, and skipped nested-query probe filtering.
Concept-review workflow: core-parser-analyzer-change, api-output-shape-review, changeset-classification, packages/core AGENTS.md, and packages/core DESIGN.md.
Concept-review result: No package-boundary or API-shape blockers found; result.sql/result.query remain production-safe and debugSql/debugQuery are diagnostic-only.

## CLI Surface Migration

- [x] No migration packet required for this CLI change.
- [ ] CLI/user-facing surface change and migration packet completed.

No-migration rationale: No CLI command, option, help text, or CLI output contract is changed.
Upgrade note: Not applicable; no CLI migration required.
Deprecation/removal plan or issue: Not applicable; no deprecation or removal.
Docs/help/examples updated: Not applicable; no CLI docs/help/examples changed.
Release/changeset wording: Patch changeset `.changeset/left-join-debug-probes.md` added.

## Scaffold Contract Proof

- [x] No scaffold contract proof required for this PR.
- [ ] Scaffold contract proof completed.

No-proof rationale: No scaffold-owned files, generated scaffold runtime, or scaffold input contract changed.
Non-edit assertion: Not applicable; no scaffold output is touched.
Fail-fast input-contract proof: Not applicable; no scaffold input contract changed.
Generated-output viability proof: Not applicable; no generated scaffold output changed.
